### PR TITLE
Fix constant-time fingerprint comparison

### DIFF
--- a/c/test_match_fingerprint.c
+++ b/c/test_match_fingerprint.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "tls_cert_validator.c"
+
+int main(void)
+{
+    unsigned char expected[FINGERPRINT_LEN];
+    unsigned char same[FINGERPRINT_LEN];
+    unsigned char different[FINGERPRINT_LEN];
+
+    memset(expected, 0x41, sizeof(expected));
+    memcpy(same, expected, sizeof(same));
+    memcpy(different, expected, sizeof(different));
+    different[FINGERPRINT_LEN - 1] ^= 0xff;
+
+    if (match_fingerprint(expected, same) != 0) {
+        fprintf(stderr, "matching fingerprints must return 0\n");
+        return 1;
+    }
+
+    if (match_fingerprint(expected, different) == 0) {
+        fprintf(stderr, "different fingerprints must return nonzero\n");
+        return 1;
+    }
+
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN);
 }
 
 static int check_expiry(X509 *cert)
@@ -169,7 +169,7 @@ static int validate_chain(chain_context_t *ctx)
     if (ctx->pinned_fingerprint) {
         if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0)
             return CERT_STATUS_INVALID;
-        if (!match_fingerprint(fp, ctx->pinned_fingerprint)) {
+        if (match_fingerprint(fp, ctx->pinned_fingerprint) != 0) {
             log_cert_event(LOG_LEVEL_ERROR, "leaf fingerprint mismatch");
             return CERT_STATUS_UNTRUSTED;
         }


### PR DESCRIPTION
/claim #6

Fixes #6

## Summary
- Replace `memcmp` with OpenSSL `CRYPTO_memcmp` in `match_fingerprint`.
- Preserve the issue's nonzero-means-mismatch contract and update `validate_chain` to reject nonzero results.
- Add a focused C regression harness for matching and mismatching fingerprints.

## Verification
- `cc -Wall -Wextra -Wno-unused-function -I/opt/homebrew/opt/openssl@3/include c/test_match_fingerprint.c -L/opt/homebrew/opt/openssl@3/lib -lcrypto -o /tmp/test_match_fingerprint`
- `/tmp/test_match_fingerprint`
- `git diff --check`