### PR TITLE
Filter RC4 and 3DES cipher suites

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module bountyhunters/tlscipher
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -183,22 +183,23 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 }
 
 // FilterWeakSuites removes cipher suites that do not meet the minimum
-// security threshold. Currently only checks key size against a fixed
-// floor of 128 bits.
-//
-// BUG(3): Only filters by key size. Suites using RC4 or 3DES are
-// considered weak regardless of key size, but this function does not
-// check the cipher algorithm name.
+// security threshold.
 func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 	const minKeyBits = 128
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
-			result = append(result, s)
+		if s.KeySize < minKeyBits || isBrokenCipherAlgorithm(s.Name) {
+			continue
 		}
+		result = append(result, s)
 	}
 	return result
+}
+
+func isBrokenCipherAlgorithm(name string) bool {
+	upper := strings.ToUpper(name)
+	return strings.Contains(upper, "RC4") || strings.Contains(upper, "3DES")
 }
 
 // SortByPreference returns a copy of the slice ordered by server

--- a/go/tls_cipher_filter_test.go
+++ b/go/tls_cipher_filter_test.go
@@ -1,0 +1,31 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestFilterWeakSuitesRejectsRC4And3DES(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	filtered := reg.FilterWeakSuites(reg.knownSuites)
+
+	if containsSuiteID(filtered, 0x0005) {
+		t.Fatal("expected TLS_RSA_WITH_RC4_128_SHA to be filtered")
+	}
+	if containsSuiteID(filtered, 0x000a) {
+		t.Fatal("expected TLS_RSA_WITH_3DES_EDE_CBC_SHA to be filtered")
+	}
+	if !containsSuiteID(filtered, tls.TLS_AES_128_GCM_SHA256) {
+		t.Fatal("expected TLS_AES_128_GCM_SHA256 to remain allowed")
+	}
+}
+
+func containsSuiteID(suites []*CipherSuite, id uint16) bool {
+	for _, suite := range suites {
+		if suite.ID == id {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
/claim #13

## Summary
- Reject RC4 and 3DES cipher suites by algorithm name in addition to the minimum key-size check.
- Keep modern AEAD suites such as `TLS_AES_128_GCM_SHA256` allowed.
- Add a focused regression test for RC4, 3DES, and modern AEAD filtering.

## Demo
- https://github.com/Ahmadkhattak1/Bounty-Hunters/releases/download/bounty-go-demo-pr31/go-tls-cipher-bounty-demo.mp4

## Verification
- `go test ./...`