### PR TITLE
fix(go): guard suite cache lookup

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -137,8 +137,10 @@ func (r *SuiteRegistry) loadDefaults() {
 
 // lookupSuite retrieves a suite from the cache, falling back to a linear
 // scan of knownSuites. Results are cached for faster repeated lookups.
-// BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,42 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestConcurrentLookupProtectsSuiteCache(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	ids := make([]uint16, 100)
+	for i := range ids {
+		ids[i] = tls.TLS_AES_128_GCM_SHA256
+	}
+
+	results, err := registry.ConcurrentLookup(ids)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != len(ids) {
+		t.Fatalf("expected %d results, got %d", len(ids), len(results))
+	}
+	for i, suite := range results {
+		if suite == nil || suite.ID != tls.TLS_AES_128_GCM_SHA256 {
+			t.Fatalf("unexpected suite at index %d: %#v", i, suite)
+		}
+	}
+}
+
+func TestLookupSuiteUsesCacheForKnownSuite(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	first := registry.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+	second := registry.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+
+	if first == nil {
+		t.Fatal("expected suite lookup to succeed")
+	}
+	if first != second {
+		t.Fatal("expected repeated lookup to return cached suite pointer")
+	}
+}


### PR DESCRIPTION
## Issue
Closes #15
/claim #15

## Summary
Protects lookupSuite() cache reads and writes with the registry mutex so ConcurrentLookup() no longer races on suiteCache. Adds tests for 100 concurrent lookups and cached lookups returning TLS_AES_128_GCM_SHA256.

## Acceptance criteria
- [x] Running ConcurrentLookup with 100 goroutines under go test -race produces no race warnings
- [x] lookupSuite acquires r.mu before reading or writing r.suiteCache
- [x] Cached lookups still return correct results (e.g., ID 0x1301 returns TLS_AES_128_GCM_SHA256)
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- GOCACHE=/Users/t800/Desktop/Proj/Tryin/.codex_tmp/go-build GO111MODULE=off go test ./go
- GOCACHE=/Users/t800/Desktop/Proj/Tryin/.codex_tmp/go-build GO111MODULE=off go test -race ./go