### PR TITLE
Fix Python key exchange exception handling

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,52 @@
+import struct
+import unittest
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+def client_key_exchange_payload(secret: bytes) -> bytes:
+    return struct.pack("!H", len(secret)) + secret
+
+
+class KeyExchangeErrorHandlingTests(unittest.TestCase):
+    def test_process_key_exchange_logs_expected_errors(self) -> None:
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00")
+
+        with self.assertLogs("tls_handshake", level="WARNING") as logs:
+            self.assertFalse(handshake.process_key_exchange(message))
+
+        self.assertIn("Key exchange payload too short", logs.output[0])
+
+    def test_process_key_exchange_propagates_unexpected_errors(self) -> None:
+        handshake = TLSHandshake()
+        secret = b"a" * 48
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            client_key_exchange_payload(secret),
+        )
+
+        def raise_type_error(_: bytes) -> bytes:
+            raise TypeError("unexpected failure")
+
+        handshake._decrypt_pre_master_secret = raise_type_error
+
+        with self.assertRaises(TypeError):
+            handshake.process_key_exchange(message)
+
+    def test_process_key_exchange_still_accepts_valid_payload(self) -> None:
+        handshake = TLSHandshake()
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        secret = b"p" * 48
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            client_key_exchange_payload(secret),
+        )
+
+        self.assertTrue(handshake.process_key_exchange(message))
+        self.assertIsNotNone(handshake.master_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,10 +6,13 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
 from typing import Optional, Dict, List, Tuple, Any
+
+logger = logging.getLogger(__name__)
 
 
 class HandshakeState(Enum):
@@ -256,10 +259,9 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error) as exc:
+            logger.warning("Failed to process key exchange: %s", exc)
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
/claim #20

## Summary
- Replace the bare `except` in `process_key_exchange()` with explicit `ValueError` and `struct.error` handling.
- Log expected key exchange failures before returning `False`.
- Let unexpected exceptions propagate normally and add regression coverage for that behavior.

## Demo
https://github.com/Ahmadkhattak1/Bounty-Hunters/releases/download/bounty-python-key-exchange-20-demo/python-key-exchange-20-demo.mp4

## Verification
- `python -m unittest -v`