### PR TITLE
fix(#22): replace unwrap() with ? in get_session()

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -136,7 +136,7 @@ impl SessionCache {
     pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
         // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
         // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+        let ticket = self.cache.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;


### PR DESCRIPTION
Fixes #22

Replaces `.unwrap()` with `?` operator in `get_session()` to return `None` instead of panicking when a ticket_id does not exist in the cache.

Verified: `rustc --edition 2021 rust/tls_session.rs --crate-type lib` passes