### PR TITLE
Reject records with truncated payloads

### DIFF
--- a/assembly/test_payload_availability.py
+++ b/assembly/test_payload_availability.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm")
+
+
+def test_declared_payload_length_is_checked_against_bytes_read():
+    source = SOURCE.read_text()
+    start = source.index("; Validate length doesn't exceed TLS maximum")
+    end = source.index("; --- Read payload data ---", start)
+    block = source[start:end]
+
+    assert "cmp r15d, TLS_MAX_RECORD_LEN" in block
+    assert "ja .invalid_length" in block
+    assert "lea eax, [r15 + 5]" in block
+    assert "cmp eax, r12d" in block
+
+
+if __name__ == "__main__":
+    test_declared_payload_length_is_checked_against_bytes_read()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -161,6 +161,10 @@ parse_tls_record:
     cmp r15d, TLS_MAX_RECORD_LEN
     ja .invalid_length
 
+    lea eax, [r15 + 5]
+    cmp eax, r12d
+    ja .invalid_length
+
     ; --- Read payload data ---
     ; BUG: No check that r12 (bytes in buffer) >= r15 + 5
     ; If the record claims a large payload but we only read a few


### PR DESCRIPTION
## Summary
- compare declared payload length plus TLS header size against bytes actually read
- reject incomplete records with the existing truncated-record error before payload handlers run
- add a source-level regression check for the availability guard

## Verification
- `python3 assembly/test_payload_availability.py`
- `git diff --check`

Fixes #2
/claim #2