### PR TITLE
fix(python): reject direct finished transition

### DIFF
--- a/python/test_state_transitions.py
+++ b/python/test_state_transitions.py
@@ -1,0 +1,21 @@
+import unittest
+
+from tls_handshake import HandshakeState, TLSHandshake, VALID_TRANSITIONS
+
+
+class StateTransitionTests(unittest.TestCase):
+    def test_client_hello_cannot_transition_directly_to_finished(self):
+        self.assertEqual(
+            VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO],
+            [HandshakeState.SERVER_HELLO],
+        )
+
+        handshake = TLSHandshake()
+        handshake.state = HandshakeState.CLIENT_HELLO
+
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -55,7 +55,6 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
## Issue
Closes #16

## Summary
Remove the invalid ClientHello-to-Finished transition and add a focused regression test for the rejected transition.

## Acceptance criteria
- [x] VALID_TRANSITIONS[CLIENT_HELLO] contains only SERVER_HELLO
- [x] transition_to(FINISHED) returns false from CLIENT_HELLO
- [x] Invalid transition sets state to ERROR
- [x] Existing tests pass
- [x] New regression test added

/claim #16