### PR TITLE
fix(python): parse sni host names

### DIFF
--- a/python/test_sni_extensions.py
+++ b/python/test_sni_extensions.py
@@ -1,0 +1,40 @@
+import struct
+import unittest
+
+from tls_handshake import (
+    EXT_EXTENDED_MASTER_SECRET,
+    EXT_SNI,
+    TLSHandshake,
+)
+
+
+def build_extension(ext_type, payload):
+    return struct.pack("!HH", ext_type, len(payload)) + payload
+
+
+class SNIExtensionTests(unittest.TestCase):
+    def test_parse_extensions_extracts_sni_host_name(self):
+        hostname = b"example.com"
+        sni_entry = b"\x00" + struct.pack("!H", len(hostname)) + hostname
+        sni_payload = struct.pack("!H", len(sni_entry)) + sni_entry
+
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(
+            build_extension(EXT_SNI, sni_payload)
+        )
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_parse_extensions_without_sni_leaves_server_name_unset(self):
+        handshake = TLSHandshake()
+
+        handshake.parse_extensions(
+            build_extension(EXT_EXTENDED_MASTER_SECRET, b"")
+        )
+
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,12 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                server_name = self._parse_sni_server_name(ext_data)
+                if server_name is not None:
+                    ext.server_name = server_name
+                    self.server_name = server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +219,34 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_server_name(self, data: bytes) -> Optional[str]:
+        """Extract the first host_name entry from an SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = offset + list_len
+        if end > len(data):
+            return None
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            if offset + name_len > end:
+                return None
+
+            name = data[offset:offset + name_len]
+            offset += name_len
+            if name_type == 0x00:
+                try:
+                    return name.decode("ascii")
+                except UnicodeDecodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """


### PR DESCRIPTION
## Issue
Closes #17

## Summary
Decode host_name entries from SNI extensions and store the parsed server name on both the extension and handshake.

## Acceptance criteria
- [x] EXT_SNI decodes RFC 6066 host_name entries
- [x] ext.server_name and handshake.server_name are set
- [x] Non-SNI extensions leave server_name unset
- [x] Existing tests pass
- [x] New regression tests added

/claim #17