### PR TITLE
Fix ClientHello to Finished state bypass

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,16 @@
+import unittest
+
+from tls_handshake import HandshakeState, TLSHandshake
+
+
+class TLSHandshakeRegressionTests(unittest.TestCase):
+    def test_finished_cannot_follow_client_hello_directly(self):
+        handshake = TLSHandshake()
+
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -53,10 +53,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],


### PR DESCRIPTION
/claim #16

## Summary
- remove the direct CLIENT_HELLO -> FINISHED transition
- add a regression test that the bypass fails and moves the state machine to ERROR

## Verification
- python python/test_tls_handshake.py