### PR TITLE
Complete missing song sections

### DIFF
--- a/english/songs.md
+++ b/english/songs.md
@@ -16,15 +16,20 @@ But the server returned an empty frame,
 **[Chorus]**
 Heart not found, heart not found,
 I keep refreshing but you're not around,
-[TODO: write 2 more chorus lines — must maintain the "internet/heartbreak" metaphor, rhyme scheme AABB]
+Your ghost keeps typing on my screen,
+Then fades before the message is seen.
 
 **[Verse 2]**
 Your profile says you're online tonight,
 The green dot glowing, soft and bright,
-[TODO: write 2 more verse lines — continue the theme of digital loneliness, rhyme with each other]
+I type hello, then close the pane,
+Alone inside this pixel rain.
 
 **[Bridge]**
-[TODO: write 4-line bridge — shift tone to acceptance, slower rhythm, can break rhyme scheme]
+I let the loading circle fade,
+No more tabs kept open late,
+Some pages close without a sign,
+I'll log off and call the silence mine.
 
 **[Chorus — Final]**
 Heart not found, heart not found,
@@ -45,15 +50,21 @@ And that was the end of the Cretaceous ball!
 
 **[Chorus]**
 Extinction polka, one-two-three!
-[TODO: write 3 more chorus lines — must be upbeat and absurd, reference different extinct species, maintain polka rhythm]
+Mammoths twirl with ivory glee!
+Saber-tooths tap in harmony!
+Trilobites clap beneath the sea!
 
 **[Verse 2]**
 The dodo bird walked without a care,
 With its fluffy wings and its vacant stare,
-[TODO: write 2 more verse lines — rhyme with each other, reference the dodo's obliviousness]
+It waved at hunters passing by,
+And never thought to ask them why.
 
 **[Verse 3]**
-[TODO: write full 4-line verse — pick another extinct animal (mammoth, saber-tooth, etc.), maintain humorous polka tone, AABB rhyme]
+A mammoth bought a tiny hat,
+And wore it proudly, just like that,
+But when the glaciers left the floor,
+He polkaed south and found no more.
 
 **[Outro]**
 So raise a glass to the ones who are gone,
@@ -73,9 +84,13 @@ The garbage collector will sweep while you sleep,
 And free all the pointers you promised to keep.
 
 **[Verse 2]**
-[TODO: write full 4-line verse — continue the "computer science lullaby" theme, reference threads/deadlocks/race conditions in a soothing way, AABB rhyme]
+Threads curl softly in their beds,
+Deadlocks loosen sleepy heads,
+Race conditions drift away,
+While mutex moonbeams guard the day.
 
 **[Verse 3]**
 The kernel is humming a low steady tune,
 The clock ticks in cycles from midnight to noon,
-[TODO: write 2 closing lines — wrap up the lullaby, reference shutdown/sleep mode, rhyme with each other]
+Now shutdown dreams begin to glide,
+And sleep mode holds you safe inside.


### PR DESCRIPTION
/claim #204

## Summary
- Completed the missing sections in `english/songs.md`
- Preserved the existing song structure markers and completed lyrics
- Matched the requested themes for internet heartbreak, extinct-species polka, and computer-science lullaby

## Validation
- Confirmed no `TODO` placeholders remain in `english/songs.md`
- Checked the requested rhyme constraints:
  - 404 chorus uses found/around and screen/seen
  - Coffee lines rhyme pane/rain in the verse
  - Mass Extinction Polka references mammoths, saber-tooths, trilobites, dodo, and mammoth verse AABB
  - Segfault Lullaby references threads, deadlocks, race conditions, shutdown, and sleep mode

Demo: markdown-only content change; the PR diff shows each completed song section in place.