### PR TITLE
fix: reject assembly TLS types above maximum

### DIFF
--- a/assembly/test_tls_record_parser_issue3.py
+++ b/assembly/test_tls_record_parser_issue3.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class ContentTypeBoundsTests(unittest.TestCase):
+    def test_types_above_max_branch_to_invalid_type(self):
+        max_cmp = SOURCE.index("cmp r13d, TLS_CT_MAX")
+        accept = SOURCE.index("jle .type_ok", max_cmp)
+        reject = SOURCE.index("jg .invalid_type", accept)
+        type_ok = SOURCE.index(".type_ok:", reject)
+
+        self.assertLess(max_cmp, accept)
+        self.assertLess(accept, reject)
+        self.assertLess(reject, type_ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -102,14 +102,8 @@ parse_tls_record:
     cmp r13d, TLS_CT_MIN
     jl .invalid_type
     cmp r13d, TLS_CT_MAX
-    jle .type_ok                ; BUG: should be jl, not jle -- but wait,
-                                ; 0x18 (heartbeat) is valid so jle is needed...
-                                ; actually TLS_CT_MAX is 0x18 and we want <= 0x18
-
-    ; --- Actually the check above is wrong for a different reason ---
-    ; Content type 0x17 is application_data which is VALID, and 0x18
-    ; is heartbeat. The jle here means we accept up to AND including
-    ; 0x18 which is correct. But see the LOWER bound check below...
+    jle .type_ok
+    jg .invalid_type
 
 .type_ok:
     ; Print content type


### PR DESCRIPTION
## Summary
- add the missing upper-bound rejection branch after the valid TLS content-type check
- keep `0x17` application data and `0x18` heartbeat accepted
- add a regression test for the compare/accept/reject branch order

## Verification
- `python -m unittest discover -s assembly -p 'test_*.py'`
- `git diff --check`

/claim #3