### PR TITLE
fix(python): prevent ClientHello to Finished state transition bypass

### DIFF
--- a/python/test_issue_16.py
+++ b/python/test_issue_16.py
@@ -1,0 +1,21 @@
+from tls_handshake import TLSHandshake, HandshakeState, VALID_TRANSITIONS
+
+
+def test_client_hello_only_allows_server_hello():
+    assert VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO] == [HandshakeState.SERVER_HELLO]
+
+
+def test_client_hello_to_finished_is_rejected_and_enters_error():
+    hs = TLSHandshake()
+    hs.state = HandshakeState.CLIENT_HELLO
+
+    result = hs.transition_to(HandshakeState.FINISHED)
+
+    assert result is False
+    assert hs.state == HandshakeState.ERROR
+
+
+if __name__ == "__main__":
+    test_client_hello_only_allows_server_hello()
+    test_client_hello_to_finished_is_rejected_and_enters_error()
+    print("issue #16 tests passed")

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -55,7 +55,6 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
## Summary

Fixes the state machine bypass bug where `VALID_TRANSITIONS[CLIENT_HELLO]` incorrectly included `FINISHED`, allowing clients to skip critical handshake steps.

## Changes

- Remove `HandshakeState.FINISHED` from `VALID_TRANSITIONS[CLIENT_HELLO]`
- Now only `SERVER_HELLO` is allowed after `CLIENT_HELLO`
- Add tests verifying the fix

## Acceptance Criteria Met

- ✅ `VALID_TRANSITIONS[CLIENT_HELLO]` contains only `[HandshakeState.SERVER_HELLO]`
- ✅ `transition_to(HandshakeState.FINISHED)` returns `False` when state is `CLIENT_HELLO`
- ✅ Attempting `CLIENT_HELLO → FINISHED` sets state to `HandshakeState.ERROR`
- ✅ Tests added covering the fixed bug

Closes #16

/claim #16
