### PR TITLE
Fix TLS handshake and session bounty issues

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,128 @@
+import struct
+import unittest
+
+from tls_handshake import (
+    EXT_SNI,
+    HandshakeMessage,
+    HandshakeState,
+    HandshakeType,
+    TLSHandshake,
+    VALID_TRANSITIONS,
+)
+
+
+def handshake_record(msg_type, payload):
+    handshake = bytes([msg_type.value]) + len(payload).to_bytes(3, "big") + payload
+    return b"\x16\x03\x03" + len(handshake).to_bytes(2, "big") + handshake
+
+
+def client_hello_payload(extensions=b""):
+    payload = bytearray()
+    payload.extend(b"\x03\x03")
+    payload.extend(b"\x01" * 32)
+    payload.append(0)
+    payload.extend(struct.pack("!H", 2))
+    payload.extend(b"\x00\x2f")
+    payload.append(1)
+    payload.append(0)
+    if extensions:
+        payload.extend(struct.pack("!H", len(extensions)))
+        payload.extend(extensions)
+    return bytes(payload)
+
+
+def sni_extension(hostname):
+    name = hostname.encode("utf-8")
+    server_name = b"\x00" + struct.pack("!H", len(name)) + name
+    body = struct.pack("!H", len(server_name)) + server_name
+    return struct.pack("!HH", EXT_SNI, len(body)) + body
+
+
+class TLSHandshakeTests(unittest.TestCase):
+    def test_client_hello_cannot_transition_directly_to_finished(self):
+        tls = TLSHandshake()
+
+        self.assertEqual(
+            VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO],
+            [HandshakeState.SERVER_HELLO],
+        )
+        ok, _ = tls.process_message(
+            handshake_record(
+                HandshakeType.CLIENT_HELLO,
+                client_hello_payload(),
+            )
+        )
+        self.assertTrue(ok)
+        self.assertFalse(tls.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(tls.state, HandshakeState.ERROR)
+
+    def test_finished_after_client_hello_sets_error(self):
+        tls = TLSHandshake()
+
+        self.assertTrue(
+            tls.process_message(
+                handshake_record(
+                    HandshakeType.CLIENT_HELLO,
+                    client_hello_payload(),
+                )
+            )[0]
+        )
+
+        ok, message = tls.process_message(
+            handshake_record(HandshakeType.FINISHED, b"\x00" * 12)
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(message, "Invalid state for Finished")
+        self.assertEqual(tls.state, HandshakeState.ERROR)
+        self.assertIsNone(tls.master_secret)
+
+    def test_parse_sni_extension_sets_server_name(self):
+        tls = TLSHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_HELLO,
+            client_hello_payload(sni_extension("example.com")),
+        )
+
+        self.assertTrue(tls.parse_client_hello(message))
+
+        self.assertEqual(tls.server_name, "example.com")
+        self.assertEqual(message.extensions[0].server_name, "example.com")
+
+    def test_client_hello_without_sni_leaves_server_name_none(self):
+        tls = TLSHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_HELLO,
+            client_hello_payload(),
+        )
+
+        self.assertTrue(tls.parse_client_hello(message))
+
+        self.assertIsNone(tls.server_name)
+
+    def test_process_key_exchange_returns_false_for_expected_errors(self):
+        tls = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30short")
+
+        self.assertFalse(tls.process_key_exchange(message))
+
+    def test_process_key_exchange_propagates_unexpected_errors(self):
+        tls = TLSHandshake()
+        tls.client_random = b"\x01" * 32
+        tls.server_random = b"\x02" * 32
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x30" + b"x" * 48,
+        )
+
+        def raise_type_error(_):
+            raise TypeError("unexpected")
+
+        tls._decrypt_pre_master_secret = raise_type_error
+
+        with self.assertRaises(TypeError):
+            tls.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,6 +6,7 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
@@ -53,10 +54,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],
@@ -203,9 +201,12 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                server_name = self._parse_sni_extension(ext_data)
+                if server_name is not None:
+                    ext.server_name = server_name
+                    self.server_name = server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +217,34 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_extension(self, data: bytes) -> Optional[str]:
+        """Extract the first host_name entry from an RFC 6066 SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = min(len(data), 2 + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+
+            if offset + name_len > end:
+                return None
+
+            name_bytes = data[offset:offset + name_len]
+            offset += name_len
+
+            if name_type == 0x00:
+                try:
+                    return name_bytes.decode("utf-8")
+                except UnicodeDecodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """
@@ -256,10 +285,9 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error) as exc:
+            logging.getLogger(__name__).debug("key exchange failed: %s", exc)
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of cached sessions before eviction kicks in.
@@ -7,10 +8,7 @@ const MAX_CACHE_SIZE: usize = 4096;
 
 /// Default ticket lifetime in seconds (2 hours).
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
-
-/// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+static NONCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -134,9 +132,7 @@ impl SessionCache {
     ///
     /// Returns the ticket if it exists **and** has not expired.
     pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
-        // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
-        // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+        let ticket = self.cache.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;
@@ -166,10 +162,12 @@ impl SessionCache {
 
     /// Calculate the age of a ticket in seconds.
     fn calculate_ticket_age(&self, ticket: &SessionTicket) -> u64 {
-        // BUG(trap4): subtracts creation_time from issued_at instead of
-        // computing `now - issued_at`.  The result is a fixed delta that
-        // never grows, so tickets effectively never expire.
-        ticket.issued_at.saturating_sub(ticket.creation_time)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        now.saturating_sub(ticket.issued_at)
     }
 
     /// Evict all expired sessions from the map.
@@ -231,10 +229,7 @@ impl SessionCache {
             ));
         }
 
-        // BUG(trap5): uses the constant ENCRYPTION_NONCE for every call
-        // instead of generating a fresh random nonce.  Nonce reuse with
-        // the same key breaks AEAD confidentiality guarantees.
-        let nonce = ENCRYPTION_NONCE;
+        let nonce = Self::generate_nonce();
 
         let key = &self.encryption_key.key_material;
         let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
@@ -247,6 +242,17 @@ impl SessionCache {
         }
 
         Ok(ciphertext)
+    }
+
+    fn generate_nonce() -> [u8; 12] {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_nanos();
+        let counter = NONCE_COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+        let mut nonce = [0_u8; 12];
+        nonce.copy_from_slice(&(now ^ counter).to_be_bytes()[4..]);
+        nonce
     }
 
     /// Decrypt ticket data using the current encryption key.
@@ -295,5 +301,92 @@ impl SessionCache {
             self.encryption_key.key_id,
             self.max_size,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs()
+    }
+
+    fn ticket(ticket_id: &str, issued_at: u64, lifetime_secs: u64) -> SessionTicket {
+        SessionTicket {
+            ticket_id: ticket_id.to_string(),
+            cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+            master_secret: vec![0x42; 48],
+            issued_at,
+            lifetime_secs,
+            encrypted_state: vec![0x99; 48],
+            creation_time: issued_at,
+        }
+    }
+
+    #[test]
+    fn get_session_returns_none_for_missing_ticket() {
+        let cache = SessionCache::new(vec![0x11; 32]);
+
+        assert!(cache.get_session("nonexistent_ticket").is_none());
+    }
+
+    #[test]
+    fn get_session_returns_existing_unexpired_ticket() {
+        let mut cache = SessionCache::new(vec![0x11; 32]);
+        cache
+            .store_session(ticket("tkt_1_12345", now_secs(), DEFAULT_TICKET_LIFETIME_SECS))
+            .unwrap();
+
+        assert!(cache.get_session("tkt_1_12345").is_some());
+    }
+
+    #[test]
+    fn get_session_returns_none_for_expired_ticket() {
+        let mut cache = SessionCache::new(vec![0x11; 32]);
+        cache
+            .store_session(ticket(
+                "expired_ticket",
+                now_secs() - 7201,
+                DEFAULT_TICKET_LIFETIME_SECS,
+            ))
+            .unwrap();
+
+        assert!(cache.get_session("expired_ticket").is_none());
+    }
+
+    #[test]
+    fn calculate_ticket_age_uses_current_time() {
+        let cache = SessionCache::new(vec![0x11; 32]);
+        let old_ticket = ticket(
+            "old_ticket",
+            now_secs() - 7201,
+            DEFAULT_TICKET_LIFETIME_SECS,
+        );
+        let fresh_ticket = ticket(
+            "fresh_ticket",
+            now_secs() - 100,
+            DEFAULT_TICKET_LIFETIME_SECS,
+        );
+
+        assert!(cache.calculate_ticket_age(&old_ticket) >= 7201);
+        assert!(cache.is_ticket_expired(&old_ticket));
+        assert!(!cache.is_ticket_expired(&fresh_ticket));
+    }
+
+    #[test]
+    fn encrypt_ticket_uses_fresh_nonce_and_decrypts() {
+        let cache = SessionCache::new(vec![0x11; 32]);
+        let plaintext = b"session secret";
+
+        let first = cache.encrypt_ticket(plaintext).unwrap();
+        let second = cache.encrypt_ticket(plaintext).unwrap();
+
+        assert_ne!(&first[..12], &second[..12]);
+        assert_eq!(cache.decrypt_ticket(&first).unwrap(), plaintext);
+        assert_eq!(cache.decrypt_ticket(&second).unwrap(), plaintext);
     }
 }


### PR DESCRIPTION
## Issue
Closes #16
Closes #17
Closes #20
Closes #22
Closes #25
Closes #26

## Summary
- Fixed the TLS handshake state machine so `CLIENT_HELLO` can only transition to `SERVER_HELLO`, preventing a direct `CLIENT_HELLO -> FINISHED` bypass.
- Added SNI extension parsing so `server_name` is extracted from `host_name` entries and stored on both the parsed extension and handshake state.
- Replaced silent key exchange exception swallowing with explicit handling for expected parse/validation errors while allowing unexpected exceptions to surface.
- Fixed Rust session lookup so missing tickets return `None` instead of panicking on `unwrap()`.
- Fixed ticket age calculation to use current time minus `issued_at`, allowing expired tickets to expire correctly.
- Replaced the fixed ticket encryption nonce with a fresh nonce for each encryption call.

## Acceptance criteria
- [x] `VALID_TRANSITIONS[CLIENT_HELLO]` contains only `HandshakeState.SERVER_HELLO`
- [x] `transition_to(HandshakeState.FINISHED)` returns `False` when state is `CLIENT_HELLO`
- [x] Attempting `CLIENT_HELLO -> FINISHED` sets state to `HandshakeState.ERROR`
- [x] SNI extension type `0x0000` extracts `example.com` from the extension data
- [x] ClientHello without SNI leaves `server_name` as `None`
- [x] Key exchange returns `False` for malformed payloads without silently swallowing unexpected exceptions
- [x] `get_session("nonexistent_ticket")` returns `None` instead of panicking
- [x] `get_session("tkt_1_12345")` still returns `Some(&ticket)` when the ticket exists and is not expired
- [x] `get_session()` returns `None` for an existing but expired ticket without panicking
- [x] Ticket age is calculated from current time and `issued_at`
- [x] Repeated ticket encryption uses different nonces and remains decryptable
- [x] Added tests covering the fixed bugs

## Test Results
- [x] `python3 -m unittest discover -s python -p 'test_*.py'`
- [x] `python3 -m py_compile python/tls_handshake.py python/test_tls_handshake.py`
- [x] `git diff --check`

Rust tests were added to `rust/tls_session.rs`, but the local environment does not have `rustc`, `cargo`, or `rustfmt` installed, so they require Rust toolchain/CI to run.
