### PR TITLE
Synchronize cipher suite cache lookups

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module bountyhunters/tlscipher
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -43,8 +43,8 @@ type SuiteRegistry struct {
 	knownSuites []*CipherSuite
 	minStrength CipherStrength
 	preferredID uint16
-	suiteCache  map[uint16]*CipherSuite // BUG(5): unprotected shared cache
-	mu          sync.Mutex              // guards knownSuites only
+	suiteCache  map[uint16]*CipherSuite
+	mu          sync.Mutex // guards knownSuites and suiteCache
 }
 
 // NewSuiteRegistry creates a registry pre-loaded with common cipher suites.
@@ -137,8 +137,10 @@ func (r *SuiteRegistry) loadDefaults() {
 
 // lookupSuite retrieves a suite from the cache, falling back to a linear
 // scan of knownSuites. Results are cached for faster repeated lookups.
-// BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}
@@ -232,10 +234,7 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 }
 
 // ConcurrentLookup demonstrates a batch lookup of suite IDs from
-// multiple goroutines. Each goroutine writes to the shared suiteCache
-// without synchronization.
-// BUG(5): data race — multiple goroutines call lookupSuite which reads
-// and writes r.suiteCache without locking.
+// multiple goroutines.
 func (r *SuiteRegistry) ConcurrentLookup(ids []uint16) ([]*CipherSuite, error) {
 	results := make([]*CipherSuite, len(ids))
 	var wg sync.WaitGroup

--- a/go/tls_cipher_concurrent_test.go
+++ b/go/tls_cipher_concurrent_test.go
@@ -1,0 +1,29 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestConcurrentLookupUsesSynchronizedCache(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	ids := make([]uint16, 100)
+	for i := range ids {
+		if i%2 == 0 {
+			ids[i] = tls.TLS_AES_128_GCM_SHA256
+		} else {
+			ids[i] = tls.TLS_CHACHA20_POLY1305_SHA256
+		}
+	}
+
+	results, err := reg.ConcurrentLookup(ids)
+	if err != nil {
+		t.Fatalf("expected concurrent lookup to succeed: %v", err)
+	}
+	if len(results) != len(ids) {
+		t.Fatalf("expected %d results, got %d", len(ids), len(results))
+	}
+	if got := reg.lookupSuite(tls.TLS_AES_128_GCM_SHA256); got == nil || got.Name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("cached lookup returned wrong suite: %#v", got)
+	}
+}


### PR DESCRIPTION
/claim #15

## Summary
- Guard `lookupSuite` cache reads and writes with the registry mutex.
- Keep cached lookups returning the expected suite metadata.
- Add a concurrency regression test with 100 lookup goroutines.

## Demo
- https://github.com/Ahmadkhattak1/Bounty-Hunters/releases/download/bounty-go-demo-pr31/go-tls-cipher-bounty-demo.mp4

## Verification
- `go test ./...`
- `docker run --rm -v ${PWD}:/src -w /src golang:1.26 go test -race ./...`