### PR TITLE
fix: avoid C TLS expiry overflow

### DIFF
--- a/c/test_tls_cert_validator_issue8.py
+++ b/c/test_tls_cert_validator_issue8.py
@@ -1,0 +1,23 @@
+import re
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c").read_text()
+
+
+class CheckExpiryOverflowTests(unittest.TestCase):
+    def test_remaining_seconds_uses_wide_integer_math(self):
+        body = re.search(
+            r"static int check_expiry\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+            SOURCE,
+            re.S,
+        ).group("body")
+
+        self.assertIn("int64_t remaining_seconds;", body)
+        self.assertIn("remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;", body)
+        self.assertIn("(long long)remaining_seconds", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -83,7 +83,7 @@ static int check_expiry(X509 *cert)
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
     int day_diff, sec_diff;
-    int remaining_seconds;
+    int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
         return CERT_STATUS_INVALID;
@@ -99,9 +99,10 @@ static int check_expiry(X509 *cert)
     if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = day_diff * 86400 + sec_diff;
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
     if (remaining_seconds < 86400 * 30)
-        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %d seconds", remaining_seconds);
+        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %lld seconds",
+                       (long long)remaining_seconds);
     return CERT_STATUS_OK;
 }
 


### PR DESCRIPTION
## Summary
- store certificate remaining lifetime in `int64_t`
- cast `day_diff` before multiplying by seconds per day
- log the wide value safely and add a regression test for the overflow fix

## Verification
- `python -m unittest discover -s c -p 'test_*.py'`
- `git diff --check`

/claim #8