### PR TITLE
fix: prefer AEAD Go cipher suites

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -216,7 +216,7 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_issue14_test.go
+++ b/go/tls_cipher_issue14_test.go
@@ -1,0 +1,45 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePutsAEADBeforeNonAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	suites := []*CipherSuite{
+		suiteByIDForIssue14Test(t, reg, tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256),
+		suiteByIDForIssue14Test(t, reg, tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+	}
+
+	sorted := reg.SortByPreference(suites)
+
+	if sorted[0].ID != tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
+		t.Fatalf("expected AEAD suite first, got %s", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferenceKeepsAdvancedBeforeModernAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	suites := []*CipherSuite{
+		suiteByIDForIssue14Test(t, reg, tls.TLS_AES_128_GCM_SHA256),
+		suiteByIDForIssue14Test(t, reg, tls.TLS_AES_256_GCM_SHA384),
+	}
+
+	sorted := reg.SortByPreference(suites)
+
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected advanced AEAD suite first, got %s", sorted[0].Name)
+	}
+}
+
+func suiteByIDForIssue14Test(t *testing.T, reg *SuiteRegistry, id uint16) *CipherSuite {
+	t.Helper()
+	suite := reg.lookupSuite(id)
+	if suite == nil {
+		t.Fatalf("missing test fixture suite 0x%04x", id)
+	}
+	return suite
+}


### PR DESCRIPTION
## Summary
- fix the inverted AEAD comparator so AEAD suites sort before non-AEAD suites
- preserve strength-based ordering among AEAD suites
- add focused regression tests for AEAD and advanced-vs-modern ordering

## Validation
- `GO111MODULE=off CGO_ENABLED=0 go test ./...`

/claim #14

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.