### PR TITLE
Fix TLS handshake state, SNI, key exchange, and EMS regressions

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from tls_handshake import (
     EXT_SNI,
@@ -78,6 +79,21 @@ class TLSHandshakeRegressionTests(unittest.TestCase):
         self.assertEqual(standard.labels[-1], b"master secret")
         self.assertEqual(ems.labels[-1], b"extended master secret")
         self.assertNotEqual(standard.master_secret, ems.master_secret)
+
+    def test_verify_finished_uses_constant_time_compare_digest(self):
+        class FixedVerifyHandshake(TLSHandshake):
+            def _prf(self, secret, label, seed, output_len):
+                return b"v" * output_len
+
+        handshake = FixedVerifyHandshake()
+        handshake.master_secret = b"m" * 48
+
+        with patch("tls_handshake.hmac.compare_digest", return_value=True) as compare_digest:
+            self.assertTrue(handshake.verify_finished(b"v" * 12, "client finished"))
+
+        compare_digest.assert_called_once_with(b"v" * 12, b"v" * 12)
+
+        self.assertFalse(handshake.verify_finished(b"x" * 12, "client finished"))
 
 
 if __name__ == "__main__":

--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,84 @@
+import unittest
+
+from tls_handshake import (
+    EXT_SNI,
+    HandshakeMessage,
+    HandshakeState,
+    HandshakeType,
+    TLSHandshake,
+)
+
+
+class TLSHandshakeRegressionTests(unittest.TestCase):
+    def test_finished_cannot_follow_client_hello_directly(self):
+        handshake = TLSHandshake()
+
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+    def test_parse_extensions_decodes_sni_hostname(self):
+        hostname = b"api.example.test"
+        sni_entry = b"\x00" + len(hostname).to_bytes(2, "big") + hostname
+        sni_list = len(sni_entry).to_bytes(2, "big") + sni_entry
+        extension = (
+            EXT_SNI.to_bytes(2, "big")
+            + len(sni_list).to_bytes(2, "big")
+            + sni_list
+        )
+        handshake = TLSHandshake()
+
+        parsed = handshake.parse_extensions(extension)
+
+        self.assertEqual(parsed[0].server_name, "api.example.test")
+        self.assertEqual(handshake.server_name, "api.example.test")
+
+    def test_process_key_exchange_returns_false_for_expected_parse_errors(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x30" + b"x" * 47,
+        )
+
+        self.assertFalse(handshake.process_key_exchange(message))
+
+    def test_process_key_exchange_does_not_swallow_unexpected_errors(self):
+        class ExplodingHandshake(TLSHandshake):
+            def _decrypt_pre_master_secret(self, encrypted):
+                raise RuntimeError("unexpected decrypt failure")
+
+        handshake = ExplodingHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x30" + b"x" * 48,
+        )
+
+        with self.assertRaises(RuntimeError):
+            handshake.process_key_exchange(message)
+
+    def test_derive_master_secret_uses_ems_label_when_negotiated(self):
+        class RecordingHandshake(TLSHandshake):
+            def __init__(self, negotiated_ems):
+                super().__init__()
+                self.negotiated_ems = negotiated_ems
+                self._pre_master_secret = b"p" * 48
+                self.client_random = b"c" * 32
+                self.server_random = b"s" * 32
+                self.labels = []
+
+            def _prf(self, secret, label, seed, output_len):
+                self.labels.append(label)
+                return bytes([len(label) % 256]) * output_len
+
+        standard = RecordingHandshake(False)
+        standard._derive_master_secret()
+        ems = RecordingHandshake(True)
+        ems._derive_master_secret()
+
+        self.assertEqual(standard.labels[-1], b"master secret")
+        self.assertEqual(ems.labels[-1], b"extended master secret")
+        self.assertNotEqual(standard.master_secret, ems.master_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -53,10 +53,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],
@@ -203,10 +200,11 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
             if ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
+            elif ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_hostname(ext_data)
+                self.server_name = ext.server_name
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
             elif ext_type == EXT_SUPPORTED_VERSIONS:
@@ -216,6 +214,32 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_hostname(self, data: bytes) -> Optional[str]:
+        """Return the first host_name entry from an RFC 6066 SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = min(len(data), offset + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            if offset + name_len > end:
+                return None
+
+            name_bytes = data[offset:offset + name_len]
+            offset += name_len
+            if name_type == 0x00:
+                try:
+                    return name_bytes.decode("idna")
+                except UnicodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """
@@ -256,9 +280,8 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
+        except (ValueError, struct.error):
+            return False
         return False
 
     def _derive_master_secret(self) -> None:
@@ -271,9 +294,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -257,8 +257,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Summary

Fixes five focused TLS handshake bounty issues in `python/tls_handshake.py`:

/claim #16
/claim #17
/claim #18
/claim #20
/claim #21

Changes:
- Restricts `CLIENT_HELLO` to transition only to `SERVER_HELLO`, so `FINISHED` cannot skip the handshake path.
- Parses RFC 6066 SNI host_name entries and stores the decoded hostname on both the extension and handshake state.
- Uses `hmac.compare_digest()` for Finished verify-data comparison.
- Replaces the bare `except` in key exchange handling with expected parse/decryption exceptions only.
- Uses the RFC 7627 `extended master secret` PRF label when EMS is negotiated.
- Adds focused unittest coverage for all five regressions.

## Demo / verification

```text
python -m unittest discover -s python -v

test_derive_master_secret_uses_ems_label_when_negotiated ... ok
test_finished_cannot_follow_client_hello_directly ... ok
test_parse_extensions_decodes_sni_hostname ... ok
test_process_key_exchange_does_not_swallow_unexpected_errors ... ok
test_process_key_exchange_returns_false_for_expected_parse_errors ... ok
test_verify_finished_uses_constant_time_compare_digest ... ok

Ran 6 tests in 0.017s
OK
```

Also verified:

```text
python -m py_compile python/tls_handshake.py python/test_tls_handshake.py
git diff --check
```