### PR TITLE
fix(python): parse sni hostnames

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,52 @@
+import struct
+import unittest
+
+from tls_handshake import EXT_SNI, HandshakeMessage, HandshakeType, TLSHandshake
+
+
+def make_extension(ext_type, data):
+    return struct.pack("!HH", ext_type, len(data)) + data
+
+
+def make_sni_payload(hostname):
+    hostname_bytes = hostname.encode("ascii")
+    server_name = b"\x00" + struct.pack("!H", len(hostname_bytes)) + hostname_bytes
+    return struct.pack("!H", len(server_name)) + server_name
+
+
+def make_client_hello_payload(extensions=b""):
+    payload = (
+        b"\x03\x03"
+        + b"c" * 32
+        + b"\x00"
+        + struct.pack("!H", 2)
+        + b"\x00\x2f"
+        + b"\x01\x00"
+    )
+    if extensions:
+        payload += struct.pack("!H", len(extensions)) + extensions
+    return payload
+
+
+class SNIExtensionTests(unittest.TestCase):
+    def test_parse_extensions_decodes_sni_hostname(self):
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(
+            make_extension(EXT_SNI, make_sni_payload("example.com"))
+        )
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_no_sni_extension_leaves_server_name_none(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_HELLO, make_client_hello_payload()
+        )
+
+        self.assertTrue(handshake.parse_client_hello(message))
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,11 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_hostname(ext_data)
+                if ext.server_name is not None:
+                    self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +218,37 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_hostname(self, data: bytes) -> Optional[str]:
+        """Decode the first RFC 6066 host_name entry from an SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        if 2 + list_len > len(data):
+            return None
+
+        offset = 2
+        end = 2 + list_len
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+
+            if offset + name_len > end:
+                return None
+
+            name = data[offset:offset + name_len]
+            offset += name_len
+
+            if name_type == 0x00:
+                try:
+                    return name.decode("ascii")
+                except UnicodeDecodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """


### PR DESCRIPTION
## Issue
Closes #17
/claim #17

## Summary
Adds RFC 6066 SNI host_name parsing in parse_extensions(), storing the decoded hostname on both the extension and TLSHandshake. Adds focused tests for SNI decoding and ClientHello parsing without SNI.

## Acceptance criteria
- [x] parse_extensions() adds an elif branch for EXT_SNI that decodes the SNI list per RFC 6066 (name_type 0x00 = host_name)
- [x] After parsing, ext.server_name and self.server_name equal the decoded hostname string (e.g., "example.com")
- [x] A ClientHello with no SNI extension leaves self.server_name as None
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- python3 -m unittest discover python