### PR TITLE
Parse SNI hostnames from TLS extensions

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,11 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_hostname(ext_data)
+                if ext.server_name is not None:
+                    self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +218,31 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_hostname(self, data: bytes) -> Optional[str]:
+        """Decode the first host_name entry from a TLS SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = min(len(data), offset + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            name_end = offset + name_len
+            if name_end > end:
+                return None
+            if name_type == 0x00:
+                try:
+                    return data[offset:name_end].decode("utf-8")
+                except UnicodeDecodeError:
+                    return None
+            offset = name_end
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """

--- a/tests/test_python_issue17.py
+++ b/tests/test_python_issue17.py
@@ -1,0 +1,43 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def load_tls_handshake():
+    path = ROOT / "python" / "tls_handshake.py"
+    spec = importlib.util.spec_from_file_location("tls_handshake", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SNIExtensionTests(unittest.TestCase):
+    def test_sni_extension_sets_server_name(self):
+        tls = load_tls_handshake()
+        hostname = b"example.com"
+        server_name = b"\x00" + len(hostname).to_bytes(2, "big") + hostname
+        ext_data = len(server_name).to_bytes(2, "big") + server_name
+        raw_ext = (
+            tls.EXT_SNI.to_bytes(2, "big")
+            + len(ext_data).to_bytes(2, "big")
+            + ext_data
+        )
+
+        handshake = tls.TLSHandshake()
+        extensions = handshake.parse_extensions(raw_ext)
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_missing_sni_leaves_server_name_unset(self):
+        tls = load_tls_handshake()
+        handshake = tls.TLSHandshake()
+        handshake.parse_extensions(b"")
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Decode host_name entries from the SNI extension in `parse_extensions()`.
- Store the decoded hostname on both `TLSExtension.server_name` and `TLSHandshake.server_name`.
- Add focused SNI parsing tests.

## Validation
- `python -B -m unittest tests.test_python_issue17`
- `git diff --check`

/claim #17