### PR TITLE
Add Python SNI extension parsing

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,37 @@
+import struct
+import unittest
+
+from tls_handshake import EXT_EXTENDED_MASTER_SECRET, EXT_SNI, TLSHandshake
+
+
+def extension(ext_type: int, data: bytes) -> bytes:
+    return struct.pack("!HH", ext_type, len(data)) + data
+
+
+def sni_extension_data(hostname: str) -> bytes:
+    host_bytes = hostname.encode("ascii")
+    server_name = b"\x00" + struct.pack("!H", len(host_bytes)) + host_bytes
+    return struct.pack("!H", len(server_name)) + server_name
+
+
+class SNIParsingTests(unittest.TestCase):
+    def test_parse_extensions_decodes_sni_host_name(self) -> None:
+        handshake = TLSHandshake()
+
+        extensions = handshake.parse_extensions(
+            extension(EXT_SNI, sni_extension_data("example.com"))
+        )
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_parse_extensions_without_sni_leaves_server_name_empty(self) -> None:
+        handshake = TLSHandshake()
+
+        handshake.parse_extensions(extension(EXT_EXTENDED_MASTER_SECRET, b""))
+
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,12 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                server_name = self._decode_sni_host_name(ext_data)
+                if server_name is not None:
+                    ext.server_name = server_name
+                    self.server_name = server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +219,36 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _decode_sni_host_name(self, data: bytes) -> Optional[str]:
+        """Decode the first host_name entry from an RFC 6066 SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = offset + list_len
+        if end > len(data):
+            return None
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+
+            if offset + name_len > end:
+                return None
+
+            name_bytes = data[offset:offset + name_len]
+            offset += name_len
+
+            if name_type == 0x00:
+                try:
+                    return name_bytes.decode("idna")
+                except UnicodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """


### PR DESCRIPTION
/claim #17

## Summary
- Decode RFC 6066 SNI host_name entries in `parse_extensions()`.
- Store the decoded hostname on both `TLSExtension.server_name` and `TLSHandshake.server_name`.
- Add focused unittest coverage for SNI and no-SNI parsing.

## Demo
https://github.com/Ahmadkhattak1/Bounty-Hunters/releases/download/bounty-python-sni-17-demo/python-sni-bounty-17-demo.mp4

## Verification
- `python -m unittest -v`