### PR TITLE
fix: harden Go TLS cipher negotiation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -43,9 +43,11 @@ type SuiteRegistry struct {
 	knownSuites []*CipherSuite
 	minStrength CipherStrength
 	preferredID uint16
-	suiteCache  map[uint16]*CipherSuite // BUG(5): unprotected shared cache
-	mu          sync.Mutex              // guards knownSuites only
+	suiteCache  map[uint16]*CipherSuite
+	mu          sync.RWMutex
 }
+
+var hasAESNI = HasAESNI
 
 // NewSuiteRegistry creates a registry pre-loaded with common cipher suites.
 func NewSuiteRegistry(minStrength CipherStrength) *SuiteRegistry {
@@ -137,12 +139,20 @@ func (r *SuiteRegistry) loadDefaults() {
 
 // lookupSuite retrieves a suite from the cache, falling back to a linear
 // scan of knownSuites. Results are cached for faster repeated lookups.
-// BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.RLock()
+	if cached, ok := r.suiteCache[id]; ok {
+		r.mu.RUnlock()
+		return cached
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}
-
 	for _, s := range r.knownSuites {
 		if s.ID == id {
 			r.suiteCache[id] = s
@@ -178,7 +188,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 
@@ -194,7 +207,9 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
+		if s.KeySize >= minKeyBits &&
+			!strings.Contains(s.Name, "RC4") &&
+			!strings.Contains(s.Name, "3DES") {
 			result = append(result, s)
 		}
 	}
@@ -214,14 +229,21 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first
 		if si.Strength != sj.Strength {
 			return si.Strength > sj.Strength
+		}
+
+		if si.Strength == sj.Strength && !hasAESNI() {
+			siChaCha := strings.Contains(si.Name, "CHACHA20")
+			sjChaCha := strings.Contains(sj.Name, "CHACHA20")
+			if siChaCha != sjChaCha {
+				return siChaCha
+			}
 		}
 
 		// Larger key size breaks ties

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,166 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"sync"
+	"testing"
+)
+
+func TestNegotiateSuiteReturnsErrorWhenNoSuiteMatches(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	name, err := reg.NegotiateSuite([]uint16{0xffff})
+	if err == nil {
+		t.Fatal("expected unsupported client suite to return an error")
+	}
+	if name != "" {
+		t.Fatalf("expected no selected suite, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteKeepsValidSuite(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("expected valid suite to negotiate: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected suite %q", name)
+	}
+}
+
+func TestSortByPreferencePrefersChaCha20WithoutAESNI(t *testing.T) {
+	original := hasAESNI
+	hasAESNI = func() bool { return false }
+	defer func() { hasAESNI = original }()
+
+	reg := NewSuiteRegistry(StrengthModern)
+
+	sorted := reg.SortByPreference([]*CipherSuite{
+		{
+			ID:       tls.TLS_AES_256_GCM_SHA384,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+		{
+			ID:       tls.TLS_CHACHA20_POLY1305_SHA256,
+			Name:     "TLS_CHACHA20_POLY1305_SHA256",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	})
+
+	if sorted[0].ID != tls.TLS_CHACHA20_POLY1305_SHA256 {
+		t.Fatalf("expected ChaCha20 first without AES-NI, got %s", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferencePreservesAESPreferenceWithAESNI(t *testing.T) {
+	original := hasAESNI
+	hasAESNI = func() bool { return true }
+	defer func() { hasAESNI = original }()
+
+	reg := NewSuiteRegistry(StrengthModern)
+
+	sorted := reg.SortByPreference([]*CipherSuite{
+		{
+			ID:       tls.TLS_AES_256_GCM_SHA384,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+		{
+			ID:       tls.TLS_CHACHA20_POLY1305_SHA256,
+			Name:     "TLS_CHACHA20_POLY1305_SHA256",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	})
+
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected original AES-first ordering with AES-NI, got %s", sorted[0].Name)
+	}
+}
+
+func TestFilterWeakSuitesRejectsRC4And3DES(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	filtered := reg.FilterWeakSuites([]*CipherSuite{
+		{
+			ID:      0x0005,
+			Name:    "TLS_RSA_WITH_RC4_128_SHA",
+			KeySize: 128,
+		},
+		{
+			ID:      0x000a,
+			Name:    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+			KeySize: 168,
+		},
+		{
+			ID:      tls.TLS_AES_128_GCM_SHA256,
+			Name:    "TLS_AES_128_GCM_SHA256",
+			KeySize: 128,
+			IsAEAD:  true,
+		},
+	})
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected one modern suite to remain, got %d", len(filtered))
+	}
+	if filtered[0].ID != tls.TLS_AES_128_GCM_SHA256 {
+		t.Fatalf("expected AES-GCM suite to remain, got %s", filtered[0].Name)
+	}
+}
+
+func TestSortByPreferencePrefersAEADBeforeCBC(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	sorted := reg.SortByPreference([]*CipherSuite{
+		{
+			ID:       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+			KeySize:  128,
+			IsAEAD:   false,
+			Strength: StrengthLegacy,
+		},
+		{
+			ID:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+	})
+
+	if !sorted[0].IsAEAD {
+		t.Fatalf("expected AEAD suite first, got %s", sorted[0].Name)
+	}
+}
+
+func TestConcurrentLookupDoesNotRaceOrFail(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+	ids := []uint16{
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := reg.ConcurrentLookup(ids); err != nil {
+				t.Errorf("ConcurrentLookup returned error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Closes #11, closes #12, closes #13, closes #14, closes #15.
/claim #11
/claim #12
/claim #13
/claim #14
/claim #15

This fixes the five Go TLS cipher bounty issues in one focused change:

- Return a normal error when no client cipher suite matches instead of dereferencing nil.
- Prefer ChaCha20-Poly1305 over same-strength AES-GCM suites when AES-NI is unavailable.
- Filter RC4 and 3DES suites even when their key sizes meet the bit-length floor.
- Sort AEAD suites before non-AEAD suites.
- Guard the shared suite cache with an RWMutex for concurrent lookup safety.

I also added Go regression tests for each behavior and a minimal go.mod so the Go package is directly testable with `go test ./go`.

Verification note: the current local environment does not have Go installed, so I could not execute the tests before opening this PR.
