### PR TITLE
Detect TLS 1.3 inner record type

### DIFF
--- a/assembly/test_tls13_inner_type.py
+++ b/assembly/test_tls13_inner_type.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_record_parser.asm")
+
+
+def test_application_handler_detects_tls13_inner_type():
+    source = SOURCE.read_text()
+
+    assert 'msg_tls13       db "TLS 1.3 record detected", 10, 0' in source
+    assert 'msg_inner_type  db "Inner content type: 0x", 0' in source
+
+    start = source.index(".handle_application:")
+    end = source.index(".handle_heartbeat:", start)
+    block = source[start:end]
+
+    assert "cmp r14d, 0x0303" in block
+    assert "je .handle_tls13_record" in block
+    assert ".handle_tls13_record:" in block
+    assert "cmp ecx, 0" in block
+    assert "jle .parse_done" in block
+    assert "movzx edi, byte [rdi + rcx - 1]" in block
+    assert "call print_hex_byte" in block
+
+
+if __name__ == "__main__":
+    test_application_handler_detects_tls13_inner_type()

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -11,6 +11,8 @@ section .data
     msg_type        db "Content type: 0x", 0
     msg_version     db "Protocol version: 0x", 0
     msg_length      db "Payload length: ", 0
+    msg_tls13       db "TLS 1.3 record detected", 10, 0
+    msg_inner_type  db "Inner content type: 0x", 0
     msg_newline     db 10, 0
 
     ; --- Content type labels ---
@@ -228,8 +230,26 @@ parse_tls_record:
     lea rdi, [rel lbl_application]
     call print_string
     pop rdi
+    cmp r14d, 0x0303
+    je .handle_tls13_record
     ; Application data is encrypted, just report the length
-    ; No TLS 1.3 inner content type detection is performed
+    jmp .parse_done
+
+.handle_tls13_record:
+    push rdi
+    lea rdi, [rel msg_tls13]
+    call print_string
+    pop rdi
+    cmp ecx, 0
+    jle .parse_done
+    push rdi
+    lea rdi, [rel msg_inner_type]
+    call print_string
+    pop rdi
+    movzx edi, byte [rdi + rcx - 1]
+    call print_hex_byte
+    lea rdi, [rel msg_newline]
+    call print_string
     jmp .parse_done
 
 .handle_heartbeat:


### PR DESCRIPTION
## Summary
- detect application_data records with legacy version `0x0303` as TLS 1.3 records
- print a TLS 1.3 marker and the final payload byte as the inner content type when present
- add a source-level regression check for the TLS 1.3 branch

## Verification
- `python3 assembly/test_tls13_inner_type.py`
- `git diff --check`

Fixes #4
/claim #4