### PR TITLE
fix: handle missing Rust session tickets

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -9,8 +9,9 @@ const MAX_CACHE_SIZE: usize = 4096;
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
 
 /// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+const ENCRYPTION_NONCE: [u8; 12] = [
+    0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+];
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -134,9 +135,7 @@ impl SessionCache {
     ///
     /// Returns the ticket if it exists **and** has not expired.
     pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
-        // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
-        // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+        let ticket = self.cache.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;
@@ -295,5 +294,61 @@ impl SessionCache {
             self.encryption_key.key_id,
             self.max_size,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic;
+
+    fn test_ticket(
+        ticket_id: &str,
+        issued_at: u64,
+        creation_time: u64,
+        lifetime_secs: u64,
+    ) -> SessionTicket {
+        SessionTicket {
+            ticket_id: ticket_id.to_string(),
+            cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+            master_secret: b"secret".to_vec(),
+            issued_at,
+            lifetime_secs,
+            encrypted_state: b"encrypted".to_vec(),
+            creation_time,
+        }
+    }
+
+    #[test]
+    fn get_session_returns_none_for_missing_ticket_without_panic() {
+        let cache = SessionCache::new(b"key material".to_vec());
+
+        let result = panic::catch_unwind(|| cache.get_session("missing_ticket"));
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn get_session_returns_existing_unexpired_ticket() {
+        let mut cache = SessionCache::new(b"key material".to_vec());
+        let ticket = test_ticket("tkt_1_12345", 100, 100, DEFAULT_TICKET_LIFETIME_SECS);
+
+        cache.store_session(ticket).unwrap();
+
+        assert_eq!(
+            cache.get_session("tkt_1_12345").unwrap().ticket_id,
+            "tkt_1_12345"
+        );
+    }
+
+    #[test]
+    fn get_session_returns_none_for_existing_expired_ticket() {
+        let mut cache = SessionCache::new(b"key material".to_vec());
+        let ticket = test_ticket("expired", 10, 0, 1);
+
+        cache.store_session(ticket).unwrap();
+
+        assert!(cache.get_session("expired").is_none());
     }
 }

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -120,7 +120,7 @@ impl SessionCache {
         let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
 
         if inner.len() >= self.max_size {
-            self.evict_expired_sessions(inner);
+            Self::evict_expired_sessions(inner);
         }
 
         if inner.len() >= self.max_size {
@@ -159,8 +159,7 @@ impl SessionCache {
 
     /// Check whether a ticket has exceeded its lifetime.
     fn is_ticket_expired(&self, ticket: &SessionTicket) -> bool {
-        let age = self.calculate_ticket_age(ticket);
-        age > ticket.lifetime_secs
+        Self::ticket_is_expired(ticket)
     }
 
     /// Calculate the age of a ticket in seconds.
@@ -172,16 +171,21 @@ impl SessionCache {
     }
 
     /// Evict all expired sessions from the map.
-    fn evict_expired_sessions(&self, map: &mut HashMap<String, SessionTicket>) {
+    fn evict_expired_sessions(map: &mut HashMap<String, SessionTicket>) {
         let expired_keys: Vec<String> = map
             .iter()
-            .filter(|(_, t)| self.is_ticket_expired(t))
+            .filter(|(_, t)| Self::ticket_is_expired(t))
             .map(|(k, _)| k.clone())
             .collect();
 
         for key in expired_keys {
             map.remove(&key);
         }
+    }
+
+    fn ticket_is_expired(ticket: &SessionTicket) -> bool {
+        let age = ticket.issued_at.saturating_sub(ticket.creation_time);
+        age > ticket.lifetime_secs
     }
 }
 

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -159,7 +159,8 @@ impl SessionCache {
 
     /// Check whether a ticket has exceeded its lifetime.
     fn is_ticket_expired(&self, ticket: &SessionTicket) -> bool {
-        Self::ticket_is_expired(ticket)
+        let age = self.calculate_ticket_age(ticket);
+        age > ticket.lifetime_secs
     }
 
     /// Calculate the age of a ticket in seconds.


### PR DESCRIPTION
## Summary
- replace the missing-ticket `unwrap()` with an `Option` lookup
- keep valid unexpired tickets returning normally
- add focused tests for missing, valid, and expired ticket lookup paths

## Validation
- `rustfmt --edition 2021 rust/tls_session.rs`
- `rustc --edition 2021 --test rust/tls_session.rs -C linker=rust-lld.exe`
- `.tools/tls_session_issue22_tests.exe` (3 passed)

/claim #22

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.