### PR TITLE
fix(#25): compute ticket age from current time instead of creation_time

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -136,7 +136,7 @@ impl SessionCache {
     pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
         // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
         // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+        let ticket = self.cache.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -136,7 +136,7 @@ impl SessionCache {
     pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
         // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
         // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id)?;
+        let ticket = self.cache.get(ticket_id).unwrap();
 
         if self.is_ticket_expired(ticket) {
             return None;
@@ -166,10 +166,11 @@ impl SessionCache {
 
     /// Calculate the age of a ticket in seconds.
     fn calculate_ticket_age(&self, ticket: &SessionTicket) -> u64 {
-        // BUG(trap4): subtracts creation_time from issued_at instead of
-        // computing `now - issued_at`.  The result is a fixed delta that
-        // never grows, so tickets effectively never expire.
-        ticket.issued_at.saturating_sub(ticket.creation_time)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        now.saturating_sub(ticket.issued_at)
     }
 
     /// Evict all expired sessions from the map.


### PR DESCRIPTION
Fixes #25

Changes `calculate_ticket_age()` to compute `now - issued_at` instead of `issued_at - creation_time`. The old code always returned ~0 because both timestamps were set to the same value, making tickets effectively immortal.

Verified: `rustc` compiles clean