### PR TITLE
fix(english): complete acrostic missing lines

### DIFF
--- a/english/acrostics.md
+++ b/english/acrostics.md
@@ -9,15 +9,20 @@ Each poem's first letters spell a hidden word.
 Under the glow of a flickering screen,
 Nothing is quite what it seems to have been,
 Shadows are lurking in functions unseen,
-[TODO: write line 4 — must start with 'A', theme of hidden danger]
-[TODO: write line 5 — must start with 'F', building tension]
-[TODO: write line 6 — must start with 'E', conclude with revelation]
+A warning blooms where no alarm has been,
+Fault lines awaken beneath the screen,
+Every hidden flaw steps into the scene.
 
 ---
 
 ### Acrostic #2 — (Should spell: BOUNTY)
 
-[TODO: write full 6-line acrostic poem spelling BOUNTY — theme: treasure hunting, each line ~8-10 syllables, first letters must spell B-O-U-N-T-Y]
+Beneath old maps, the lanterns gleam,
+Over dark ridges, we follow the stream,
+Under flat stones, a coin starts to shine,
+Near buried roots, we trace the line,
+Treasure waits where patient hands pry,
+Yielding gold beneath the dawn sky.
 
 ---
 


### PR DESCRIPTION
## Issue
Closes #205
/claim #205

## Summary
Completed the missing acrostic lines in `english/acrostics.md` so the first poem spells UNSAFE and the second spells BOUNTY.

## Acceptance criteria
- [x] Acrostic #1 line 4 starts with A and follows the hidden-danger theme
- [x] Acrostic #1 line 5 starts with F and builds tension
- [x] Acrostic #1 line 6 starts with E and concludes with revelation
- [x] Acrostic #2 contains six lines whose initials spell BOUNTY
- [x] Acrostic #2 follows the treasure-hunting theme
- [x] Acrostic #2 lines are approximately 8-10 syllables each
- [x] POETRY remains unchanged
- [x] All [TODO: ...] placeholders are fully replaced
- [x] The file still renders correctly as valid markdown

## Verification
- `rg -n "TODO" english/acrostics.md || true`
- `awk` check confirmed the completed initials spell `UNSAFE` and `BOUNTY`

No runtime demo video applies to this static Markdown-only change.