### PR TITLE
fix(rust): correct rotate_key implementation for issue #24

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -270,6 +270,38 @@ impl SessionCache {
 
         Ok(plaintext)
     }
+
+    /// Rotate the encryption key and re-encrypt all cached tickets.
+    ///
+    /// Creates a new EncryptionKey with key_id incremented by 1, then
+    /// decrypts and re-encrypts every ticket's encrypted_state with the new key.
+    pub fn rotate_key(&mut self, new_material: Vec<u8>) -> Result<(), SessionError> {
+        let old_key = self.encryption_key.clone();
+        let new_key = EncryptionKey::new(old_key.key_id + 1, new_material);
+        
+        // Temporarily swap to new key for re-encryption
+        self.encryption_key = new_key;
+        
+        let inner = Arc::get_mut(&mut self.cache)
+            .ok_or(SessionError::InvalidTicket("cache locked during rotation".to_string()))?;
+        
+        // Re-encrypt all tickets
+        for ticket in inner.values_mut() {
+            // Decrypt with old key
+            let old_encryption_key = self.encryption_key.clone();
+            self.encryption_key = old_key.clone();
+            
+            let plaintext = self.decrypt_ticket(&ticket.encrypted_state)?;
+            
+            // Re-encrypt with new key
+            self.encryption_key = old_encryption_key;
+            let new_ciphertext = self.encrypt_ticket(&plaintext)?;
+            
+            ticket.encrypted_state = new_ciphertext;
+        }
+        
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -295,5 +327,118 @@ impl SessionCache {
             self.encryption_key.key_id,
             self.max_size,
         )
+    }
+}
+
+#[cfg(test)]
+mod test_issue_24 {
+    use super::*;
+
+    fn create_test_cache() -> SessionCache {
+        SessionCache::new(vec![0x42; 32])
+    }
+
+    #[test]
+    fn test_rotate_key_increments_key_id() {
+        let mut cache = create_test_cache();
+        let old_key_id = cache.encryption_key.key_id;
+        
+        cache.rotate_key(vec![0x99; 32]).unwrap();
+        
+        assert_eq!(cache.encryption_key.key_id, old_key_id + 1);
+        println!("✓ rotate_key() increments key_id by 1");
+    }
+
+    #[test]
+    fn test_rotate_key_re_encrypts_all_tickets() {
+        let mut cache = create_test_cache();
+        
+        // Issue a ticket with old key
+        let ticket = cache.issue_ticket(CipherSuite::TlsAes128GcmSha256, vec![0x01; 48]).unwrap();
+        let old_encrypted = ticket.encrypted_state.clone();
+        
+        // Rotate key
+        cache.rotate_key(vec![0x99; 32]).unwrap();
+        
+        // Get ticket and check encrypted_state changed
+        let updated_ticket = cache.get_session(&ticket.ticket_id).unwrap();
+        assert_ne!(updated_ticket.encrypted_state, old_encrypted);
+        println!("✓ rotate_key() re-encrypts all cached tickets");
+    }
+
+    #[test]
+    fn test_decrypt_after_rotation_returns_original_master_secret() {
+        let mut cache = create_test_cache();
+        
+        let original_master_secret = vec![0x01; 48];
+        let ticket = cache.issue_ticket(CipherSuite::TlsAes128GcmSha256, original_master_secret.clone()).unwrap();
+        
+        // Rotate key
+        cache.rotate_key(vec![0x99; 32]).unwrap();
+        
+        // Get ticket and decrypt its encrypted_state
+        let updated_ticket = cache.get_session(&ticket.ticket_id).unwrap();
+        let decrypted = cache.decrypt_ticket(&updated_ticket.encrypted_state).unwrap();
+        
+        assert_eq!(decrypted, original_master_secret);
+        println!("✓ decrypt_ticket() after rotation returns original master_secret");
+    }
+
+    #[test]
+    fn test_rotate_key_on_empty_cache_succeeds() {
+        let mut cache = create_test_cache();
+        
+        let result = cache.rotate_key(vec![0x99; 32]);
+        
+        assert!(result.is_ok());
+        assert_eq!(cache.encryption_key.key_id, 2);
+        println!("✓ rotate_key() on empty cache succeeds without error");
+    }
+
+    #[test]
+    fn test_multiple_rotations() {
+        let mut cache = create_test_cache();
+        
+        let original_master_secret = vec![0xAB; 48];
+        let ticket = cache.issue_ticket(CipherSuite::TlsAes128GcmSha256, original_master_secret.clone()).unwrap();
+        
+        // Rotate twice
+        cache.rotate_key(vec![0x11; 32]).unwrap();
+        cache.rotate_key(vec![0x22; 32]).unwrap();
+        
+        assert_eq!(cache.encryption_key.key_id, 3);
+        
+        let updated_ticket = cache.get_session(&ticket.ticket_id).unwrap();
+        let decrypted = cache.decrypt_ticket(&updated_ticket.encrypted_state).unwrap();
+        
+        assert_eq!(decrypted, original_master_secret);
+        println!("✓ Multiple rotations preserve master_secret integrity");
+    }
+
+    #[test]
+    fn test_rotate_key_with_multiple_tickets() {
+        let mut cache = create_test_cache();
+        
+        let secrets: Vec<Vec<u8>> = vec![
+            vec![0x01; 48],
+            vec![0x02; 48],
+            vec![0x03; 48],
+        ];
+        
+        let mut ticket_ids = vec![];
+        for secret in &secrets {
+            let ticket = cache.issue_ticket(CipherSuite::TlsAes128GcmSha256, secret.clone()).unwrap();
+            ticket_ids.push(ticket.ticket_id);
+        }
+        
+        cache.rotate_key(vec![0xFF; 32]).unwrap();
+        
+        for (i, ticket_id) in ticket_ids.iter().enumerate() {
+            let ticket = cache.get_session(ticket_id).unwrap();
+            let decrypted = cache.decrypt_ticket(&ticket.encrypted_state).unwrap();
+            assert_eq!(decrypted, secrets[i]);
+        }
+        
+        println!("✓ rotate_key() correctly re-encrypts multiple tickets");
     }
 }

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -251,15 +251,52 @@ impl SessionCache {
 
     /// Decrypt ticket data using the current encryption key.
     pub fn decrypt_ticket(&self, ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
+        Self::decrypt_ticket_with_key(ciphertext, &self.encryption_key)
+    }
+
+    fn encrypt_ticket_with_key(
+        plaintext: &[u8],
+        encryption_key: &EncryptionKey,
+    ) -> Result<Vec<u8>, SessionError> {
+        if encryption_key.key_material.is_empty() {
+            return Err(SessionError::EncryptionFailed(
+                "empty key material".to_string(),
+            ));
+        }
+
+        let nonce = ENCRYPTION_NONCE;
+        let key = &encryption_key.key_material;
+        let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
+        ciphertext.extend_from_slice(&nonce);
+
+        for (i, &byte) in plaintext.iter().enumerate() {
+            let key_byte = key[i % key.len()];
+            let nonce_byte = nonce[i % nonce.len()];
+            ciphertext.push(byte ^ key_byte ^ nonce_byte);
+        }
+
+        Ok(ciphertext)
+    }
+
+    fn decrypt_ticket_with_key(
+        ciphertext: &[u8],
+        encryption_key: &EncryptionKey,
+    ) -> Result<Vec<u8>, SessionError> {
         if ciphertext.len() < 12 {
             return Err(SessionError::DecryptionFailed(
                 "ciphertext too short".to_string(),
             ));
         }
 
+        if encryption_key.key_material.is_empty() {
+            return Err(SessionError::DecryptionFailed(
+                "empty key material".to_string(),
+            ));
+        }
+
         let nonce = &ciphertext[..12];
         let data = &ciphertext[12..];
-        let key = &self.encryption_key.key_material;
+        let key = &encryption_key.key_material;
 
         let mut plaintext = Vec::with_capacity(data.len());
         for (i, &byte) in data.iter().enumerate() {
@@ -279,25 +316,26 @@ impl SessionCache {
         let old_key = self.encryption_key.clone();
         let new_key = EncryptionKey::new(old_key.key_id + 1, new_material);
         
-        // Temporarily swap to new key for re-encryption
-        self.encryption_key = new_key;
-        
         let inner = Arc::get_mut(&mut self.cache)
             .ok_or(SessionError::InvalidTicket("cache locked during rotation".to_string()))?;
         
-        // Re-encrypt all tickets
-        for ticket in inner.values_mut() {
-            // Decrypt with old key
-            let old_encryption_key = self.encryption_key.clone();
-            self.encryption_key = old_key.clone();
-            
-            let plaintext = self.decrypt_ticket(&ticket.encrypted_state)?;
-            
-            // Re-encrypt with new key
-            self.encryption_key = old_encryption_key;
-            let new_ciphertext = self.encrypt_ticket(&plaintext)?;
-            
-            ticket.encrypted_state = new_ciphertext;
+        // Step 1: Decrypt all tickets with OLD key and store plaintexts
+        let mut plaintexts: Vec<(String, Vec<u8>)> = Vec::new();
+        for (ticket_id, ticket) in inner.iter() {
+            let plaintext = Self::decrypt_ticket_with_key(&ticket.encrypted_state, &old_key)?;
+            plaintexts.push((ticket_id.clone(), plaintext));
+        }
+        
+        // Step 2: Switch to NEW key
+        self.encryption_key = new_key;
+        
+        // Step 3: Re-encrypt all tickets with NEW key
+        let current_key = self.encryption_key.clone();
+        for (ticket_id, plaintext) in plaintexts {
+            if let Some(ticket) = inner.get_mut(&ticket_id) {
+                let new_ciphertext = Self::encrypt_ticket_with_key(&plaintext, &current_key)?;
+                ticket.encrypted_state = new_ciphertext;
+            }
         }
         
         Ok(())
@@ -426,9 +464,20 @@ mod test_issue_24 {
         ];
         
         let mut ticket_ids = vec![];
-        for secret in &secrets {
-            let ticket = cache.issue_ticket(CipherSuite::TlsAes128GcmSha256, secret.clone()).unwrap();
-            ticket_ids.push(ticket.ticket_id);
+        for (idx, secret) in secrets.iter().enumerate() {
+            let ticket_id = format!("ticket_{}", idx);
+            let encrypted_state = cache.encrypt_ticket(secret).unwrap();
+            let ticket = SessionTicket {
+                ticket_id: ticket_id.clone(),
+                cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+                master_secret: secret.clone(),
+                issued_at: 1,
+                lifetime_secs: DEFAULT_TICKET_LIFETIME_SECS,
+                encrypted_state,
+                creation_time: 1,
+            };
+            cache.store_session(ticket).unwrap();
+            ticket_ids.push(ticket_id);
         }
         
         cache.rotate_key(vec![0xFF; 32]).unwrap();


### PR DESCRIPTION
## Summary

Fixes the `rotate_key()` implementation to correctly decrypt all tickets with the old key before re-encrypting with the new key.

## Changes

- Extract helper functions `encrypt_ticket_with_key` and `decrypt_ticket_with_key` to avoid borrow checker issues
- Implement clear 3-step rotation process:
  1. Decrypt all tickets with OLD key and store plaintexts
  2. Switch to NEW key
  3. Re-encrypt all tickets with NEW key
- Fix `test_rotate_key_with_multiple_tickets` to use unique ticket IDs instead of relying on `issue_ticket()` timestamp-based IDs

## Acceptance Criteria Met

- ✅ `rotate_key(new_material)` creates new EncryptionKey with `key_id + 1`
- ✅ After rotation, `self.encryption_key.key_id` equals old `key_id + 1`
- ✅ Every SessionTicket decrypted with old key, re-encrypted with new key
- ✅ `decrypt_ticket()` after rotation returns original `master_secret` bytes
- ✅ Calling `rotate_key()` on empty cache succeeds without error
- ✅ New tests added covering rotation scenarios

Closes #24

/claim #24
