### PR TITLE
Use constant-time Finished verify comparison

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,44 @@
+import hashlib
+import unittest
+from unittest.mock import patch
+
+import tls_handshake
+from tls_handshake import TLSHandshake
+
+
+class VerifyFinishedTests(unittest.TestCase):
+    def make_handshake(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"\x11" * 48
+        handshake.handshake_hash.update(b"client hello server hello")
+        return handshake
+
+    def expected_verify_data(self, handshake, label="client finished"):
+        transcript_hash = handshake.handshake_hash.copy().digest()
+        return handshake._prf(
+            handshake.master_secret,
+            label.encode("ascii"),
+            transcript_hash,
+            12,
+        )
+
+    def test_verify_finished_uses_compare_digest(self):
+        handshake = self.make_handshake()
+        expected = self.expected_verify_data(handshake)
+
+        with patch.object(tls_handshake.hmac, "compare_digest", return_value=True) as compare:
+            self.assertTrue(handshake.verify_finished(expected, "client finished"))
+
+        compare.assert_called_once_with(expected, expected)
+
+    def test_verify_finished_preserves_bool_match_behavior(self):
+        handshake = self.make_handshake()
+        expected = self.expected_verify_data(handshake)
+        mismatch = hashlib.sha256(expected).digest()[:12]
+
+        self.assertTrue(handshake.verify_finished(expected, "client finished"))
+        self.assertFalse(handshake.verify_finished(mismatch, "client finished"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Summary
- replace direct Finished verify-data equality with `hmac.compare_digest`
- preserve True/False behavior for matching and mismatching verify data
- add unittest coverage for compare_digest usage and bool behavior

## Verification
- `cd python && python3 -m unittest test_tls_handshake.py`
- `git diff --check`

Fixes #18
/claim #18