### PR TITLE
fix(assembly): terminate alert messages

### DIFF
--- a/assembly/test_tls_record_parser.py
+++ b/assembly/test_tls_record_parser.py
@@ -1,0 +1,32 @@
+import re
+from pathlib import Path
+import unittest
+
+
+ASM_SOURCE = Path(__file__).with_name("tls_record_parser.asm")
+
+
+class AlertStringTerminationTests(unittest.TestCase):
+    def setUp(self):
+        self.source = ASM_SOURCE.read_text(encoding="utf-8")
+
+    def _db_line_for(self, label):
+        match = re.search(rf"^\s*{label}\s+db\s+(.+)$", self.source, re.MULTILINE)
+        self.assertIsNotNone(match, f"{label} definition not found")
+        return match.group(1)
+
+    def test_warning_alert_string_is_newline_and_null_terminated(self):
+        self.assertEqual(
+            self._db_line_for("err_alert_warning"),
+            '"WARNING: alert received from peer", 10, 0',
+        )
+
+    def test_fatal_alert_string_still_stops_before_warning_message(self):
+        self.assertEqual(
+            self._db_line_for("err_alert_fatal"),
+            '"FATAL ALERT received from peer", 10, 0',
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -24,8 +24,8 @@ section .data
     ; --- Error strings ---
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
-    err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_fatal     db "FATAL ALERT received from peer", 10, 0
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---


### PR DESCRIPTION
## Issue
Closes #5
/claim #5

## Summary
- Add newline and NUL terminators to the assembly fatal and warning alert messages so `print_string` stops before the next data label.
- Add source-level unittest coverage for both alert message definitions, including the warning message regression.

## Verification
- `python3 -m unittest assembly/test_tls_record_parser.py`
- `git diff --check`

## Disclosure
AI-assisted implementation, manually scoped and verified locally.