### PR TITLE
Fix AEAD cipher preference ordering

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module bountyhunters/tlscipher
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -204,9 +204,6 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 // SortByPreference returns a copy of the slice ordered by server
 // preference. AEAD suites should be preferred over non-AEAD, and
 // higher strength suites should come first within each group.
-//
-// BUG(4): The AEAD comparison is inverted — non-AEAD suites end up
-// ranked above AEAD suites.
 func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sorted := make([]*CipherSuite, len(suites))
 	copy(sorted, suites)
@@ -214,9 +211,8 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_aead_order_test.go
+++ b/go/tls_cipher_aead_order_test.go
@@ -1,0 +1,45 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferenceRanksAEADBeforeNonAEADAndPreservesStrength(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	suites := []*CipherSuite{
+		{
+			ID:       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+			KeySize:  128,
+			IsAEAD:   false,
+			Strength: StrengthLegacy,
+		},
+		{
+			ID:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+		{
+			ID:       tls.TLS_AES_256_GCM_SHA384,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	}
+
+	sorted := reg.SortByPreference(suites)
+
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected advanced AEAD first, got %s", sorted[0].Name)
+	}
+	if sorted[1].ID != tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
+		t.Fatalf("expected modern AEAD before non-AEAD, got %s", sorted[1].Name)
+	}
+	if sorted[2].ID != tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 {
+		t.Fatalf("expected non-AEAD last, got %s", sorted[2].Name)
+	}
+}


### PR DESCRIPTION
/claim #14

## Summary
- Correct the AEAD comparator so AEAD suites rank before non-AEAD suites.
- Preserve strength ordering among AEAD suites.
- Add a focused regression test for AEAD-before-CBC plus advanced-before-modern AEAD ordering.

## Demo
- https://github.com/Ahmadkhattak1/Bounty-Hunters/releases/download/bounty-go-demo-pr31/go-tls-cipher-bounty-demo.mp4

## Verification
- `go test ./...`