### PR TITLE
Filter RC4 and 3DES cipher suites

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,9 +194,11 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
-			result = append(result, s)
+		name := strings.ToUpper(s.Name)
+		if s.KeySize < minKeyBits || strings.Contains(name, "RC4") || strings.Contains(name, "3DES") {
+			continue
 		}
+		result = append(result, s)
 	}
 	return result
 }

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,23 @@
+package tlscipher
+
+import "testing"
+
+func TestFilterWeakSuitesRejectsRC4And3DES(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	filtered := registry.FilterWeakSuites(registry.knownSuites)
+	names := make(map[string]bool, len(filtered))
+	for _, suite := range filtered {
+		names[suite.Name] = true
+	}
+
+	if names["TLS_RSA_WITH_RC4_128_SHA"] {
+		t.Fatal("RC4 suite should be filtered even with a 128-bit key")
+	}
+	if names["TLS_RSA_WITH_3DES_EDE_CBC_SHA"] {
+		t.Fatal("3DES suite should be filtered even with a 168-bit key")
+	}
+	if !names["TLS_AES_128_GCM_SHA256"] {
+		t.Fatal("modern TLS_AES_128_GCM_SHA256 suite should remain allowed")
+	}
+}


### PR DESCRIPTION
## Summary
- reject RC4 and 3DES suites in FilterWeakSuites regardless of nominal key size
- keep modern TLS_AES_128_GCM_SHA256 allowed
- add focused Go regression coverage for the weak and allowed suites

## Verification
- `cd go && GO111MODULE=off go test ./...`
- `git diff --check`

Fixes #13
/claim #13