### PR TITLE
Add Rust session ticket key rotation

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tls-session"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "tls_session.rs"

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -9,8 +9,9 @@ const MAX_CACHE_SIZE: usize = 4096;
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
 
 /// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+const ENCRYPTION_NONCE: [u8; 12] = [
+    0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+];
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -119,7 +120,7 @@ impl SessionCache {
         let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
 
         if inner.len() >= self.max_size {
-            self.evict_expired_sessions(inner);
+            Self::evict_expired_sessions(inner);
         }
 
         if inner.len() >= self.max_size {
@@ -156,6 +157,27 @@ impl SessionCache {
         self.cache.len()
     }
 
+    /// Rotate the session ticket encryption key and re-encrypt cached tickets.
+    pub fn rotate_key(&mut self, new_material: Vec<u8>) -> Result<(), SessionError> {
+        if new_material.is_empty() {
+            return Err(SessionError::EncryptionFailed(
+                "empty key material".to_string(),
+            ));
+        }
+
+        let old_key = self.encryption_key.clone();
+        let new_key = EncryptionKey::new(old_key.key_id + 1, new_material);
+        let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
+
+        for ticket in inner.values_mut() {
+            let plaintext = Self::decrypt_with_key(&old_key.key_material, &ticket.encrypted_state)?;
+            ticket.encrypted_state = Self::encrypt_with_key(&new_key.key_material, &plaintext)?;
+        }
+
+        self.encryption_key = new_key;
+        Ok(())
+    }
+
     // -- internal helpers ---------------------------------------------------
 
     /// Check whether a ticket has exceeded its lifetime.
@@ -173,16 +195,25 @@ impl SessionCache {
     }
 
     /// Evict all expired sessions from the map.
-    fn evict_expired_sessions(&self, map: &mut HashMap<String, SessionTicket>) {
+    fn evict_expired_sessions(map: &mut HashMap<String, SessionTicket>) {
         let expired_keys: Vec<String> = map
             .iter()
-            .filter(|(_, t)| self.is_ticket_expired(t))
+            .filter(|(_, t)| Self::is_ticket_expired_at_current_time(t))
             .map(|(k, _)| k.clone())
             .collect();
 
         for key in expired_keys {
             map.remove(&key);
         }
+    }
+
+    fn is_ticket_expired_at_current_time(ticket: &SessionTicket) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        now.saturating_sub(ticket.issued_at) > ticket.lifetime_secs
     }
 }
 
@@ -225,7 +256,11 @@ impl SessionCache {
     /// In production this would call into a real AEAD cipher; here we
     /// use a simplified XOR-based placeholder.
     pub fn encrypt_ticket(&self, plaintext: &[u8]) -> Result<Vec<u8>, SessionError> {
-        if self.encryption_key.key_material.is_empty() {
+        Self::encrypt_with_key(&self.encryption_key.key_material, plaintext)
+    }
+
+    fn encrypt_with_key(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, SessionError> {
+        if key.is_empty() {
             return Err(SessionError::EncryptionFailed(
                 "empty key material".to_string(),
             ));
@@ -236,7 +271,6 @@ impl SessionCache {
         // the same key breaks AEAD confidentiality guarantees.
         let nonce = ENCRYPTION_NONCE;
 
-        let key = &self.encryption_key.key_material;
         let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
         ciphertext.extend_from_slice(&nonce);
 
@@ -251,15 +285,23 @@ impl SessionCache {
 
     /// Decrypt ticket data using the current encryption key.
     pub fn decrypt_ticket(&self, ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
+        Self::decrypt_with_key(&self.encryption_key.key_material, ciphertext)
+    }
+
+    fn decrypt_with_key(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
         if ciphertext.len() < 12 {
             return Err(SessionError::DecryptionFailed(
                 "ciphertext too short".to_string(),
             ));
         }
+        if key.is_empty() {
+            return Err(SessionError::DecryptionFailed(
+                "empty key material".to_string(),
+            ));
+        }
 
         let nonce = &ciphertext[..12];
         let data = &ciphertext[12..];
-        let key = &self.encryption_key.key_material;
 
         let mut plaintext = Vec::with_capacity(data.len());
         for (i, &byte) in data.iter().enumerate() {
@@ -269,6 +311,50 @@ impl SessionCache {
         }
 
         Ok(plaintext)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotate_key_reencrypts_cached_tickets_with_incremented_key_id() {
+        let mut cache = SessionCache::new(b"old-key".to_vec());
+        let ticket = cache
+            .issue_ticket(CipherSuite::TlsAes128GcmSha256, b"secret".to_vec())
+            .expect("issue ticket");
+        let ticket_id = ticket.ticket_id.clone();
+        let old_encrypted_state = ticket.encrypted_state.clone();
+
+        cache
+            .rotate_key(b"new-key".to_vec())
+            .expect("rotate key should succeed");
+
+        assert_eq!(cache.encryption_key.key_id, 2);
+
+        let rotated = cache
+            .get_session(&ticket_id)
+            .expect("rotated ticket exists");
+        assert_ne!(rotated.encrypted_state, old_encrypted_state);
+        assert_eq!(
+            cache
+                .decrypt_ticket(&rotated.encrypted_state)
+                .expect("decrypt rotated ticket"),
+            rotated.master_secret
+        );
+    }
+
+    #[test]
+    fn rotate_key_succeeds_for_empty_cache() {
+        let mut cache = SessionCache::new(b"old-key".to_vec());
+
+        cache
+            .rotate_key(b"new-key".to_vec())
+            .expect("rotate empty cache");
+
+        assert_eq!(cache.encryption_key.key_id, 2);
+        assert_eq!(cache.session_count(), 0);
     }
 }
 


### PR DESCRIPTION
/claim #24

## Summary
- Add `rotate_key(new_material)` that increments the key id and re-encrypts cached ticket state under the new key.
- Split encryption/decryption helpers so rotation can decrypt with the old key and encrypt with the new key.
- Handle empty-cache rotation successfully.
- Add regression tests for populated and empty cache rotation.

## Verification
- `cargo test`