### PR TITLE
fix: terminate assembly warning alert string

### DIFF
--- a/assembly/test_tls_record_parser_issue5.py
+++ b/assembly/test_tls_record_parser_issue5.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class AlertWarningStringTests(unittest.TestCase):
+    def test_warning_alert_string_is_null_terminated(self):
+        self.assertIn(
+            'err_alert_warning   db "WARNING: alert received from peer", 10, 0',
+            SOURCE,
+        )
+        self.assertLess(SOURCE.index("err_alert_warning"), SOURCE.index("err_truncated"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -25,7 +25,7 @@ section .data
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
     err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---


### PR DESCRIPTION
## Summary
- add newline and null terminator to the warning alert string
- prevent `print_string` from reading into the truncated-record message
- add a regression test for the string definition

## Verification
- `python -m unittest discover -s assembly -p 'test_*.py'`
- `git diff --check`

/claim #5