### PR TITLE
Validate stapled OCSP response

### DIFF
--- a/c/test_ocsp_stapling_source.py
+++ b/c/test_ocsp_stapling_source.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c")
+
+
+def test_ocsp_stapling_parses_status_and_frees_openssl_structures():
+    source = SOURCE.read_text()
+
+    assert "const unsigned char *ocsp_response_der;" in source
+    assert "size_t          ocsp_response_len;" in source
+    assert "static int check_ocsp_stapling(" in source
+    assert "d2i_OCSP_RESPONSE(NULL, &p, (long)resp_len)" in source
+    assert "OCSP_RESPONSE_STATUS_SUCCESSFUL" in source
+    assert "OCSP_response_get1_basic(resp)" in source
+    assert "OCSP_cert_to_id(NULL, leaf, issuer)" in source
+    assert "OCSP_resp_find_status(basic, cert_id" in source
+    assert "status == V_OCSP_CERTSTATUS_REVOKED" in source
+    assert "status == V_OCSP_CERTSTATUS_GOOD" in source
+    assert "OCSP_CERTID_free(cert_id)" in source
+    assert "OCSP_BASICRESP_free(basic)" in source
+    assert "OCSP_RESPONSE_free(resp)" in source
+
+
+def test_validate_chain_calls_ocsp_before_fingerprint_pinning():
+    source = SOURCE.read_text()
+    validate_start = source.index("static int validate_chain")
+    validate_end = source.index("static void cleanup_cert_store", validate_start)
+    body = source[validate_start:validate_end]
+
+    ocsp_pos = body.index("check_ocsp_stapling(ctx->chain[0]")
+    pinning_pos = body.index("/* Fingerprint pinning on leaf */")
+
+    assert "if (ctx->verify_ocsp)" in body
+    assert "ctx->ocsp_response_der" in body
+    assert "ctx->ocsp_response_len" in body
+    assert ocsp_pos < pinning_pos
+
+
+if __name__ == "__main__":
+    test_ocsp_stapling_parses_status_and_frees_openssl_structures()
+    test_validate_chain_calls_ocsp_before_fingerprint_pinning()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -46,6 +46,8 @@ typedef struct chain_context {
     int             chain_len;
     cert_store_t   *trusted_store;
     unsigned char  *pinned_fingerprint;
+    const unsigned char *ocsp_response_der;
+    size_t          ocsp_response_len;
     int             verify_ocsp;
 } chain_context_t;
 
@@ -120,6 +122,72 @@ static int verify_signature(X509 *cert, X509 *issuer)
     return CERT_STATUS_OK;
 }
 
+static int check_ocsp_stapling(X509 *leaf, X509 *issuer,
+                               const unsigned char *resp_der, size_t resp_len)
+{
+    const unsigned char *p = resp_der;
+    OCSP_RESPONSE *resp = NULL;
+    OCSP_BASICRESP *basic = NULL;
+    OCSP_CERTID *cert_id = NULL;
+    int status = V_OCSP_CERTSTATUS_UNKNOWN;
+    int reason = 0;
+    ASN1_GENERALIZEDTIME *revtime = NULL;
+    ASN1_GENERALIZEDTIME *thisupd = NULL;
+    ASN1_GENERALIZEDTIME *nextupd = NULL;
+    int rc = CERT_STATUS_INVALID;
+
+    if (!leaf || !issuer || !resp_der || resp_len == 0) {
+        log_cert_event(LOG_LEVEL_ERROR, "missing OCSP stapling response");
+        goto cleanup;
+    }
+
+    resp = d2i_OCSP_RESPONSE(NULL, &p, (long)resp_len);
+    if (!resp) {
+        log_cert_event(LOG_LEVEL_ERROR, "failed to parse OCSP response");
+        goto cleanup;
+    }
+
+    if (OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP responder returned unsuccessful status");
+        goto cleanup;
+    }
+
+    basic = OCSP_response_get1_basic(resp);
+    if (!basic) {
+        log_cert_event(LOG_LEVEL_ERROR, "failed to extract basic OCSP response");
+        goto cleanup;
+    }
+
+    cert_id = OCSP_cert_to_id(NULL, leaf, issuer);
+    if (!cert_id) {
+        log_cert_event(LOG_LEVEL_ERROR, "failed to build OCSP certificate id");
+        goto cleanup;
+    }
+
+    if (!OCSP_resp_find_status(basic, cert_id, &status, &reason, &revtime,
+                               &thisupd, &nextupd)) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response does not include leaf status");
+        goto cleanup;
+    }
+
+    if (status == V_OCSP_CERTSTATUS_REVOKED) {
+        log_cert_event(LOG_LEVEL_ERROR, "OCSP response marks leaf certificate revoked");
+        rc = CERT_STATUS_REVOKED;
+        goto cleanup;
+    }
+
+    rc = (status == V_OCSP_CERTSTATUS_GOOD) ? CERT_STATUS_OK : CERT_STATUS_INVALID;
+
+cleanup:
+    if (cert_id)
+        OCSP_CERTID_free(cert_id);
+    if (basic)
+        OCSP_BASICRESP_free(basic);
+    if (resp)
+        OCSP_RESPONSE_free(resp);
+    return rc;
+}
+
 static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 {
     X509_NAME *issuer_name = X509_get_issuer_name(cert);
@@ -164,6 +232,14 @@ static int validate_chain(chain_context_t *ctx)
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
     if (rc != CERT_STATUS_OK)
         return rc;
+
+    if (ctx->verify_ocsp) {
+        X509 *leaf_issuer = (ctx->chain_len > 1) ? ctx->chain[1] : trusted_issuer->cert;
+        rc = check_ocsp_stapling(ctx->chain[0], leaf_issuer,
+                                 ctx->ocsp_response_der, ctx->ocsp_response_len);
+        if (rc != CERT_STATUS_OK)
+            return rc;
+    }
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {


### PR DESCRIPTION
## Summary
- add `check_ocsp_stapling()` using OpenSSL OCSP response parsing
- return revoked when the stapled response marks the leaf certificate revoked
- call OCSP validation from `validate_chain()` before fingerprint pinning when `verify_ocsp` is enabled
- add a source-level regression check for parsing, freeing, and call ordering

## Verification
- `python3 c/test_ocsp_stapling_source.py`
- `cc -Wall -Wextra -Wno-unused-function -I/opt/homebrew/opt/openssl@3/include -c c/tls_cert_validator.c -o /tmp/tls_cert_validator_ocsp.o`
- `git diff --check`

Fixes #9
/claim #9