### PR TITLE
fix(go): prefer AEAD suites in cipher ordering

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -216,7 +216,7 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,54 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePrefersAEADOverNonAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	sorted := reg.SortByPreference([]*CipherSuite{
+		{
+			ID:       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+			KeySize:  128,
+			IsAEAD:   false,
+			Strength: StrengthLegacy,
+		},
+		{
+			ID:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+	})
+
+	if sorted[0].ID != tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
+		t.Fatalf("expected AEAD suite first, got %s", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferenceOrdersAEADByStrength(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	modern := &CipherSuite{
+		ID:       tls.TLS_AES_128_GCM_SHA256,
+		Name:     "TLS_AES_128_GCM_SHA256",
+		KeySize:  128,
+		IsAEAD:   true,
+		Strength: StrengthModern,
+	}
+	advanced := &CipherSuite{
+		ID:       tls.TLS_AES_256_GCM_SHA384,
+		Name:     "TLS_AES_256_GCM_SHA384",
+		KeySize:  256,
+		IsAEAD:   true,
+		Strength: StrengthAdvanced,
+	}
+
+	sorted := reg.SortByPreference([]*CipherSuite{modern, advanced})
+
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected advanced AEAD suite first, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
## Issue
Closes #14

/claim #14

## Summary
Fixes the Go TLS cipher suite preference comparator so AEAD suites sort before non-AEAD suites, then adds focused regression tests for the issue acceptance criteria.

## Acceptance criteria
- [x] SortByPreference places TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (IsAEAD true) before TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (IsAEAD false).
- [x] Among AEAD-only suites, StrengthAdvanced still sorts above StrengthModern.
- [ ] All existing tests still pass. Could not run locally because this environment does not have the Go toolchain installed (`go`/`gofmt` unavailable).
- [x] Add new tests covering the fixed bugs.

## Verification
- Added `go/tls_cipher_test.go` covering AEAD ordering and AEAD strength ordering.
- Local Go test execution was not possible in this environment because `go` is not installed.