### PR TITLE
fix(go): guard suite cache with a mutex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -43,8 +43,8 @@ type SuiteRegistry struct {
 	knownSuites []*CipherSuite
 	minStrength CipherStrength
 	preferredID uint16
-	suiteCache  map[uint16]*CipherSuite // BUG(5): unprotected shared cache
-	mu          sync.Mutex              // guards knownSuites only
+	suiteCache  map[uint16]*CipherSuite
+	mu          sync.RWMutex
 }
 
 // NewSuiteRegistry creates a registry pre-loaded with common cipher suites.
@@ -137,12 +137,20 @@ func (r *SuiteRegistry) loadDefaults() {
 
 // lookupSuite retrieves a suite from the cache, falling back to a linear
 // scan of knownSuites. Results are cached for faster repeated lookups.
-// BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.RLock()
+	if cached, ok := r.suiteCache[id]; ok {
+		r.mu.RUnlock()
+		return cached
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}
-
 	for _, s := range r.knownSuites {
 		if s.ID == id {
 			r.suiteCache[id] = s

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,29 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"sync"
+	"testing"
+)
+
+func TestConcurrentLookupDoesNotRaceOrFail(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthModern)
+	ids := []uint16{
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := reg.ConcurrentLookup(ids); err != nil {
+				t.Errorf("ConcurrentLookup returned error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #15
/claim #15

Summary:
- Protect suiteCache reads and writes with a RWMutex.
- Add concurrent access regression coverage.

Verification:
- go test ./go