### PR TITLE
fix(english): complete haiku missing lines

### DIFF
--- a/english/haikus.md
+++ b/english/haikus.md
@@ -8,7 +8,7 @@ A curated set of original haikus on nature, technology, and solitude.
 
 Dew drips from the leaf
 A spider weaves silver thread
-[TODO: write closing line — must be 5 syllables, reference sunrise]
+Sun lifts gold again
 
 ---
 
@@ -32,7 +32,7 @@ Seagulls call goodnight
 
 Dust gathers softly
 A chair waits by the window
-[TODO: write closing line — must be 5 syllables, convey absence]
+No footsteps return
 
 ---
 
@@ -40,12 +40,12 @@ A chair waits by the window
 
 Semicolon missed
 The build fails at line forty
-[TODO: write closing line — must be 5 syllables, humorous tone]
+The brackets revolt
 
 ---
 
 ### Autumn Walk
 
 Leaves crunch underfoot
-[TODO: write middle line — must be 7 syllables, describe the wind]
+West wind combs the dry branches
 Cold hands find warm pockets


### PR DESCRIPTION
## Issue
Closes #200
/claim #200

## Summary
Replaced the four TODO placeholders in `english/haikus.md` with original lines matching the requested themes and syllable counts.

## Acceptance criteria
- [x] Each completed line matches the required syllable count exactly (5 or 7)
- [x] Lines follow the thematic direction given in the TODO comment
- [x] The [TODO: ...] placeholder is fully replaced with the new line
- [x] All other existing haikus remain unchanged
- [x] The file still renders correctly as valid markdown

## Verification
- `rg -n "TODO" english/haikus.md || true`
- reviewed the changed lines for the requested 5/7 syllable counts and themes

No runtime demo video applies to this static Markdown-only change.