### PR TITLE
[Go] Fix AEAD ordering in SortByPreference

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -214,9 +214,9 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
+		// Prefer AEAD suites over non-AEAD suites.
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,53 @@
+package tlscipher
+
+import "testing"
+
+func TestSortByPreferencePrefersAEADOverNonAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	aead := &CipherSuite{
+		Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		IsAEAD:   true,
+		Strength: StrengthModern,
+		KeySize:  128,
+	}
+	nonAEAD := &CipherSuite{
+		Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+		IsAEAD:   false,
+		Strength: StrengthLegacy,
+		KeySize:  128,
+	}
+
+	sorted := reg.SortByPreference([]*CipherSuite{nonAEAD, aead})
+	if len(sorted) != 2 {
+		t.Fatalf("expected 2 suites, got %d", len(sorted))
+	}
+	if sorted[0] != aead {
+		t.Fatalf("expected AEAD suite first, got %q", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferenceOrdersStrengthWithinAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	modern := &CipherSuite{
+		Name:     "TLS_AES_128_GCM_SHA256",
+		IsAEAD:   true,
+		Strength: StrengthModern,
+		KeySize:  128,
+	}
+	advanced := &CipherSuite{
+		Name:     "TLS_AES_256_GCM_SHA384",
+		IsAEAD:   true,
+		Strength: StrengthAdvanced,
+		KeySize:  256,
+	}
+
+	sorted := reg.SortByPreference([]*CipherSuite{modern, advanced})
+	if len(sorted) != 2 {
+		t.Fatalf("expected 2 suites, got %d", len(sorted))
+	}
+	if sorted[0] != advanced {
+		t.Fatalf("expected StrengthAdvanced suite first, got %q", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
Fixes #14

/claim #14

Summary:
- fix AEAD comparator in SortByPreference so AEAD suites are prioritized over non-AEAD suites
- add regression test that ensures TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 sorts before TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
- add regression test that ensures StrengthAdvanced sorts above StrengthModern among AEAD suites

Verification:
- go test ./... (please run in CI/local with Go installed; Go toolchain is not available in this environment)
