### PR TITLE
fix: harden Rust TLS session cache

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::fs::File;
+use std::io::Read;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of cached sessions before eviction kicks in.
@@ -7,10 +9,6 @@ const MAX_CACHE_SIZE: usize = 4096;
 
 /// Default ticket lifetime in seconds (2 hours).
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
-
-/// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -66,9 +64,7 @@ pub struct EncryptionKey {
 #[derive(Debug, Clone)]
 pub struct SessionCache {
     /// Thread-safe reference to the inner cache map.
-    // BUG(trap2): Arc alone does not provide interior mutability or
-    // synchronisation.  Concurrent callers can race on the HashMap.
-    cache: Arc<HashMap<String, SessionTicket>>,
+    cache: Arc<RwLock<HashMap<String, SessionTicket>>>,
     encryption_key: EncryptionKey,
     max_size: usize,
 }
@@ -108,18 +104,21 @@ impl SessionCache {
     pub fn new(key_material: Vec<u8>) -> Self {
         let key = EncryptionKey::new(1, key_material);
         SessionCache {
-            cache: Arc::new(HashMap::new()),
+            cache: Arc::new(RwLock::new(HashMap::new())),
             encryption_key: key,
             max_size: MAX_CACHE_SIZE,
         }
     }
 
     /// Store a session ticket in the cache.
-    pub fn store_session(&mut self, ticket: SessionTicket) -> Result<(), SessionError> {
-        let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
+    pub fn store_session(&self, ticket: SessionTicket) -> Result<(), SessionError> {
+        let mut inner = self
+            .cache
+            .write()
+            .map_err(|_| SessionError::InvalidTicket("session cache lock poisoned".to_string()))?;
 
         if inner.len() >= self.max_size {
-            self.evict_expired_sessions(inner);
+            self.evict_expired_sessions(&mut inner);
         }
 
         if inner.len() >= self.max_size {
@@ -133,12 +132,13 @@ impl SessionCache {
     /// Look up a session by ticket id.
     ///
     /// Returns the ticket if it exists **and** has not expired.
-    pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
-        // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
-        // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+    pub fn get_session(&self, ticket_id: &str) -> Option<SessionTicket> {
+        let ticket = {
+            let inner = self.cache.read().ok()?;
+            inner.get(ticket_id).cloned()?
+        };
 
-        if self.is_ticket_expired(ticket) {
+        if self.is_ticket_expired(&ticket) {
             return None;
         }
 
@@ -146,14 +146,14 @@ impl SessionCache {
     }
 
     /// Remove a specific ticket from the cache.
-    pub fn remove_session(&mut self, ticket_id: &str) -> Option<SessionTicket> {
-        let inner = Arc::get_mut(&mut self.cache)?;
+    pub fn remove_session(&self, ticket_id: &str) -> Option<SessionTicket> {
+        let mut inner = self.cache.write().ok()?;
         inner.remove(ticket_id)
     }
 
     /// Return the number of cached sessions.
     pub fn session_count(&self) -> usize {
-        self.cache.len()
+        self.cache.read().map(|inner| inner.len()).unwrap_or(0)
     }
 
     // -- internal helpers ---------------------------------------------------
@@ -166,10 +166,7 @@ impl SessionCache {
 
     /// Calculate the age of a ticket in seconds.
     fn calculate_ticket_age(&self, ticket: &SessionTicket) -> u64 {
-        // BUG(trap4): subtracts creation_time from issued_at instead of
-        // computing `now - issued_at`.  The result is a fixed delta that
-        // never grows, so tickets effectively never expire.
-        ticket.issued_at.saturating_sub(ticket.creation_time)
+        current_timestamp().saturating_sub(ticket.issued_at)
     }
 
     /// Evict all expired sessions from the map.
@@ -183,6 +180,131 @@ impl SessionCache {
         for key in expired_keys {
             map.remove(&key);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn ticket(ticket_id: &str, issued_at: u64, lifetime_secs: u64) -> SessionTicket {
+        let cache = SessionCache::new(b"test-key".to_vec());
+        SessionTicket {
+            ticket_id: ticket_id.to_string(),
+            cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+            master_secret: b"master-secret".to_vec(),
+            issued_at,
+            lifetime_secs,
+            encrypted_state: cache.encrypt_ticket(b"master-secret").unwrap(),
+            creation_time: issued_at,
+        }
+    }
+
+    #[test]
+    fn missing_ticket_returns_none() {
+        let cache = SessionCache::new(b"test-key".to_vec());
+
+        assert!(cache.get_session("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn valid_ticket_is_returned() {
+        let cache = SessionCache::new(b"test-key".to_vec());
+        let stored = ticket("tkt_1_12345", current_timestamp(), DEFAULT_TICKET_LIFETIME_SECS);
+
+        cache.store_session(stored).unwrap();
+
+        assert!(cache.get_session("tkt_1_12345").is_some());
+    }
+
+    #[test]
+    fn expired_ticket_returns_none() {
+        let cache = SessionCache::new(b"test-key".to_vec());
+        let issued_at = current_timestamp().saturating_sub(DEFAULT_TICKET_LIFETIME_SECS + 1);
+        let stored = ticket("expired", issued_at, DEFAULT_TICKET_LIFETIME_SECS);
+
+        cache.store_session(stored).unwrap();
+
+        assert!(cache.get_session("expired").is_none());
+    }
+
+    #[test]
+    fn concurrent_store_and_get_completes() {
+        let cache = Arc::new(SessionCache::new(b"test-key".to_vec()));
+        let mut handles = Vec::new();
+
+        for idx in 0..10 {
+            let cache = Arc::clone(&cache);
+            handles.push(thread::spawn(move || {
+                let id = format!("ticket-{idx}");
+                let stored = ticket(&id, current_timestamp(), DEFAULT_TICKET_LIFETIME_SECS);
+                cache.store_session(stored).unwrap();
+                assert!(cache.get_session(&id).is_some());
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn calculate_ticket_age_uses_current_time() {
+        let cache = SessionCache::new(b"test-key".to_vec());
+        let old_ticket = ticket(
+            "old",
+            current_timestamp().saturating_sub(DEFAULT_TICKET_LIFETIME_SECS + 1),
+            DEFAULT_TICKET_LIFETIME_SECS,
+        );
+        let fresh_ticket = ticket(
+            "fresh",
+            current_timestamp().saturating_sub(100),
+            DEFAULT_TICKET_LIFETIME_SECS,
+        );
+
+        assert!(cache.is_ticket_expired(&old_ticket));
+        assert!(!cache.is_ticket_expired(&fresh_ticket));
+    }
+
+    #[test]
+    fn rotate_key_reencrypts_cached_tickets() {
+        let mut cache = SessionCache::new(b"old-key".to_vec());
+        let mut stored = ticket("rotated", current_timestamp(), DEFAULT_TICKET_LIFETIME_SECS);
+        let original_secret = stored.master_secret.clone();
+        stored.encrypted_state = cache.encrypt_ticket(&original_secret).unwrap();
+        cache.store_session(stored.clone()).unwrap();
+
+        cache.rotate_key(b"new-key".to_vec()).unwrap();
+
+        assert_eq!(cache.encryption_key.key_id, 2);
+        let rotated = cache.get_session("rotated").unwrap();
+        assert_eq!(
+            cache.decrypt_ticket(&rotated.encrypted_state).unwrap(),
+            original_secret
+        );
+    }
+
+    #[test]
+    fn rotate_key_on_empty_cache_succeeds() {
+        let mut cache = SessionCache::new(b"old-key".to_vec());
+
+        cache.rotate_key(b"new-key".to_vec()).unwrap();
+
+        assert_eq!(cache.encryption_key.key_id, 2);
+        assert_eq!(cache.session_count(), 0);
+    }
+
+    #[test]
+    fn encrypt_ticket_uses_fresh_nonce_and_round_trips() {
+        let cache = SessionCache::new(b"test-key".to_vec());
+
+        let first = cache.encrypt_ticket(b"same-data").unwrap();
+        let second = cache.encrypt_ticket(b"same-data").unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(cache.decrypt_ticket(&first).unwrap(), b"same-data");
+        assert_eq!(cache.decrypt_ticket(&second).unwrap(), b"same-data");
     }
 }
 
@@ -225,51 +347,100 @@ impl SessionCache {
     /// In production this would call into a real AEAD cipher; here we
     /// use a simplified XOR-based placeholder.
     pub fn encrypt_ticket(&self, plaintext: &[u8]) -> Result<Vec<u8>, SessionError> {
-        if self.encryption_key.key_material.is_empty() {
+        encrypt_with_key(&self.encryption_key.key_material, plaintext)
+    }
+
+    /// Decrypt ticket data using the current encryption key.
+    pub fn decrypt_ticket(&self, ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
+        decrypt_with_key(&self.encryption_key.key_material, ciphertext)
+    }
+
+    /// Rotate the encryption key and re-encrypt all cached tickets.
+    pub fn rotate_key(&mut self, new_material: Vec<u8>) -> Result<(), SessionError> {
+        if new_material.is_empty() {
             return Err(SessionError::EncryptionFailed(
                 "empty key material".to_string(),
             ));
         }
 
-        // BUG(trap5): uses the constant ENCRYPTION_NONCE for every call
-        // instead of generating a fresh random nonce.  Nonce reuse with
-        // the same key breaks AEAD confidentiality guarantees.
-        let nonce = ENCRYPTION_NONCE;
+        let old_key_material = self.encryption_key.key_material.clone();
+        let new_key = EncryptionKey::new(self.encryption_key.key_id + 1, new_material);
 
-        let key = &self.encryption_key.key_material;
-        let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
-        ciphertext.extend_from_slice(&nonce);
+        {
+            let mut inner = self.cache.write().map_err(|_| {
+                SessionError::InvalidTicket("session cache lock poisoned".to_string())
+            })?;
 
-        for (i, &byte) in plaintext.iter().enumerate() {
-            let key_byte = key[i % key.len()];
-            let nonce_byte = nonce[i % nonce.len()];
-            ciphertext.push(byte ^ key_byte ^ nonce_byte);
+            for ticket in inner.values_mut() {
+                let plaintext = decrypt_with_key(&old_key_material, &ticket.encrypted_state)?;
+                ticket.encrypted_state = encrypt_with_key(&new_key.key_material, &plaintext)?;
+            }
         }
 
-        Ok(ciphertext)
+        self.encryption_key = new_key;
+        Ok(())
+    }
+}
+
+fn current_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+
+fn random_nonce() -> Result<[u8; 12], SessionError> {
+    let mut nonce = [0u8; 12];
+    let mut file = File::open("/dev/urandom")
+        .map_err(|error| SessionError::EncryptionFailed(error.to_string()))?;
+    file.read_exact(&mut nonce)
+        .map_err(|error| SessionError::EncryptionFailed(error.to_string()))?;
+    Ok(nonce)
+}
+
+fn encrypt_with_key(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, SessionError> {
+    if key.is_empty() {
+        return Err(SessionError::EncryptionFailed(
+            "empty key material".to_string(),
+        ));
     }
 
-    /// Decrypt ticket data using the current encryption key.
-    pub fn decrypt_ticket(&self, ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
-        if ciphertext.len() < 12 {
-            return Err(SessionError::DecryptionFailed(
-                "ciphertext too short".to_string(),
-            ));
-        }
+    let nonce = random_nonce()?;
+    let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
+    ciphertext.extend_from_slice(&nonce);
 
-        let nonce = &ciphertext[..12];
-        let data = &ciphertext[12..];
-        let key = &self.encryption_key.key_material;
-
-        let mut plaintext = Vec::with_capacity(data.len());
-        for (i, &byte) in data.iter().enumerate() {
-            let key_byte = key[i % key.len()];
-            let nonce_byte = nonce[i % nonce.len()];
-            plaintext.push(byte ^ key_byte ^ nonce_byte);
-        }
-
-        Ok(plaintext)
+    for (i, &byte) in plaintext.iter().enumerate() {
+        let key_byte = key[i % key.len()];
+        let nonce_byte = nonce[i % nonce.len()];
+        ciphertext.push(byte ^ key_byte ^ nonce_byte);
     }
+
+    Ok(ciphertext)
+}
+
+fn decrypt_with_key(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
+    if key.is_empty() {
+        return Err(SessionError::DecryptionFailed(
+            "empty key material".to_string(),
+        ));
+    }
+    if ciphertext.len() < 12 {
+        return Err(SessionError::DecryptionFailed(
+            "ciphertext too short".to_string(),
+        ));
+    }
+
+    let nonce = &ciphertext[..12];
+    let data = &ciphertext[12..];
+    let mut plaintext = Vec::with_capacity(data.len());
+
+    for (i, &byte) in data.iter().enumerate() {
+        let key_byte = key[i % key.len()];
+        let nonce_byte = nonce[i % nonce.len()];
+        plaintext.push(byte ^ key_byte ^ nonce_byte);
+    }
+
+    Ok(plaintext)
 }
 
 // ---------------------------------------------------------------------------
@@ -291,7 +462,7 @@ impl SessionCache {
     pub fn summary(&self) -> String {
         format!(
             "SessionCache {{ sessions: {}, key_id: {}, max: {} }}",
-            self.cache.len(),
+            self.session_count(),
             self.encryption_key.key_id,
             self.max_size,
         )


### PR DESCRIPTION
Closes #22, closes #23, closes #24, closes #25, closes #26.
/claim #22
/claim #23
/claim #24
/claim #25
/claim #26

This fixes the five Rust TLS session bounty issues in one focused change:

- `get_session` now returns `None` for missing or expired tickets instead of panicking.
- Session cache storage is protected by `RwLock` for concurrent store/get access.
- Added `rotate_key` and re-encryption of cached ticket state under the new key.
- Ticket age is computed from current time minus `issued_at`, so expiration works.
- Ticket encryption now generates a fresh 12-byte nonce for every call and keeps decrypt round-trips working.

Regression coverage is included in `rust/tls_session.rs` under `#[cfg(test)]`.

Verification:
- `rustc --test rust/tls_session.rs -o ../bounty_hunters_tls_session_tests.local.bin`
- `../bounty_hunters_tls_session_tests.local.bin --nocapture`
- Result: 8 passed, 0 failed.