### PR TITLE
fix(python): use EMS PRF label

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import TLSHandshake
+
+
+class DeriveMasterSecretTests(unittest.TestCase):
+    def make_handshake(self, negotiated_ems):
+        handshake = TLSHandshake()
+        handshake._pre_master_secret = b"p" * 48
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        handshake.negotiated_ems = negotiated_ems
+        return handshake
+
+    def test_ems_uses_extended_master_secret_prf_label(self):
+        handshake = self.make_handshake(negotiated_ems=True)
+
+        with patch.object(
+            handshake, "_prf", return_value=b"m" * 48
+        ) as prf:
+            handshake._derive_master_secret()
+
+        prf.assert_called_once_with(
+            handshake._pre_master_secret,
+            b"extended master secret",
+            handshake.client_random + handshake.server_random,
+            48,
+        )
+        self.assertEqual(handshake.master_secret, b"m" * 48)
+
+    def test_non_ems_keeps_master_secret_prf_label(self):
+        handshake = self.make_handshake(negotiated_ems=False)
+
+        with patch.object(
+            handshake, "_prf", return_value=b"m" * 48
+        ) as prf:
+            handshake._derive_master_secret()
+
+        prf.assert_called_once_with(
+            handshake._pre_master_secret,
+            b"master secret",
+            handshake.client_random + handshake.server_random,
+            48,
+        )
+
+    def test_ems_and_non_ems_master_secrets_differ(self):
+        ems = self.make_handshake(negotiated_ems=True)
+        non_ems = self.make_handshake(negotiated_ems=False)
+
+        ems._derive_master_secret()
+        non_ems._derive_master_secret()
+
+        self.assertEqual(len(ems.master_secret), 48)
+        self.assertEqual(len(non_ems.master_secret), 48)
+        self.assertNotEqual(ems.master_secret, non_ems.master_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -273,7 +273,7 @@ class TLSHandshake:
         if self.negotiated_ems:
             # BUG 5: should use "extended master secret" label per RFC 7627,
             # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Issue
Closes #21
/claim #21

## Summary
Uses the RFC 7627 `extended master secret` PRF label when EMS is negotiated while leaving the standard non-EMS `master secret` label unchanged.

## Acceptance criteria
- [x] When self.negotiated_ems is True, label is b"extended master secret"
- [x] When self.negotiated_ems is False, label remains b"master secret"
- [x] _prf() receives the correct label, producing different 48-byte master_secret values for EMS vs non-EMS
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- python3 -m unittest discover python