### PR TITLE
fix(python): replace bare except with specific exception handling

### DIFF
--- a/python/test_issue_20.py
+++ b/python/test_issue_20.py
@@ -1,0 +1,30 @@
+from tls_handshake import TLSHandshake, HandshakeMessage, HandshakeType
+import struct
+
+
+def test_expected_value_error_returns_false():
+    hs = TLSHandshake()
+    msg = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30short")
+    assert hs.process_key_exchange(msg) is False
+
+
+def test_unexpected_type_error_propagates():
+    hs = TLSHandshake()
+    msg = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30" + b"x" * 48)
+
+    def boom(_):
+        raise TypeError("unexpected bug")
+
+    hs._decrypt_pre_master_secret = boom
+    try:
+        hs.process_key_exchange(msg)
+    except TypeError as exc:
+        assert "unexpected bug" in str(exc)
+    else:
+        raise AssertionError("TypeError should propagate")
+
+
+if __name__ == "__main__":
+    test_expected_value_error_returns_false()
+    test_unexpected_type_error_propagates()
+    print("issue #20 tests passed")

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -256,10 +256,9 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error) as exc:
+            print(f"key exchange failed: {exc}")
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
## Summary

Fixes silent exception swallowing in `process_key_exchange()` by replacing bare `except: pass` with specific exception handling.

## Changes

- Replace bare `except` with `except (ValueError, struct.error) as exc`
- Log error message before returning `False`
- Allow unexpected exceptions to propagate normally
- Add tests verifying expected errors return `False` and unexpected errors propagate

## Acceptance Criteria Met

- ✅ Bare except replaced with `except (ValueError, struct.error)`
- ✅ Unexpected exceptions (TypeError, KeyboardInterrupt) propagate normally
- ✅ `process_key_exchange()` still returns `False` on expected errors
- ✅ Error is logged for diagnostics
- ✅ Tests added covering the fix

Closes #20

/claim #20
