### PR TITLE
fix: parse Python TLS SNI extension

### DIFF
--- a/python/test_tls_handshake_issue17.py
+++ b/python/test_tls_handshake_issue17.py
@@ -1,0 +1,41 @@
+import struct
+import unittest
+
+from tls_handshake import EXT_SNI, TLSHandshake
+
+
+def sni_extension_data(hostname: str) -> bytes:
+    host = hostname.encode("idna")
+    server_name = b"\x00" + struct.pack("!H", len(host)) + host
+    return struct.pack("!H", len(server_name)) + server_name
+
+
+class SNIParsingTests(unittest.TestCase):
+    def test_parse_extensions_extracts_sni_server_name(self):
+        handshake = TLSHandshake()
+        ext_payload = sni_extension_data("example.com")
+        extension_bytes = (
+            struct.pack("!H", EXT_SNI)
+            + struct.pack("!H", len(ext_payload))
+            + ext_payload
+        )
+
+        extensions = handshake.parse_extensions(extension_bytes)
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+        self.assertIs(handshake.extensions[EXT_SNI], extensions[0])
+
+    def test_malformed_sni_extension_is_ignored(self):
+        handshake = TLSHandshake()
+
+        extensions = handshake.parse_extensions(
+            struct.pack("!H", EXT_SNI) + struct.pack("!H", 2) + b"\x00\x10"
+        )
+
+        self.assertIsNone(extensions[0].server_name)
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,11 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_server_name(ext_data)
+                if ext.server_name is not None:
+                    self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +218,34 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_server_name(self, data: bytes) -> Optional[str]:
+        """Extract the first host_name entry from an SNI extension."""
+        if len(data) < 5:
+            return None
+
+        list_len = struct.unpack("!H", data[0:2])[0]
+        if list_len + 2 > len(data):
+            return None
+
+        offset = 2
+        end = offset + list_len
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            if offset + name_len > end:
+                return None
+
+            name = data[offset:offset + name_len]
+            offset += name_len
+            if name_type == 0:
+                try:
+                    return name.decode("idna")
+                except UnicodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """


### PR DESCRIPTION
## Summary
- parse SNI extension server-name-list data
- populate `TLSExtension.server_name` and `TLSHandshake.server_name` for host_name entries
- ignore malformed SNI payloads safely
- add focused unit tests for valid and malformed SNI extension data

## Validation
- `python -m unittest discover -s python -p 'test_*.py'`

/claim #17

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.