### PR TITLE
Complete missing sonnet lines

### DIFF
--- a/english/sonnets.md
+++ b/english/sonnets.md
@@ -13,13 +13,16 @@ A whispered prayer dissolving in the cloud.
 
 The moon ascends her throne of silver light,
 And casts her gaze upon the sleeping earth,
-[TODO: write lines 7-8 — must rhyme with "light" and "earth", ~10 syllables each, iambic pentameter]
+Yet still my heart keeps vigil through the night,
+And weighs the silence of my hidden worth.
 
 The rivers carry secrets to the sea,
 And mountains hold the memories of rain,
-[TODO: write lines 11-12 — must rhyme with "sea" and "rain", ~10 syllables each]
+Their ancient songs drift back and answer me,
+That solitude may ripen into gain.
 
-[TODO: write closing couplet (lines 13-14) — must rhyme with each other, provide resolution to the theme of cosmic solitude]
+So though the stars keep watch from realms above,
+I find within their hush a patient love.
 
 ---
 


### PR DESCRIPTION
/claim #202

## Summary
- Completed the missing lines in Sonnet I in `english/sonnets.md`
- Preserved Sonnet II unchanged
- Matched the requested ABAB/EFEF/GG rhyme structure and resolved the cosmic-solitude theme

## Validation
- Confirmed no `TODO` placeholders remain in `english/sonnets.md`
- Checked line rhymes: light/night, earth/worth, sea/me, rain/gain, above/love

Demo: markdown-only content change; the PR diff shows the completed sonnet lines in place.