### PR TITLE
fix: harden Python TLS handshake

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,110 @@
+import hmac
+import struct
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import (
+    EXT_SNI,
+    HandshakeMessage,
+    HandshakeState,
+    HandshakeType,
+    TLSHandshake,
+    VALID_TRANSITIONS,
+)
+
+
+def handshake_record(message_type: HandshakeType, payload: bytes) -> bytes:
+    handshake = bytes([message_type.value]) + len(payload).to_bytes(3, "big") + payload
+    return bytes([22, 3, 3]) + len(handshake).to_bytes(2, "big") + handshake
+
+
+def sni_extension(hostname: str) -> bytes:
+    name = hostname.encode("idna")
+    server_name = bytes([0]) + len(name).to_bytes(2, "big") + name
+    server_name_list = len(server_name).to_bytes(2, "big") + server_name
+    return struct.pack("!HH", EXT_SNI, len(server_name_list)) + server_name_list
+
+
+class TLSHandshakeSecurityTest(unittest.TestCase):
+    def test_client_hello_cannot_transition_directly_to_finished(self):
+        self.assertEqual(
+            VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO],
+            [HandshakeState.SERVER_HELLO],
+        )
+
+        handshake = TLSHandshake()
+        handshake.state = HandshakeState.CLIENT_HELLO
+
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+    def test_finished_after_client_hello_is_rejected_and_sets_error(self):
+        handshake = TLSHandshake()
+        handshake.state = HandshakeState.CLIENT_HELLO
+        handshake.master_secret = b"x" * 48
+
+        ok, message = handshake.process_message(
+            handshake_record(HandshakeType.FINISHED, b"bad-verify")
+        )
+
+        self.assertFalse(ok)
+        self.assertIn("Finished", message)
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+    def test_parse_extensions_decodes_sni_hostname(self):
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(sni_extension("example.com"))
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_no_sni_leaves_server_name_unset(self):
+        handshake = TLSHandshake()
+
+        self.assertEqual(handshake.parse_extensions(b""), [])
+        self.assertIsNone(handshake.server_name)
+
+    def test_verify_finished_uses_constant_time_compare(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"x" * 48
+
+        with patch("tls_handshake.hmac.compare_digest", wraps=hmac.compare_digest) as compare:
+            handshake.verify_finished(b"bad-verify", "client finished")
+
+        compare.assert_called_once()
+
+    def test_process_key_exchange_marks_state_error_on_bad_payload(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30short")
+
+        self.assertFalse(handshake.process_key_exchange(message))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+    def test_extended_master_secret_uses_rfc7627_label(self):
+        handshake = TLSHandshake()
+        handshake.negotiated_ems = True
+        handshake._pre_master_secret = b"p" * 48
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+
+        handshake._derive_master_secret()
+
+        expected = handshake._prf(
+            b"p" * 48,
+            b"extended master secret",
+            b"c" * 32 + b"s" * 32,
+            48,
+        )
+        standard = handshake._prf(
+            b"p" * 48,
+            b"master secret",
+            b"c" * 32 + b"s" * 32,
+            48,
+        )
+
+        self.assertEqual(handshake.master_secret, expected)
+        self.assertNotEqual(handshake.master_secret, standard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -55,7 +55,6 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
@@ -203,9 +202,10 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_hostname(ext_data)
+                self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +216,34 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_hostname(self, data: bytes) -> Optional[str]:
+        """Parse an RFC 6066 server_name extension and return host_name."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[0:2])[0]
+        offset = 2
+        end = min(len(data), 2 + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+
+            if offset + name_len > end:
+                return None
+
+            name_bytes = data[offset:offset + name_len]
+            offset += name_len
+
+            if name_type == 0:
+                try:
+                    return name_bytes.decode("idna")
+                except UnicodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """
@@ -233,8 +261,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""
@@ -256,9 +283,8 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
+        except (ValueError, struct.error):
+            self.state = HandshakeState.ERROR
         return False
 
     def _derive_master_secret(self) -> None:
@@ -271,9 +297,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
Closes #16, closes #17, closes #18, closes #20, closes #21.
/claim #16
/claim #17
/claim #18
/claim #20
/claim #21

This fixes the Python TLS handshake bounty issues in one focused change:

- Removes the invalid CLIENT_HELLO -> FINISHED transition.
- Parses RFC 6066 SNI host_name values and stores the decoded server name.
- Uses hmac.compare_digest for Finished verify_data comparison.
- Handles key-exchange parse/decrypt failures explicitly and marks the handshake ERROR.
- Uses the RFC 7627 `extended master secret` PRF label when EMS is negotiated.

Regression coverage is included in `python/test_tls_handshake.py`.

Verification:
- `python3 -m unittest discover -s python -p 'test_*.py'`
- Result: passed.