### PR TITLE
fix: handle missing negotiated cipher suite

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.21

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("no matching suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,28 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuite_UnknownID(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	name, err := r.NegotiateSuite([]uint16{0xFFFF})
+	if err == nil {
+		t.Fatal("expected an error for an unknown suite")
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name, got %q", name)
+	}
+}
+
+func TestNegotiateSuite_ValidID(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	name, err := r.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}


### PR DESCRIPTION
## Summary

Return a clear error when no client-offered cipher suite matches instead of dereferencing a nil selected suite.

## Changes

- Added a nil check after suite negotiation.
- Added tests for unknown and valid suite negotiation.
- Added the Go module definition.

## Testing

- `cd go && go test -v -count=1 -race`

Fixes #11
/claim #11
