### PR TITLE
fix: guard suite cache access

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters
+
+go 1.21

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -137,8 +137,10 @@ func (r *SuiteRegistry) loadDefaults() {
 
 // lookupSuite retrieves a suite from the cache, falling back to a linear
 // scan of knownSuites. Results are cached for faster repeated lookups.
-// BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,35 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestConcurrentLookup(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	ids := make([]uint16, 100)
+	for i := range ids {
+		ids[i] = tls.TLS_AES_128_GCM_SHA256
+	}
+	results, err := r.ConcurrentLookup(ids)
+	if err != nil {
+		t.Fatalf("ConcurrentLookup returned error: %v", err)
+	}
+	for i, suite := range results {
+		if suite == nil || suite.ID != tls.TLS_AES_128_GCM_SHA256 {
+			t.Fatalf("result %d = %#v, want TLS_AES_128_GCM_SHA256", i, suite)
+		}
+	}
+}
+
+func TestLookupSuite_Cached(t *testing.T) {
+	r := NewSuiteRegistry(StrengthWeak)
+	first := r.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+	second := r.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+	if first == nil || second == nil {
+		t.Fatal("expected cached suite lookups to return a suite")
+	}
+	if first != second {
+		t.Fatal("expected repeated lookups to return the cached suite pointer")
+	}
+}


### PR DESCRIPTION
## Summary

Protect cipher suite cache reads and writes with the registry mutex to eliminate concurrent map races.

## Changes

- Locked `lookupSuite` around cache reads, cache writes, and known suite scans.
- Added concurrent lookup and cached lookup regression tests.
- Added the Go module definition.

## Testing

- `cd go && go test -v -count=1 -race`

Fixes #15
/claim #15
