### PR TITLE
Validate stapled OCSP responses

### DIFF
--- a/c/test_ocsp_stapling_static.py
+++ b/c/test_ocsp_stapling_static.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c").read_text()
+VALIDATE_CHAIN = SOURCE[SOURCE.index("static int validate_chain") :]
+VALIDATE_CHAIN = VALIDATE_CHAIN[: VALIDATE_CHAIN.index("static void cleanup_cert_store")]
+
+
+class OcspStaplingStaticTests(unittest.TestCase):
+    def test_context_carries_stapled_ocsp_response(self):
+        self.assertIn("const unsigned char *ocsp_response_der;", SOURCE)
+        self.assertIn("size_t          ocsp_response_len;", SOURCE)
+
+    def test_ocsp_check_is_called_before_fingerprint_pinning(self):
+        ocsp_idx = VALIDATE_CHAIN.index("check_ocsp_stapling(ctx->chain[0], leaf_issuer")
+        pin_idx = VALIDATE_CHAIN.index("/* Fingerprint pinning on leaf */")
+        self.assertLess(ocsp_idx, pin_idx)
+        self.assertIn(
+            "leaf_issuer = (ctx->chain_len > 1) ? ctx->chain[1] : trusted_issuer->cert;",
+            VALIDATE_CHAIN,
+        )
+
+    def test_ocsp_response_statuses_and_allocations_are_handled(self):
+        self.assertIn("static int check_ocsp_stapling(", SOURCE)
+        self.assertIn("d2i_OCSP_RESPONSE(NULL, &p, (long)resp_len)", SOURCE)
+        self.assertIn("OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL", SOURCE)
+        self.assertIn("OCSP_response_get1_basic(resp)", SOURCE)
+        self.assertIn("OCSP_cert_to_id(NULL, leaf, issuer)", SOURCE)
+        self.assertIn("OCSP_resp_find_status(basic, cert_id, &cert_status", SOURCE)
+        self.assertIn("cert_status == V_OCSP_CERTSTATUS_GOOD", SOURCE)
+        self.assertIn("cert_status == V_OCSP_CERTSTATUS_REVOKED", SOURCE)
+        self.assertIn("rc = CERT_STATUS_REVOKED;", SOURCE)
+        self.assertIn("OCSP_CERTID_free(cert_id);", SOURCE)
+        self.assertIn("OCSP_BASICRESP_free(basic);", SOURCE)
+        self.assertIn("OCSP_RESPONSE_free(resp);", SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -47,6 +47,8 @@ typedef struct chain_context {
     cert_store_t   *trusted_store;
     unsigned char  *pinned_fingerprint;
     int             verify_ocsp;
+    const unsigned char *ocsp_response_der;
+    size_t          ocsp_response_len;
 } chain_context_t;
 
 static int g_log_level = LOG_LEVEL_INFO;
@@ -120,6 +122,72 @@ static int verify_signature(X509 *cert, X509 *issuer)
     return CERT_STATUS_OK;
 }
 
+static int check_ocsp_stapling(X509 *leaf, X509 *issuer,
+                               const unsigned char *resp_der,
+                               size_t resp_len)
+{
+    const unsigned char *p = resp_der;
+    OCSP_RESPONSE *resp = NULL;
+    OCSP_BASICRESP *basic = NULL;
+    OCSP_CERTID *cert_id = NULL;
+    int cert_status = V_OCSP_CERTSTATUS_UNKNOWN;
+    int reason = -1;
+    ASN1_GENERALIZEDTIME *revtime = NULL;
+    ASN1_GENERALIZEDTIME *thisupd = NULL;
+    ASN1_GENERALIZEDTIME *nextupd = NULL;
+    int rc = CERT_STATUS_INVALID;
+
+    if (!leaf || !issuer || !resp_der || resp_len == 0) {
+        log_cert_event(LOG_LEVEL_ERROR, "missing OCSP stapling response");
+        return CERT_STATUS_INVALID;
+    }
+
+    resp = d2i_OCSP_RESPONSE(NULL, &p, (long)resp_len);
+    if (!resp) {
+        log_cert_event(LOG_LEVEL_ERROR, "failed to parse OCSP response");
+        goto cleanup;
+    }
+
+    if (OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response was not successful");
+        goto cleanup;
+    }
+
+    basic = OCSP_response_get1_basic(resp);
+    if (!basic) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response missing basic response");
+        goto cleanup;
+    }
+
+    cert_id = OCSP_cert_to_id(NULL, leaf, issuer);
+    if (!cert_id) {
+        log_cert_event(LOG_LEVEL_ERROR, "failed to build OCSP cert id");
+        goto cleanup;
+    }
+
+    if (!OCSP_resp_find_status(basic, cert_id, &cert_status, &reason,
+                               &revtime, &thisupd, &nextupd)) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response missing leaf status");
+        goto cleanup;
+    }
+
+    if (cert_status == V_OCSP_CERTSTATUS_GOOD) {
+        rc = CERT_STATUS_OK;
+    } else if (cert_status == V_OCSP_CERTSTATUS_REVOKED) {
+        log_cert_event(LOG_LEVEL_ERROR, "leaf certificate revoked by OCSP");
+        rc = CERT_STATUS_REVOKED;
+    } else {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response returned unknown cert status");
+        rc = CERT_STATUS_INVALID;
+    }
+
+cleanup:
+    OCSP_CERTID_free(cert_id);
+    OCSP_BASICRESP_free(basic);
+    OCSP_RESPONSE_free(resp);
+    return rc;
+}
+
 static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 {
     X509_NAME *issuer_name = X509_get_issuer_name(cert);
@@ -137,6 +205,7 @@ static int validate_chain(chain_context_t *ctx)
     int             i, rc;
     unsigned char   fp[FINGERPRINT_LEN];
     cert_entry_t   *trusted_issuer;
+    X509           *leaf_issuer;
 
     if (!ctx || !ctx->chain || ctx->chain_len <= 0)
         return CERT_STATUS_INVALID;
@@ -164,6 +233,15 @@ static int validate_chain(chain_context_t *ctx)
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
     if (rc != CERT_STATUS_OK)
         return rc;
+
+    if (ctx->verify_ocsp) {
+        leaf_issuer = (ctx->chain_len > 1) ? ctx->chain[1] : trusted_issuer->cert;
+        rc = check_ocsp_stapling(ctx->chain[0], leaf_issuer,
+                                 ctx->ocsp_response_der,
+                                 ctx->ocsp_response_len);
+        if (rc != CERT_STATUS_OK)
+            return rc;
+    }
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {


### PR DESCRIPTION
## Summary
- Add `check_ocsp_stapling()` using OpenSSL OCSP response parsing.
- Return `CERT_STATUS_OK` for GOOD responses and `CERT_STATUS_REVOKED` for revoked leaf status.
- Wire OCSP validation before fingerprint pinning when `verify_ocsp` is enabled.
- Add focused source-level regression checks for wiring, status handling, and frees.

/claim #9

## Verification
- `python3 -m unittest c/test_ocsp_stapling_static.py -v`
- `git diff --check`

Note: OpenSSL development headers are not installed in this environment, so verification uses a focused static regression test.