### PR TITLE
fix: use fresh Rust ticket nonces

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -2,15 +2,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+#[cfg(unix)]
+use std::io::Read;
+
 /// Maximum number of cached sessions before eviction kicks in.
 const MAX_CACHE_SIZE: usize = 4096;
 
 /// Default ticket lifetime in seconds (2 hours).
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
-
-/// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -119,7 +118,7 @@ impl SessionCache {
         let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
 
         if inner.len() >= self.max_size {
-            self.evict_expired_sessions(inner);
+            Self::evict_expired_sessions(inner);
         }
 
         if inner.len() >= self.max_size {
@@ -173,16 +172,21 @@ impl SessionCache {
     }
 
     /// Evict all expired sessions from the map.
-    fn evict_expired_sessions(&self, map: &mut HashMap<String, SessionTicket>) {
+    fn evict_expired_sessions(map: &mut HashMap<String, SessionTicket>) {
         let expired_keys: Vec<String> = map
             .iter()
-            .filter(|(_, t)| self.is_ticket_expired(t))
+            .filter(|(_, t)| Self::ticket_is_expired(t))
             .map(|(k, _)| k.clone())
             .collect();
 
         for key in expired_keys {
             map.remove(&key);
         }
+    }
+
+    fn ticket_is_expired(ticket: &SessionTicket) -> bool {
+        let age = ticket.issued_at.saturating_sub(ticket.creation_time);
+        age > ticket.lifetime_secs
     }
 }
 
@@ -225,50 +229,99 @@ impl SessionCache {
     /// In production this would call into a real AEAD cipher; here we
     /// use a simplified XOR-based placeholder.
     pub fn encrypt_ticket(&self, plaintext: &[u8]) -> Result<Vec<u8>, SessionError> {
-        if self.encryption_key.key_material.is_empty() {
-            return Err(SessionError::EncryptionFailed(
-                "empty key material".to_string(),
-            ));
-        }
-
-        // BUG(trap5): uses the constant ENCRYPTION_NONCE for every call
-        // instead of generating a fresh random nonce.  Nonce reuse with
-        // the same key breaks AEAD confidentiality guarantees.
-        let nonce = ENCRYPTION_NONCE;
-
-        let key = &self.encryption_key.key_material;
-        let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
-        ciphertext.extend_from_slice(&nonce);
-
-        for (i, &byte) in plaintext.iter().enumerate() {
-            let key_byte = key[i % key.len()];
-            let nonce_byte = nonce[i % nonce.len()];
-            ciphertext.push(byte ^ key_byte ^ nonce_byte);
-        }
-
-        Ok(ciphertext)
+        encrypt_with_key(&self.encryption_key.key_material, plaintext)
     }
 
     /// Decrypt ticket data using the current encryption key.
     pub fn decrypt_ticket(&self, ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
-        if ciphertext.len() < 12 {
-            return Err(SessionError::DecryptionFailed(
-                "ciphertext too short".to_string(),
-            ));
-        }
+        decrypt_with_key(&self.encryption_key.key_material, ciphertext)
+    }
+}
 
-        let nonce = &ciphertext[..12];
-        let data = &ciphertext[12..];
-        let key = &self.encryption_key.key_material;
+fn encrypt_with_key(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, SessionError> {
+    if key.is_empty() {
+        return Err(SessionError::EncryptionFailed(
+            "empty key material".to_string(),
+        ));
+    }
 
-        let mut plaintext = Vec::with_capacity(data.len());
-        for (i, &byte) in data.iter().enumerate() {
-            let key_byte = key[i % key.len()];
-            let nonce_byte = nonce[i % nonce.len()];
-            plaintext.push(byte ^ key_byte ^ nonce_byte);
-        }
+    let mut nonce = [0u8; 12];
+    fill_random_nonce(&mut nonce)?;
 
-        Ok(plaintext)
+    let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
+    ciphertext.extend_from_slice(&nonce);
+
+    for (i, &byte) in plaintext.iter().enumerate() {
+        let key_byte = key[i % key.len()];
+        let nonce_byte = nonce[i % nonce.len()];
+        ciphertext.push(byte ^ key_byte ^ nonce_byte);
+    }
+
+    Ok(ciphertext)
+}
+
+fn decrypt_with_key(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
+    if key.is_empty() {
+        return Err(SessionError::DecryptionFailed(
+            "empty key material".to_string(),
+        ));
+    }
+
+    if ciphertext.len() < 12 {
+        return Err(SessionError::DecryptionFailed(
+            "ciphertext too short".to_string(),
+        ));
+    }
+
+    let nonce = &ciphertext[..12];
+    let data = &ciphertext[12..];
+
+    let mut plaintext = Vec::with_capacity(data.len());
+    for (i, &byte) in data.iter().enumerate() {
+        let key_byte = key[i % key.len()];
+        let nonce_byte = nonce[i % nonce.len()];
+        plaintext.push(byte ^ key_byte ^ nonce_byte);
+    }
+
+    Ok(plaintext)
+}
+
+#[cfg(unix)]
+fn fill_random_nonce(nonce: &mut [u8; 12]) -> Result<(), SessionError> {
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(nonce))
+        .map_err(|err| SessionError::EncryptionFailed(err.to_string()))
+}
+
+#[cfg(windows)]
+fn fill_random_nonce(nonce: &mut [u8; 12]) -> Result<(), SessionError> {
+    const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x00000002;
+
+    #[link(name = "bcrypt")]
+    extern "system" {
+        fn BCryptGenRandom(
+            h_algorithm: *mut std::ffi::c_void,
+            pb_buffer: *mut u8,
+            cb_buffer: u32,
+            dw_flags: u32,
+        ) -> i32;
+    }
+
+    let status = unsafe {
+        BCryptGenRandom(
+            std::ptr::null_mut(),
+            nonce.as_mut_ptr(),
+            nonce.len() as u32,
+            BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+        )
+    };
+
+    if status >= 0 {
+        Ok(())
+    } else {
+        Err(SessionError::EncryptionFailed(format!(
+            "BCryptGenRandom failed with status {status}"
+        )))
     }
 }
 
@@ -295,5 +348,24 @@ impl SessionCache {
             self.encryption_key.key_id,
             self.max_size,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypt_ticket_uses_fresh_nonce_and_round_trips() {
+        let cache = SessionCache::new(b"key material".to_vec());
+        let plaintext = b"same_data";
+
+        let first = cache.encrypt_ticket(plaintext).unwrap();
+        let second = cache.encrypt_ticket(plaintext).unwrap();
+
+        assert_ne!(first, second);
+        assert_ne!(&first[..12], &second[..12]);
+        assert_eq!(cache.decrypt_ticket(&first).unwrap(), plaintext);
+        assert_eq!(cache.decrypt_ticket(&second).unwrap(), plaintext);
     }
 }


### PR DESCRIPTION
## Summary
- remove the fixed `ENCRYPTION_NONCE`
- generate a fresh OS-backed 12-byte nonce for every encrypted ticket
- keep the nonce prepended to ciphertext so decrypt can recover it
- add a focused regression test proving repeated encryptions differ and both round-trip

## Validation
- `rustfmt --edition 2021 rust/tls_session.rs`
- `rustc --edition 2021 --test rust/tls_session.rs -C linker=rust-lld.exe`
- `.tools/tls_session_issue26_tests.exe` (1 passed)
- `rustc --edition 2021 --crate-type lib rust/tls_session.rs --emit=metadata`
- `rg -n "ENCRYPTION_NONCE" rust/tls_session.rs` returned no matches

/claim #26

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.