### PR TITLE
Terminate warning alert string

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -25,7 +25,7 @@ section .data
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
     err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---

--- a/tests/test_assembly_issue5.py
+++ b/tests/test_assembly_issue5.py
@@ -1,0 +1,22 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class AlertWarningStringTests(unittest.TestCase):
+    def test_warning_alert_string_is_newline_and_null_terminated(self):
+        source = (ROOT / "assembly" / "tls_record_parser.asm").read_text()
+        self.assertIn(
+            'err_alert_warning   db "WARNING: alert received from peer", 10, 0',
+            source,
+        )
+        self.assertNotIn(
+            'err_alert_warning   db "WARNING: alert received from peer"\n',
+            source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add the missing newline and null terminator to `err_alert_warning`.
- Prevent `print_string` from leaking into the following `err_truncated` string.
- Add a focused static regression check for the assembly data declaration.

## Validation
- `python -B -m unittest tests.test_assembly_issue5`
- `git diff --check`

Note: `nasm` is not installed in this local environment, so validation here is static source coverage.

/claim #5