### PR TITLE
fix(go): return error when no suite matches

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", fmt.Errorf("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,36 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+)
+
+func TestNegotiateSuiteUnknownSuiteReturnsError(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	name, err := registry.NegotiateSuite([]uint16{0xffff})
+
+	if err == nil {
+		t.Fatal("expected an error for unknown suite")
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name, got %q", name)
+	}
+	if !strings.Contains(err.Error(), "no mutually supported cipher suite") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNegotiateSuiteValidSuiteReturnsName(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	name, err := registry.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected suite name: %q", name)
+	}
+}


### PR DESCRIPTION
## Issue
Closes #11
/claim #11

## Summary
Adds an explicit no-match path in NegotiateSuite() so unsupported client cipher suites return an error instead of dereferencing a nil selectedSuite. Adds Go tests for both an unknown suite and a valid TLS_AES_128_GCM_SHA256 negotiation.

## Acceptance criteria
- [x] NegotiateSuite([]uint16{0xFFFF}) returns ("", non-nil error), no panic
- [x] NegotiateSuite with a valid ID like TLS_AES_128_GCM_SHA256 still returns its name
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- GOCACHE=/Users/t800/Desktop/Proj/Tryin/.codex_tmp/go-build GO111MODULE=off go test ./go