### PR TITLE
fix(python): decode SNI extension server_name per RFC 6066

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,59 @@
+"""Regression tests for parse_extensions() SNI handling (issue #17)."""
+
+import struct
+import unittest
+
+from tls_handshake import EXT_SNI, EXT_EXTENDED_MASTER_SECRET, TLSHandshake
+
+
+def _build_sni_extension(hostname: str) -> bytes:
+    name_bytes = hostname.encode("ascii")
+    server_name = bytes([0x00]) + struct.pack("!H", len(name_bytes)) + name_bytes
+    server_name_list = struct.pack("!H", len(server_name)) + server_name
+    ext_header = struct.pack("!HH", EXT_SNI, len(server_name_list))
+    return ext_header + server_name_list
+
+
+def _build_ems_extension() -> bytes:
+    return struct.pack("!HH", EXT_EXTENDED_MASTER_SECRET, 0)
+
+
+class ParseExtensionsSNITests(unittest.TestCase):
+    def test_sni_hostname_decoded(self):
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(_build_sni_extension("example.com"))
+
+        self.assertEqual(handshake.server_name, "example.com")
+        sni_ext = next(ext for ext in extensions if ext.ext_type == EXT_SNI)
+        self.assertEqual(sni_ext.server_name, "example.com")
+
+    def test_no_sni_leaves_server_name_none(self):
+        handshake = TLSHandshake()
+        handshake.parse_extensions(_build_ems_extension())
+
+        self.assertIsNone(handshake.server_name)
+        self.assertTrue(handshake.negotiated_ems)
+
+    def test_non_host_name_entry_ignored(self):
+        # name_type 0x01 is reserved and must not populate server_name.
+        custom_entry = bytes([0x01]) + struct.pack("!H", 4) + b"\x00\x01\x02\x03"
+        list_payload = struct.pack("!H", len(custom_entry)) + custom_entry
+        ext_data = struct.pack("!HH", EXT_SNI, len(list_payload)) + list_payload
+
+        handshake = TLSHandshake()
+        handshake.parse_extensions(ext_data)
+
+        self.assertIsNone(handshake.server_name)
+
+    def test_sni_alongside_ems(self):
+        handshake = TLSHandshake()
+        handshake.parse_extensions(
+            _build_sni_extension("api.example.org") + _build_ems_extension()
+        )
+
+        self.assertEqual(handshake.server_name, "api.example.org")
+        self.assertTrue(handshake.negotiated_ems)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,31 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                # Decode ServerNameList per RFC 6066 §3.
+                if len(ext_data) >= 2:
+                    list_len = struct.unpack("!H", ext_data[:2])[0]
+                    list_data = ext_data[2:2 + list_len]
+                    sub_offset = 0
+                    while sub_offset + 3 <= len(list_data):
+                        name_type = list_data[sub_offset]
+                        name_len = struct.unpack(
+                            "!H", list_data[sub_offset + 1:sub_offset + 3]
+                        )[0]
+                        sub_offset += 3
+                        if sub_offset + name_len > len(list_data):
+                            break
+                        if name_type == 0x00:  # host_name
+                            try:
+                                hostname = list_data[
+                                    sub_offset:sub_offset + name_len
+                                ].decode("ascii")
+                                ext.server_name = hostname
+                                self.server_name = hostname
+                            except UnicodeDecodeError:
+                                pass
+                        sub_offset += name_len
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use


### PR DESCRIPTION
## Issue
Closes #17
/claim #17

## Summary
- Add a parse_extensions() branch for EXT_SNI (0x0000) that walks the ServerNameList per RFC 6066 §3 and decodes the first host_name entry.
- The decoded hostname is stored on both the TLSExtension instance (ext.server_name) and the parent TLSHandshake (self.server_name).
- Non-host_name name_types and empty SNI extensions leave self.server_name as None.

## Verification
- python3 -m unittest discover python
  (4 tests: SNI decoded, no-SNI keeps None, non-host_name ignored, SNI + EMS coexist)

## Disclosure
AI-assisted patch, manually reviewed and exercised locally with the included regression tests.