### PR TITLE
Use compare_digest for Finished verification

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import TLSHandshake
+
+
+class TLSHandshakeRegressionTests(unittest.TestCase):
+    def test_verify_finished_uses_constant_time_compare_digest(self):
+        class FixedVerifyHandshake(TLSHandshake):
+            def _prf(self, secret, label, seed, output_len):
+                return b"v" * output_len
+
+        handshake = FixedVerifyHandshake()
+        handshake.master_secret = b"m" * 48
+
+        with patch("tls_handshake.hmac.compare_digest", return_value=True) as compare_digest:
+            self.assertTrue(handshake.verify_finished(b"v" * 12, "client finished"))
+
+        compare_digest.assert_called_once_with(b"v" * 12, b"v" * 12)
+
+        self.assertFalse(handshake.verify_finished(b"x" * 12, "client finished"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
/claim #18

## Summary
- replace the Finished verify_data equality check with hmac.compare_digest
- add a regression test that verifies compare_digest is called and mismatch still returns False

## Verification
- python python/test_tls_handshake.py