### PR TITLE
Parse TLS record version as big endian

### DIFF
--- a/assembly/test_version_big_endian.py
+++ b/assembly/test_version_big_endian.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm")
+
+
+def test_tls_version_is_loaded_big_endian():
+    source = SOURCE.read_text()
+    marker = "; --- Bytes 1-2: Protocol Version (big-endian) ---"
+    start = source.index(marker)
+    end = source.index("; Print version", start)
+    block = source[start:end]
+
+    assert "mov ax, [rsi+1]" not in block
+    assert "movzx eax, byte [rsi+1]" in block
+    assert "shl eax, 8" in block
+    assert "movzx ebx, byte [rsi+2]" in block
+    assert "or eax, ebx" in block
+    assert "mov r14d, eax" in block
+
+
+if __name__ == "__main__":
+    test_tls_version_is_loaded_big_endian()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -125,10 +125,11 @@ parse_tls_record:
     ; --- Bytes 1-2: Protocol Version (big-endian) ---
     ; TLS version is 2 bytes, network byte order (big-endian)
     ; e.g. TLS 1.2 = 0x0303, TLS 1.0 = 0x0301
-    mov ax, [rsi+1]             ; BUG: loads in little-endian on x86
-                                ; For input bytes 03 03 this works by coincidence
-                                ; but 03 01 would be read as 0x0103 instead of 0x0301
-    movzx r14d, ax              ; r14 = version (incorrectly byte-swapped)
+    movzx eax, byte [rsi+1]
+    shl eax, 8
+    movzx ebx, byte [rsi+2]
+    or eax, ebx
+    mov r14d, eax               ; r14 = version in network byte order
 
     ; Print version
     push rsi


### PR DESCRIPTION
## Summary
- decode TLS record version bytes explicitly as network-order big-endian
- preserve TLS 1.2 parsing while fixing TLS 1.0 byte order
- add a source-level regression check for the byte-load/shift sequence

## Verification
- `python3 assembly/test_version_big_endian.py`
- `git diff --check`

Fixes #1
/claim #1