### PR TITLE
fix: prefer ChaCha without AES-NI

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -47,6 +47,8 @@ type SuiteRegistry struct {
 	mu          sync.Mutex              // guards knownSuites only
 }
 
+var hasAESNI = HasAESNI
+
 // NewSuiteRegistry creates a registry pre-loaded with common cipher suites.
 func NewSuiteRegistry(minStrength CipherStrength) *SuiteRegistry {
 	reg := &SuiteRegistry{
@@ -224,11 +226,22 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 			return si.Strength > sj.Strength
 		}
 
+		if !hasAESNI() {
+			siChaCha, sjChaCha := isChaCha20Suite(si), isChaCha20Suite(sj)
+			if siChaCha != sjChaCha {
+				return siChaCha
+			}
+		}
+
 		// Larger key size breaks ties
 		return si.KeySize > sj.KeySize
 	})
 
 	return sorted
+}
+
+func isChaCha20Suite(s *CipherSuite) bool {
+	return strings.Contains(strings.ToUpper(s.Name), "CHACHA20")
 }
 
 // ConcurrentLookup demonstrates a batch lookup of suite IDs from

--- a/go/tls_cipher_issue12_test.go
+++ b/go/tls_cipher_issue12_test.go
@@ -1,0 +1,54 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func setAESNIForIssue12Test(t *testing.T, enabled bool) {
+	t.Helper()
+	orig := hasAESNI
+	hasAESNI = func() bool { return enabled }
+	t.Cleanup(func() { hasAESNI = orig })
+}
+
+func TestSortByPreferencePrefersChaChaWithoutAESNI(t *testing.T) {
+	setAESNIForIssue12Test(t, false)
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	suites := []*CipherSuite{
+		suiteByIDForIssue12Test(t, reg, tls.TLS_AES_256_GCM_SHA384),
+		suiteByIDForIssue12Test(t, reg, tls.TLS_CHACHA20_POLY1305_SHA256),
+	}
+
+	sorted := reg.SortByPreference(suites)
+
+	if sorted[0].ID != tls.TLS_CHACHA20_POLY1305_SHA256 {
+		t.Fatalf("expected ChaCha20 first without AES-NI, got %s", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferencePreservesAESOrderWithAESNI(t *testing.T) {
+	setAESNIForIssue12Test(t, true)
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	suites := []*CipherSuite{
+		suiteByIDForIssue12Test(t, reg, tls.TLS_AES_256_GCM_SHA384),
+		suiteByIDForIssue12Test(t, reg, tls.TLS_CHACHA20_POLY1305_SHA256),
+	}
+
+	sorted := reg.SortByPreference(suites)
+
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected AES ordering to remain with AES-NI, got %s", sorted[0].Name)
+	}
+}
+
+func suiteByIDForIssue12Test(t *testing.T, reg *SuiteRegistry, id uint16) *CipherSuite {
+	t.Helper()
+	suite := reg.lookupSuite(id)
+	if suite == nil {
+		t.Fatalf("missing test fixture suite 0x%04x", id)
+	}
+	return suite
+}


### PR DESCRIPTION
## Summary
- make `SortByPreference` prefer ChaCha20 over same-strength AES-GCM when AES-NI is unavailable
- preserve existing AES-first ordering when AES-NI is available
- add focused ordering regression tests using a test hook for AES-NI detection

## Validation
- `GO111MODULE=off CGO_ENABLED=0 go test ./...`

/claim #12

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.