### PR TITLE
Prefer ChaCha20 on platforms without AES acceleration

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module bountyhunters/tlscipher
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -47,6 +47,8 @@ type SuiteRegistry struct {
 	mu          sync.Mutex              // guards knownSuites only
 }
 
+var hasAESNI = HasAESNI
+
 // NewSuiteRegistry creates a registry pre-loaded with common cipher suites.
 func NewSuiteRegistry(minStrength CipherStrength) *SuiteRegistry {
 	reg := &SuiteRegistry{
@@ -224,11 +226,26 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 			return si.Strength > sj.Strength
 		}
 
+		if !hasAESNI() && prefersChaChaOverAESGCM(si.Name, sj.Name) {
+			return true
+		}
+		if !hasAESNI() && prefersChaChaOverAESGCM(sj.Name, si.Name) {
+			return false
+		}
+
 		// Larger key size breaks ties
 		return si.KeySize > sj.KeySize
 	})
 
 	return sorted
+}
+
+func prefersChaChaOverAESGCM(leftName, rightName string) bool {
+	left := strings.ToUpper(leftName)
+	right := strings.ToUpper(rightName)
+	return strings.Contains(left, "CHACHA20") &&
+		strings.Contains(right, "AES") &&
+		strings.Contains(right, "GCM")
 }
 
 // ConcurrentLookup demonstrates a batch lookup of suite IDs from

--- a/go/tls_cipher_chacha_test.go
+++ b/go/tls_cipher_chacha_test.go
@@ -1,0 +1,41 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePrefersChaChaWithoutAESNI(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	suites := []*CipherSuite{
+		{
+			ID:       tls.TLS_AES_256_GCM_SHA384,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+		{
+			ID:       tls.TLS_CHACHA20_POLY1305_SHA256,
+			Name:     "TLS_CHACHA20_POLY1305_SHA256",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	}
+
+	originalHasAESNI := hasAESNI
+	defer func() { hasAESNI = originalHasAESNI }()
+
+	hasAESNI = func() bool { return false }
+	sorted := reg.SortByPreference(suites)
+	if sorted[0].ID != tls.TLS_CHACHA20_POLY1305_SHA256 {
+		t.Fatalf("expected ChaCha first without AES-NI, got %s", sorted[0].Name)
+	}
+
+	hasAESNI = func() bool { return true }
+	sorted = reg.SortByPreference(suites)
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected original AES-GCM ordering with AES-NI, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
/claim #12

## Summary
- Prefer ChaCha20-Poly1305 over same-strength AES-GCM suites when AES acceleration is unavailable.
- Preserve AES-GCM ordering when AES acceleration is available.
- Add a focused regression test for both branches.

## Demo
- https://github.com/Ahmadkhattak1/Bounty-Hunters/releases/download/bounty-go-demo-pr31/go-tls-cipher-bounty-demo.mp4

## Verification
- `go test ./...`