### PR TITLE
fix: reject truncated assembly TLS payloads

### DIFF
--- a/assembly/test_tls_record_parser_issue2.py
+++ b/assembly/test_tls_record_parser_issue2.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class PayloadBoundsTests(unittest.TestCase):
+    def test_payload_length_is_checked_against_bytes_read(self):
+        self.assertIn("lea eax, [r15d+5]", SOURCE)
+        self.assertIn("cmp eax, r12d", SOURCE)
+        self.assertIn("ja .err_truncated", SOURCE)
+        self.assertIn(".err_truncated:", SOURCE)
+
+        check_pos = SOURCE.index("lea eax, [r15d+5]")
+        payload_pos = SOURCE.index("lea rdi, [rsi+5]")
+        self.assertLess(check_pos, payload_pos)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -159,12 +159,13 @@ parse_tls_record:
 
     ; Validate length doesn't exceed TLS maximum
     cmp r15d, TLS_MAX_RECORD_LEN
-    ja .invalid_length
+    ja .err_truncated
 
     ; --- Read payload data ---
-    ; BUG: No check that r12 (bytes in buffer) >= r15 + 5
-    ; If the record claims a large payload but we only read a few
-    ; bytes, we'll process past the end of valid data
+    lea eax, [r15d+5]
+    cmp eax, r12d
+    ja .err_truncated
+
     lea rdi, [rsi+5]            ; rdi = start of payload
     mov ecx, r15d               ; ecx = payload length
 
@@ -249,7 +250,7 @@ parse_tls_record:
     call print_string
     jmp .parse_done
 
-.invalid_length:
+.err_truncated:
     lea rdi, [rel err_truncated]
     call print_string
 


### PR DESCRIPTION
## Summary
- compare declared payload length plus header size against bytes actually read
- route oversized or incomplete records to the existing truncated-record error message
- add a regression test that keeps the bounds check before payload dispatch

## Verification
- `python -m unittest discover -s assembly -p 'test_*.py'`
- `git diff --check`

/claim #2