### PR TITLE
fix(python): use constant-time comparison in verify_finished()

### DIFF
--- a/python/test_issue_18.py
+++ b/python/test_issue_18.py
@@ -1,0 +1,33 @@
+from tls_handshake import TLSHandshake
+import hmac
+
+
+def test_verify_finished_uses_compare_digest(monkey_patch=None):
+    calls = []
+    original = hmac.compare_digest
+
+    def spy(a, b):
+        calls.append((a, b))
+        return original(a, b)
+
+    hmac.compare_digest = spy
+    try:
+        hs = TLSHandshake()
+        hs.master_secret = b"m" * 48
+        expected = hs._prf(hs.master_secret, b"client finished", hs.handshake_hash.copy().digest(), 12)
+        assert hs.verify_finished(expected, "client finished") is True
+        assert len(calls) == 1
+    finally:
+        hmac.compare_digest = original
+
+
+def test_verify_finished_returns_false_on_mismatch():
+    hs = TLSHandshake()
+    hs.master_secret = b"m" * 48
+    assert hs.verify_finished(b"x" * 12, "client finished") is False
+
+
+if __name__ == "__main__":
+    test_verify_finished_uses_compare_digest()
+    test_verify_finished_returns_false_on_mismatch()
+    print("issue #18 tests passed")

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Summary

Fixes timing attack vulnerability in `verify_finished()` by replacing `==` with `hmac.compare_digest()`.

## Changes

- Replace `computed_verify == received_verify` with `hmac.compare_digest(computed_verify, received_verify)`
- Add tests verifying constant-time comparison is used

## Acceptance Criteria Met

- ✅ `verify_finished()` uses `hmac.compare_digest()` instead of `==`
- ✅ `hmac` module already imported, no new imports needed
- ✅ Return value still `bool`
- ✅ Tests added covering the fix

Closes #18

/claim #18
