### PR TITLE
fix(python): stop swallowing key exchange errors

### DIFF
--- a/python/test_key_exchange_errors.py
+++ b/python/test_key_exchange_errors.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest import mock
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class KeyExchangeErrorTests(unittest.TestCase):
+    def test_process_key_exchange_logs_expected_errors(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x01x",
+        )
+
+        with self.assertLogs("tls_handshake", level="DEBUG") as logs:
+            result = handshake.process_key_exchange(message)
+
+        self.assertFalse(result)
+        self.assertIn("Failed to decrypt pre-master secret", logs.output[0])
+
+    def test_process_key_exchange_propagates_unexpected_errors(self):
+        handshake = TLSHandshake()
+        handshake._decrypt_pre_master_secret = mock.Mock(
+            side_effect=TypeError("unexpected")
+        )
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x30" + (b"x" * 48),
+        )
+
+        with self.assertRaises(TypeError):
+            handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,6 +6,7 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
@@ -256,10 +257,9 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error) as exc:
+            logging.getLogger(__name__).debug("Key exchange failed: %s", exc)
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
## Issue
Closes #20

## Summary
Replace the bare exception handler with expected error handling, diagnostic logging, and propagation for unexpected exceptions.

## Acceptance criteria
- [x] Bare except replaced with explicit expected exceptions
- [x] Expected key exchange failures return false and log diagnostics
- [x] Unexpected exceptions propagate
- [x] Existing tests pass
- [x] New regression tests added

/claim #20