### PR TITLE
fix(go): filter rc4 and 3des suites

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,6 +194,9 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
+		if strings.Contains(s.Name, "RC4") || strings.Contains(s.Name, "3DES") {
+			continue
+		}
 		if s.KeySize >= minKeyBits {
 			result = append(result, s)
 		}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,31 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func containsSuite(suites []*CipherSuite, id uint16) bool {
+	for _, suite := range suites {
+		if suite.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFilterWeakSuitesRemovesRC4And3DES(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	filtered := registry.FilterWeakSuites(registry.knownSuites)
+
+	if containsSuite(filtered, 0x0005) {
+		t.Fatal("expected TLS_RSA_WITH_RC4_128_SHA to be filtered")
+	}
+	if containsSuite(filtered, 0x000a) {
+		t.Fatal("expected TLS_RSA_WITH_3DES_EDE_CBC_SHA to be filtered")
+	}
+	if !containsSuite(filtered, tls.TLS_AES_128_GCM_SHA256) {
+		t.Fatal("expected TLS_AES_128_GCM_SHA256 to remain")
+	}
+}


### PR DESCRIPTION
## Issue
Closes #13
/claim #13

## Summary
Updates FilterWeakSuites() to reject RC4 and 3DES suites by algorithm name regardless of key size. Adds a focused Go test that verifies RC4 and 3DES are removed while TLS_AES_128_GCM_SHA256 remains available.

## Acceptance criteria
- [x] FilterWeakSuites removes TLS_RSA_WITH_RC4_128_SHA (ID 0x0005, KeySize 128)
- [x] FilterWeakSuites removes TLS_RSA_WITH_3DES_EDE_CBC_SHA (ID 0x000a, KeySize 168)
- [x] FilterWeakSuites still keeps TLS_AES_128_GCM_SHA256 (KeySize 128, AEAD)
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- GOCACHE=/Users/t800/Desktop/Proj/Tryin/.codex_tmp/go-build GO111MODULE=off go test ./go