### PR TITLE
Terminate warning alert string

### DIFF
--- a/assembly/test_alert_strings.py
+++ b/assembly/test_alert_strings.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm")
+
+
+def test_alert_strings_are_terminated_before_next_error():
+    source = SOURCE.read_text()
+
+    assert 'err_alert_fatal     db "FATAL ALERT received from peer", 10' in source
+    assert 'err_alert_warning   db "WARNING: alert received from peer", 10, 0' in source
+
+    warning_pos = source.index("err_alert_warning")
+    truncated_pos = source.index("err_truncated")
+    warning_line = source[warning_pos:truncated_pos].splitlines()[0]
+
+    assert warning_line.endswith(', 10, 0')
+
+
+if __name__ == "__main__":
+    test_alert_strings_are_terminated_before_next_error()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -25,7 +25,7 @@ section .data
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
     err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---


### PR DESCRIPTION
## Summary
- terminate `err_alert_warning` with newline and NUL
- prevent `print_string` from reading into `err_truncated` for warning alerts
- add a source-level regression check for the alert string terminator

## Verification
- `python3 assembly/test_alert_strings.py`
- `git diff --check`

Fixes #5
/claim #5