### PR TITLE
fix: use Python TLS EMS PRF label

### DIFF
--- a/python/test_tls_handshake_issue21.py
+++ b/python/test_tls_handshake_issue21.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import TLSHandshake
+
+
+class ExtendedMasterSecretTests(unittest.TestCase):
+    def test_ems_uses_extended_master_secret_label(self):
+        handshake = TLSHandshake()
+        handshake._pre_master_secret = b"p" * 48
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        handshake.negotiated_ems = True
+
+        with patch.object(handshake, "_prf", return_value=b"m" * 48) as prf:
+            handshake._derive_master_secret()
+
+        self.assertEqual(prf.call_args.args[1], b"extended master secret")
+        self.assertEqual(handshake.master_secret, b"m" * 48)
+
+    def test_non_ems_keeps_standard_master_secret_label(self):
+        handshake = TLSHandshake()
+        handshake._pre_master_secret = b"p" * 48
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        handshake.negotiated_ems = False
+
+        with patch.object(handshake, "_prf", return_value=b"m" * 48) as prf:
+            handshake._derive_master_secret()
+
+        self.assertEqual(prf.call_args.args[1], b"master secret")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Summary
- use the RFC 7627 `extended master secret` PRF label when EMS is negotiated
- keep the standard `master secret` label for non-EMS handshakes
- add focused tests that assert both PRF labels directly

## Validation
- `python -m unittest discover -s python -p 'test_*.py'`

/claim #21

Disclosure: AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.