### PR TITLE
fix(english): complete acrostic poems

### DIFF
--- a/english/acrostics.md
+++ b/english/acrostics.md
@@ -9,15 +9,20 @@ Each poem's first letters spell a hidden word.
 Under the glow of a flickering screen,
 Nothing is quite what it seems to have been,
 Shadows are lurking in functions unseen,
-[TODO: write line 4 — must start with 'A', theme of hidden danger]
-[TODO: write line 5 — must start with 'F', building tension]
-[TODO: write line 6 — must start with 'E', conclude with revelation]
+A whispering flaw waits below the sheen,
+Footsteps of warnings grow sharp and keen,
+Every last secret breaks out of the machine,
 
 ---
 
 ### Acrostic #2 — (Should spell: BOUNTY)
 
-[TODO: write full 6-line acrostic poem spelling BOUNTY — theme: treasure hunting, each line ~8-10 syllables, first letters must spell B-O-U-N-T-Y]
+Buried maps gleam under moonlit sand,
+Old coins wake in a careful hand,
+Under stone, the silver signs appear,
+Northward trails pull the seekers near,
+Treasure calls from the cavern's eye,
+Yielding gold where the shadows lie,
 
 ---
 


### PR DESCRIPTION
## Issue
Closes #205

## Summary
Completes the missing lines in `english/acrostics.md` so the UNSAFE poem and BOUNTY poem are complete while preserving the existing POETRY acrostic unchanged.

## Acceptance criteria
- [x] The first acrostic spells U-N-S-A-F-E
- [x] Lines four through six match the rhythm and dark/mysterious tone of the opening lines
- [x] The second acrostic spells B-O-U-N-T-Y
- [x] The second acrostic has a treasure hunting theme with roughly eight to ten syllables per line
- [x] The POETRY acrostic remains completely unchanged
- [x] All TODO placeholders are fully replaced
- [x] The file renders correctly as valid markdown

## Verification
- Ran a Python check confirming no TODO placeholders remain and the acrostics spell UNSAFE, BOUNTY, and POETRY.

/claim #205