### PR TITLE
Complete missing haiku lines

### DIFF
--- a/english/haikus.md
+++ b/english/haikus.md
@@ -8,7 +8,7 @@ A curated set of original haikus on nature, technology, and solitude.
 
 Dew drips from the leaf
 A spider weaves silver thread
-[TODO: write closing line — must be 5 syllables, reference sunrise]
+Sunrise paints the sky
 
 ---
 
@@ -32,7 +32,7 @@ Seagulls call goodnight
 
 Dust gathers softly
 A chair waits by the window
-[TODO: write closing line — must be 5 syllables, convey absence]
+No footsteps return
 
 ---
 
@@ -40,12 +40,12 @@ A chair waits by the window
 
 Semicolon missed
 The build fails at line forty
-[TODO: write closing line — must be 5 syllables, humorous tone]
+Coffee blames the code
 
 ---
 
 ### Autumn Walk
 
 Leaves crunch underfoot
-[TODO: write middle line — must be 7 syllables, describe the wind]
+Wind combs through brittle branches
 Cold hands find warm pockets


### PR DESCRIPTION
/claim #200

## Summary
- Replaced the four TODO placeholders in `english/haikus.md`
- Kept the existing haikus and markdown structure unchanged
- Added lines matching the requested themes: sunrise, absence, humor, and wind

## Validation
- Confirmed no `TODO` placeholders remain in `english/haikus.md`
- Checked the new lines against the requested 5/7 syllable constraints:
  - `Sunrise paints the sky` = 5
  - `No footsteps return` = 5
  - `Coffee blames the code` = 5
  - `Wind combs through brittle branches` = 7

Demo: this is a markdown-only content change; the diff itself shows each completed haiku line in place.