### PR TITLE
Fix cert cleanup debug logging use-after-free

### DIFF
--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -189,9 +189,9 @@ static void cleanup_cert_store(cert_store_t *store)
     while (entry) {
         next = entry->next;
         X509_free(entry->cert);
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }

--- a/tests/test_cleanup_cert_store.c
+++ b/tests/test_cleanup_cert_store.c
@@ -1,0 +1,68 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Keep this unit test focused on cleanup_cert_store() string lifetime ordering. */
+#define X509_free test_X509_free
+#include "../c/tls_cert_validator.c"
+#undef X509_free
+
+void test_X509_free(X509 *cert)
+{
+    (void)cert;
+}
+
+static cert_entry_t *make_entry(const char *subject, const char *issuer)
+{
+    cert_entry_t *entry = calloc(1, sizeof(*entry));
+    assert(entry);
+    entry->subject = strdup(subject);
+    entry->issuer = strdup(issuer);
+    assert(entry->subject);
+    assert(entry->issuer);
+    return entry;
+}
+
+int main(void)
+{
+    cert_store_t store = { 0 };
+    char log_template[] = "/tmp/cert-cleanup-log.XXXXXX";
+    char log_output[2048] = { 0 };
+    int log_fd = mkstemp(log_template);
+    int saved_stderr = dup(STDERR_FILENO);
+    ssize_t bytes_read;
+
+    assert(log_fd >= 0);
+    assert(saved_stderr >= 0);
+
+    store.head = make_entry("subject-one", "issuer-one");
+    store.head->next = make_entry("subject-two", "issuer-two");
+    store.head->next->next = make_entry("subject-three", "issuer-three");
+    store.count = 3;
+    store.max_depth = MAX_CHAIN_DEPTH;
+
+    assert(dup2(log_fd, STDERR_FILENO) >= 0);
+    g_log_level = LOG_LEVEL_DEBUG;
+    cleanup_cert_store(&store);
+    fflush(stderr);
+    assert(dup2(saved_stderr, STDERR_FILENO) >= 0);
+    close(saved_stderr);
+
+    assert(store.head == NULL);
+    assert(store.count == 0);
+
+    assert(lseek(log_fd, 0, SEEK_SET) == 0);
+    bytes_read = read(log_fd, log_output, sizeof(log_output) - 1);
+    assert(bytes_read > 0);
+    close(log_fd);
+    unlink(log_template);
+
+    assert(strstr(log_output, "issuer-one"));
+    assert(strstr(log_output, "issuer-two"));
+    assert(strstr(log_output, "issuer-three"));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- moves the `cleanup_cert_store()` debug log before freeing `entry->issuer`, avoiding the use-after-free in debug logging
- adds a focused regression test that cleans up three entries at debug level and verifies all issuer names are logged while the store is cleared

## Verification
- `cc -g -O0 -Wall -Wextra -Wno-unused-function -ffunction-sections -fdata-sections -Wl,-dead_strip -I/opt/homebrew/opt/openssl@3/include tests/test_cleanup_cert_store.c -o /tmp/test_cleanup_cert_store && /tmp/test_cleanup_cert_store`
- `cc -Wall -Wextra -I/opt/homebrew/opt/openssl@3/include -fsyntax-only c/tls_cert_validator.c` (only existing unused static function warnings)
- `git diff --check`

AddressSanitizer note: I attempted the ASAN variant locally, but this macOS toolchain hangs even for an empty `int main(){return 0;}` ASAN binary, so I could not get a meaningful local ASAN result. The added test is isolated so it can be run under ASAN in a working sanitizer environment.

/claim #10
