### PR TITLE
Complete missing limerick lines

### DIFF
--- a/english/limericks.md
+++ b/english/limericks.md
@@ -10,7 +10,7 @@ There once was a dev who loved Rust,
 Whose code never once gathered dust,
 He wrote every night,
 Till the tests were all right,
-[TODO: write closing line — must rhyme with "Rust" and "dust"]
+Then shipped it with cargo and trust.
 
 ---
 
@@ -28,8 +28,8 @@ And vanished with feline defense.
 
 A barista who worked the night shift,
 Made lattes incredibly swift,
-[TODO: write line 3 — short line, ~5 syllables, setup for punchline]
-[TODO: write line 4 — short line, ~5 syllables, rhymes with line 3]
+She foamed in a lift,
+And poured with a drift,
 But her espresso game was a gift.
 
 ---
@@ -40,4 +40,4 @@ There once was a girl from the stars,
 Who dreamed about living on Mars,
 She built her own ship,
 And went on a trip,
-[TODO: write closing line — must rhyme with "stars" and "Mars"]
+And sent postcards back from the stars.


### PR DESCRIPTION
## Issue
/claim #201

## Summary
Completed the missing limerick lines in `english/limericks.md` while preserving every existing completed line.

## Acceptance criteria
- [x] The Programmer line 5 rhymes with Rust and dust
- [x] The Coffee lines 3-4 rhyme with each other and are approximately 5 syllables
- [x] The Astronaut line 5 rhymes with stars and Mars
- [x] Completed limericks read naturally with the requested rhythm
- [x] All `[TODO: ...]` placeholders are fully replaced
- [x] All other existing limericks remain unchanged

## Verification
- [x] `Select-String -Path english\limericks.md -Pattern TODO -SimpleMatch` returns no matches
- [x] `git diff --check`

## Demo
Markdown-only limerick completion; the finished lines are visible directly in the PR diff.
