### PR TITLE
fix: handle missing Go cipher suite

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_issue11_test.go
+++ b/go/tls_cipher_issue11_test.go
@@ -1,0 +1,32 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteReturnsErrorWhenNoSuiteMatches(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	name, err := reg.NegotiateSuite([]uint16{0xffff})
+
+	if err == nil {
+		t.Fatal("expected a no-match error")
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name on error, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteReturnsValidSuiteName(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+
+	if err != nil {
+		t.Fatalf("expected valid suite negotiation, got error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}


### PR DESCRIPTION
## Summary
- return a clear error when no offered client cipher suite matches
- keep successful negotiation behavior unchanged
- add regression coverage for unsupported and valid client suite inputs

## Validation
- `GO111MODULE=off CGO_ENABLED=0 go test ./...`

/claim #11

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.