### PR TITLE
fix(python): add SNI extension parsing in parse_extensions()

### DIFF
--- a/python/test_issue_17.py
+++ b/python/test_issue_17.py
@@ -1,0 +1,29 @@
+from tls_handshake import TLSHandshake, EXT_SNI
+import struct
+
+
+def build_sni_ext(hostname: str) -> bytes:
+    host = hostname.encode("ascii")
+    server_name = b"\x00" + struct.pack("!H", len(host)) + host
+    sni_list = struct.pack("!H", len(server_name)) + server_name
+    return struct.pack("!HH", EXT_SNI, len(sni_list)) + sni_list
+
+
+def test_parse_extensions_decodes_sni_hostname():
+    hs = TLSHandshake()
+    extensions = hs.parse_extensions(build_sni_ext("example.com"))
+    assert extensions[0].server_name == "example.com"
+    assert hs.server_name == "example.com"
+
+
+def test_no_sni_leaves_server_name_none():
+    hs = TLSHandshake()
+    # Extended master secret extension with zero-length data
+    hs.parse_extensions(struct.pack("!HH", 0x0017, 0))
+    assert hs.server_name is None
+
+
+if __name__ == "__main__":
+    test_parse_extensions_decodes_sni_hostname()
+    test_no_sni_leaves_server_name_none()
+    print("issue #17 tests passed")

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,27 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                if len(ext_data) >= 2:
+                    list_len = struct.unpack("!H", ext_data[:2])[0]
+                    pos = 2
+                    end = min(2 + list_len, len(ext_data))
+                    while pos + 3 <= end:
+                        name_type = ext_data[pos]
+                        name_len = struct.unpack("!H", ext_data[pos + 1:pos + 3])[0]
+                        pos += 3
+                        if pos + name_len > end:
+                            break
+                        name_bytes = ext_data[pos:pos + name_len]
+                        pos += name_len
+                        if name_type == 0x00:
+                            try:
+                                ext.server_name = name_bytes.decode("ascii")
+                                self.server_name = ext.server_name
+                            except UnicodeDecodeError:
+                                ext.server_name = None
+                            break
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use


### PR DESCRIPTION
## Summary

Adds SNI (Server Name Indication) extension parsing to decode hostname from ClientHello per RFC 6066.

## Changes

- Add `elif` branch for `EXT_SNI` (0x0000) in `parse_extensions()`
- Decode SNI list with name_type 0x00 (host_name)
- Set `ext.server_name` and `self.server_name` to decoded hostname string
- Handle missing SNI extension (leaves `server_name` as `None`)
- Add tests verifying SNI parsing and None fallback

## Acceptance Criteria Met

- ✅ `parse_extensions()` adds `elif` branch for `EXT_SNI`
- ✅ After parsing, `ext.server_name` and `self.server_name` equal decoded hostname
- ✅ ClientHello with no SNI extension leaves `self.server_name` as `None`
- ✅ Tests added covering the fix

Closes #17

/claim #17
