### PR TITLE
Fix match_fingerprint timing side-channel

### DIFF
--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c")
+
+
+class TLSCertValidatorStaticTests(unittest.TestCase):
+    def setUp(self):
+        self.source = SOURCE.read_text(encoding="utf-8")
+
+    def test_fingerprint_match_uses_openssl_constant_time_compare(self):
+        self.assertIn(
+            "return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;",
+            self.source,
+        )
+        self.assertNotIn("return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;", self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)


### PR DESCRIPTION
/claim #6

## Summary
- replace the pinned fingerprint comparison with OpenSSL CRYPTO_memcmp
- add a focused static regression test for the constant-time compare call

## Verification
- python -m unittest c/test_tls_cert_validator_static.py