### PR TITLE
fix(c): log cert store entries before free

### DIFF
--- a/c/test_cleanup_cert_store.c
+++ b/c/test_cleanup_cert_store.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tls_cert_validator.c"
+
+static cert_entry_t *make_entry(const char *subject, const char *issuer)
+{
+    cert_entry_t *entry = calloc(1, sizeof(cert_entry_t));
+    assert(entry != NULL);
+    entry->subject = strdup(subject);
+    entry->issuer = strdup(issuer);
+    assert(entry->subject != NULL);
+    assert(entry->issuer != NULL);
+    return entry;
+}
+
+int main(void)
+{
+    cert_store_t store = { 0 };
+    cert_entry_t *first = make_entry("subject-1", "issuer-1");
+    cert_entry_t *second = make_entry("subject-2", "issuer-2");
+    cert_entry_t *third = make_entry("subject-3", "issuer-3");
+
+    first->next = second;
+    second->next = third;
+    store.head = first;
+    store.count = 3;
+    g_log_level = LOG_LEVEL_DEBUG;
+
+    cleanup_cert_store(&store);
+
+    assert(store.head == NULL);
+    assert(store.count == 0);
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -188,10 +188,10 @@ static void cleanup_cert_store(cert_store_t *store)
     entry = store->head;
     while (entry) {
         next = entry->next;
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         X509_free(entry->cert);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }


### PR DESCRIPTION
## Issue
Closes #10

## Summary
Move the debug log before freeing cert store strings and add an AddressSanitizer-covered cleanup test.

## Acceptance criteria
- [x] log_cert_event runs before entry->issuer is freed
- [x] cleanup logs all issuer strings without freed-memory access
- [x] AddressSanitizer reports no use-after-free
- [x] Existing tests pass
- [x] New regression test added

/claim #10