### PR TITLE
Complete missing sonnet lines

### DIFF
--- a/english/sonnets.md
+++ b/english/sonnets.md
@@ -13,13 +13,16 @@ A whispered prayer dissolving in the cloud.
 
 The moon ascends her throne of silver light,
 And casts her gaze upon the sleeping earth,
-[TODO: write lines 7-8 — must rhyme with "light" and "earth", ~10 syllables each, iambic pentameter]
+She threads my shadow through the fields of night,
+And names the hush that gave my longing birth.
 
 The rivers carry secrets to the sea,
 And mountains hold the memories of rain,
-[TODO: write lines 11-12 — must rhyme with "sea" and "rain", ~10 syllables each]
+Yet every tide returns those names to me,
+And every summit answers pain with pain.
 
-[TODO: write closing couplet (lines 13-14) — must rhyme with each other, provide resolution to the theme of cosmic solitude]
+So though the heavens set my soul apart,
+Their far-off fires keep vigil in my heart.
 
 ---
 


### PR DESCRIPTION
## Issue
/claim #202

## Summary
Completed the missing lines in Sonnet I while preserving Sonnet II unchanged.

## Acceptance criteria
- [x] Lines 7 and 5 rhyme in the ABAB pattern
- [x] Lines 8 and 6 rhyme in the ABAB pattern
- [x] Lines 11 and 9 rhyme in the EFEF pattern
- [x] Lines 12 and 10 rhyme in the EFEF pattern
- [x] Lines 13 and 14 form a rhyming closing couplet
- [x] New lines are approximately 10 syllables and fit the sonnet rhythm
- [x] The closing couplet resolves the theme of cosmic solitude
- [x] All `[TODO: ...]` placeholders are fully replaced
- [x] Sonnet II remains unchanged

## Verification
- [x] `Select-String -Path english\sonnets.md -Pattern TODO -SimpleMatch` returns no matches
- [x] `git diff --check`

## Demo
Markdown-only sonnet completion; the finished lines are visible directly in the PR diff.
