### PR TITLE
Route chain validation errors through cleanup

### DIFF
--- a/c/test_validate_chain_cleanup.py
+++ b/c/test_validate_chain_cleanup.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c")
+
+
+def validate_chain_body():
+    source = SOURCE.read_text()
+    start = source.index("static int validate_chain")
+    end = source.index("static void cleanup_cert_store", start)
+    return source[start:end]
+
+
+def test_validate_chain_routes_errors_through_cleanup_label():
+    body = validate_chain_body()
+
+    assert "cleanup:" in body
+    assert body.count("goto cleanup;") >= 7
+    assert "cert at depth %d failed expiry check" in body
+    assert "signature invalid at depth %d" in body
+    assert "root not found in trusted store" in body
+    assert "leaf fingerprint mismatch" in body
+
+    before_cleanup = body.split("cleanup:", 1)[0]
+    assert "return rc;" not in before_cleanup
+    assert "return CERT_STATUS_" not in before_cleanup
+
+
+if __name__ == "__main__":
+    test_validate_chain_routes_errors_through_cleanup_label()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -138,45 +138,58 @@ static int validate_chain(chain_context_t *ctx)
     unsigned char   fp[FINGERPRINT_LEN];
     cert_entry_t   *trusted_issuer;
 
-    if (!ctx || !ctx->chain || ctx->chain_len <= 0)
-        return CERT_STATUS_INVALID;
-    if (ctx->chain_len > MAX_CHAIN_DEPTH)
-        return CERT_STATUS_INVALID;
+    rc = CERT_STATUS_OK;
+    trusted_issuer = NULL;
+
+    if (!ctx || !ctx->chain || ctx->chain_len <= 0) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
+    if (ctx->chain_len > MAX_CHAIN_DEPTH) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
 
     for (i = 0; i < ctx->chain_len - 1; i++) {
         rc = check_expiry(ctx->chain[i]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "cert at depth %d failed expiry check", i);
-            return rc;
+            goto cleanup;
         }
         rc = verify_signature(ctx->chain[i], ctx->chain[i + 1]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "signature invalid at depth %d", i);
-            return rc;
+            goto cleanup;
         }
     }
 
     trusted_issuer = find_issuer(ctx->trusted_store, ctx->chain[ctx->chain_len - 1]);
     if (!trusted_issuer) {
         log_cert_event(LOG_LEVEL_ERROR, "root not found in trusted store");
-        return CERT_STATUS_UNTRUSTED;
+        rc = CERT_STATUS_UNTRUSTED;
+        goto cleanup;
     }
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
     if (rc != CERT_STATUS_OK)
-        return rc;
+        goto cleanup;
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {
-        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0)
-            return CERT_STATUS_INVALID;
+        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0) {
+            rc = CERT_STATUS_INVALID;
+            goto cleanup;
+        }
         if (!match_fingerprint(fp, ctx->pinned_fingerprint)) {
             log_cert_event(LOG_LEVEL_ERROR, "leaf fingerprint mismatch");
-            return CERT_STATUS_UNTRUSTED;
+            rc = CERT_STATUS_UNTRUSTED;
+            goto cleanup;
         }
     }
 
     log_cert_event(LOG_LEVEL_INFO, "chain validated successfully (%d certs)", ctx->chain_len);
-    return CERT_STATUS_OK;
+
+cleanup:
+    return rc;
 }
 
 static void cleanup_cert_store(cert_store_t *store)


### PR DESCRIPTION
## Summary
- refactor `validate_chain()` to set `rc` and route validation failures through one `cleanup:` label
- preserve existing error logs and return codes for expiry, signature, trust-store, and fingerprint failures
- add a source-level regression check for the cleanup flow

## Verification
- `python3 c/test_validate_chain_cleanup.py`
- `cc -Wall -Wextra -Wno-unused-function -I/opt/homebrew/opt/openssl@3/include -c c/tls_cert_validator.c -o /tmp/tls_cert_validator.o`
- `git diff --check`

Fixes #7
/claim #7