### PR TITLE
Reject invalid TLS record content types

### DIFF
--- a/assembly/test_tls_record_parser_bounds.py
+++ b/assembly/test_tls_record_parser_bounds.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class TlsRecordParserBoundsTests(unittest.TestCase):
+    def test_values_above_tls_content_type_max_are_rejected(self):
+        self.assertRegex(
+            SOURCE,
+            r"cmp r13d, TLS_CT_MAX\s*\n\s*jle \.type_ok\s*;[^\n]*\n"
+            r"(?:\s*;[^\n]*\n)*\s*jg \.invalid_type",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -105,6 +105,7 @@ parse_tls_record:
     jle .type_ok                ; BUG: should be jl, not jle -- but wait,
                                 ; 0x18 (heartbeat) is valid so jle is needed...
                                 ; actually TLS_CT_MAX is 0x18 and we want <= 0x18
+    jg .invalid_type
 
     ; --- Actually the check above is wrong for a different reason ---
     ; Content type 0x17 is application_data which is VALID, and 0x18


### PR DESCRIPTION
## Summary
- Reject TLS content types greater than `TLS_CT_MAX` before dispatch.
- Add a focused source-level regression check for the upper-bound branch.

/claim #3

## Verification
- `python3 -m unittest assembly/test_tls_record_parser_bounds.py -v`
- `git diff --check`

Note: `nasm` is not installed in this environment, so verification uses a focused static regression test.