### PR TITLE
fix(python): use extended master secret label when EMS is negotiated

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,57 @@
+"""Tests for _derive_master_secret EMS label fix (issue #21)."""
+
+import unittest
+
+from tls_handshake import TLSHandshake
+
+
+class TestDeriveMasterSecret(unittest.TestCase):
+    """Tests for _derive_master_secret() EMS label fix (issue #21)."""
+
+    def setUp(self):
+        self.handshake = TLSHandshake(is_server=False)
+        self.handshake.client_random = b"\x00" * 32
+        self.handshake.server_random = b"\x01" * 32
+        self.handshake._pre_master_secret = b"\x02" * 48
+
+    def test_ems_label(self):
+        """When EMS is negotiated, label is 'extended master secret'."""
+        self.handshake.negotiated_ems = True
+        self.handshake._derive_master_secret()
+        seed = self.handshake.client_random + self.handshake.server_random
+        expected = self.handshake._prf(
+            self.handshake._pre_master_secret,
+            b"extended master secret",
+            seed,
+            48,
+        )
+        self.assertEqual(self.handshake.master_secret, expected)
+
+    def test_non_ems_label(self):
+        """When EMS is not negotiated, label remains 'master secret'."""
+        self.handshake.negotiated_ems = False
+        self.handshake._derive_master_secret()
+        seed = self.handshake.client_random + self.handshake.server_random
+        expected = self.handshake._prf(
+            self.handshake._pre_master_secret,
+            b"master secret",
+            seed,
+            48,
+        )
+        self.assertEqual(self.handshake.master_secret, expected)
+
+    def test_ems_produces_different_secret(self):
+        """EMS and non-EMS produce different master secrets."""
+        self.handshake.negotiated_ems = False
+        self.handshake._derive_master_secret()
+        non_ems_secret = self.handshake.master_secret
+
+        self.handshake.negotiated_ems = True
+        self.handshake._derive_master_secret()
+        ems_secret = self.handshake.master_secret
+
+        self.assertNotEqual(non_ems_secret, ems_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Issue
Closes #21

## Summary
Corrects _derive_master_secret() to use b'extended master secret' instead of b'master secret' when the Extended Master Secret extension (RFC 7627) has been negotiated.

## Acceptance criteria
- [x] When self.negotiated_ems is True, label is b'extended master secret'
- [x] When self.negotiated_ems is False, label remains b'master secret'
- [x] _prf() receives the correct label, producing different 48-byte master_secret values for EMS vs non-EMS
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

/claim #21