### PR TITLE
fix(go): handle no matching cipher suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,30 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteReturnsErrorWhenNoSuiteMatches(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	name, err := reg.NegotiateSuite([]uint16{0xffff})
+	if err == nil {
+		t.Fatal("expected unsupported client suite to return an error")
+	}
+	if name != "" {
+		t.Fatalf("expected no selected suite, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteKeepsValidSuite(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("expected valid suite to negotiate: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected suite %q", name)
+	}
+}


### PR DESCRIPTION
Fixes #11
/claim #11

Summary:
- Return a normal error when no client cipher suite matches instead of dereferencing nil.
- Add regression coverage for unsupported and valid suite negotiation.

Verification:
- go test ./go