### PR TITLE
fix: complete missing limerick lines

### DIFF
--- a/english/limericks.md
+++ b/english/limericks.md
@@ -10,7 +10,7 @@ There once was a dev who loved Rust,
 Whose code never once gathered dust,
 He wrote every night,
 Till the tests were all right,
-[TODO: write closing line — must rhyme with "Rust" and "dust"]
+Then pushed it before the first gust.
 
 ---
 
@@ -28,8 +28,8 @@ And vanished with feline defense.
 
 A barista who worked the night shift,
 Made lattes incredibly swift,
-[TODO: write line 3 — short line, ~5 syllables, setup for punchline]
-[TODO: write line 4 — short line, ~5 syllables, rhymes with line 3]
+She foamed up a crown,
+Then spun it around,
 But her espresso game was a gift.
 
 ---
@@ -40,4 +40,4 @@ There once was a girl from the stars,
 Who dreamed about living on Mars,
 She built her own ship,
 And went on a trip,
-[TODO: write closing line — must rhyme with "stars" and "Mars"]
+And waved to the moons over Mars.


### PR DESCRIPTION
## Summary
- Complete the missing limerick lines in `english/limericks.md`
- Remove the remaining `[TODO:]` placeholders for issue #201

## Validation
- `git diff --check`
- Verified no `[TODO:]` placeholders remain in `english/limericks.md`

Fixes #201
/claim #201
