### PR TITLE
Complete missing limerick lines

### DIFF
--- a/english/limericks.md
+++ b/english/limericks.md
@@ -10,7 +10,7 @@ There once was a dev who loved Rust,
 Whose code never once gathered dust,
 He wrote every night,
 Till the tests were all right,
-[TODO: write closing line — must rhyme with "Rust" and "dust"]
+And shipped it with fearless trust.
 
 ---
 
@@ -28,8 +28,8 @@ And vanished with feline defense.
 
 A barista who worked the night shift,
 Made lattes incredibly swift,
-[TODO: write line 3 — short line, ~5 syllables, setup for punchline]
-[TODO: write line 4 — short line, ~5 syllables, rhymes with line 3]
+With one foamy beam,
+She spun clouds of steam,
 But her espresso game was a gift.
 
 ---
@@ -40,4 +40,4 @@ There once was a girl from the stars,
 Who dreamed about living on Mars,
 She built her own ship,
 And went on a trip,
-[TODO: write closing line — must rhyme with "stars" and "Mars"]
+Then bottled moonbeams in jars.


### PR DESCRIPTION
/claim #201

## Summary
- Replaced the TODO placeholders in `english/limericks.md`
- Preserved all existing completed limericks
- Matched the requested rhyme targets for Rust/dust, Coffee lines 3-4, and stars/Mars

## Validation
- Confirmed no `TODO` placeholders remain in `english/limericks.md`
- Checked the new lines against the requested rhyme and approximate syllable constraints

Demo: markdown-only content change; the PR diff shows each completed limerick line in place.