### PR TITLE
fix: harden python TLS handshake helpers

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,10 +6,14 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
 from typing import Optional, Dict, List, Tuple, Any
+
+
+logger = logging.getLogger(__name__)
 
 
 class HandshakeState(Enum):
@@ -233,8 +237,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""
@@ -256,10 +259,9 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error) as exc:
+            logger.warning("Failed to process key exchange: %s", exc)
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""
@@ -271,9 +273,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 

--- a/tests/test_tls_handshake_python_bounties.py
+++ b/tests/test_tls_handshake_python_bounties.py
@@ -1,0 +1,82 @@
+import logging
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake, hmac  # noqa: E402
+
+
+def test_verify_finished_uses_constant_time_compare(monkeypatch):
+    handshake = TLSHandshake()
+    handshake.master_secret = b"m" * 48
+    expected = handshake._prf(
+        handshake.master_secret,
+        b"server finished",
+        handshake.handshake_hash.copy().digest(),
+        12,
+    )
+    calls = []
+
+    def fake_compare_digest(left, right):
+        calls.append((left, right))
+        return True
+
+    monkeypatch.setattr(hmac, "compare_digest", fake_compare_digest)
+
+    assert handshake.verify_finished(expected, "server finished") is True
+    assert calls == [(expected, expected)]
+
+
+def test_process_key_exchange_returns_false_and_logs_expected_errors(caplog):
+    handshake = TLSHandshake()
+    message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00")
+
+    with caplog.at_level(logging.WARNING):
+        assert handshake.process_key_exchange(message) is False
+
+    assert "Failed to process key exchange" in caplog.text
+
+
+def test_process_key_exchange_propagates_unexpected_errors(monkeypatch):
+    handshake = TLSHandshake()
+    payload = struct.pack("!H", 48) + (b"x" * 48)
+    message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, payload)
+
+    def raise_type_error(_encrypted):
+        raise TypeError("unexpected bug")
+
+    monkeypatch.setattr(handshake, "_decrypt_pre_master_secret", raise_type_error)
+
+    with pytest.raises(TypeError, match="unexpected bug"):
+        handshake.process_key_exchange(message)
+
+
+def test_derive_master_secret_uses_extended_master_secret_label(monkeypatch):
+    labels = []
+
+    def fake_prf(_secret, label, _seed, output_len):
+        labels.append(label)
+        return label.ljust(output_len, b"!")[:output_len]
+
+    handshake = TLSHandshake()
+    handshake._pre_master_secret = b"p" * 48
+    handshake.client_random = b"c" * 32
+    handshake.server_random = b"s" * 32
+    monkeypatch.setattr(handshake, "_prf", fake_prf)
+
+    handshake.negotiated_ems = False
+    handshake._derive_master_secret()
+    regular_secret = handshake.master_secret
+
+    handshake.negotiated_ems = True
+    handshake._derive_master_secret()
+    ems_secret = handshake.master_secret
+
+    assert labels == [b"master secret", b"extended master secret"]
+    assert regular_secret != ems_secret
+    assert len(regular_secret) == 48
+    assert len(ems_secret) == 48


### PR DESCRIPTION
Fixes three Python TLS handshake bounty issues:

/claim #18
/claim #20
/claim #21

Changes:
- Use `hmac.compare_digest()` for Finished verify_data comparison to avoid timing leaks.
- Replace the bare `except` in `process_key_exchange()` with `except (ValueError, struct.error)` plus warning logging, while allowing unexpected exceptions to propagate.
- Use the RFC 7627 `extended master secret` PRF label when EMS is negotiated.
- Add focused pytest coverage for all three fixes.

Validation / demo:
```text
$ pytest tests/test_tls_handshake_python_bounties.py -q
....                                                                     [100%]
4 passed in 0.03s

$ python -m py_compile python/tls_handshake.py
# passed
```
