### PR TITLE
Fix Python TLS handshake security regressions

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,6 +6,7 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
@@ -53,10 +54,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],
@@ -203,9 +201,10 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_hostname(ext_data)
+                self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +215,29 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_hostname(self, data: bytes) -> Optional[str]:
+        """Return the first RFC 6066 host_name entry from SNI extension data."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = min(len(data), 2 + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            if offset + name_len > end:
+                return None
+            name = data[offset:offset + name_len]
+            offset += name_len
+
+            if name_type == 0x00 and len(name) == name_len:
+                return name.decode("ascii")
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """
@@ -233,8 +255,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""
@@ -256,9 +277,8 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
+        except (ValueError, struct.error) as error:
+            logging.debug("Key exchange failed: %s", error)
         return False
 
     def _derive_master_secret(self) -> None:
@@ -271,9 +291,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 

--- a/tests/test_tls_handshake.py
+++ b/tests/test_tls_handshake.py
@@ -1,0 +1,100 @@
+import struct
+import unittest
+from unittest import mock
+
+from python.tls_handshake import (
+    EXT_SNI,
+    HandshakeMessage,
+    HandshakeState,
+    HandshakeType,
+    TLSHandshake,
+)
+
+
+class TLSHandshakeRegressionTests(unittest.TestCase):
+    def test_client_hello_cannot_transition_directly_to_finished(self) -> None:
+        handshake = TLSHandshake()
+
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+    def test_sni_extension_decodes_host_name(self) -> None:
+        hostname = b"example.com"
+        server_name = b"\x00" + struct.pack("!H", len(hostname)) + hostname
+        sni_data = struct.pack("!H", len(server_name)) + server_name
+
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(
+            struct.pack("!HH", EXT_SNI, len(sni_data)) + sni_data
+        )
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_absent_sni_leaves_server_name_unset(self) -> None:
+        handshake = TLSHandshake()
+
+        handshake.parse_extensions(b"")
+
+        self.assertIsNone(handshake.server_name)
+
+    def test_verify_finished_uses_constant_time_compare(self) -> None:
+        handshake = TLSHandshake()
+        handshake.master_secret = b"m" * 48
+
+        with mock.patch(
+            "python.tls_handshake.hmac.compare_digest",
+            return_value=True,
+        ) as compare_digest:
+            self.assertTrue(handshake.verify_finished(b"verify-data", "client finished"))
+
+        compare_digest.assert_called_once()
+
+    def test_process_key_exchange_logs_expected_errors(self) -> None:
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00")
+
+        with self.assertLogs(level="DEBUG") as logs:
+            self.assertFalse(handshake.process_key_exchange(message))
+
+        self.assertIn("Key exchange failed", logs.output[0])
+
+    def test_process_key_exchange_propagates_unexpected_errors(self) -> None:
+        handshake = TLSHandshake()
+        payload = struct.pack("!H", 48) + (b"x" * 48)
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, payload)
+
+        with mock.patch.object(
+            handshake,
+            "_decrypt_pre_master_secret",
+            side_effect=TypeError("unexpected"),
+        ):
+            with self.assertRaises(TypeError):
+                handshake.process_key_exchange(message)
+
+    def test_extended_master_secret_uses_distinct_label(self) -> None:
+        pre_master_secret = b"p" * 48
+        client_random = b"c" * 32
+        server_random = b"s" * 32
+
+        standard = TLSHandshake()
+        standard._pre_master_secret = pre_master_secret
+        standard.client_random = client_random
+        standard.server_random = server_random
+        standard.negotiated_ems = False
+        standard._derive_master_secret()
+
+        extended = TLSHandshake()
+        extended._pre_master_secret = pre_master_secret
+        extended.client_random = client_random
+        extended.server_random = server_random
+        extended.negotiated_ems = True
+        extended._derive_master_secret()
+
+        self.assertEqual(len(extended.master_secret), 48)
+        self.assertNotEqual(standard.master_secret, extended.master_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix CLIENT_HELLO -> FINISHED state transition bypass.
- Decode RFC 6066 SNI host_name values into extension and handshake state.
- Use hmac.compare_digest for Finished verify_data checks.
- Replace bare key-exchange exception swallowing with expected exception handling and debug logging.
- Use the RFC 7627 `extended master secret` PRF label when EMS is negotiated.
- Add focused unittest regression coverage for the fixed Python TLS issues.

## Bounty claims
/claim #16
/claim #17
/claim #18
/claim #20
/claim #21

## Validation
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile python/tls_handshake.py tests/test_tls_handshake.py`
- `git diff --check`

## AI assistance disclosure
This PR was implemented with AI assistance and manually reviewed before submission.