### PR TITLE
fix(go): prefer chacha20 suites without aes-ni

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -47,6 +47,8 @@ type SuiteRegistry struct {
 	mu          sync.Mutex              // guards knownSuites only
 }
 
+var hasAESNI = HasAESNI
+
 // NewSuiteRegistry creates a registry pre-loaded with common cipher suites.
 func NewSuiteRegistry(minStrength CipherStrength) *SuiteRegistry {
 	reg := &SuiteRegistry{
@@ -222,6 +224,14 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 		// Higher strength first
 		if si.Strength != sj.Strength {
 			return si.Strength > sj.Strength
+		}
+
+		if si.Strength == sj.Strength && !hasAESNI() {
+			siChaCha := strings.Contains(si.Name, "CHACHA20")
+			sjChaCha := strings.Contains(sj.Name, "CHACHA20")
+			if siChaCha != sjChaCha {
+				return siChaCha
+			}
 		}
 
 		// Larger key size breaks ties

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,64 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePrefersChaCha20WithoutAESNI(t *testing.T) {
+	original := hasAESNI
+	hasAESNI = func() bool { return false }
+	defer func() { hasAESNI = original }()
+
+	reg := NewSuiteRegistry(StrengthModern)
+
+	sorted := reg.SortByPreference([]*CipherSuite{
+		{
+			ID:       tls.TLS_AES_256_GCM_SHA384,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+		{
+			ID:       tls.TLS_CHACHA20_POLY1305_SHA256,
+			Name:     "TLS_CHACHA20_POLY1305_SHA256",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	})
+
+	if sorted[0].ID != tls.TLS_CHACHA20_POLY1305_SHA256 {
+		t.Fatalf("expected ChaCha20 first without AES-NI, got %s", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferencePreservesAESPreferenceWithAESNI(t *testing.T) {
+	original := hasAESNI
+	hasAESNI = func() bool { return true }
+	defer func() { hasAESNI = original }()
+
+	reg := NewSuiteRegistry(StrengthModern)
+
+	sorted := reg.SortByPreference([]*CipherSuite{
+		{
+			ID:       tls.TLS_AES_256_GCM_SHA384,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+		{
+			ID:       tls.TLS_CHACHA20_POLY1305_SHA256,
+			Name:     "TLS_CHACHA20_POLY1305_SHA256",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	})
+
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected original AES-first ordering with AES-NI, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
Fixes #12
/claim #12

Summary:
- Prefer ChaCha20-Poly1305 over AES-GCM when AES acceleration is unavailable.
- Add regression coverage for AES-NI and non-AES-NI ordering.

Verification:
- go test ./go