### PR TITLE
fix(c): compare fingerprints in constant time

### DIFF
--- a/c/test_match_fingerprint.c
+++ b/c/test_match_fingerprint.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <string.h>
+
+#include "tls_cert_validator.c"
+
+int main(void)
+{
+    unsigned char expected[FINGERPRINT_LEN];
+    unsigned char matching[FINGERPRINT_LEN];
+    unsigned char mismatched[FINGERPRINT_LEN];
+
+    memset(expected, 0x7a, sizeof(expected));
+    memcpy(matching, expected, sizeof(matching));
+    memcpy(mismatched, expected, sizeof(mismatched));
+    mismatched[FINGERPRINT_LEN - 1] ^= 0xff;
+
+    assert(match_fingerprint(expected, matching));
+    assert(!match_fingerprint(expected, mismatched));
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)


### PR DESCRIPTION
## Issue
Closes #6

## Summary
Replace memcmp with OpenSSL CRYPTO_memcmp for fingerprint comparison and keep match/mismatch behavior covered by a focused test.

## Acceptance criteria
- [x] match_fingerprint calls CRYPTO_memcmp
- [x] Match return behavior is preserved
- [x] Fingerprint mismatch still rejects
- [x] Existing tests pass
- [x] New regression test added

## Demo / verification

![Demo](https://raw.githubusercontent.com/MNgaminhhh/Bounty-Hunters/demo-pr-164/demo/pr-164-match-fingerprint.gif)

Local verification run:

```sh
cc -Wall -Wextra -I/opt/homebrew/opt/openssl@3/include c/test_match_fingerprint.c \
  -L/opt/homebrew/opt/openssl@3/lib -lcrypto -o /tmp/test_match_fingerprint
/tmp/test_match_fingerprint
```

Result: exit code 0. The focused regression test covers matching fingerprints and one-byte mismatches while the implementation now uses `CRYPTO_memcmp`.

/claim #6