### PR TITLE
Fix check_expiry remaining_seconds overflow

### DIFF
--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -1,0 +1,24 @@
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c")
+
+
+class TLSCertValidatorStaticTests(unittest.TestCase):
+    def setUp(self):
+        self.source = SOURCE.read_text(encoding="utf-8")
+
+    def test_remaining_seconds_uses_64_bit_overflow_safe_math(self):
+        self.assertIn("int64_t remaining_seconds;", self.source)
+        self.assertIn(
+            "remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;",
+            self.source,
+        )
+        self.assertIn("(long long)remaining_seconds", self.source)
+        self.assertNotIn("int remaining_seconds;", self.source)
+        self.assertNotIn("remaining_seconds = day_diff * 86400 + sec_diff;", self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -83,7 +83,7 @@ static int check_expiry(X509 *cert)
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
     int day_diff, sec_diff;
-    int remaining_seconds;
+    int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
         return CERT_STATUS_INVALID;
@@ -99,9 +99,13 @@ static int check_expiry(X509 *cert)
     if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = day_diff * 86400 + sec_diff;
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
     if (remaining_seconds < 86400 * 30)
-        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %d seconds", remaining_seconds);
+        log_cert_event(
+            LOG_LEVEL_WARN,
+            "certificate expires in %lld seconds",
+            (long long)remaining_seconds
+        );
     return CERT_STATUS_OK;
 }
 


### PR DESCRIPTION
/claim #8

## Summary
- store remaining certificate lifetime in int64_t
- cast day_diff before multiplying by seconds per day
- update the warning log format for the wider value
- add a focused static regression test

## Verification
- python -m unittest c/test_tls_cert_validator_static.py