### PR TITLE
Reject TLS content types above the maximum

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -105,6 +105,7 @@ parse_tls_record:
     jle .type_ok                ; BUG: should be jl, not jle -- but wait,
                                 ; 0x18 (heartbeat) is valid so jle is needed...
                                 ; actually TLS_CT_MAX is 0x18 and we want <= 0x18
+    jg .invalid_type
 
     ; --- Actually the check above is wrong for a different reason ---
     ; Content type 0x17 is application_data which is VALID, and 0x18

--- a/tests/test_assembly_issue3.py
+++ b/tests/test_assembly_issue3.py
@@ -1,0 +1,21 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class ContentTypeBoundsTests(unittest.TestCase):
+    def test_upper_bound_rejects_values_above_tls_ct_max(self):
+        source = (ROOT / "assembly" / "tls_record_parser.asm").read_text()
+        bounds = source.split("; Validate content type range", 1)[1].split(".type_ok:", 1)[0]
+
+        self.assertIn("cmp r13d, TLS_CT_MIN", bounds)
+        self.assertIn("jl .invalid_type", bounds)
+        self.assertIn("cmp r13d, TLS_CT_MAX", bounds)
+        self.assertIn("jle .type_ok", bounds)
+        self.assertIn("jg .invalid_type", bounds)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add the missing branch to `.invalid_type` when the content type is above `TLS_CT_MAX`.
- Values like `0x19` or `0xff` no longer fall through into `.type_ok`.
- Add a focused static regression check for the content-type bounds block.

## Validation
- `python -B -m unittest tests.test_assembly_issue3`
- `git diff --check`

Note: `nasm` is not installed in this local environment, so validation here is static source coverage.

/claim #3