### PR TITLE
fix(c): compare fingerprints in constant time

### DIFF
--- a/c/test_match_fingerprint.c
+++ b/c/test_match_fingerprint.c
@@ -1,0 +1,39 @@
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+static int crypto_memcmp_calls = 0;
+
+int test_crypto_memcmp(const void *a, const void *b, size_t len);
+
+#define CRYPTO_memcmp test_crypto_memcmp
+#include "tls_cert_validator.c"
+#undef CRYPTO_memcmp
+
+int test_crypto_memcmp(const void *a, const void *b, size_t len)
+{
+    crypto_memcmp_calls++;
+    return memcmp(a, b, len);
+}
+
+int main(void)
+{
+    unsigned char expected[FINGERPRINT_LEN];
+    unsigned char matching[FINGERPRINT_LEN];
+    unsigned char mismatched[FINGERPRINT_LEN];
+
+    memset(expected, 0x7a, sizeof(expected));
+    memcpy(matching, expected, sizeof(matching));
+    memcpy(mismatched, expected, sizeof(mismatched));
+    mismatched[FINGERPRINT_LEN - 1] ^= 0xff;
+
+    crypto_memcmp_calls = 0;
+    assert(match_fingerprint(expected, matching));
+    assert(crypto_memcmp_calls == 1);
+
+    crypto_memcmp_calls = 0;
+    assert(!match_fingerprint(expected, mismatched));
+    assert(crypto_memcmp_calls == 1);
+
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)


### PR DESCRIPTION
## Issue
Closes #6

## Summary
Replace the fingerprint comparison memcmp call with OpenSSL CRYPTO_memcmp, preserving match and mismatch behavior. The regression test intercepts CRYPTO_memcmp during compilation so it verifies the constant-time API is actually called.

## Acceptance criteria
- [x] match_fingerprint calls CRYPTO_memcmp
- [x] Match return behavior is preserved
- [x] Fingerprint mismatch still rejects
- [x] Existing tests pass
- [x] New regression test added

## Demo / verification

![Demo](https://raw.githubusercontent.com/MNgaminhhh/Bounty-Hunters/demo-pr-164/demo/pr-164-match-fingerprint.gif)

Local verification run:

```sh
cc -Wall -Wextra -I/opt/homebrew/opt/openssl@3/include c/test_match_fingerprint.c \
  -L/opt/homebrew/opt/openssl@3/lib -lcrypto -o /tmp/test_match_fingerprint
/tmp/test_match_fingerprint
```

Result: exit code 0. The regression test covers matching fingerprints, one-byte mismatches, and that the CRYPTO_memcmp call path is used.

/claim #6