### PR TITLE
fix: reject broken Go cipher suites

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,11 +194,16 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
+		if s.KeySize >= minKeyBits && !isBrokenCipherSuite(s) {
 			result = append(result, s)
 		}
 	}
 	return result
+}
+
+func isBrokenCipherSuite(s *CipherSuite) bool {
+	name := strings.ToUpper(s.Name)
+	return strings.Contains(name, "RC4") || strings.Contains(name, "3DES")
 }
 
 // SortByPreference returns a copy of the slice ordered by server

--- a/go/tls_cipher_issue13_test.go
+++ b/go/tls_cipher_issue13_test.go
@@ -1,0 +1,23 @@
+package tlscipher
+
+import "testing"
+
+func TestFilterWeakSuitesRejectsRC4And3DES(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	filtered := reg.FilterWeakSuites(reg.knownSuites)
+	seen := make(map[string]bool, len(filtered))
+	for _, suite := range filtered {
+		seen[suite.Name] = true
+	}
+
+	if seen["TLS_RSA_WITH_RC4_128_SHA"] {
+		t.Fatal("expected RC4 suite to be filtered")
+	}
+	if seen["TLS_RSA_WITH_3DES_EDE_CBC_SHA"] {
+		t.Fatal("expected 3DES suite to be filtered")
+	}
+	if !seen["TLS_AES_128_GCM_SHA256"] {
+		t.Fatal("expected modern AEAD suite to remain")
+	}
+}


### PR DESCRIPTION
## Summary
- reject RC4 and 3DES suites even when their key sizes meet the old threshold
- keep modern AEAD suites in the filtered result
- add a focused regression test for RC4, 3DES, and AES-GCM filtering behavior

## Validation
- `GO111MODULE=off CGO_ENABLED=0 go test ./...`

/claim #13

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.