### PR TITLE
Route validate_chain errors through cleanup

### DIFF
--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -1,0 +1,32 @@
+import re
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c")
+
+
+class TLSCertValidatorStaticTests(unittest.TestCase):
+    def setUp(self):
+        self.source = SOURCE.read_text(encoding="utf-8")
+
+    def test_validate_chain_routes_failures_through_single_cleanup(self):
+        validate_chain = re.search(
+            r"static int validate_chain\(chain_context_t \*ctx\)(.*?)"
+            r"static void cleanup_cert_store",
+            self.source,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(validate_chain)
+        body = validate_chain.group(1)
+        cleanup_index = body.index("cleanup:")
+
+        self.assertEqual(body.count("cleanup:"), 1)
+        self.assertEqual(body.count("return "), 1)
+        self.assertGreater(body.index("return rc;"), cleanup_index)
+        self.assertIn("goto cleanup;", body[:cleanup_index])
+        self.assertNotIn("return CERT_STATUS_", body[:cleanup_index])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -134,49 +134,59 @@ static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 
 static int validate_chain(chain_context_t *ctx)
 {
-    int             i, rc;
+    int             i, rc = CERT_STATUS_OK;
     unsigned char   fp[FINGERPRINT_LEN];
     cert_entry_t   *trusted_issuer;
 
-    if (!ctx || !ctx->chain || ctx->chain_len <= 0)
-        return CERT_STATUS_INVALID;
-    if (ctx->chain_len > MAX_CHAIN_DEPTH)
-        return CERT_STATUS_INVALID;
+    if (!ctx || !ctx->chain || ctx->chain_len <= 0) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
+    if (ctx->chain_len > MAX_CHAIN_DEPTH) {
+        rc = CERT_STATUS_INVALID;
+        goto cleanup;
+    }
 
     for (i = 0; i < ctx->chain_len - 1; i++) {
         rc = check_expiry(ctx->chain[i]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "cert at depth %d failed expiry check", i);
-            return rc;
+            goto cleanup;
         }
         rc = verify_signature(ctx->chain[i], ctx->chain[i + 1]);
         if (rc != CERT_STATUS_OK) {
             log_cert_event(LOG_LEVEL_ERROR, "signature invalid at depth %d", i);
-            return rc;
+            goto cleanup;
         }
     }
 
     trusted_issuer = find_issuer(ctx->trusted_store, ctx->chain[ctx->chain_len - 1]);
     if (!trusted_issuer) {
         log_cert_event(LOG_LEVEL_ERROR, "root not found in trusted store");
-        return CERT_STATUS_UNTRUSTED;
+        rc = CERT_STATUS_UNTRUSTED;
+        goto cleanup;
     }
     rc = verify_signature(ctx->chain[ctx->chain_len - 1], trusted_issuer->cert);
     if (rc != CERT_STATUS_OK)
-        return rc;
+        goto cleanup;
 
     /* Fingerprint pinning on leaf */
     if (ctx->pinned_fingerprint) {
-        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0)
-            return CERT_STATUS_INVALID;
+        if (compute_fingerprint(ctx->chain[0], fp, sizeof(fp)) != 0) {
+            rc = CERT_STATUS_INVALID;
+            goto cleanup;
+        }
         if (!match_fingerprint(fp, ctx->pinned_fingerprint)) {
             log_cert_event(LOG_LEVEL_ERROR, "leaf fingerprint mismatch");
-            return CERT_STATUS_UNTRUSTED;
+            rc = CERT_STATUS_UNTRUSTED;
+            goto cleanup;
         }
     }
 
     log_cert_event(LOG_LEVEL_INFO, "chain validated successfully (%d certs)", ctx->chain_len);
-    return CERT_STATUS_OK;
+
+cleanup:
+    return rc;
 }
 
 static void cleanup_cert_store(cert_store_t *store)


### PR DESCRIPTION
/claim #7

## Summary
- route validate_chain failure exits through a single cleanup label
- preserve each existing error code while avoiding direct early returns
- add a static regression test for the unified-exit structure

## Verification
- python -m unittest c/test_tls_cert_validator_static.py