### PR TITLE
fix(python): compare finished data safely

### DIFF
--- a/python/test_finished_verification.py
+++ b/python/test_finished_verification.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest import mock
+
+from tls_handshake import TLSHandshake
+
+
+class FinishedVerificationTests(unittest.TestCase):
+    def test_verify_finished_uses_compare_digest(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"m" * 48
+
+        with mock.patch(
+            "tls_handshake.hmac.compare_digest", return_value=False
+        ) as compare_digest:
+            result = handshake.verify_finished(b"received", "client finished")
+
+        self.assertFalse(result)
+        compare_digest.assert_called_once()
+        self.assertEqual(compare_digest.call_args.args[1], b"received")
+        self.assertIsInstance(result, bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Issue
Closes #18

## Summary
Use hmac.compare_digest for Finished verify data comparison and cover the call path with a focused test.

## Acceptance criteria
- [x] verify_finished uses hmac.compare_digest
- [x] Return value remains bool
- [x] Existing tests pass
- [x] New regression test added

/claim #18