### PR TITLE
Reject content types above TLS_CT_MAX

### DIFF
--- a/assembly/test_content_type_bounds.py
+++ b/assembly/test_content_type_bounds.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm")
+
+
+def test_content_type_upper_bound_branches_to_invalid_type():
+    source = SOURCE.read_text()
+    start = source.index("; Validate content type range")
+    end = source.index(".type_ok:", start)
+    block = source[start:end]
+
+    assert "cmp r13d, TLS_CT_MIN" in block
+    assert "jl .invalid_type" in block
+    assert "cmp r13d, TLS_CT_MAX" in block
+    assert "jle .type_ok" in block
+    assert "jg .invalid_type" in block
+
+
+if __name__ == "__main__":
+    test_content_type_upper_bound_branches_to_invalid_type()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -105,6 +105,7 @@ parse_tls_record:
     jle .type_ok                ; BUG: should be jl, not jle -- but wait,
                                 ; 0x18 (heartbeat) is valid so jle is needed...
                                 ; actually TLS_CT_MAX is 0x18 and we want <= 0x18
+    jg .invalid_type
 
     ; --- Actually the check above is wrong for a different reason ---
     ; Content type 0x17 is application_data which is VALID, and 0x18


### PR DESCRIPTION
## Summary
- add the missing upper-bound branch to reject content types above `TLS_CT_MAX`
- preserve the valid 0x17 application_data and 0x18 heartbeat boundary
- add a source-level regression check for the validation block

## Verification
- `python3 assembly/test_content_type_bounds.py`
- `git diff --check`

Fixes #3
/claim #3