### PR TITLE
fix(#18): replace == with hmac.compare_digest() in verify_finished()

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -234,7 +234,7 @@ class TLSHandshake:
         )
 
         # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""

--- a/tests/test_tls_handshake_python_bounties.py
+++ b/tests/test_tls_handshake_python_bounties.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from tls_handshake import TLSHandshake, hmac  # noqa: E402
+import pytest
+
+
+def test_verify_finished_uses_constant_time_compare(monkeypatch):
+    handshake = TLSHandshake()
+    handshake.master_secret = b"m" * 48
+    expected = handshake._prf(
+        handshake.master_secret,
+        b"server finished",
+        handshake.handshake_hash.copy().digest(),
+        12,
+    )
+    calls = []
+
+    def fake_compare_digest(left, right):
+        calls.append((left, right))
+        return True
+
+    monkeypatch.setattr(hmac, "compare_digest", fake_compare_digest)
+
+    result = handshake.verify_finished(expected, "server finished")
+    assert result is True
+    assert calls == [(expected, expected)]


### PR DESCRIPTION
Fixes #18

## Summary
Replaces `==` comparison with `hmac.compare_digest()` in `verify_finished()` to prevent timing side-channel attacks.

## Verification
- `python -m py_compile python/tls_handshake.py` → passed
- `python -m pytest tests/test_tls_handshake_python_bounties.py -v` → 1 passed
