### PR TITLE
fix(c): route validate_chain errors through cleanup

### DIFF
--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -134,49 +134,57 @@ static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 
 static int validate_chain(chain_context_t *ctx)
 {
-    int             i, rc;
+    int             i;
+    int             rc = CERT_STATUS_INVALID;
     unsigned char   fp[FINGERPRINT_LEN];
     cert_entry_t   *trusted_issuer;
 
     if (!ctx || !ctx->chain || ctx->chain_len <= 0)
-        return CERT_STATUS_INVALID;
+        goto cleanup;
     if (ctx->chain_len > MAX_CHAIN_DEPTH)
-        return CERT_STATUS_INVALID;
+        goto cleanup;
 
     for (i = 0; i < ctx->chain_len - 1; i++) {
         rc = check_expiry(ctx->chain[i]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "cert at depth %d failed expiry check", i);
-            return rc;
+            goto cleanup;
         }
         rc = verify_signature(ctx->chain[i], ctx->chain[i + 1]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "signature invalid at depth %d", i);
-            return rc;
+            goto cleanup;
         }
     }
 
     trusted_issuer = find_issuer(ctx->trusted_store, ctx->chain[ctx->chain_len - 1]);
     if (!trusted_issuer) {
         log_cert_event(LOG_LEVEL_ERROR, "root not found in trusted store");
-        return CERT_STATUS_UNTRUSTED;
+        rc = CERT_STATUS_UNTRUSTED;
+        goto cleanup;
     }
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
     if (rc != CERT_STATUS_OK)
-        return rc;
+        goto cleanup;
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {
-        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0)
-            return CERT_STATUS_INVALID;
+        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0) {
+            rc = CERT_STATUS_INVALID;
+            goto cleanup;
+        }
         if (!match_fingerprint(fp, ctx->pinned_fingerprint)) {
             log_cert_event(LOG_LEVEL_ERROR, "leaf fingerprint mismatch");
-            return CERT_STATUS_UNTRUSTED;
+            rc = CERT_STATUS_UNTRUSTED;
+            goto cleanup;
         }
     }
 
     log_cert_event(LOG_LEVEL_INFO, "chain validated successfully (%d certs)", ctx->chain_len);
-    return CERT_STATUS_OK;
+    rc = CERT_STATUS_OK;
+
+cleanup:
+    return rc;
 }
 
 static void cleanup_cert_store(cert_store_t *store)

--- a/tests/test_c_validate_chain_cleanup.py
+++ b/tests/test_c_validate_chain_cleanup.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import re
+
+SOURCE = Path(__file__).resolve().parents[1] / "c" / "tls_cert_validator.c"
+
+
+def _validate_chain_body():
+    text = SOURCE.read_text()
+    match = re.search(r"static int validate_chain\(chain_context_t \*ctx\)\n\{(?P<body>.*?)\n\}", text, re.S)
+    assert match, "validate_chain() not found"
+    return match.group("body")
+
+
+def test_validate_chain_error_paths_use_single_cleanup_label():
+    body = _validate_chain_body()
+    assert "cleanup:" in body
+
+    before_cleanup, after_cleanup = body.split("cleanup:", 1)
+    assert "goto cleanup;" in before_cleanup
+    assert "return " not in before_cleanup
+    assert after_cleanup.count("return rc;") == 1


### PR DESCRIPTION
/claim #7

## Summary
- Refactor `validate_chain()` error exits to set `rc` and route through a single `cleanup:` label.
- Preserve existing error codes and log messages for expiry, signature, missing root, and fingerprint failures.
- Add a focused regression test that verifies `validate_chain()` uses a unified cleanup path before returning.

## Test plan
- `python3 -m pytest tests/test_c_validate_chain_cleanup.py -q`
- `gcc -Wall -Wextra -Werror -Wno-unused-function -c c/tls_cert_validator.c -o /tmp/tls_cert_validator.o $(pkg-config --cflags openssl 2>/dev/null || true)`
- `git diff --check`

Note: I verified compile locally after installing the OpenSSL development headers (`libssl-dev`) in the runner environment.
