### PR TITLE
fix: compare Python TLS finished data safely

### DIFF
--- a/python/test_tls_handshake_issue18.py
+++ b/python/test_tls_handshake_issue18.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import TLSHandshake
+
+
+class FinishedVerificationTests(unittest.TestCase):
+    def test_verify_finished_uses_constant_time_compare(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"master secret"
+        expected = handshake._prf(
+            handshake.master_secret,
+            b"client finished",
+            handshake.handshake_hash.copy().digest(),
+            12,
+        )
+
+        with patch("tls_handshake.hmac.compare_digest", return_value=True) as compare_digest:
+            self.assertTrue(handshake.verify_finished(expected, "client finished"))
+
+        compare_digest.assert_called_once()
+        self.assertEqual(compare_digest.call_args.args[0], expected)
+        self.assertEqual(compare_digest.call_args.args[1], expected)
+
+    def test_verify_finished_rejects_mismatch(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"master secret"
+
+        self.assertFalse(handshake.verify_finished(b"wrong verify", "client finished"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Summary
- replace direct Finished verify-data equality with `hmac.compare_digest`
- keep mismatch rejection behavior unchanged
- add focused tests proving `compare_digest` is used and mismatches fail

## Validation
- `python -m unittest discover -s python -p 'test_*.py'`

/claim #18

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.