### PR TITLE
Detect TLS 1.3 inner record content type

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -20,6 +20,8 @@ section .data
     lbl_application     db "ApplicationData", 10, 0
     lbl_heartbeat       db "Heartbeat", 10, 0
     lbl_unknown         db "Unknown content type", 10, 0
+    msg_tls13_record    db "TLS 1.3 record detected", 10, 0
+    msg_inner_type      db "Inner content type: 0x", 0
 
     ; --- Error strings ---
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
@@ -224,12 +226,29 @@ parse_tls_record:
     jmp .parse_done
 
 .handle_application:
+    cmp r14d, 0x0303
+    je .handle_tls13_record
     push rdi
     lea rdi, [rel lbl_application]
     call print_string
     pop rdi
-    ; Application data is encrypted, just report the length
-    ; No TLS 1.3 inner content type detection is performed
+    jmp .parse_done
+
+.handle_tls13_record:
+    push rdi
+    lea rdi, [rel msg_tls13_record]
+    call print_string
+    pop rdi
+    cmp ecx, 0
+    jle .parse_done
+    push rdi
+    lea rdi, [rel msg_inner_type]
+    call print_string
+    pop rdi
+    movzx edi, byte [rdi+rcx-1]
+    call print_hex_byte
+    lea rdi, [rel msg_newline]
+    call print_string
     jmp .parse_done
 
 .handle_heartbeat:

--- a/tests/test_assembly_issue4.py
+++ b/tests/test_assembly_issue4.py
@@ -1,0 +1,21 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class TLS13ApplicationRecordTests(unittest.TestCase):
+    def test_application_records_detect_tls13_inner_type(self):
+        source = (ROOT / "assembly" / "tls_record_parser.asm").read_text()
+        app_block = source.split(".handle_application:", 1)[1].split(".handle_heartbeat:", 1)[0]
+
+        self.assertIn('msg_tls13_record    db "TLS 1.3 record detected", 10, 0', source)
+        self.assertIn('msg_inner_type      db "Inner content type: 0x", 0', source)
+        self.assertIn("cmp r14d, 0x0303", app_block)
+        self.assertIn("je .handle_tls13_record", app_block)
+        self.assertIn("movzx edi, byte [rdi+rcx-1]", app_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Detect TLS 1.3-style application records when the legacy record version is `0x0303`.
- Print a TLS 1.3 detection message and report the last payload byte as the inner content type when present.
- Preserve the existing `ApplicationData` path for non-TLS-1.3 application records.
- Add a focused static regression check for the assembly dispatch block.

## Validation
- `python -B -m unittest tests.test_assembly_issue4`
- `git diff --check`

Note: `nasm` is not installed in this local environment, so validation here is static source coverage.

/claim #4