### PR TITLE
Complete haiku placeholders

### DIFF
--- a/english/haikus.md
+++ b/english/haikus.md
@@ -8,7 +8,7 @@ A curated set of original haikus on nature, technology, and solitude.
 
 Dew drips from the leaf
 A spider weaves silver thread
-[TODO: write closing line — must be 5 syllables, reference sunrise]
+Sunrise paints the sky
 
 ---
 
@@ -32,7 +32,7 @@ Seagulls call goodnight
 
 Dust gathers softly
 A chair waits by the window
-[TODO: write closing line — must be 5 syllables, convey absence]
+No footsteps return
 
 ---
 
@@ -40,12 +40,12 @@ A chair waits by the window
 
 Semicolon missed
 The build fails at line forty
-[TODO: write closing line — must be 5 syllables, humorous tone]
+My coffee blamed it
 
 ---
 
 ### Autumn Walk
 
 Leaves crunch underfoot
-[TODO: write middle line — must be 7 syllables, describe the wind]
+West wind whistles through branches
 Cold hands find warm pockets


### PR DESCRIPTION
/claim #200

Summary:
- Replaced the four TODO placeholders in english/haikus.md.
- Left the rest of the haiku collection unchanged.

Verification:
- git diff --check
- Manual syllable check:
  - "Sunrise paints the sky" = 5
  - "No footsteps return" = 5
  - "My coffee blamed it" = 5
  - "West wind whistles through branches" = 7

Demo:
- Markdown-only content change; the completed lines are visible directly in the PR diff.
