### PR TITLE
fix: prefer chacha20 on arm64

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.21

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -43,6 +43,7 @@ type SuiteRegistry struct {
 	knownSuites []*CipherSuite
 	minStrength CipherStrength
 	preferredID uint16
+	goarch      string
 	suiteCache  map[uint16]*CipherSuite // BUG(5): unprotected shared cache
 	mu          sync.Mutex              // guards knownSuites only
 }
@@ -51,6 +52,7 @@ type SuiteRegistry struct {
 func NewSuiteRegistry(minStrength CipherStrength) *SuiteRegistry {
 	reg := &SuiteRegistry{
 		minStrength: minStrength,
+		goarch:      runtime.GOARCH,
 		suiteCache:  make(map[uint16]*CipherSuite),
 	}
 	reg.loadDefaults()
@@ -217,6 +219,14 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
 			return !si.IsAEAD && sj.IsAEAD
+		}
+
+		if r.goarch == "arm64" {
+			siChaCha := strings.Contains(si.Name, "CHACHA20_POLY1305")
+			sjChaCha := strings.Contains(sj.Name, "CHACHA20_POLY1305")
+			if siChaCha != sjChaCha {
+				return siChaCha
+			}
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,43 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func suiteIndex(suites []*CipherSuite, id uint16) int {
+	for i, suite := range suites {
+		if suite.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestSortByPreference_ARM64_PrefersChaCha20(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	r.goarch = "arm64"
+	sorted := r.SortByPreference(r.FilterWeakSuites(r.knownSuites))
+	chacha := suiteIndex(sorted, tls.TLS_CHACHA20_POLY1305_SHA256)
+	aes128 := suiteIndex(sorted, tls.TLS_AES_128_GCM_SHA256)
+	aes256 := suiteIndex(sorted, tls.TLS_AES_256_GCM_SHA384)
+	if chacha == -1 || aes128 == -1 || aes256 == -1 {
+		t.Fatalf("expected ChaCha20 and AES-GCM suites in sorted list")
+	}
+	if chacha > aes128 || chacha > aes256 {
+		t.Fatalf("expected ChaCha20 before AES-GCM on arm64, got chacha=%d aes128=%d aes256=%d", chacha, aes128, aes256)
+	}
+}
+
+func TestSortByPreference_AMD64_PrefersAEAD(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	r.goarch = "amd64"
+	suites := []*CipherSuite{
+		r.knownSuites[1], // AES-256-GCM
+		r.knownSuites[2], // ChaCha20
+	}
+	sorted := r.SortByPreference(suites)
+	if sorted[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected amd64 ordering to leave AES-GCM ahead of ChaCha20, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary

Prefer ChaCha20-Poly1305 ahead of AES-GCM when sorting cipher suites on arm64 platforms.

## Changes

- Track the registry architecture from `runtime.GOARCH`.
- Move ChaCha20-Poly1305 ahead of AES-GCM suites on arm64.
- Added tests for arm64 and amd64 preference behavior.
- Added the Go module definition.

## Testing

- `cd go && go test -v -count=1 -race`

Fixes #12
/claim #12
