### PR TITLE
fix: route C chain validation cleanup

### DIFF
--- a/c/test_tls_cert_validator_issue7.py
+++ b/c/test_tls_cert_validator_issue7.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c").read_text()
+
+
+class ValidateChainCleanupTests(unittest.TestCase):
+    def test_validate_chain_errors_route_through_cleanup_label(self):
+        start = SOURCE.index("static int validate_chain")
+        end = SOURCE.index("static void cleanup_cert_store")
+        body = SOURCE[start:end]
+
+        self.assertIn("cleanup:", body)
+        self.assertEqual(body.count("return rc;"), 1)
+        self.assertNotIn("return CERT_STATUS_INVALID;", body)
+        self.assertNotIn("return CERT_STATUS_UNTRUSTED;", body)
+        self.assertGreaterEqual(body.count("goto cleanup;"), 6)
+        self.assertIn('log_cert_event(LOG_LEVEL_ERROR, "cert at depth %d failed expiry check", i);', body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -134,49 +134,59 @@ static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 
 static int validate_chain(chain_context_t *ctx)
 {
-    int             i, rc;
+    int             i, rc = CERT_STATUS_OK;
     unsigned char   fp[FINGERPRINT_LEN];
-    cert_entry_t   *trusted_issuer;
+    cert_entry_t   *trusted_issuer = NULL;
 
-    if (!ctx || !ctx->chain || ctx->chain_len <= 0)
-        return CERT_STATUS_INVALID;
-    if (ctx->chain_len > MAX_CHAIN_DEPTH)
-        return CERT_STATUS_INVALID;
+    if (!ctx || !ctx->chain || ctx->chain_len <= 0) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
+    if (ctx->chain_len > MAX_CHAIN_DEPTH) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
 
     for (i = 0; i < ctx->chain_len - 1; i++) {
         rc = check_expiry(ctx->chain[i]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "cert at depth %d failed expiry check", i);
-            return rc;
+            goto cleanup;
         }
         rc = verify_signature(ctx->chain[i], ctx->chain[i + 1]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "signature invalid at depth %d", i);
-            return rc;
+            goto cleanup;
         }
     }
 
     trusted_issuer = find_issuer(ctx->trusted_store, ctx->chain[ctx->chain_len - 1]);
     if (!trusted_issuer) {
         log_cert_event(LOG_LEVEL_ERROR, "root not found in trusted store");
-        return CERT_STATUS_UNTRUSTED;
+        rc = CERT_STATUS_UNTRUSTED;
+        goto cleanup;
     }
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
     if (rc != CERT_STATUS_OK)
-        return rc;
+        goto cleanup;
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {
-        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0)
-            return CERT_STATUS_INVALID;
+        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0) {
+            rc = CERT_STATUS_INVALID;
+            goto cleanup;
+        }
         if (!match_fingerprint(fp, ctx->pinned_fingerprint)) {
             log_cert_event(LOG_LEVEL_ERROR, "leaf fingerprint mismatch");
-            return CERT_STATUS_UNTRUSTED;
+            rc = CERT_STATUS_UNTRUSTED;
+            goto cleanup;
         }
     }
 
     log_cert_event(LOG_LEVEL_INFO, "chain validated successfully (%d certs)", ctx->chain_len);
-    return CERT_STATUS_OK;
+
+cleanup:
+    return rc;
 }
 
 static void cleanup_cert_store(cert_store_t *store)


### PR DESCRIPTION
## Summary
- initialize `validate_chain` return state and route validation failures through `cleanup`
- preserve the existing failure codes and error log messages
- add a regression test that enforces the single return path

## Verification
- `python -m unittest discover -s c -p 'test_*.py'`
- `git diff --check`

/claim #7