### PR TITLE
fix(python): use constant-time Finished verification

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest import mock
+
+from tls_handshake import TLSHandshake
+
+
+class VerifyFinishedTests(unittest.TestCase):
+    def test_verify_finished_uses_constant_time_compare(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"master-secret"
+
+        with mock.patch(
+            "tls_handshake.hmac.compare_digest",
+            return_value=True,
+        ) as compare_digest:
+            self.assertTrue(handshake.verify_finished(b"received-verify", "client finished"))
+
+        compare_digest.assert_called_once()
+        computed_verify, received_verify = compare_digest.call_args.args
+        self.assertEqual(received_verify, b"received-verify")
+        self.assertIsInstance(computed_verify, bytes)
+
+    def test_verify_finished_preserves_bool_result(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"master-secret"
+
+        expected = handshake._prf(
+            handshake.master_secret,
+            b"client finished",
+            handshake.handshake_hash.copy().digest(),
+            12,
+        )
+
+        self.assertTrue(handshake.verify_finished(expected, "client finished"))
+        mismatch = expected[:-1] + bytes([expected[-1] ^ 0x01])
+        self.assertFalse(handshake.verify_finished(mismatch, "client finished"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Issue
Closes #18
/claim #18

## Summary
- Replace the Finished verify-data equality check with `hmac.compare_digest` to avoid short-circuit timing leakage.
- Add focused unittest coverage proving `compare_digest` is used and that matching/mismatching verify data still returns the expected boolean result.

## Verification
- `python3 -m unittest discover python`
- `git diff --check`

## Disclosure
AI-assisted implementation, manually scoped and verified locally.