### PR TITLE
Fix TLS bounty batch across assembly, Python, and Rust

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -20,12 +20,14 @@ section .data
     lbl_application     db "ApplicationData", 10, 0
     lbl_heartbeat       db "Heartbeat", 10, 0
     lbl_unknown         db "Unknown content type", 10, 0
+    msg_tls13_record    db "TLS 1.3 record detected", 10, 0
+    msg_inner_type      db "Inner content type: 0x", 0
 
     ; --- Error strings ---
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
     err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---
@@ -105,6 +107,7 @@ parse_tls_record:
     jle .type_ok                ; BUG: should be jl, not jle -- but wait,
                                 ; 0x18 (heartbeat) is valid so jle is needed...
                                 ; actually TLS_CT_MAX is 0x18 and we want <= 0x18
+    jg .invalid_type
 
     ; --- Actually the check above is wrong for a different reason ---
     ; Content type 0x17 is application_data which is VALID, and 0x18
@@ -125,10 +128,11 @@ parse_tls_record:
     ; --- Bytes 1-2: Protocol Version (big-endian) ---
     ; TLS version is 2 bytes, network byte order (big-endian)
     ; e.g. TLS 1.2 = 0x0303, TLS 1.0 = 0x0301
-    mov ax, [rsi+1]             ; BUG: loads in little-endian on x86
-                                ; For input bytes 03 03 this works by coincidence
-                                ; but 03 01 would be read as 0x0103 instead of 0x0301
-    movzx r14d, ax              ; r14 = version (incorrectly byte-swapped)
+    movzx eax, byte [rsi+1]
+    shl eax, 8
+    movzx ebx, byte [rsi+2]
+    or eax, ebx
+    mov r14d, eax               ; r14 = version in network byte order
 
     ; Print version
     push rsi
@@ -162,9 +166,11 @@ parse_tls_record:
     ja .invalid_length
 
     ; --- Read payload data ---
-    ; BUG: No check that r12 (bytes in buffer) >= r15 + 5
-    ; If the record claims a large payload but we only read a few
-    ; bytes, we'll process past the end of valid data
+    mov eax, r15d
+    add eax, 5
+    cmp rax, r12
+    ja .invalid_length
+
     lea rdi, [rsi+5]            ; rdi = start of payload
     mov ecx, r15d               ; ecx = payload length
 
@@ -224,12 +230,29 @@ parse_tls_record:
     jmp .parse_done
 
 .handle_application:
+    cmp r14d, 0x0303
+    je .handle_tls13_record
     push rdi
     lea rdi, [rel lbl_application]
     call print_string
     pop rdi
-    ; Application data is encrypted, just report the length
-    ; No TLS 1.3 inner content type detection is performed
+    jmp .parse_done
+
+.handle_tls13_record:
+    push rdi
+    lea rdi, [rel msg_tls13_record]
+    call print_string
+    pop rdi
+    cmp ecx, 0
+    jle .parse_done
+    push rdi
+    lea rdi, [rel msg_inner_type]
+    call print_string
+    pop rdi
+    movzx edi, byte [rdi+rcx-1]
+    call print_hex_byte
+    lea rdi, [rel msg_newline]
+    call print_string
     jmp .parse_done
 
 .handle_heartbeat:

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,11 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_hostname(ext_data)
+                if ext.server_name is not None:
+                    self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +218,31 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_hostname(self, data: bytes) -> Optional[str]:
+        """Decode the first host_name entry from a TLS SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = min(len(data), offset + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            name_end = offset + name_len
+            if name_end > end:
+                return None
+            if name_type == 0x00:
+                try:
+                    return data[offset:name_end].decode("utf-8")
+                except UnicodeDecodeError:
+                    return None
+            offset = name_end
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """
@@ -233,8 +260,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""
@@ -271,9 +297,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of cached sessions before eviction kicks in.
@@ -8,9 +10,7 @@ const MAX_CACHE_SIZE: usize = 4096;
 /// Default ticket lifetime in seconds (2 hours).
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
 
-/// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+static NONCE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -66,9 +66,7 @@ pub struct EncryptionKey {
 #[derive(Debug, Clone)]
 pub struct SessionCache {
     /// Thread-safe reference to the inner cache map.
-    // BUG(trap2): Arc alone does not provide interior mutability or
-    // synchronisation.  Concurrent callers can race on the HashMap.
-    cache: Arc<HashMap<String, SessionTicket>>,
+    cache: Arc<RwLock<HashMap<String, SessionTicket>>>,
     encryption_key: EncryptionKey,
     max_size: usize,
 }
@@ -108,18 +106,20 @@ impl SessionCache {
     pub fn new(key_material: Vec<u8>) -> Self {
         let key = EncryptionKey::new(1, key_material);
         SessionCache {
-            cache: Arc::new(HashMap::new()),
+            cache: Arc::new(RwLock::new(HashMap::new())),
             encryption_key: key,
             max_size: MAX_CACHE_SIZE,
         }
     }
 
     /// Store a session ticket in the cache.
-    pub fn store_session(&mut self, ticket: SessionTicket) -> Result<(), SessionError> {
-        let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
+    pub fn store_session(&self, ticket: SessionTicket) -> Result<(), SessionError> {
+        let mut inner = self.cache.write().map_err(|_| {
+            SessionError::InvalidTicket("session cache lock poisoned".to_string())
+        })?;
 
         if inner.len() >= self.max_size {
-            self.evict_expired_sessions(inner);
+            self.evict_expired_sessions(&mut inner);
         }
 
         if inner.len() >= self.max_size {
@@ -133,27 +133,26 @@ impl SessionCache {
     /// Look up a session by ticket id.
     ///
     /// Returns the ticket if it exists **and** has not expired.
-    pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
-        // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
-        // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+    pub fn get_session(&self, ticket_id: &str) -> Option<SessionTicket> {
+        let inner = self.cache.read().ok()?;
+        let ticket = inner.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;
         }
 
-        Some(ticket)
+        Some(ticket.clone())
     }
 
     /// Remove a specific ticket from the cache.
-    pub fn remove_session(&mut self, ticket_id: &str) -> Option<SessionTicket> {
-        let inner = Arc::get_mut(&mut self.cache)?;
+    pub fn remove_session(&self, ticket_id: &str) -> Option<SessionTicket> {
+        let mut inner = self.cache.write().ok()?;
         inner.remove(ticket_id)
     }
 
     /// Return the number of cached sessions.
     pub fn session_count(&self) -> usize {
-        self.cache.len()
+        self.cache.read().map(|inner| inner.len()).unwrap_or(0)
     }
 
     // -- internal helpers ---------------------------------------------------
@@ -166,10 +165,11 @@ impl SessionCache {
 
     /// Calculate the age of a ticket in seconds.
     fn calculate_ticket_age(&self, ticket: &SessionTicket) -> u64 {
-        // BUG(trap4): subtracts creation_time from issued_at instead of
-        // computing `now - issued_at`.  The result is a fixed delta that
-        // never grows, so tickets effectively never expire.
-        ticket.issued_at.saturating_sub(ticket.creation_time)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        now.saturating_sub(ticket.issued_at)
     }
 
     /// Evict all expired sessions from the map.
@@ -231,10 +231,7 @@ impl SessionCache {
             ));
         }
 
-        // BUG(trap5): uses the constant ENCRYPTION_NONCE for every call
-        // instead of generating a fresh random nonce.  Nonce reuse with
-        // the same key breaks AEAD confidentiality guarantees.
-        let nonce = ENCRYPTION_NONCE;
+        let nonce = fresh_nonce();
 
         let key = &self.encryption_key.key_material;
         let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
@@ -256,20 +253,83 @@ impl SessionCache {
                 "ciphertext too short".to_string(),
             ));
         }
-
-        let nonce = &ciphertext[..12];
-        let data = &ciphertext[12..];
-        let key = &self.encryption_key.key_material;
-
-        let mut plaintext = Vec::with_capacity(data.len());
-        for (i, &byte) in data.iter().enumerate() {
-            let key_byte = key[i % key.len()];
-            let nonce_byte = nonce[i % nonce.len()];
-            plaintext.push(byte ^ key_byte ^ nonce_byte);
+        if self.encryption_key.key_material.is_empty() {
+            return Err(SessionError::DecryptionFailed(
+                "empty key material".to_string(),
+            ));
         }
 
-        Ok(plaintext)
+        xor_crypt_ticket(ciphertext, &self.encryption_key.key_material)
+            .map_err(SessionError::DecryptionFailed)
     }
+
+    /// Rotate the ticket encryption key and re-encrypt cached tickets.
+    pub fn rotate_key(&mut self, new_material: Vec<u8>) -> Result<(), SessionError> {
+        if new_material.is_empty() {
+            return Err(SessionError::EncryptionFailed(
+                "empty key material".to_string(),
+            ));
+        }
+
+        let old_key = self.encryption_key.clone();
+        let new_key = EncryptionKey::new(old_key.key_id + 1, new_material);
+        let mut inner = self.cache.write().map_err(|_| {
+            SessionError::InvalidTicket("session cache lock poisoned".to_string())
+        })?;
+
+        for ticket in inner.values_mut() {
+            let plaintext = xor_crypt_ticket(&ticket.encrypted_state, &old_key.key_material)
+                .map_err(SessionError::DecryptionFailed)?;
+            ticket.encrypted_state = encrypt_with_key(&plaintext, &new_key.key_material);
+        }
+
+        self.encryption_key = new_key;
+        Ok(())
+    }
+}
+
+fn fresh_nonce() -> [u8; 12] {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_nanos();
+    let counter = NONCE_COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+    let mixed = now ^ counter.rotate_left(17) ^ ((std::process::id() as u128) << 32);
+    let bytes = mixed.to_le_bytes();
+    let mut nonce = [0u8; 12];
+    nonce.copy_from_slice(&bytes[..12]);
+    nonce
+}
+
+fn encrypt_with_key(plaintext: &[u8], key: &[u8]) -> Vec<u8> {
+    let nonce = fresh_nonce();
+    let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
+    ciphertext.extend_from_slice(&nonce);
+    for (i, &byte) in plaintext.iter().enumerate() {
+        let key_byte = key[i % key.len()];
+        let nonce_byte = nonce[i % nonce.len()];
+        ciphertext.push(byte ^ key_byte ^ nonce_byte);
+    }
+    ciphertext
+}
+
+fn xor_crypt_ticket(ciphertext: &[u8], key: &[u8]) -> Result<Vec<u8>, String> {
+    if ciphertext.len() < 12 {
+        return Err("ciphertext too short".to_string());
+    }
+    if key.is_empty() {
+        return Err("empty key material".to_string());
+    }
+
+    let nonce = &ciphertext[..12];
+    let data = &ciphertext[12..];
+    let mut plaintext = Vec::with_capacity(data.len());
+    for (i, &byte) in data.iter().enumerate() {
+        let key_byte = key[i % key.len()];
+        let nonce_byte = nonce[i % nonce.len()];
+        plaintext.push(byte ^ key_byte ^ nonce_byte);
+    }
+    Ok(plaintext)
 }
 
 // ---------------------------------------------------------------------------
@@ -291,9 +351,91 @@ impl SessionCache {
     pub fn summary(&self) -> String {
         format!(
             "SessionCache {{ sessions: {}, key_id: {}, max: {} }}",
-            self.cache.len(),
+            self.session_count(),
             self.encryption_key.key_id,
             self.max_size,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn ticket(id: &str, issued_at: u64, lifetime_secs: u64) -> SessionTicket {
+        SessionTicket {
+            ticket_id: id.to_string(),
+            cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+            master_secret: b"secret".to_vec(),
+            issued_at,
+            lifetime_secs,
+            encrypted_state: Vec::new(),
+            creation_time: issued_at,
+        }
+    }
+
+    #[test]
+    fn get_missing_session_returns_none() {
+        let cache = SessionCache::new(b"key".to_vec());
+        assert!(cache.get_session("missing").is_none());
+    }
+
+    #[test]
+    fn get_session_filters_expired_tickets() {
+        let cache = SessionCache::new(b"key".to_vec());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        cache.store_session(ticket("fresh", now - 100, DEFAULT_TICKET_LIFETIME_SECS)).unwrap();
+        cache.store_session(ticket("expired", now - 7201, DEFAULT_TICKET_LIFETIME_SECS)).unwrap();
+        assert!(cache.get_session("fresh").is_some());
+        assert!(cache.get_session("expired").is_none());
+    }
+
+    #[test]
+    fn concurrent_store_and_lookup_is_synchronized() {
+        let cache = Arc::new(SessionCache::new(b"key".to_vec()));
+        let mut handles = Vec::new();
+        for idx in 0..10 {
+            let cache = Arc::clone(&cache);
+            handles.push(thread::spawn(move || {
+                let id = format!("tkt_{}", idx);
+                cache.store_session(ticket(&id, 1, u64::MAX)).unwrap();
+                assert!(cache.get_session(&id).is_some());
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        assert_eq!(cache.session_count(), 10);
+    }
+
+    #[test]
+    fn rotate_key_reencrypts_cached_tickets() {
+        let mut cache = SessionCache::new(b"old-key".to_vec());
+        let ticket = cache.issue_ticket(
+            CipherSuite::TlsAes128GcmSha256,
+            b"master-secret".to_vec(),
+        ).unwrap();
+        let old_encrypted = ticket.encrypted_state.clone();
+
+        cache.rotate_key(b"new-key".to_vec()).unwrap();
+        let rotated = cache.get_session(&ticket.ticket_id).unwrap();
+
+        assert_eq!(cache.encryption_key.key_id, 2);
+        assert_ne!(rotated.encrypted_state, old_encrypted);
+        assert_eq!(cache.decrypt_ticket(&rotated.encrypted_state).unwrap(), b"master-secret");
+    }
+
+    #[test]
+    fn encrypt_ticket_uses_fresh_nonce() {
+        let cache = SessionCache::new(b"key".to_vec());
+        let first = cache.encrypt_ticket(b"same_data").unwrap();
+        let second = cache.encrypt_ticket(b"same_data").unwrap();
+        assert_ne!(first, second);
+        assert_eq!(cache.decrypt_ticket(&first).unwrap(), b"same_data");
+        assert_eq!(cache.decrypt_ticket(&second).unwrap(), b"same_data");
     }
 }

--- a/tests/test_tls_batch.py
+++ b/tests/test_tls_batch.py
@@ -1,0 +1,97 @@
+import hmac
+import importlib.util
+import pathlib
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def load_tls_handshake():
+    path = ROOT / "python" / "tls_handshake.py"
+    spec = importlib.util.spec_from_file_location("tls_handshake", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PythonTLSHandshakeTests(unittest.TestCase):
+    def setUp(self):
+        self.tls = load_tls_handshake()
+
+    def test_sni_extension_sets_server_name(self):
+        hostname = b"example.com"
+        server_name = b"\x00" + len(hostname).to_bytes(2, "big") + hostname
+        ext_data = len(server_name).to_bytes(2, "big") + server_name
+        raw_ext = (
+            self.tls.EXT_SNI.to_bytes(2, "big")
+            + len(ext_data).to_bytes(2, "big")
+            + ext_data
+        )
+
+        handshake = self.tls.TLSHandshake()
+        extensions = handshake.parse_extensions(raw_ext)
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_missing_sni_leaves_server_name_unset(self):
+        handshake = self.tls.TLSHandshake()
+        handshake.parse_extensions(b"")
+        self.assertIsNone(handshake.server_name)
+
+    def test_verify_finished_uses_compare_digest(self):
+        handshake = self.tls.TLSHandshake()
+        handshake.master_secret = b"m" * 48
+        received = handshake._prf(
+            handshake.master_secret,
+            b"client finished",
+            handshake.handshake_hash.copy().digest(),
+            12,
+        )
+
+        with mock.patch.object(hmac, "compare_digest", wraps=hmac.compare_digest) as compare:
+            self.assertTrue(handshake.verify_finished(received, "client finished"))
+            compare.assert_called_once()
+
+    def test_ems_uses_distinct_prf_label(self):
+        base = self.tls.TLSHandshake()
+        base._pre_master_secret = b"p" * 48
+        base.client_random = b"c" * 32
+        base.server_random = b"s" * 32
+        base.negotiated_ems = False
+        base._derive_master_secret()
+
+        ems = self.tls.TLSHandshake()
+        ems._pre_master_secret = b"p" * 48
+        ems.client_random = b"c" * 32
+        ems.server_random = b"s" * 32
+        ems.negotiated_ems = True
+        ems._derive_master_secret()
+
+        self.assertNotEqual(base.master_secret, ems.master_secret)
+
+
+class StaticSourceChecks(unittest.TestCase):
+    def test_assembly_batch_fixes_are_present(self):
+        source = (ROOT / "assembly" / "tls_record_parser.asm").read_text()
+        self.assertIn('err_alert_warning   db "WARNING: alert received from peer", 10, 0', source)
+        self.assertIn("jg .invalid_type", source)
+        self.assertIn("movzx eax, byte [rsi+1]", source)
+        self.assertIn("cmp rax, r12", source)
+        self.assertIn('msg_tls13_record    db "TLS 1.3 record detected", 10, 0', source)
+        self.assertIn("movzx edi, byte [rdi+rcx-1]", source)
+
+    def test_rust_batch_fixes_are_present(self):
+        source = (ROOT / "rust" / "tls_session.rs").read_text()
+        self.assertIn("Arc<RwLock<HashMap<String, SessionTicket>>>", source)
+        self.assertIn("pub fn get_session(&self, ticket_id: &str) -> Option<SessionTicket>", source)
+        self.assertIn("pub fn rotate_key(&mut self, new_material: Vec<u8>)", source)
+        self.assertIn("fn fresh_nonce() -> [u8; 12]", source)
+        self.assertNotIn("const ENCRYPTION_NONCE", source)
+        self.assertIn("now.saturating_sub(ticket.issued_at)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix TLS record parser issues around version byte order, content-type bounds, truncated payload checks, TLS 1.3 inner content reporting, and alert warning string termination.
- Fix TLS handshake SNI parsing, constant-time Finished verification, and EMS PRF label selection.
- Make the Rust session cache synchronized, non-panicking on missing tickets, expiration-aware, key-rotatable, and nonce-fresh for ticket encryption.
- Add a no-dependency unittest suite covering Python behavior plus static checks for the assembly/Rust changes.

## Validation
- `python -B -m unittest discover -s tests`
- `python -B -m py_compile python\tls_handshake.py tests\test_tls_batch.py`
- `git diff --check`

Notes: this local environment does not have `nasm` or `rustc` installed, so the assembly/Rust coverage is static source validation plus in-file Rust unit tests for maintainers to run where Rust is available.

/claim #1
/claim #2
/claim #3
/claim #4
/claim #5
/claim #17
/claim #18
/claim #21
/claim #22
/claim #23
/claim #24
/claim #25
/claim #26