### PR TITLE
fix(python): use correct PRF label for Extended Master Secret

### DIFF
--- a/python/test_issue_21.py
+++ b/python/test_issue_21.py
@@ -1,0 +1,36 @@
+from tls_handshake import TLSHandshake
+
+
+def derive(ems: bool) -> bytes:
+    hs = TLSHandshake()
+    hs._pre_master_secret = b"p" * 48
+    hs.client_random = b"c" * 32
+    hs.server_random = b"s" * 32
+    hs.negotiated_ems = ems
+    hs._derive_master_secret()
+    return hs.master_secret
+
+
+def test_ems_and_non_ems_use_different_prf_labels():
+    ems_secret = derive(True)
+    normal_secret = derive(False)
+    assert len(ems_secret) == 48
+    assert len(normal_secret) == 48
+    assert ems_secret != normal_secret
+
+
+def test_ems_label_matches_extended_master_secret():
+    hs = TLSHandshake()
+    hs._pre_master_secret = b"p" * 48
+    hs.client_random = b"c" * 32
+    hs.server_random = b"s" * 32
+    hs.negotiated_ems = True
+    expected = hs._prf(hs._pre_master_secret, b"extended master secret", hs.client_random + hs.server_random, 48)
+    hs._derive_master_secret()
+    assert hs.master_secret == expected
+
+
+if __name__ == "__main__":
+    test_ems_and_non_ems_use_different_prf_labels()
+    test_ems_label_matches_extended_master_secret()
+    print("issue #21 tests passed")

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Summary

Fixes incorrect PRF label when Extended Master Secret is negotiated per RFC 7627.

## Changes

- When `self.negotiated_ems` is `True`, use `b"extended master secret"` label
- When `False`, use `b"master secret"` label
- Add tests verifying different master secrets are derived

## Acceptance Criteria Met

- ✅ When `self.negotiated_ems` is `True`, label is `b"extended master secret"`
- ✅ When `False`, label remains `b"master secret"`
- ✅ `_prf()` receives correct label, producing different 48-byte values
- ✅ Tests added covering the fix

Closes #21

/claim #21
