### PR TITLE
fix(python): use distinct PRF label for Extended Master Secret

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,58 @@
+"""Regression tests for _derive_master_secret() EMS label (issue #21)."""
+
+import unittest
+
+from tls_handshake import TLSHandshake
+
+
+class DeriveMasterSecretLabelTests(unittest.TestCase):
+    def _prepare(self, ems: bool) -> TLSHandshake:
+        handshake = TLSHandshake()
+        handshake._pre_master_secret = b"\x42" * 48
+        handshake.client_random = b"\x01" * 32
+        handshake.server_random = b"\x02" * 32
+        handshake.negotiated_ems = ems
+        return handshake
+
+    def test_non_ems_path_uses_master_secret_label(self):
+        handshake = self._prepare(ems=False)
+        captured = {}
+        original_prf = handshake._prf
+
+        def capturing_prf(secret, label, seed, length):
+            captured["label"] = label
+            return original_prf(secret, label, seed, length)
+
+        handshake._prf = capturing_prf
+        handshake._derive_master_secret()
+
+        self.assertEqual(captured["label"], b"master secret")
+        self.assertEqual(len(handshake.master_secret), 48)
+
+    def test_ems_path_uses_extended_master_secret_label(self):
+        handshake = self._prepare(ems=True)
+        captured = {}
+        original_prf = handshake._prf
+
+        def capturing_prf(secret, label, seed, length):
+            captured["label"] = label
+            return original_prf(secret, label, seed, length)
+
+        handshake._prf = capturing_prf
+        handshake._derive_master_secret()
+
+        self.assertEqual(captured["label"], b"extended master secret")
+        self.assertEqual(len(handshake.master_secret), 48)
+
+    def test_ems_and_non_ems_produce_distinct_master_secrets(self):
+        non_ems = self._prepare(ems=False)
+        non_ems._derive_master_secret()
+
+        ems = self._prepare(ems=True)
+        ems._derive_master_secret()
+
+        self.assertNotEqual(non_ems.master_secret, ems.master_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Issue
Closes #21
/claim #21

## Summary
- _derive_master_secret() now selects b"extended master secret" when self.negotiated_ems is True and b"master secret" otherwise, matching RFC 7627 §4 vs RFC 5246 §8.1.
- The PRF now receives the correct label so the EMS and non-EMS code paths produce distinct 48-byte master_secret values, fixing the silent equivalence between the two modes.

## Verification
- python3 -m unittest discover python
  (3 tests: non-EMS label captured, EMS label captured, EMS vs non-EMS master_secret are distinct)

## Disclosure
AI-assisted patch, manually reviewed and exercised locally with the included regression tests.