### PR TITLE
fix(go): filter legacy rc4 and 3des suites

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,7 +194,9 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
+		if s.KeySize >= minKeyBits &&
+			!strings.Contains(s.Name, "RC4") &&
+			!strings.Contains(s.Name, "3DES") {
 			result = append(result, s)
 		}
 	}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,36 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestFilterWeakSuitesRejectsRC4And3DES(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	filtered := reg.FilterWeakSuites([]*CipherSuite{
+		{
+			ID:      0x0005,
+			Name:    "TLS_RSA_WITH_RC4_128_SHA",
+			KeySize: 128,
+		},
+		{
+			ID:      0x000a,
+			Name:    "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+			KeySize: 168,
+		},
+		{
+			ID:      tls.TLS_AES_128_GCM_SHA256,
+			Name:    "TLS_AES_128_GCM_SHA256",
+			KeySize: 128,
+			IsAEAD:  true,
+		},
+	})
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected one modern suite to remain, got %d", len(filtered))
+	}
+	if filtered[0].ID != tls.TLS_AES_128_GCM_SHA256 {
+		t.Fatalf("expected AES-GCM suite to remain, got %s", filtered[0].Name)
+	}
+}


### PR DESCRIPTION
Fixes #13
/claim #13

Summary:
- Reject RC4 and 3DES cipher suites during server preference filtering.
- Add regression coverage for legacy and modern suite selection.

Verification:
- go test ./go