### PR TITLE
Parse TLS record version in network byte order

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -125,10 +125,11 @@ parse_tls_record:
     ; --- Bytes 1-2: Protocol Version (big-endian) ---
     ; TLS version is 2 bytes, network byte order (big-endian)
     ; e.g. TLS 1.2 = 0x0303, TLS 1.0 = 0x0301
-    mov ax, [rsi+1]             ; BUG: loads in little-endian on x86
-                                ; For input bytes 03 03 this works by coincidence
-                                ; but 03 01 would be read as 0x0103 instead of 0x0301
-    movzx r14d, ax              ; r14 = version (incorrectly byte-swapped)
+    movzx eax, byte [rsi+1]
+    shl eax, 8
+    movzx ebx, byte [rsi+2]
+    or eax, ebx
+    mov r14d, eax               ; r14 = version in network byte order
 
     ; Print version
     push rsi

--- a/tests/test_assembly_issue1.py
+++ b/tests/test_assembly_issue1.py
@@ -1,0 +1,22 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class VersionByteOrderTests(unittest.TestCase):
+    def test_version_bytes_are_loaded_big_endian(self):
+        source = (ROOT / "assembly" / "tls_record_parser.asm").read_text()
+        version_block = source.split("; --- Bytes 1-2: Protocol Version", 1)[1].split("; Print version", 1)[0]
+
+        self.assertIn("movzx eax, byte [rsi+1]", version_block)
+        self.assertIn("shl eax, 8", version_block)
+        self.assertIn("movzx ebx, byte [rsi+2]", version_block)
+        self.assertIn("or eax, ebx", version_block)
+        self.assertIn("mov r14d, eax", version_block)
+        self.assertNotIn("mov ax, [rsi+1]", version_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Parse TLS version bytes explicitly in network byte order instead of loading a little-endian word on x86.
- TLS 1.0 bytes `03 01` now become `0x0301`, while TLS 1.2 `03 03` remains `0x0303`.
- Add a focused static regression check for the version parsing block.

## Validation
- `python -B -m unittest tests.test_assembly_issue1`
- `git diff --check`

Note: `nasm` is not installed in this local environment, so validation here is static source coverage.

/claim #1