### PR TITLE
Fix NegotiateSuite nil match handling

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module bountyhunters/tlscipher
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -156,8 +156,6 @@ func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
 // It iterates server-side preferences and returns the first match found
 // in the client's offered list.
 //
-// BUG(1): When no suite matches, selectedSuite remains nil and the
-// function dereferences it to build the return value.
 func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 	if len(clientSuites) == 0 {
 		return "", errors.New("tlscipher: client offered no cipher suites")
@@ -178,7 +176,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_negotiation_test.go
+++ b/go/tls_cipher_negotiation_test.go
@@ -1,0 +1,22 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteHandlesUnknownAndValidSuites(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	if name, err := reg.NegotiateSuite([]uint16{0xffff}); err == nil {
+		t.Fatalf("expected error for unknown suite, got name %q", name)
+	}
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("expected valid suite negotiation to succeed: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected negotiated suite: %q", name)
+	}
+}


### PR DESCRIPTION
/claim #11

## Summary
- Return a clear error from `NegotiateSuite` when no offered suite matches instead of dereferencing nil.
- Add a focused regression test covering unsupported client suites and a valid suite path.

## Demo
- https://github.com/Ahmadkhattak1/Bounty-Hunters/releases/download/bounty-go-demo-pr31/go-tls-cipher-bounty-demo.mp4

## Verification
- `go test ./...`