### PR TITLE
Terminate TLS alert messages

### DIFF
--- a/assembly/test_alert_terminators_static.py
+++ b/assembly/test_alert_terminators_static.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class AlertTerminatorStaticTests(unittest.TestCase):
+    def test_alert_messages_are_independently_null_terminated(self):
+        self.assertIn(
+            'err_alert_fatal     db "FATAL ALERT received from peer", 10, 0',
+            SOURCE,
+        )
+        self.assertIn(
+            'err_alert_warning   db "WARNING: alert received from peer", 10, 0',
+            SOURCE,
+        )
+        warning_idx = SOURCE.index("err_alert_warning")
+        truncated_idx = SOURCE.index("err_truncated")
+        self.assertLess(warning_idx, truncated_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -24,8 +24,8 @@ section .data
     ; --- Error strings ---
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
-    err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_fatal     db "FATAL ALERT received from peer", 10, 0
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---


### PR DESCRIPTION
## Summary
- Add explicit newline + null terminators to alert strings so warning output cannot run into the next error message.
- Preserve fatal alert output as an independently terminated string.
- Add a focused source-level regression check.

/claim #5

## Verification
- `python3 -m unittest assembly/test_alert_terminators_static.py -v`
- `git diff --check`

Note: `nasm` is not installed in this environment, so verification uses a focused static regression test.