### PR TITLE
fix(rust): guard session cache with rwlock

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of cached sessions before eviction kicks in.
@@ -68,7 +68,7 @@ pub struct SessionCache {
     /// Thread-safe reference to the inner cache map.
     // BUG(trap2): Arc alone does not provide interior mutability or
     // synchronisation.  Concurrent callers can race on the HashMap.
-    cache: Arc<HashMap<String, SessionTicket>>,
+    cache: Arc<RwLock<HashMap<String, SessionTicket>>>,
     encryption_key: EncryptionKey,
     max_size: usize,
 }
@@ -108,18 +108,21 @@ impl SessionCache {
     pub fn new(key_material: Vec<u8>) -> Self {
         let key = EncryptionKey::new(1, key_material);
         SessionCache {
-            cache: Arc::new(HashMap::new()),
+            cache: Arc::new(RwLock::new(HashMap::new())),
             encryption_key: key,
             max_size: MAX_CACHE_SIZE,
         }
     }
 
     /// Store a session ticket in the cache.
-    pub fn store_session(&mut self, ticket: SessionTicket) -> Result<(), SessionError> {
-        let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
+    pub fn store_session(&self, ticket: SessionTicket) -> Result<(), SessionError> {
+        let mut inner = self
+            .cache
+            .write()
+            .map_err(|_| SessionError::InvalidTicket("session cache lock poisoned".to_string()))?;
 
         if inner.len() >= self.max_size {
-            self.evict_expired_sessions(inner);
+            self.evict_expired_sessions(&mut inner);
         }
 
         if inner.len() >= self.max_size {
@@ -133,12 +136,15 @@ impl SessionCache {
     /// Look up a session by ticket id.
     ///
     /// Returns the ticket if it exists **and** has not expired.
-    pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
+    pub fn get_session(&self, ticket_id: &str) -> Option<SessionTicket> {
         // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
         // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+        let ticket = {
+            let inner = self.cache.read().ok()?;
+            inner.get(ticket_id).unwrap().clone()
+        };
 
-        if self.is_ticket_expired(ticket) {
+        if self.is_ticket_expired(&ticket) {
             return None;
         }
 
@@ -146,14 +152,14 @@ impl SessionCache {
     }
 
     /// Remove a specific ticket from the cache.
-    pub fn remove_session(&mut self, ticket_id: &str) -> Option<SessionTicket> {
-        let inner = Arc::get_mut(&mut self.cache)?;
+    pub fn remove_session(&self, ticket_id: &str) -> Option<SessionTicket> {
+        let mut inner = self.cache.write().ok()?;
         inner.remove(ticket_id)
     }
 
     /// Return the number of cached sessions.
     pub fn session_count(&self) -> usize {
-        self.cache.len()
+        self.cache.read().map(|inner| inner.len()).unwrap_or(0)
     }
 
     // -- internal helpers ---------------------------------------------------
@@ -286,12 +292,56 @@ impl std::fmt::Display for SessionTicket {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn ticket(ticket_id: &str) -> SessionTicket {
+        let cache = SessionCache::new(b"test-key".to_vec());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        SessionTicket {
+            ticket_id: ticket_id.to_string(),
+            cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+            master_secret: b"master-secret".to_vec(),
+            issued_at: now,
+            lifetime_secs: DEFAULT_TICKET_LIFETIME_SECS,
+            encrypted_state: cache.encrypt_ticket(b"master-secret").unwrap(),
+            creation_time: now,
+        }
+    }
+
+    #[test]
+    fn concurrent_store_and_get_completes() {
+        let cache = Arc::new(SessionCache::new(b"test-key".to_vec()));
+        let mut handles = Vec::new();
+
+        for idx in 0..10 {
+            let cache = Arc::clone(&cache);
+            handles.push(thread::spawn(move || {
+                let id = format!("ticket-{idx}");
+                cache.store_session(ticket(&id)).unwrap();
+                assert!(cache.get_session(&id).is_some());
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(cache.session_count(), 10);
+    }
+}
+
 impl SessionCache {
     /// Return a summary line for logging / diagnostics.
     pub fn summary(&self) -> String {
         format!(
             "SessionCache {{ sessions: {}, key_id: {}, max: {} }}",
-            self.cache.len(),
+            self.session_count(),
             self.encryption_key.key_id,
             self.max_size,
         )


### PR DESCRIPTION
Fixes #23
/claim #23

Summary:
- Wrap the shared session cache map in RwLock.
- Use write locking for inserts/removals and read locking for lookups/counts.
- Add concurrent store/get regression coverage.

Verification:
- rustc --edition=2021 --test rust/tls_session.rs
- test binary --nocapture