### PR TITLE
fix(english): complete song missing sections

### DIFF
--- a/english/songs.md
+++ b/english/songs.md
@@ -16,15 +16,20 @@ But the server returned an empty frame,
 **[Chorus]**
 Heart not found, heart not found,
 I keep refreshing but you're not around,
-[TODO: write 2 more chorus lines — must maintain the "internet/heartbreak" metaphor, rhyme scheme AABB]
+Your name still glows at the edge of my screen,
+But every saved password forgets what we mean.
 
 **[Verse 2]**
 Your profile says you're online tonight,
 The green dot glowing, soft and bright,
-[TODO: write 2 more verse lines — continue the theme of digital loneliness, rhyme with each other]
+I type a message, then delete the light,
+Alone with a cursor that blinks in white.
 
 **[Bridge]**
-[TODO: write 4-line bridge — shift tone to acceptance, slower rhythm, can break rhyme scheme]
+I close the tabs that kept me awake,
+Let silence load where your picture stayed,
+The network fades into morning air,
+And I learn to leave the page right there.
 
 **[Chorus — Final]**
 Heart not found, heart not found,
@@ -45,15 +50,21 @@ And that was the end of the Cretaceous ball!
 
 **[Chorus]**
 Extinction polka, one-two-three!
-[TODO: write 3 more chorus lines — must be upbeat and absurd, reference different extinct species, maintain polka rhythm]
+The trilobites twirl in the fossil sea,
+The mammoths mambo with jubilee,
+And dodos dip by the baobab tree!
 
 **[Verse 2]**
 The dodo bird walked without a care,
 With its fluffy wings and its vacant stare,
-[TODO: write 2 more verse lines — rhyme with each other, reference the dodo's obliviousness]
+It waved at the hunters with innocent flair,
+And booked a parade for the next county fair.
 
 **[Verse 3]**
-[TODO: write full 4-line verse — pick another extinct animal (mammoth, saber-tooth, etc.), maintain humorous polka tone, AABB rhyme]
+A mammoth arrived in a shaggy old coat,
+And tried to polka on ice like a boat,
+His tusks kept the rhythm, his feet missed the beat,
+He bowed to the glacier and shuffled offbeat.
 
 **[Outro]**
 So raise a glass to the ones who are gone,
@@ -73,9 +84,13 @@ The garbage collector will sweep while you sleep,
 And free all the pointers you promised to keep.
 
 **[Verse 2]**
-[TODO: write full 4-line verse — continue the "computer science lullaby" theme, reference threads/deadlocks/race conditions in a soothing way, AABB rhyme]
+The threads will untangle their dreams in a row,
+While deadlocks loosen and let the bits flow,
+No races will chase you through stacks deep and wide,
+The scheduler rocks you with sleep on each side.
 
 **[Verse 3]**
 The kernel is humming a low steady tune,
 The clock ticks in cycles from midnight to noon,
-[TODO: write 2 closing lines — wrap up the lullaby, reference shutdown/sleep mode, rhyme with each other]
+So drift into sleep mode, your sockets all tight,
+The shutdown is gentle; the logs say goodnight.


### PR DESCRIPTION
## Issue
Closes #204
/claim #204

## Summary
Completed all missing sections in `english/songs.md` with original lines matching the requested themes, rhyme patterns, and tones.

## Acceptance criteria
- [x] 404 chorus keeps the internet/heartbreak metaphor and AABB-style rhyme
- [x] 404 verse continues digital loneliness with rhyming lines
- [x] 404 bridge shifts toward acceptance with a slower rhythm
- [x] Mass Extinction Polka chorus is upbeat, absurd, and references extinct species
- [x] Dodo verse lines rhyme and show the dodo's obliviousness
- [x] Mammoth verse uses humorous polka tone with AABB rhyme
- [x] Segfault Lullaby verse references threads, deadlocks, and race conditions soothingly with AABB rhyme
- [x] Segfault Lullaby closing lines reference sleep mode/shutdown and rhyme
- [x] All [TODO: ...] placeholders are fully replaced
- [x] The file still renders correctly as valid markdown

## Verification
- `rg -n "TODO" english/songs.md || true`
- reviewed the changed sections against each TODO requirement

No runtime demo video applies to this static Markdown-only change.