### PR TITLE
fix: log C cert cleanup before free

### DIFF
--- a/c/test_tls_cert_validator_issue10.py
+++ b/c/test_tls_cert_validator_issue10.py
@@ -1,0 +1,26 @@
+import re
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c").read_text()
+
+
+class CleanupCertStoreTests(unittest.TestCase):
+    def test_debug_log_uses_issuer_before_free(self):
+        body = re.search(
+            r"static void cleanup_cert_store\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+            SOURCE,
+            re.S,
+        ).group("body")
+
+        log_pos = body.index('log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);')
+        subject_free_pos = body.index("free(entry->subject);")
+        issuer_free_pos = body.index("free(entry->issuer);")
+
+        self.assertLess(log_pos, subject_free_pos)
+        self.assertLess(log_pos, issuer_free_pos)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -188,10 +188,10 @@ static void cleanup_cert_store(cert_store_t *store)
     entry = store->head;
     while (entry) {
         next = entry->next;
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         X509_free(entry->cert);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }


### PR DESCRIPTION
## Summary
- move the cleanup debug log before freeing the issuer string
- preserve the existing cleanup order after the log is emitted
- add a regression test that enforces log-before-free ordering

## Verification
- `python -m unittest discover -s c -p 'test_*.py'`
- `git diff --check`

/claim #10