### PR TITLE
Add SNI hostname parsing

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,32 @@
+import unittest
+
+from tls_handshake import EXT_SNI, TLSHandshake
+
+
+class TLSHandshakeRegressionTests(unittest.TestCase):
+    def test_parse_extensions_decodes_sni_hostname(self):
+        hostname = b"api.example.test"
+        sni_entry = b"\x00" + len(hostname).to_bytes(2, "big") + hostname
+        sni_list = len(sni_entry).to_bytes(2, "big") + sni_entry
+        extension = (
+            EXT_SNI.to_bytes(2, "big")
+            + len(sni_list).to_bytes(2, "big")
+            + sni_list
+        )
+        handshake = TLSHandshake()
+
+        parsed = handshake.parse_extensions(extension)
+
+        self.assertEqual(parsed[0].server_name, "api.example.test")
+        self.assertEqual(handshake.server_name, "api.example.test")
+
+    def test_parse_extensions_without_sni_keeps_hostname_empty(self):
+        handshake = TLSHandshake()
+
+        handshake.parse_extensions(b"")
+
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,10 +203,11 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
             if ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
+            elif ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_hostname(ext_data)
+                self.server_name = ext.server_name
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
             elif ext_type == EXT_SUPPORTED_VERSIONS:
@@ -216,6 +217,32 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_hostname(self, data: bytes) -> Optional[str]:
+        """Return the first host_name entry from an RFC 6066 SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = min(len(data), offset + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            if offset + name_len > end:
+                return None
+
+            name_bytes = data[offset:offset + name_len]
+            offset += name_len
+            if name_type == 0x00:
+                try:
+                    return name_bytes.decode("idna")
+                except UnicodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """


### PR DESCRIPTION
/claim #17

## Summary
- decode RFC 6066 host_name entries when parsing the SNI extension
- populate both TLSExtension.server_name and TLSHandshake.server_name
- add focused tests for SNI and no-SNI parsing

## Verification
- python python/test_tls_handshake.py