### PR TITLE
Return None for missing session tickets

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -134,9 +134,7 @@ impl SessionCache {
     ///
     /// Returns the ticket if it exists **and** has not expired.
     pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
-        // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
-        // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+        let ticket = self.cache.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;

--- a/tests/test_rust_issue22.py
+++ b/tests/test_rust_issue22.py
@@ -1,0 +1,18 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class RustMissingTicketStaticTests(unittest.TestCase):
+    def test_get_session_uses_option_short_circuit_not_unwrap(self):
+        source = (ROOT / "rust" / "tls_session.rs").read_text()
+        get_session = source.split("pub fn get_session", 1)[1].split("pub fn remove_session", 1)[0]
+
+        self.assertIn("let ticket = self.cache.get(ticket_id)?;", get_session)
+        self.assertNotIn(".unwrap()", get_session)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace the missing-ticket `unwrap()` in `get_session()` with Option short-circuiting.
- Missing ticket IDs now return `None` instead of panicking.
- Add a focused static regression check for the non-panicking lookup path.

## Validation
- `python -B -m unittest tests.test_rust_issue22`
- `git diff --check`

Note: `rustc` is not installed in this local environment, so validation here is static source coverage.

/claim #22