### PR TITLE
Fix check_expiry remaining_seconds overflow

### DIFF
--- a/c/test_check_expiry.c
+++ b/c/test_check_expiry.c
@@ -11,22 +11,19 @@ static X509 *make_cert_with_offset_days(int days_from_now)
     assert(cert != NULL);
 
     assert(X509_gmtime_adj(X509_getm_notBefore(cert), -60) != NULL);
-    assert(X509_gmtime_adj(X509_getm_notAfter(cert), (long)days_from_now * 86400L) != NULL);
+    assert(X509_time_adj_ex(X509_getm_notAfter(cert), days_from_now, 0, NULL) != NULL);
     return cert;
 }
 
 static void test_check_expiry_handles_large_remaining_seconds(void)
 {
     X509 *cert = make_cert_with_offset_days(25000);
-    int day_diff = 0;
-    int sec_diff = 0;
     int64_t remaining_seconds = 0;
 
-    assert(ASN1_TIME_diff(&day_diff, &sec_diff, NULL, X509_get0_notAfter(cert)) == 1);
-    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
-
+    assert(get_remaining_seconds(X509_get0_notAfter(cert), &remaining_seconds) == 1);
     assert(check_expiry(cert) == CERT_STATUS_OK);
-    assert(remaining_seconds >= 2160000000LL);
+    assert(remaining_seconds > INT32_MAX);
+    assert(remaining_seconds > (int64_t)86400 * 30);
 
     X509_free(cert);
 }

--- a/c/test_check_expiry.c
+++ b/c/test_check_expiry.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdint.h>
+#include <time.h>
+#include <openssl/x509.h>
+
+#include "tls_cert_validator.c"
+
+static X509 *make_cert_with_offset_days(int days_from_now)
+{
+    X509 *cert = X509_new();
+    assert(cert != NULL);
+
+    assert(X509_gmtime_adj(X509_getm_notBefore(cert), -60) != NULL);
+    assert(X509_gmtime_adj(X509_getm_notAfter(cert), (long)days_from_now * 86400L) != NULL);
+    return cert;
+}
+
+static void test_check_expiry_handles_large_remaining_seconds(void)
+{
+    X509 *cert = make_cert_with_offset_days(25000);
+    int day_diff = 0;
+    int sec_diff = 0;
+    int64_t remaining_seconds = 0;
+
+    assert(ASN1_TIME_diff(&day_diff, &sec_diff, NULL, X509_get0_notAfter(cert)) == 1);
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
+
+    assert(check_expiry(cert) == CERT_STATUS_OK);
+    assert(remaining_seconds >= 2160000000LL);
+
+    X509_free(cert);
+}
+
+int main(void)
+{
+    test_check_expiry_handles_large_remaining_seconds();
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <time.h>
 #include <openssl/x509.h>
@@ -83,7 +84,7 @@ static int check_expiry(X509 *cert)
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
     int day_diff, sec_diff;
-    int remaining_seconds;
+    int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
         return CERT_STATUS_INVALID;
@@ -99,9 +100,9 @@ static int check_expiry(X509 *cert)
     if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = day_diff * 86400 + sec_diff;
-    if (remaining_seconds < 86400 * 30)
-        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %d seconds", remaining_seconds);
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
+    if (remaining_seconds < (int64_t)86400 * 30)
+        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %" PRId64 " seconds", remaining_seconds);
     return CERT_STATUS_OK;
 }
 

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -79,11 +79,24 @@ static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
     return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
+static int get_remaining_seconds(const ASN1_TIME *not_after, int64_t *remaining_seconds)
+{
+    int day_diff = 0;
+    int sec_diff = 0;
+
+    if (!not_after || !remaining_seconds)
+        return 0;
+    if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
+        return 0;
+
+    *remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
+    return 1;
+}
+
 static int check_expiry(X509 *cert)
 {
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
-    int day_diff, sec_diff;
     int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
@@ -97,10 +110,9 @@ static int check_expiry(X509 *cert)
         log_cert_event(LOG_LEVEL_WARN, "certificate has expired");
         return CERT_STATUS_EXPIRED;
     }
-    if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
+    if (!get_remaining_seconds(not_after, &remaining_seconds))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
     if (remaining_seconds < (int64_t)86400 * 30)
         log_cert_event(LOG_LEVEL_WARN, "certificate expires in %" PRId64 " seconds", remaining_seconds);
     return CERT_STATUS_OK;


### PR DESCRIPTION
/claim #8

## Summary
- widen `remaining_seconds` to `int64_t` in `check_expiry()`
- cast `day_diff` before multiplying by `86400` to avoid overflow
- update expiry warning logging to use the correct 64-bit format specifier
- add a regression test for a certificate expiring in 25000 days

## Testing
- added `c/test_check_expiry.c` covering the long-lived certificate case

## Demo
- demo video can be provided during review if the maintainer requests it