### PR TITLE
fix(go): prefer aead suites in sorting

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -214,9 +214,8 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,30 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferenceRanksAEADBeforeNonAEAD(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	nonAEAD := registry.lookupSuite(tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256)
+	aead := registry.lookupSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+
+	sorted := registry.SortByPreference([]*CipherSuite{nonAEAD, aead})
+
+	if sorted[0].ID != aead.ID {
+		t.Fatalf("expected AEAD suite first, got %s", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferenceKeepsStrengthOrderingAmongAEAD(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	modern := registry.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+	advanced := registry.lookupSuite(tls.TLS_AES_256_GCM_SHA384)
+
+	sorted := registry.SortByPreference([]*CipherSuite{modern, advanced})
+
+	if sorted[0].ID != advanced.ID {
+		t.Fatalf("expected advanced AEAD suite first, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
## Issue
Closes #14
/claim #14

## Summary
Fixes SortByPreference() so AEAD suites sort ahead of non-AEAD suites. Adds focused Go tests for AEAD-before-CBC ordering and preserving StrengthAdvanced-before-StrengthModern ordering among AEAD suites.

## Acceptance criteria
- [x] SortByPreference places TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (IsAEAD true) before TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (IsAEAD false)
- [x] Among AEAD-only suites, StrengthAdvanced still sorts above StrengthModern
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- GOCACHE=/Users/t800/Desktop/Proj/Tryin/.codex_tmp/go-build GO111MODULE=off go test ./go