### PR TITLE
fix(go): return error from NegotiateSuite when no suite matches

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,9 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually-supported cipher suite")
+	}
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,39 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteUnknownIDsReturnsError(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	name, err := reg.NegotiateSuite([]uint16{0xFFFF})
+
+	if err == nil {
+		t.Fatalf("expected error for unknown cipher ID, got name=%q", name)
+	}
+	if name != "" {
+		t.Fatalf("expected empty name when no suite matches, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteValidIDReturnsName(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteEmptyClientList(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	name, err := reg.NegotiateSuite(nil)
+
+	if err == nil {
+		t.Fatalf("expected error for empty client list, got name=%q", name)
+	}
+}


### PR DESCRIPTION
## Issue
Closes #11
/claim #11

## Summary
NegotiateSuite now returns ("", error) when no client-offered suite matches a known server suite, instead of dereferencing a nil pointer.

## Acceptance criteria
- [x] NegotiateSuite([]uint16{0xFFFF}) returns ("", non-nil error), no panic
- [x] NegotiateSuite with a valid ID like TLS_AES_128_GCM_SHA256 still returns its name
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- go test ./... — pass (3 tests)

## Disclosure
AI-assisted patch, manually scoped and exercised locally.