### PR TITLE
fix(english): complete acrostic poems

### DIFF
--- a/english/acrostics.md
+++ b/english/acrostics.md
@@ -9,15 +9,20 @@ Each poem's first letters spell a hidden word.
 Under the glow of a flickering screen,
 Nothing is quite what it seems to have been,
 Shadows are lurking in functions unseen,
-[TODO: write line 4 — must start with 'A', theme of hidden danger]
-[TODO: write line 5 — must start with 'F', building tension]
-[TODO: write line 6 — must start with 'E', conclude with revelation]
+A whispering backdoor lies buried between,
+Faint traces awaken where warnings convene,
+Every secret spills into code unforeseen.
 
 ---
 
 ### Acrostic #2 — (Should spell: BOUNTY)
 
-[TODO: write full 6-line acrostic poem spelling BOUNTY — theme: treasure hunting, each line ~8-10 syllables, first letters must spell B-O-U-N-T-Y]
+Buried maps shimmer under moonlight,
+Old trails call across the sand,
+Under cliffs, we test each lantern,
+North stars guide the captain's hand,
+Treasure drums below the tide,
+Young hearts cheer when gold is found.
 
 ---
 


### PR DESCRIPTION
## Issue
Closes #205

## Summary
Completed the missing acrostic poem lines in `english/acrostics.md` for UNSAFE and BOUNTY while leaving the POETRY poem unchanged.

## Acceptance criteria
- [x] Acrostic #1 first letters of all 6 lines spell U-N-S-A-F-E
- [x] Acrostic #1 lines 4-6 match the rhythm and dark/mysterious tone of lines 1-3
- [x] Acrostic #2 first letters of all 6 lines spell B-O-U-N-T-Y
- [x] Acrostic #2 has a treasure hunting theme with ~8-10 syllables per line
- [x] Acrostic #3 (POETRY) remains completely unchanged
- [x] All [TODO: ...] placeholders are fully replaced
- [x] The file renders correctly as valid markdown

## Verification
- Ran a local Python check confirming no TODO placeholders remain and the first letters spell UNSAFE, BOUNTY, and POETRY.
