### PR TITLE
Fix TLS cert validator constant-time compare and cleanup logging

### DIFF
--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -32,6 +32,14 @@ class TLSCertValidatorStaticTests(unittest.TestCase):
 
         self.assertLess(log_index, issuer_free_index)
 
+    def test_remaining_seconds_uses_64_bit_overflow_safe_math(self):
+        self.assertIn("int64_t remaining_seconds;", self.source)
+        self.assertIn(
+            "remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;",
+            self.source,
+        )
+        self.assertIn("(long long)remaining_seconds", self.source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -1,0 +1,37 @@
+import re
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c")
+
+
+class TLSCertValidatorStaticTests(unittest.TestCase):
+    def setUp(self):
+        self.source = SOURCE.read_text(encoding="utf-8")
+
+    def test_fingerprint_match_uses_openssl_constant_time_compare(self):
+        self.assertIn(
+            "return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;",
+            self.source,
+        )
+        self.assertNotIn("return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;", self.source)
+
+    def test_cleanup_logs_issuer_before_freeing_it(self):
+        cleanup = re.search(
+            r"static void cleanup_cert_store\(cert_store_t \*store\)(.*?)"
+            r"int add_trusted_cert",
+            self.source,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(cleanup)
+        body = cleanup.group(1)
+
+        log_index = body.index('log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s"')
+        issuer_free_index = body.index("free(entry->issuer);")
+
+        self.assertLess(log_index, issuer_free_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -40,6 +40,23 @@ class TLSCertValidatorStaticTests(unittest.TestCase):
         )
         self.assertIn("(long long)remaining_seconds", self.source)
 
+    def test_validate_chain_routes_failures_through_single_cleanup(self):
+        validate_chain = re.search(
+            r"static int validate_chain\(chain_context_t \*ctx\)(.*?)"
+            r"static void cleanup_cert_store",
+            self.source,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(validate_chain)
+        body = validate_chain.group(1)
+        cleanup_index = body.index("cleanup:")
+
+        self.assertEqual(body.count("cleanup:"), 1)
+        self.assertEqual(body.count("return "), 1)
+        self.assertGreater(body.index("return rc;"), cleanup_index)
+        self.assertIn("goto cleanup;", body[:cleanup_index])
+        self.assertNotIn("return CERT_STATUS_", body[:cleanup_index])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)
@@ -189,9 +189,9 @@ static void cleanup_cert_store(cert_store_t *store)
     while (entry) {
         next = entry->next;
         X509_free(entry->cert);
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -138,49 +138,59 @@ static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 
 static int validate_chain(chain_context_t *ctx)
 {
-    int             i, rc;
+    int             i, rc = CERT_STATUS_OK;
     unsigned char   fp[FINGERPRINT_LEN];
     cert_entry_t   *trusted_issuer;
 
-    if (!ctx || !ctx->chain || ctx->chain_len <= 0)
-        return CERT_STATUS_INVALID;
-    if (ctx->chain_len > MAX_CHAIN_DEPTH)
-        return CERT_STATUS_INVALID;
+    if (!ctx || !ctx->chain || ctx->chain_len <= 0) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
+    if (ctx->chain_len > MAX_CHAIN_DEPTH) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
 
     for (i = 0; i < ctx->chain_len - 1; i++) {
         rc = check_expiry(ctx->chain[i]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "cert at depth %d failed expiry check", i);
-            return rc;
+            goto cleanup;
         }
         rc = verify_signature(ctx->chain[i], ctx->chain[i + 1]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "signature invalid at depth %d", i);
-            return rc;
+            goto cleanup;
         }
     }
 
     trusted_issuer = find_issuer(ctx->trusted_store, ctx->chain[ctx->chain_len - 1]);
     if (!trusted_issuer) {
         log_cert_event(LOG_LEVEL_ERROR, "root not found in trusted store");
-        return CERT_STATUS_UNTRUSTED;
+        rc = CERT_STATUS_UNTRUSTED;
+        goto cleanup;
     }
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
     if (rc != CERT_STATUS_OK)
-        return rc;
+        goto cleanup;
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {
-        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0)
-            return CERT_STATUS_INVALID;
+        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0) {
+            rc = CERT_STATUS_INVALID;
+            goto cleanup;
+        }
         if (!match_fingerprint(fp, ctx->pinned_fingerprint)) {
             log_cert_event(LOG_LEVEL_ERROR, "leaf fingerprint mismatch");
-            return CERT_STATUS_UNTRUSTED;
+            rc = CERT_STATUS_UNTRUSTED;
+            goto cleanup;
         }
     }
 
     log_cert_event(LOG_LEVEL_INFO, "chain validated successfully (%d certs)", ctx->chain_len);
-    return CERT_STATUS_OK;
+
+cleanup:
+    return rc;
 }
 
 static void cleanup_cert_store(cert_store_t *store)

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -83,7 +83,7 @@ static int check_expiry(X509 *cert)
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
     int day_diff, sec_diff;
-    int remaining_seconds;
+    int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
         return CERT_STATUS_INVALID;
@@ -99,9 +99,13 @@ static int check_expiry(X509 *cert)
     if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = day_diff * 86400 + sec_diff;
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
     if (remaining_seconds < 86400 * 30)
-        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %d seconds", remaining_seconds);
+        log_cert_event(
+            LOG_LEVEL_WARN,
+            "certificate expires in %lld seconds",
+            (long long)remaining_seconds
+        );
     return CERT_STATUS_OK;
 }
 


### PR DESCRIPTION
## Summary

Fixes four focused C TLS certificate validator bounty issues:

/claim #6
/claim #7
/claim #8
/claim #10

Changes:
- Replaces the fingerprint `memcmp()` with OpenSSL `CRYPTO_memcmp()` while preserving `true` on match.
- Refactors `validate_chain()` failures through a single `cleanup:` label while preserving return codes and log messages.
- Widens certificate remaining-lifetime math to `int64_t` and casts before multiplying by 86400 to avoid signed 32-bit overflow.
- Moves the debug issuer log before `entry->issuer` is freed in `cleanup_cert_store()`.
- Adds Python static regression checks for these fixes because this Windows environment does not have a C/OpenSSL build toolchain available.

## Demo / verification

```text
python -m unittest discover -s c -v

test_cleanup_logs_issuer_before_freeing_it ... ok
test_fingerprint_match_uses_openssl_constant_time_compare ... ok
test_remaining_seconds_uses_64_bit_overflow_safe_math ... ok
test_validate_chain_routes_failures_through_single_cleanup ... ok

Ran 4 tests in 0.008s
OK
```

Also verified:

```text
python -m py_compile c/test_tls_cert_validator_static.py
git diff --check
```