### PR TITLE
fix: decode assembly TLS version as network order

### DIFF
--- a/assembly/test_tls_record_parser_issue1.py
+++ b/assembly/test_tls_record_parser_issue1.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class VersionParsingTests(unittest.TestCase):
+    def test_tls_version_is_decoded_as_big_endian(self):
+        self.assertNotIn("mov ax, [rsi+1]", SOURCE)
+        self.assertIn("movzx eax, byte [rsi+1]", SOURCE)
+        self.assertIn("shl eax, 8", SOURCE)
+        self.assertIn("movzx ebx, byte [rsi+2]", SOURCE)
+        self.assertIn("mov r14d, eax", SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -125,10 +125,11 @@ parse_tls_record:
     ; --- Bytes 1-2: Protocol Version (big-endian) ---
     ; TLS version is 2 bytes, network byte order (big-endian)
     ; e.g. TLS 1.2 = 0x0303, TLS 1.0 = 0x0301
-    mov ax, [rsi+1]             ; BUG: loads in little-endian on x86
-                                ; For input bytes 03 03 this works by coincidence
-                                ; but 03 01 would be read as 0x0103 instead of 0x0301
-    movzx r14d, ax              ; r14 = version (incorrectly byte-swapped)
+    movzx eax, byte [rsi+1]
+    shl eax, 8
+    movzx ebx, byte [rsi+2]
+    or eax, ebx
+    mov r14d, eax               ; r14 = version decoded from network byte order
 
     ; Print version
     push rsi


### PR DESCRIPTION
## Summary
- decode TLS version bytes explicitly in network byte order
- preserve TLS 1.2 behavior while fixing TLS 1.0 byte order
- add a source-level regression test for the big-endian sequence

## Verification
- `python -m unittest discover -s assembly -p 'test_*.py'`
- `git diff --check`

/claim #1