### PR TITLE
fix: sort aead cipher suites first

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.21

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -216,7 +216,7 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,13 @@
+package tlscipher
+
+import "testing"
+
+func TestSortByPreference_AEADFirst(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	nonAEAD := &CipherSuite{Name: "TLS_RSA_WITH_AES_128_CBC_SHA", KeySize: 128, IsAEAD: false, Strength: StrengthLegacy}
+	aead := &CipherSuite{Name: "TLS_AES_128_GCM_SHA256", KeySize: 128, IsAEAD: true, Strength: StrengthModern}
+	sorted := r.SortByPreference([]*CipherSuite{nonAEAD, aead})
+	if sorted[0] != aead {
+		t.Fatalf("expected AEAD suite first, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary

Correct the AEAD comparison so AEAD cipher suites rank ahead of non-AEAD suites.

## Changes

- Flipped the AEAD sort predicate to prefer AEAD suites.
- Added a regression test for AEAD-first ordering.
- Added the Go module definition.

## Testing

- `cd go && go test -v -count=1 -race`

Fixes #14
/claim #14
