### PR TITLE
fix: avoid certificate expiry overflow

### DIFF
--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -13,6 +13,7 @@
 #include <openssl/err.h>
 #include <openssl/crypto.h>
 #include <openssl/ocsp.h>
+#include <inttypes.h>
 
 #define MAX_CHAIN_DEPTH       16
 #define FINGERPRINT_LEN       32
@@ -83,7 +84,7 @@ static int check_expiry(X509 *cert)
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
     int day_diff, sec_diff;
-    int remaining_seconds;
+    int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
         return CERT_STATUS_INVALID;
@@ -99,9 +100,9 @@ static int check_expiry(X509 *cert)
     if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = day_diff * 86400 + sec_diff;
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
     if (remaining_seconds < 86400 * 30)
-        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %d seconds", remaining_seconds);
+        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %" PRId64 " seconds", remaining_seconds);
     return CERT_STATUS_OK;
 }
 

--- a/tests/test_check_expiry_overflow.c
+++ b/tests/test_check_expiry_overflow.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <openssl/x509.h>
+
+#include "../c/tls_cert_validator.c"
+
+int main(void)
+{
+    X509 *cert = X509_new();
+    assert(cert != NULL);
+
+    assert(X509_gmtime_adj(X509_getm_notBefore(cert), -60) != NULL);
+    assert(X509_time_adj_ex(X509_getm_notAfter(cert), 25000, 0, NULL) != NULL);
+
+    assert(check_expiry(cert) == CERT_STATUS_OK);
+
+    X509_free(cert);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Fixes `check_expiry()` to compute `remaining_seconds` as `int64_t`.
- Casts `day_diff` before multiplying by 86400 so long-lived certificates do not overflow signed 32-bit `int`.
- Adds a regression test for a certificate expiring in 25000 days.

/claim #8

## Verification
Docker verification with OpenSSL headers:

```sh
docker run --rm -v "$PWD":/work -w /work debian:stable-slim sh -lc 'apt-get update >/tmp/apt.log && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential pkg-config libssl-dev ca-certificates >/tmp/apt-install.log && gcc -Wall -Wextra -Wno-unused-function -Werror -c c/tls_cert_validator.c -o /tmp/tls_cert_validator.o $(pkg-config --cflags openssl) && gcc -Wall -Wextra -Wno-unused-function -Werror -fsanitize=undefined -fno-sanitize-recover=signed-integer-overflow tests/test_check_expiry_overflow.c -o /tmp/test_check_expiry_overflow $(pkg-config --cflags --libs openssl) && /tmp/test_check_expiry_overflow'
```

Result: exit 0.

Red/green check: reverting only the overflow fix in a temporary Docker copy makes the regression fail with:

```text
tests/../c/tls_cert_validator.c:102:34: runtime error: signed integer overflow: 25000 * 86400 cannot be represented in type 'int'
```

Note: my host environment did not have OpenSSL headers installed, so the compile/test verification above was run in Docker.