### PR TITLE
fix(python): use correct PRF label for Extended Master Secret (RFC 7627)

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -273,7 +273,7 @@ class TLSHandshake:
         if self.negotiated_ems:
             # BUG 5: should use "extended master secret" label per RFC 7627,
             # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
/claim #21

When `negotiated_ems` is True, `_derive_master_secret()` was using `b"master secret"` for both EMS and non-EMS paths. Per RFC 7627, the EMS path must use `b"extended master secret"` to produce a different master_secret that binds to the full handshake transcript.

Fixes UnsafeLabs/Bounty-Hunters#21