### PR TITLE
Use fresh nonces for ticket encryption

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of cached sessions before eviction kicks in.
@@ -8,9 +9,7 @@ const MAX_CACHE_SIZE: usize = 4096;
 /// Default ticket lifetime in seconds (2 hours).
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
 
-/// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+static NONCE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -231,10 +230,7 @@ impl SessionCache {
             ));
         }
 
-        // BUG(trap5): uses the constant ENCRYPTION_NONCE for every call
-        // instead of generating a fresh random nonce.  Nonce reuse with
-        // the same key breaks AEAD confidentiality guarantees.
-        let nonce = ENCRYPTION_NONCE;
+        let nonce = fresh_nonce();
 
         let key = &self.encryption_key.key_material;
         let mut ciphertext = Vec::with_capacity(nonce.len() + plaintext.len());
@@ -270,6 +266,19 @@ impl SessionCache {
 
         Ok(plaintext)
     }
+}
+
+fn fresh_nonce() -> [u8; 12] {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_nanos();
+    let counter = NONCE_COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+    let mixed = now ^ counter.rotate_left(17) ^ ((std::process::id() as u128) << 32);
+    let bytes = mixed.to_le_bytes();
+    let mut nonce = [0u8; 12];
+    nonce.copy_from_slice(&bytes[..12]);
+    nonce
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_rust_issue26.py
+++ b/tests/test_rust_issue26.py
@@ -1,0 +1,20 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class RustNonceStaticTests(unittest.TestCase):
+    def test_encrypt_ticket_uses_fresh_nonce_helper(self):
+        source = (ROOT / "rust" / "tls_session.rs").read_text()
+        encrypt_ticket = source.split("pub fn encrypt_ticket", 1)[1].split("pub fn decrypt_ticket", 1)[0]
+
+        self.assertNotIn("const ENCRYPTION_NONCE", source)
+        self.assertIn("static NONCE_COUNTER", source)
+        self.assertIn("fn fresh_nonce() -> [u8; 12]", source)
+        self.assertIn("let nonce = fresh_nonce();", encrypt_ticket)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Remove the fixed ticket-encryption nonce constant.
- Generate a fresh 12-byte nonce for each `encrypt_ticket()` call and continue prepending it for decryption.
- Add a focused static regression check for the fresh nonce path.

## Validation
- `python -B -m unittest tests.test_rust_issue26`
- `git diff --check`

Note: `rustc` is not installed in this local environment, so validation here is static source coverage.

/claim #26