### PR TITLE
fix: filter rc4 and 3des cipher suites

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.21

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,6 +194,9 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
+		if strings.Contains(s.Name, "RC4") || strings.Contains(s.Name, "3DES") {
+			continue
+		}
 		if s.KeySize >= minKeyBits {
 			result = append(result, s)
 		}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,22 @@
+package tlscipher
+
+import "testing"
+
+func TestFilterWeakSuites_RemovesRC4(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	filtered := r.FilterWeakSuites([]*CipherSuite{
+		{ID: 0xCC13, Name: "TLS_RSA_WITH_RC4_128_SHA", KeySize: 128},
+	})
+	if len(filtered) != 0 {
+		t.Fatalf("expected RC4 suite to be filtered, got %d suites", len(filtered))
+	}
+}
+
+func TestFilterWeakSuites_KeepsAES(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	aes := &CipherSuite{ID: 0x1301, Name: "TLS_AES_128_GCM_SHA256", KeySize: 128}
+	filtered := r.FilterWeakSuites([]*CipherSuite{aes})
+	if len(filtered) != 1 || filtered[0] != aes {
+		t.Fatalf("expected AES suite to be kept, got %#v", filtered)
+	}
+}


### PR DESCRIPTION
## Summary

Filter RC4 and 3DES cipher suites as weak regardless of their key size.

## Changes

- Added name-based filtering for RC4 and 3DES cipher suites.
- Added tests proving RC4 is removed and AES is retained.
- Added the Go module definition.

## Testing

- `cd go && go test -v -count=1 -race`

Fixes #13
/claim #13
