### PR TITLE
fix: guard Go cipher suite cache

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -139,6 +139,9 @@ func (r *SuiteRegistry) loadDefaults() {
 // scan of knownSuites. Results are cached for faster repeated lookups.
 // BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}

--- a/go/tls_cipher_issue15_test.go
+++ b/go/tls_cipher_issue15_test.go
@@ -1,0 +1,32 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestConcurrentLookupIsSafeAndCachesSuites(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	ids := make([]uint16, 100)
+	for i := range ids {
+		if i%2 == 0 {
+			ids[i] = tls.TLS_AES_128_GCM_SHA256
+		} else {
+			ids[i] = tls.TLS_AES_256_GCM_SHA384
+		}
+	}
+
+	results, err := reg.ConcurrentLookup(ids)
+
+	if err != nil {
+		t.Fatalf("expected concurrent lookup to succeed, got error: %v", err)
+	}
+	for i, suite := range results {
+		if suite == nil {
+			t.Fatalf("result %d was nil", i)
+		}
+	}
+	if got := reg.lookupSuite(tls.TLS_AES_128_GCM_SHA256); got == nil || got.Name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("expected cached TLS_AES_128_GCM_SHA256 lookup, got %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- guard `suiteCache` reads and writes with the existing registry mutex
- keep cached suite lookup behavior intact
- add a concurrent lookup regression test that is verified under the Go race detector

## Validation
- `GO111MODULE=off CGO_ENABLED=1 CC=.tools/w64devkit-x64/w64devkit/bin/gcc.exe go test -race ./...`

/claim #15

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.