### PR TITLE
fix: expose Python TLS key exchange errors

### DIFF
--- a/python/test_tls_handshake_issue20.py
+++ b/python/test_tls_handshake_issue20.py
@@ -1,0 +1,42 @@
+import struct
+import unittest
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class KeyExchangeErrorTests(unittest.TestCase):
+    def test_process_key_exchange_records_expected_validation_errors(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30short")
+
+        self.assertFalse(handshake.process_key_exchange(message))
+        self.assertEqual(handshake.last_error, "Pre-master secret length mismatch")
+
+    def test_process_key_exchange_success_clears_last_error(self):
+        handshake = TLSHandshake()
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        handshake.last_error = "previous error"
+        pms = b"x" * 48
+        payload = struct.pack("!H", len(pms)) + pms
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, payload)
+
+        self.assertTrue(handshake.process_key_exchange(message))
+        self.assertIsNone(handshake.last_error)
+        self.assertIsNotNone(handshake.master_secret)
+
+    def test_unexpected_key_exchange_errors_are_not_swallowed(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30" + b"x" * 48)
+
+        def explode(_encrypted):
+            raise RuntimeError("boom")
+
+        handshake._decrypt_pre_master_secret = explode
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -110,6 +110,7 @@ class TLSHandshake:
         self.negotiated_ems: bool = False
         self.server_name: Optional[str] = None
         self._pre_master_secret: Optional[bytes] = None
+        self.last_error: Optional[str] = None
         self.transcript: bytearray = bytearray()
 
     def transition_to(self, new_state: HandshakeState) -> bool:
@@ -254,11 +255,12 @@ class TLSHandshake:
                 raise ValueError("Failed to decrypt pre-master secret")
 
             self._derive_master_secret()
+            self.last_error = None
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
+        except ValueError as exc:
+            self.last_error = str(exc)
+            return False
         return False
 
     def _derive_master_secret(self) -> None:


### PR DESCRIPTION
## Summary
- replace the bare `except: pass` path with explicit `ValueError` handling
- preserve `False` returns for expected validation failures while storing `last_error`
- let unexpected exceptions propagate instead of being silently swallowed
- add focused tests for validation errors, success cleanup, and unexpected exception propagation

## Validation
- `python -m unittest discover -s python -p 'test_*.py'`

/claim #20

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.