### PR TITLE
Fix cleanup_cert_store debug log use-after-free

### DIFF
--- a/c/test_tls_cert_validator_static.py
+++ b/c/test_tls_cert_validator_static.py
@@ -1,0 +1,30 @@
+import re
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("tls_cert_validator.c")
+
+
+class TLSCertValidatorStaticTests(unittest.TestCase):
+    def setUp(self):
+        self.source = SOURCE.read_text(encoding="utf-8")
+
+    def test_cleanup_logs_issuer_before_freeing_it(self):
+        cleanup = re.search(
+            r"static void cleanup_cert_store\(cert_store_t \*store\)(.*?)"
+            r"int add_trusted_cert",
+            self.source,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(cleanup)
+        body = cleanup.group(1)
+
+        log_index = body.index('log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s"')
+        issuer_free_index = body.index("free(entry->issuer);")
+
+        self.assertLess(log_index, issuer_free_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -189,9 +189,9 @@ static void cleanup_cert_store(cert_store_t *store)
     while (entry) {
         next = entry->next;
         X509_free(entry->cert);
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }


### PR DESCRIPTION
/claim #10

## Summary
- move the cleanup debug log before entry->issuer is freed
- add a focused static regression test for log/free ordering

## Verification
- python -m unittest c/test_tls_cert_validator_static.py