### PR TITLE
fix(c): log cert cleanup before free

### DIFF
--- a/c/test_tls_cert_validator.c
+++ b/c/test_tls_cert_validator.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tls_cert_validator.c"
+
+static cert_entry_t *make_entry(const char *issuer)
+{
+    cert_entry_t *entry = calloc(1, sizeof(cert_entry_t));
+    if (!entry)
+        return NULL;
+
+    entry->subject = strdup("subject");
+    entry->issuer = strdup(issuer);
+    if (!entry->subject || !entry->issuer) {
+        free(entry->subject);
+        free(entry->issuer);
+        free(entry);
+        return NULL;
+    }
+
+    return entry;
+}
+
+int main(void)
+{
+    cert_store_t store = {0};
+    const char *issuers[] = {"issuer-a", "issuer-b", "issuer-c"};
+
+    g_log_level = LOG_LEVEL_DEBUG;
+    for (size_t i = 0; i < 3; i++) {
+        cert_entry_t *entry = make_entry(issuers[i]);
+        if (!entry)
+            return 1;
+
+        entry->next = store.head;
+        store.head = entry;
+        store.count++;
+    }
+
+    cleanup_cert_store(&store);
+    if (store.head != NULL || store.count != 0) {
+        fprintf(stderr, "store was not fully cleaned up\n");
+        return 1;
+    }
+
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -188,10 +188,10 @@ static void cleanup_cert_store(cert_store_t *store)
     entry = store->head;
     while (entry) {
         next = entry->next;
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         X509_free(entry->cert);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }


### PR DESCRIPTION
## Issue
Closes #10
/claim #10

## Summary
Moves the cleanup debug log before freeing entry->issuer/entry->subject so the issuer string is still valid when logged. Adds a small C regression harness that creates three entries, enables debug logging, and runs cleanup under AddressSanitizer.

## Acceptance criteria
- [x] log_cert_event() executes before free(entry->issuer), so the pointer is still valid when dereferenced
- [x] Running cleanup_cert_store() with g_log_level = LOG_LEVEL_DEBUG on a store with 3 entries prints all 3 issuer strings without accessing freed memory
- [x] AddressSanitizer reports zero use-after-free errors during cleanup_cert_store()
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- cc -fsanitize=address -I/opt/homebrew/opt/openssl@3/include c/test_tls_cert_validator.c -L/opt/homebrew/opt/openssl@3/lib -lcrypto -o /Users/t800/Desktop/Proj/Tryin/.codex_tmp/test_tls_cert_validator
- /Users/t800/Desktop/Proj/Tryin/.codex_tmp/test_tls_cert_validator