### PR TITLE
Calculate session ticket age from current time

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -166,10 +166,11 @@ impl SessionCache {
 
     /// Calculate the age of a ticket in seconds.
     fn calculate_ticket_age(&self, ticket: &SessionTicket) -> u64 {
-        // BUG(trap4): subtracts creation_time from issued_at instead of
-        // computing `now - issued_at`.  The result is a fixed delta that
-        // never grows, so tickets effectively never expire.
-        ticket.issued_at.saturating_sub(ticket.creation_time)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        now.saturating_sub(ticket.issued_at)
     }
 
     /// Evict all expired sessions from the map.

--- a/tests/test_rust_issue25.py
+++ b/tests/test_rust_issue25.py
@@ -1,0 +1,19 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class RustTicketAgeStaticTests(unittest.TestCase):
+    def test_ticket_age_uses_current_time_minus_issued_at(self):
+        source = (ROOT / "rust" / "tls_session.rs").read_text()
+        calculate_age = source.split("fn calculate_ticket_age", 1)[1].split("fn evict_expired_sessions", 1)[0]
+
+        self.assertIn("SystemTime::now()", calculate_age)
+        self.assertIn("now.saturating_sub(ticket.issued_at)", calculate_age)
+        self.assertNotIn("ticket.issued_at.saturating_sub(ticket.creation_time)", calculate_age)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Compute ticket age as current Unix time minus `issued_at`.
- Expired tickets can now age out instead of remaining at a fixed zero-age delta.
- Add a focused static regression check for the age calculation.

## Validation
- `python -B -m unittest tests.test_rust_issue25`
- `git diff --check`

Note: `rustc` is not installed in this local environment, so validation here is static source coverage.

/claim #25