### PR TITLE
fix: guard suite cache lookups with mutex

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -43,8 +43,8 @@ type SuiteRegistry struct {
 	knownSuites []*CipherSuite
 	minStrength CipherStrength
 	preferredID uint16
-	suiteCache  map[uint16]*CipherSuite // BUG(5): unprotected shared cache
-	mu          sync.Mutex              // guards knownSuites only
+	suiteCache  map[uint16]*CipherSuite
+	mu          sync.RWMutex // guards knownSuites and suiteCache
 }
 
 // NewSuiteRegistry creates a registry pre-loaded with common cipher suites.
@@ -137,8 +137,17 @@ func (r *SuiteRegistry) loadDefaults() {
 
 // lookupSuite retrieves a suite from the cache, falling back to a linear
 // scan of knownSuites. Results are cached for faster repeated lookups.
-// BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.RLock()
+	if cached, ok := r.suiteCache[id]; ok {
+		r.mu.RUnlock()
+		return cached
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}
@@ -232,10 +241,8 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 }
 
 // ConcurrentLookup demonstrates a batch lookup of suite IDs from
-// multiple goroutines. Each goroutine writes to the shared suiteCache
-// without synchronization.
-// BUG(5): data race — multiple goroutines call lookupSuite which reads
-// and writes r.suiteCache without locking.
+// multiple goroutines. lookupSuite synchronizes cache reads and writes,
+// so this method can safely be used under the race detector.
 func (r *SuiteRegistry) ConcurrentLookup(ids []uint16) ([]*CipherSuite, error) {
 	results := make([]*CipherSuite, len(ids))
 	var wg sync.WaitGroup

--- a/go/tls_cipher_race_test.go
+++ b/go/tls_cipher_race_test.go
@@ -1,0 +1,35 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"sync"
+	"testing"
+)
+
+func TestConcurrentLookupIsRaceSafe(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthLegacy)
+	ids := []uint16{
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results, err := registry.ConcurrentLookup(ids)
+			if err != nil {
+				t.Errorf("ConcurrentLookup returned error: %v", err)
+				return
+			}
+			if len(results) != len(ids) {
+				t.Errorf("got %d results, want %d", len(results), len(ids))
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- Protects `suiteCache` reads/writes in `lookupSuite` with the registry mutex.
- Uses an RWMutex fast path for cached lookups and a write lock for cache population.
- Adds a concurrent regression test that repeatedly calls `ConcurrentLookup`; this is intended to pass under `go test -race`.

## Validation
- `git diff --check`
- `go test -race ./...` could not be run in this container because Go is not installed.

Closes #15
