### PR TITLE
[ English ] Complete the missing sonnet lines in sonnets.md

### DIFF
--- a/english/sonnets.md
+++ b/english/sonnets.md
@@ -13,13 +13,16 @@ A whispered prayer dissolving in the cloud.
 
 The moon ascends her throne of silver light,
 And casts her gaze upon the sleeping earth,
-[TODO: write lines 7-8 — must rhyme with "light" and "earth", ~10 syllables each, iambic pentameter]
+Yet still my heart remains a shard of light,
+A small, warm spark against the cold, wide earth.
 
 The rivers carry secrets to the sea,
 And mountains hold the memories of rain,
-[TODO: write lines 11-12 — must rhyme with "sea" and "rain", ~10 syllables each]
+I send my longing outward toward the sea,
+It falls back softly, mingled with the rain.
 
-[TODO: write closing couplet (lines 13-14) — must rhyme with each other, provide resolution to the theme of cosmic solitude]
+Yet in that echo, distance turns to grace,
+The stars draw near, and I have found my place.
 
 ---
 


### PR DESCRIPTION
Completes Sonnet I in `english/sonnets.md` and leaves Sonnet II unchanged.

Fixes #202
/claim #202