### PR TITLE
Reject truncated TLS record payloads

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -162,9 +162,11 @@ parse_tls_record:
     ja .invalid_length
 
     ; --- Read payload data ---
-    ; BUG: No check that r12 (bytes in buffer) >= r15 + 5
-    ; If the record claims a large payload but we only read a few
-    ; bytes, we'll process past the end of valid data
+    mov eax, r15d
+    add eax, 5
+    cmp rax, r12
+    ja .invalid_length
+
     lea rdi, [rsi+5]            ; rdi = start of payload
     mov ecx, r15d               ; ecx = payload length
 

--- a/tests/test_assembly_issue2.py
+++ b/tests/test_assembly_issue2.py
@@ -1,0 +1,20 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class PayloadTruncationTests(unittest.TestCase):
+    def test_payload_length_is_checked_against_available_bytes(self):
+        source = (ROOT / "assembly" / "tls_record_parser.asm").read_text()
+        block = source.split("; --- Read payload data ---", 1)[1].split("lea rdi, [rsi+5]", 1)[0]
+
+        self.assertIn("mov eax, r15d", block)
+        self.assertIn("add eax, 5", block)
+        self.assertIn("cmp rax, r12", block)
+        self.assertIn("ja .invalid_length", block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Check that the buffer contains `payload length + 5` bytes before payload dispatch.
- Truncated records now use the existing `.invalid_length` / `err_truncated` path instead of letting handlers read past valid input.
- Add a focused static regression check for the truncation guard.

## Validation
- `python -B -m unittest tests.test_assembly_issue2`
- `git diff --check`

Note: `nasm` is not installed in this local environment, so validation here is static source coverage.

/claim #2