### PR TITLE
fix(python): log expected key exchange failures

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,52 @@
+import struct
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class ProcessKeyExchangeTests(unittest.TestCase):
+    def make_message(self, payload):
+        return HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, payload)
+
+    def test_expected_value_error_returns_false_and_logs(self):
+        handshake = TLSHandshake()
+        message = self.make_message(b"\x00")
+
+        with self.assertLogs("tls_handshake", level="WARNING") as logs:
+            self.assertFalse(handshake.process_key_exchange(message))
+
+        self.assertIn("Key exchange failed", logs.output[0])
+        self.assertIn("payload too short", logs.output[0])
+
+    def test_expected_struct_error_returns_false_and_logs(self):
+        handshake = TLSHandshake()
+        message = self.make_message(b"\x00\x30" + b"x" * 48)
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+
+        with patch.object(
+            handshake,
+            "_decrypt_pre_master_secret",
+            side_effect=struct.error("bad structure"),
+        ):
+            with self.assertLogs("tls_handshake", level="WARNING") as logs:
+                self.assertFalse(handshake.process_key_exchange(message))
+
+        self.assertIn("Key exchange failed", logs.output[0])
+
+    def test_unexpected_type_error_propagates(self):
+        handshake = TLSHandshake()
+        message = self.make_message(b"\x00\x30" + b"x" * 48)
+
+        with patch.object(
+            handshake,
+            "_decrypt_pre_master_secret",
+            side_effect=TypeError("unexpected"),
+        ):
+            with self.assertRaises(TypeError):
+                handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,6 +6,7 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
@@ -49,6 +50,8 @@ EXT_EXTENDED_MASTER_SECRET = 0x0017
 EXT_SIGNATURE_ALGORITHMS = 0x000D
 EXT_SUPPORTED_VERSIONS = 0x002B
 EXT_KEY_SHARE = 0x0033
+
+logger = logging.getLogger(__name__)
 
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
@@ -256,9 +259,8 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
+        except (ValueError, struct.error) as exc:
+            logger.warning("Key exchange failed: %s", exc)
         return False
 
     def _derive_master_secret(self) -> None:


### PR DESCRIPTION
## Issue
Closes #20
/claim #20

## Summary
Replaces the bare exception handler in process_key_exchange() with explicit ValueError/struct.error handling, logs expected failures for diagnostics, and lets unexpected exceptions propagate.

## Acceptance criteria
- [x] The bare except is replaced with except (ValueError, struct.error) to catch only expected failures
- [x] Unexpected exceptions (e.g., TypeError, KeyboardInterrupt) propagate normally
- [x] process_key_exchange() still returns False on expected errors, but the error is logged or re-raised for diagnostics
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- python3 -m unittest discover python