### PR TITLE
feat(go): prefer chacha without aesni

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -219,6 +219,14 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 			return !si.IsAEAD && sj.IsAEAD
 		}
 
+		if si.Strength == sj.Strength && !hasAESNI() {
+			siChaCha := strings.Contains(si.Name, "CHACHA20")
+			sjChaCha := strings.Contains(sj.Name, "CHACHA20")
+			if siChaCha != sjChaCha {
+				return siChaCha
+			}
+		}
+
 		// Higher strength first
 		if si.Strength != sj.Strength {
 			return si.Strength > sj.Strength
@@ -280,6 +288,8 @@ func (r *SuiteRegistry) SuiteNames(ids []uint16) []string {
 func HasAESNI() bool {
 	return runtime.GOARCH == "amd64"
 }
+
+var hasAESNI = HasAESNI
 
 // FormatSuite returns a human-readable summary string for a suite.
 func FormatSuite(s *CipherSuite) string {

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,41 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func withAESNI(value bool, fn func()) {
+	original := hasAESNI
+	hasAESNI = func() bool { return value }
+	defer func() { hasAESNI = original }()
+	fn()
+}
+
+func TestSortByPreferencePrefersChaChaWithoutAESNI(t *testing.T) {
+	withAESNI(false, func() {
+		registry := NewSuiteRegistry(StrengthWeak)
+		aes := registry.lookupSuite(tls.TLS_AES_256_GCM_SHA384)
+		chacha := registry.lookupSuite(tls.TLS_CHACHA20_POLY1305_SHA256)
+
+		sorted := registry.SortByPreference([]*CipherSuite{aes, chacha})
+
+		if sorted[0].ID != chacha.ID {
+			t.Fatalf("expected ChaCha20 first without AES-NI, got %s", sorted[0].Name)
+		}
+	})
+}
+
+func TestSortByPreferencePreservesAESOrderingWithAESNI(t *testing.T) {
+	withAESNI(true, func() {
+		registry := NewSuiteRegistry(StrengthWeak)
+		aes := registry.lookupSuite(tls.TLS_AES_256_GCM_SHA384)
+		chacha := registry.lookupSuite(tls.TLS_CHACHA20_POLY1305_SHA256)
+
+		sorted := registry.SortByPreference([]*CipherSuite{aes, chacha})
+
+		if sorted[0].ID != aes.ID {
+			t.Fatalf("expected AES-GCM first with AES-NI, got %s", sorted[0].Name)
+		}
+	})
+}


### PR DESCRIPTION
## Issue
Closes #12
/claim #12

## Summary
Adds a ChaCha20 preference tie-breaker in SortByPreference() when AES acceleration is unavailable, while preserving the existing AES-GCM ordering when AES-NI is available. Adds Go tests for both no-AESNI and AESNI paths.

## Acceptance criteria
- [x] On arm64 (HasAESNI() == false), SortByPreference places TLS_CHACHA20_POLY1305_SHA256 before TLS_AES_256_GCM_SHA384 even though both are StrengthAdvanced
- [x] On amd64 (HasAESNI() == true), the original ordering is preserved
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- GOCACHE=/Users/t800/Desktop/Proj/Tryin/.codex_tmp/go-build GO111MODULE=off go test ./go