### PR TITLE
fix: prevent Python TLS state bypass

### DIFF
--- a/python/test_tls_handshake_issue16.py
+++ b/python/test_tls_handshake_issue16.py
@@ -1,0 +1,22 @@
+import unittest
+
+from tls_handshake import HandshakeState, TLSHandshake, VALID_TRANSITIONS
+
+
+class HandshakeTransitionTests(unittest.TestCase):
+    def test_client_hello_can_only_transition_to_server_hello(self):
+        self.assertEqual(
+            VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO],
+            [HandshakeState.SERVER_HELLO],
+        )
+
+    def test_finished_from_client_hello_moves_to_error(self):
+        handshake = TLSHandshake()
+        handshake.state = HandshakeState.CLIENT_HELLO
+
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -55,7 +55,6 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
## Summary
- remove the invalid `CLIENT_HELLO -> FINISHED` transition
- keep `CLIENT_HELLO -> SERVER_HELLO` as the only valid next state
- add focused unit tests for the transition table and invalid FINISHED transition behavior

## Validation
- `python -m unittest discover -s python -p 'test_*.py'`

/claim #16

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.