### PR TITLE
Limit process_key_exchange exception handling

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,32 @@
+import unittest
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class TLSHandshakeRegressionTests(unittest.TestCase):
+    def test_process_key_exchange_returns_false_for_expected_parse_errors(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x30" + b"x" * 47,
+        )
+
+        self.assertFalse(handshake.process_key_exchange(message))
+
+    def test_process_key_exchange_does_not_swallow_unexpected_errors(self):
+        class ExplodingHandshake(TLSHandshake):
+            def _decrypt_pre_master_secret(self, encrypted):
+                raise RuntimeError("unexpected decrypt failure")
+
+        handshake = ExplodingHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x30" + b"x" * 48,
+        )
+
+        with self.assertRaises(RuntimeError):
+            handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -256,9 +256,8 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
+        except (ValueError, struct.error):
+            return False
         return False
 
     def _derive_master_secret(self) -> None:


### PR DESCRIPTION
/claim #20

## Summary
- replace the bare except with except (ValueError, struct.error)
- keep expected parse failures returning False
- add a regression test that unexpected exceptions propagate normally

## Verification
- python python/test_tls_handshake.py