### PR TITLE
Fix TLS parser and cert validator bounty issues

### DIFF
--- a/assembly/test_tls_record_parser_static.py
+++ b/assembly/test_tls_record_parser_static.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import re
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class TlsRecordParserStaticTests(unittest.TestCase):
+    def test_content_type_upper_bound_rejects_values_above_max(self):
+        self.assertRegex(
+            SOURCE,
+            r"cmp r13d, TLS_CT_MAX\s*\n\s*jle \.type_ok\s*;[^\n]*\n"
+            r"(?:\s*;[^\n]*\n)*\s*jg \.invalid_type",
+        )
+
+    def test_alert_strings_are_independently_terminated(self):
+        self.assertIn(
+            'err_alert_fatal     db "FATAL ALERT received from peer", 10, 0',
+            SOURCE,
+        )
+        self.assertIn(
+            'err_alert_warning   db "WARNING: alert received from peer", 10, 0',
+            SOURCE,
+        )
+        fatal_idx = SOURCE.index("err_alert_fatal")
+        warning_idx = SOURCE.index("err_alert_warning")
+        truncated_idx = SOURCE.index("err_truncated")
+        self.assertLess(fatal_idx, warning_idx)
+        self.assertLess(warning_idx, truncated_idx)
+
+    def test_tls13_application_records_report_inner_content_type(self):
+        self.assertIn('lbl_tls13_record    db "TLS 1.3 record detected", 10, 0', SOURCE)
+        self.assertIn('msg_inner_type      db "Inner content type: 0x", 0', SOURCE)
+        self.assertRegex(
+            SOURCE,
+            r"\.handle_application:\s*\n\s*cmp r14d, 0x0303\s*\n"
+            r"\s*je \.handle_tls13_record",
+        )
+        self.assertTrue(
+            re.search(
+                r"\.handle_tls13_record:.*?test ecx, ecx.*?"
+                r"movzx edi, byte \[rdi \+ rcx - 1\].*?call print_hex_byte",
+                SOURCE,
+                re.S,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -19,13 +19,15 @@ section .data
     lbl_handshake       db "Handshake", 10, 0
     lbl_application     db "ApplicationData", 10, 0
     lbl_heartbeat       db "Heartbeat", 10, 0
+    lbl_tls13_record    db "TLS 1.3 record detected", 10, 0
+    msg_inner_type      db "Inner content type: 0x", 0
     lbl_unknown         db "Unknown content type", 10, 0
 
     ; --- Error strings ---
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
-    err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_fatal     db "FATAL ALERT received from peer", 10, 0
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---
@@ -105,6 +107,7 @@ parse_tls_record:
     jle .type_ok                ; BUG: should be jl, not jle -- but wait,
                                 ; 0x18 (heartbeat) is valid so jle is needed...
                                 ; actually TLS_CT_MAX is 0x18 and we want <= 0x18
+    jg .invalid_type
 
     ; --- Actually the check above is wrong for a different reason ---
     ; Content type 0x17 is application_data which is VALID, and 0x18
@@ -224,12 +227,33 @@ parse_tls_record:
     jmp .parse_done
 
 .handle_application:
+    cmp r14d, 0x0303
+    je .handle_tls13_record
     push rdi
     lea rdi, [rel lbl_application]
     call print_string
     pop rdi
     ; Application data is encrypted, just report the length
     ; No TLS 1.3 inner content type detection is performed
+    jmp .parse_done
+
+.handle_tls13_record:
+    push rdi
+    lea rdi, [rel lbl_tls13_record]
+    call print_string
+    pop rdi
+    test ecx, ecx
+    jle .parse_done
+    push rdi
+    push rcx
+    lea rdi, [rel msg_inner_type]
+    call print_string
+    pop rcx
+    pop rdi
+    movzx edi, byte [rdi + rcx - 1]
+    call print_hex_byte
+    lea rdi, [rel msg_newline]
+    call print_string
     jmp .parse_done
 
 .handle_heartbeat:

--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import re
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c").read_text()
+
+
+class TlsCertValidatorStaticTests(unittest.TestCase):
+    def test_validate_chain_uses_single_cleanup_exit_for_error_paths(self):
+        self.assertIn("cleanup:\n    return status;", SOURCE)
+        validate_chain = SOURCE[SOURCE.index("static int validate_chain") :]
+        validate_chain = validate_chain[: validate_chain.index("static void cleanup_cert_store")]
+        self.assertNotIn("return rc;", validate_chain)
+        self.assertNotIn("return CERT_STATUS_UNTRUSTED;", validate_chain)
+        self.assertNotIn("return CERT_STATUS_INVALID;", validate_chain)
+        self.assertGreaterEqual(validate_chain.count("goto cleanup;"), 8)
+
+    def test_ocsp_context_and_validation_are_wired_before_fingerprint_pinning(self):
+        self.assertIn("const unsigned char *ocsp_response_der;", SOURCE)
+        self.assertIn("size_t          ocsp_response_len;", SOURCE)
+        validate_chain = SOURCE[SOURCE.index("static int validate_chain") :]
+        validate_chain = validate_chain[: validate_chain.index("static void cleanup_cert_store")]
+        ocsp_idx = validate_chain.index("check_ocsp_stapling(ctx->chain[0], leaf_issuer")
+        pin_idx = validate_chain.index("/* Fingerprint pinning on leaf */")
+        self.assertLess(ocsp_idx, pin_idx)
+        self.assertRegex(
+            validate_chain,
+            r"leaf_issuer = \(ctx->chain_len > 1\) \? ctx->chain\[1\] : trusted_issuer->cert;",
+        )
+
+    def test_ocsp_stapling_handles_good_revoked_and_frees_openssl_objects(self):
+        self.assertIn("static int check_ocsp_stapling(", SOURCE)
+        self.assertIn("d2i_OCSP_RESPONSE(NULL, &p, (long)resp_len)", SOURCE)
+        self.assertIn("OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL", SOURCE)
+        self.assertIn("OCSP_response_get1_basic(resp)", SOURCE)
+        self.assertIn("OCSP_cert_to_id(NULL, leaf, issuer)", SOURCE)
+        self.assertIn("OCSP_resp_find_status(basic, cert_id, &cert_status", SOURCE)
+        self.assertIn("cert_status == V_OCSP_CERTSTATUS_GOOD", SOURCE)
+        self.assertIn("cert_status == V_OCSP_CERTSTATUS_REVOKED", SOURCE)
+        self.assertIn("rc = CERT_STATUS_REVOKED;", SOURCE)
+        self.assertIn("OCSP_CERTID_free(cert_id);", SOURCE)
+        self.assertIn("OCSP_BASICRESP_free(basic);", SOURCE)
+        self.assertIn("OCSP_RESPONSE_free(resp);", SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -47,6 +47,8 @@ typedef struct chain_context {
     cert_store_t   *trusted_store;
     unsigned char  *pinned_fingerprint;
     int             verify_ocsp;
+    const unsigned char *ocsp_response_der;
+    size_t          ocsp_response_len;
 } chain_context_t;
 
 static int g_log_level = LOG_LEVEL_INFO;
@@ -120,6 +122,72 @@ static int verify_signature(X509 *cert, X509 *issuer)
     return CERT_STATUS_OK;
 }
 
+static int check_ocsp_stapling(X509 *leaf, X509 *issuer,
+                               const unsigned char *resp_der,
+                               size_t resp_len)
+{
+    const unsigned char *p = resp_der;
+    OCSP_RESPONSE *resp = NULL;
+    OCSP_BASICRESP *basic = NULL;
+    OCSP_CERTID *cert_id = NULL;
+    int cert_status = V_OCSP_CERTSTATUS_UNKNOWN;
+    int reason = -1;
+    ASN1_GENERALIZEDTIME *revtime = NULL;
+    ASN1_GENERALIZEDTIME *thisupd = NULL;
+    ASN1_GENERALIZEDTIME *nextupd = NULL;
+    int rc = CERT_STATUS_INVALID;
+
+    if (!leaf || !issuer || !resp_der || resp_len == 0) {
+        log_cert_event(LOG_LEVEL_ERROR, "missing OCSP stapling response");
+        return CERT_STATUS_INVALID;
+    }
+
+    resp = d2i_OCSP_RESPONSE(NULL, &p, (long)resp_len);
+    if (!resp) {
+        log_cert_event(LOG_LEVEL_ERROR, "failed to parse OCSP response");
+        goto cleanup;
+    }
+
+    if (OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response was not successful");
+        goto cleanup;
+    }
+
+    basic = OCSP_response_get1_basic(resp);
+    if (!basic) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response missing basic response");
+        goto cleanup;
+    }
+
+    cert_id = OCSP_cert_to_id(NULL, leaf, issuer);
+    if (!cert_id) {
+        log_cert_event(LOG_LEVEL_ERROR, "failed to build OCSP cert id");
+        goto cleanup;
+    }
+
+    if (!OCSP_resp_find_status(basic, cert_id, &cert_status, &reason,
+                               &revtime, &thisupd, &nextupd)) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response missing leaf status");
+        goto cleanup;
+    }
+
+    if (cert_status == V_OCSP_CERTSTATUS_GOOD) {
+        rc = CERT_STATUS_OK;
+    } else if (cert_status == V_OCSP_CERTSTATUS_REVOKED) {
+        log_cert_event(LOG_LEVEL_ERROR, "leaf certificate revoked by OCSP");
+        rc = CERT_STATUS_REVOKED;
+    } else {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response returned unknown cert status");
+        rc = CERT_STATUS_INVALID;
+    }
+
+cleanup:
+    OCSP_CERTID_free(cert_id);
+    OCSP_BASICRESP_free(basic);
+    OCSP_RESPONSE_free(resp);
+    return rc;
+}
+
 static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 {
     X509_NAME *issuer_name = X509_get_issuer_name(cert);
@@ -135,48 +203,72 @@ static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 static int validate_chain(chain_context_t *ctx)
 {
     int             i, rc;
+    int             status = CERT_STATUS_INVALID;
     unsigned char   fp[FINGERPRINT_LEN];
     cert_entry_t   *trusted_issuer;
+    X509           *leaf_issuer;
 
     if (!ctx || !ctx->chain || ctx->chain_len <= 0)
-        return CERT_STATUS_INVALID;
+        goto cleanup;
     if (ctx->chain_len > MAX_CHAIN_DEPTH)
-        return CERT_STATUS_INVALID;
+        goto cleanup;
 
     for (i = 0; i < ctx->chain_len - 1; i++) {
         rc = check_expiry(ctx->chain[i]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "cert at depth %d failed expiry check", i);
-            return rc;
+            status = rc;
+            goto cleanup;
         }
         rc = verify_signature(ctx->chain[i], ctx->chain[i + 1]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "signature invalid at depth %d", i);
-            return rc;
+            status = rc;
+            goto cleanup;
         }
     }
 
     trusted_issuer = find_issuer(ctx->trusted_store, ctx->chain[ctx->chain_len - 1]);
     if (!trusted_issuer) {
         log_cert_event(LOG_LEVEL_ERROR, "root not found in trusted store");
-        return CERT_STATUS_UNTRUSTED;
+        status = CERT_STATUS_UNTRUSTED;
+        goto cleanup;
     }
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
-    if (rc != CERT_STATUS_OK)
-        return rc;
+    if (rc != CERT_STATUS_OK) {
+        status = rc;
+        goto cleanup;
+    }
+
+    if (ctx->verify_ocsp) {
+        leaf_issuer = (ctx->chain_len > 1) ? ctx->chain[1] : trusted_issuer->cert;
+        rc = check_ocsp_stapling(ctx->chain[0], leaf_issuer,
+                                 ctx->ocsp_response_der,
+                                 ctx->ocsp_response_len);
+        if (rc != CERT_STATUS_OK) {
+            status = rc;
+            goto cleanup;
+        }
+    }
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {
-        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0)
-            return CERT_STATUS_INVALID;
+        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0) {
+            status = CERT_STATUS_INVALID;
+            goto cleanup;
+        }
         if (!match_fingerprint(fp, ctx->pinned_fingerprint)) {
             log_cert_event(LOG_LEVEL_ERROR, "leaf fingerprint mismatch");
-            return CERT_STATUS_UNTRUSTED;
+            status = CERT_STATUS_UNTRUSTED;
+            goto cleanup;
         }
     }
 
     log_cert_event(LOG_LEVEL_INFO, "chain validated successfully (%d certs)", ctx->chain_len);
-    return CERT_STATUS_OK;
+    status = CERT_STATUS_OK;
+
+cleanup:
+    return status;
 }
 
 static void cleanup_cert_store(cert_store_t *store)


### PR DESCRIPTION
## Summary
- Reject TLS record content types above `TLS_CT_MAX`, terminate alert strings independently, and add TLS 1.3 application-data inner content type reporting.
- Route certificate-chain validation failures through a single cleanup exit.
- Add OCSP stapling parsing/status handling and wire it before fingerprint pinning when `verify_ocsp` is enabled.
- Add static regression tests for the assembly and C fixes.

/claim #3
/claim #4
/claim #5
/claim #7
/claim #9

## Verification
- `python3 -m unittest discover -s assembly -v`
- `python3 -m unittest discover -s c -v`
- `git diff --check`

Note: `nasm` and OpenSSL development headers are not installed in this environment, so I used focused source-level regression tests for the assembly and C changes.