### PR TITLE
Detect TLS 1.3 inner record type

### DIFF
--- a/assembly/test_tls13_inner_type_static.py
+++ b/assembly/test_tls13_inner_type_static.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import re
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class Tls13InnerTypeStaticTests(unittest.TestCase):
+    def test_tls13_application_data_branches_to_inner_type_handler(self):
+        self.assertRegex(
+            SOURCE,
+            r"\.handle_application:\s*\n\s*cmp r14d, 0x0303\s*\n"
+            r"\s*je \.handle_tls13_record",
+        )
+
+    def test_tls13_handler_reports_marker_and_last_payload_byte(self):
+        self.assertIn('lbl_tls13_record    db "TLS 1.3 record detected", 10, 0', SOURCE)
+        self.assertIn('msg_inner_type      db "Inner content type: 0x", 0', SOURCE)
+        self.assertTrue(
+            re.search(
+                r"\.handle_tls13_record:.*?test ecx, ecx.*?"
+                r"movzx edi, byte \[rdi \+ rcx - 1\].*?call print_hex_byte",
+                SOURCE,
+                re.S,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -19,6 +19,8 @@ section .data
     lbl_handshake       db "Handshake", 10, 0
     lbl_application     db "ApplicationData", 10, 0
     lbl_heartbeat       db "Heartbeat", 10, 0
+    lbl_tls13_record    db "TLS 1.3 record detected", 10, 0
+    msg_inner_type      db "Inner content type: 0x", 0
     lbl_unknown         db "Unknown content type", 10, 0
 
     ; --- Error strings ---
@@ -224,12 +226,33 @@ parse_tls_record:
     jmp .parse_done
 
 .handle_application:
+    cmp r14d, 0x0303
+    je .handle_tls13_record
     push rdi
     lea rdi, [rel lbl_application]
     call print_string
     pop rdi
     ; Application data is encrypted, just report the length
     ; No TLS 1.3 inner content type detection is performed
+    jmp .parse_done
+
+.handle_tls13_record:
+    push rdi
+    lea rdi, [rel lbl_tls13_record]
+    call print_string
+    pop rdi
+    test ecx, ecx
+    jle .parse_done
+    push rdi
+    push rcx
+    lea rdi, [rel msg_inner_type]
+    call print_string
+    pop rcx
+    pop rdi
+    movzx edi, byte [rdi + rcx - 1]
+    call print_hex_byte
+    lea rdi, [rel msg_newline]
+    call print_string
     jmp .parse_done
 
 .handle_heartbeat:


### PR DESCRIPTION
## Summary
- Detect TLS 1.3 records carried as legacy application data for version `0x0303`.
- Print a TLS 1.3 marker and the inner content type from the final payload byte when present.
- Add focused source-level regression checks.

/claim #4

## Verification
- `python3 -m unittest assembly/test_tls13_inner_type_static.py -v`
- `git diff --check`

Note: `nasm` is not installed in this environment, so verification uses a focused static regression test.