### PR TITLE
fix(python): block client hello finished bypass

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,42 @@
+import struct
+import unittest
+
+from tls_handshake import ContentType, HandshakeState, HandshakeType, TLSHandshake
+
+
+def make_handshake_record(msg_type, payload):
+    handshake_payload = (
+        bytes([msg_type.value]) + len(payload).to_bytes(3, "big") + payload
+    )
+    return (
+        bytes([ContentType.HANDSHAKE.value])
+        + b"\x03\x03"
+        + struct.pack("!H", len(handshake_payload))
+        + handshake_payload
+    )
+
+
+class HandshakeStateMachineTests(unittest.TestCase):
+    def test_client_hello_cannot_transition_directly_to_finished(self):
+        handshake = TLSHandshake()
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+    def test_finished_message_after_client_hello_is_rejected(self):
+        handshake = TLSHandshake()
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+        finished_record = make_handshake_record(
+            HandshakeType.FINISHED, b"\x00" * 12
+        )
+
+        success, status = handshake.process_message(finished_record)
+
+        self.assertFalse(success)
+        self.assertEqual(status, "Invalid state for Finished")
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -53,10 +53,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],


### PR DESCRIPTION
## Issue
Closes #16
/claim #16

## Summary
Removes the invalid CLIENT_HELLO -> FINISHED transition so the handshake cannot skip ServerHello, Certificate, and key exchange. Adds focused regression coverage for direct transition attempts and Finished messages received immediately after ClientHello.

## Acceptance criteria
- [x] VALID_TRANSITIONS[CLIENT_HELLO] contains only [HandshakeState.SERVER_HELLO]
- [x] transition_to(HandshakeState.FINISHED) returns False when state is CLIENT_HELLO
- [x] Attempting CLIENT_HELLO -> FINISHED sets state to HandshakeState.ERROR
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- python3 -m unittest discover python