### PR TITLE
fix: compare C TLS fingerprints safely

### DIFF
--- a/c/test_tls_cert_validator_issue6.py
+++ b/c/test_tls_cert_validator_issue6.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c").read_text()
+
+
+class MatchFingerprintTests(unittest.TestCase):
+    def test_fingerprint_comparison_uses_openssl_constant_time_api(self):
+        body = re.search(
+            r"static int match_fingerprint\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+            SOURCE,
+            re.S,
+        ).group("body")
+
+        self.assertIn("CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0", body)
+        self.assertIsNone(re.search(r"(?<!CRYPTO_)memcmp\s*\(", body))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)


### PR DESCRIPTION
## Summary
- replace fingerprint `memcmp` with OpenSSL `CRYPTO_memcmp`
- keep the existing zero-means-match behavior for fingerprint pinning
- add a source-level regression test for the constant-time comparison call

## Verification
- `python -m unittest discover -s c -p 'test_*.py'`
- `git diff --check`

/claim #6