### PR TITLE
fix: detect assembly TLS 1.3 records

### DIFF
--- a/assembly/test_tls_record_parser_issue4.py
+++ b/assembly/test_tls_record_parser_issue4.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import unittest
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm").read_text()
+
+
+class Tls13ApplicationRecordTests(unittest.TestCase):
+    def test_application_records_with_legacy_tls13_version_branch_to_inner_type_parser(self):
+        self.assertIn('msg_tls13       db "TLS 1.3 record detected", 10, 0', SOURCE)
+        self.assertIn('msg_inner_type  db "Inner content type: 0x", 0', SOURCE)
+
+        handler_start = SOURCE.index(".handle_application:")
+        tls13_start = SOURCE.index(".handle_tls13_record:")
+        heartbeat_start = SOURCE.index(".handle_heartbeat:")
+        handler_body = SOURCE[handler_start:heartbeat_start]
+
+        self.assertIn("cmp r14d, 0x0303", handler_body)
+        self.assertIn("je .handle_tls13_record", handler_body)
+        self.assertIn("test ecx, ecx", handler_body)
+        self.assertIn("movzx edi, byte [rdi+rcx-1]", handler_body)
+        self.assertLess(handler_start, tls13_start)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -11,6 +11,8 @@ section .data
     msg_type        db "Content type: 0x", 0
     msg_version     db "Protocol version: 0x", 0
     msg_length      db "Payload length: ", 0
+    msg_tls13       db "TLS 1.3 record detected", 10, 0
+    msg_inner_type  db "Inner content type: 0x", 0
     msg_newline     db 10, 0
 
     ; --- Content type labels ---
@@ -224,12 +226,30 @@ parse_tls_record:
     jmp .parse_done
 
 .handle_application:
+    cmp r14d, 0x0303
+    je .handle_tls13_record
     push rdi
     lea rdi, [rel lbl_application]
     call print_string
     pop rdi
     ; Application data is encrypted, just report the length
-    ; No TLS 1.3 inner content type detection is performed
+    jmp .parse_done
+
+.handle_tls13_record:
+    push rdi
+    lea rdi, [rel msg_tls13]
+    call print_string
+    pop rdi
+    test ecx, ecx
+    jz .parse_done
+    push rdi
+    lea rdi, [rel msg_inner_type]
+    call print_string
+    pop rdi
+    movzx edi, byte [rdi+rcx-1]
+    call print_hex_byte
+    lea rdi, [rel msg_newline]
+    call print_string
     jmp .parse_done
 
 .handle_heartbeat:


### PR DESCRIPTION
## Summary
- add a TLS 1.3 record detection path for application_data records with legacy version `0x0303`
- print the detected TLS 1.3 marker and the final payload byte as the inner content type when present
- add a regression test for the branch and inner-content-byte read

## Verification
- `python -m unittest discover -s assembly -p 'test_*.py'`
- `git diff --check`

/claim #4