### PR TITLE
fix(go): order aead suites ahead of cbc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -216,7 +216,7 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,31 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePrefersAEADBeforeCBC(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+
+	sorted := reg.SortByPreference([]*CipherSuite{
+		{
+			ID:       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+			KeySize:  128,
+			IsAEAD:   false,
+			Strength: StrengthLegacy,
+		},
+		{
+			ID:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+	})
+
+	if !sorted[0].IsAEAD {
+		t.Fatalf("expected AEAD suite first, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
Fixes #14
/claim #14

Summary:
- Correct the AEAD comparator so AEAD suites rank ahead of CBC suites.
- Add regression coverage for AEAD suite ordering.

Verification:
- go test ./go