### PR TITLE
Complete missing song sections

### DIFF
--- a/english/songs.md
+++ b/english/songs.md
@@ -16,15 +16,20 @@ But the server returned an empty frame,
 **[Chorus]**
 Heart not found, heart not found,
 I keep refreshing but you're not around,
-[TODO: write 2 more chorus lines — must maintain the "internet/heartbreak" metaphor, rhyme scheme AABB]
+My inbox pings with silence, a cold blue screen,
+Love timed out where your last seen had been.
 
 **[Verse 2]**
 Your profile says you're online tonight,
 The green dot glowing, soft and bright,
-[TODO: write 2 more verse lines — continue the theme of digital loneliness, rhyme with each other]
+I type your name in the lonely chat light,
+And watch it echo back into the night.
 
 **[Bridge]**
-[TODO: write 4-line bridge — shift tone to acceptance, slower rhythm, can break rhyme scheme]
+I close the tab and let the silence load,
+Leave your window sleeping on its own,
+No error code can bring you back to me,
+So I learn to walk offline alone.
 
 **[Chorus — Final]**
 Heart not found, heart not found,
@@ -45,15 +50,21 @@ And that was the end of the Cretaceous ball!
 
 **[Chorus]**
 Extinction polka, one-two-three!
-[TODO: write 3 more chorus lines — must be upbeat and absurd, reference different extinct species, maintain polka rhythm]
+Trilobites twirl in the deep blue sea!
+Great auks clap flippers with bright glee!
+Quaggas kick high for the VIP!
 
 **[Verse 2]**
 The dodo bird walked without a care,
 With its fluffy wings and its vacant stare,
-[TODO: write 2 more verse lines — rhyme with each other, reference the dodo's obliviousness]
+It greeted the sailors with innocent flair,
+Then asked where the flock went, still unaware.
 
 **[Verse 3]**
-[TODO: write full 4-line verse — pick another extinct animal (mammoth, saber-tooth, etc.), maintain humorous polka tone, AABB rhyme]
+The saber-tooth tiger put on a fine show,
+With tap shoes clicking through ice and snow,
+It chased its own tail with a dignified roar,
+Then slipped on a glacier and danced no more.
 
 **[Outro]**
 So raise a glass to the ones who are gone,
@@ -73,9 +84,13 @@ The garbage collector will sweep while you sleep,
 And free all the pointers you promised to keep.
 
 **[Verse 2]**
-[TODO: write full 4-line verse — continue the "computer science lullaby" theme, reference threads/deadlocks/race conditions in a soothing way, AABB rhyme]
+Let threads curl softly in queues tucked tight,
+No race condition will startle the night,
+Deadlocks can loosen their hands and release,
+While semaphores rock every core into peace.
 
 **[Verse 3]**
 The kernel is humming a low steady tune,
 The clock ticks in cycles from midnight to noon,
-[TODO: write 2 closing lines — wrap up the lullaby, reference shutdown/sleep mode, rhyme with each other]
+Now shutdown whispers and sleep mode is deep,
+So drift into standby, little program, and sleep.


### PR DESCRIPTION
## Issue
/claim #204

## Summary
Completed all missing lyric sections in `english/songs.md` while preserving the existing song structure and completed sections.

## Acceptance criteria
- [x] All `[TODO: ...]` placeholders are replaced with complete lyrics
- [x] 404 chorus has 4 total lines with AABB rhyme and a consistent internet/heartbreak metaphor
- [x] Mass Extinction Polka verse 3 introduces a new extinct animal not already mentioned
- [x] Segfault Lullaby verse 2 references threads, deadlocks, and race conditions
- [x] Song structure markers remain intact
- [x] Existing completed sections remain unchanged

## Verification
- [x] `Select-String -Path english\songs.md -Pattern TODO -SimpleMatch` returns no matches
- [x] `git diff --check`

## Demo
Markdown-only lyric completion; the completed sections are visible directly in the PR diff.
