### PR TITLE
fix(english): complete limerick missing lines

### DIFF
--- a/english/limericks.md
+++ b/english/limericks.md
@@ -10,7 +10,7 @@ There once was a dev who loved Rust,
 Whose code never once gathered dust,
 He wrote every night,
 Till the tests were all right,
-[TODO: write closing line — must rhyme with "Rust" and "dust"]
+And shipped it with borrow-checked trust.
 
 ---
 
@@ -28,8 +28,8 @@ And vanished with feline defense.
 
 A barista who worked the night shift,
 Made lattes incredibly swift,
-[TODO: write line 3 — short line, ~5 syllables, setup for punchline]
-[TODO: write line 4 — short line, ~5 syllables, rhymes with line 3]
+She foamed every cup,
+Then topped each one up,
 But her espresso game was a gift.
 
 ---
@@ -40,4 +40,4 @@ There once was a girl from the stars,
 Who dreamed about living on Mars,
 She built her own ship,
 And went on a trip,
-[TODO: write closing line — must rhyme with "stars" and "Mars"]
+And danced in red dust under stars.


### PR DESCRIPTION
## Issue
Closes #201
/claim #201

## Summary
Replaced the limerick TODO placeholders in `english/limericks.md` with original lines that preserve the requested rhyme and rhythm.

## Acceptance criteria
- [x] The Programmer closing line rhymes with "Rust" and "dust"
- [x] The Coffee lines 3 and 4 are short lines with matching rhyme
- [x] The Astronaut closing line rhymes with "stars" and "Mars"
- [x] All [TODO: ...] placeholders are fully replaced
- [x] All existing limericks remain otherwise unchanged
- [x] The file still renders correctly as valid markdown

## Verification
- `rg -n "TODO" english/limericks.md || true`
- reviewed the changed lines for rhyme, approximate syllable count, and limerick rhythm

No runtime demo video applies to this static Markdown-only change.