### PR TITLE
fix(python): use constant-time Finished verification

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,29 @@
+import hmac
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import TLSHandshake
+
+
+class VerifyFinishedTests(unittest.TestCase):
+    def test_verify_finished_uses_constant_time_comparison(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"m" * 48
+        received_verify = b"expected"
+
+        with patch.object(handshake, "_prf", return_value=received_verify), \
+                patch.object(hmac, "compare_digest", return_value=True) as compare_digest:
+            self.assertTrue(handshake.verify_finished(received_verify, "client finished"))
+
+        compare_digest.assert_called_once_with(received_verify, received_verify)
+
+    def test_verify_finished_returns_false_for_mismatch(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"m" * 48
+
+        with patch.object(handshake, "_prf", return_value=b"expected"):
+            self.assertFalse(handshake.verify_finished(b"different", "client finished"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Issue
Closes #18
/claim #18

## Summary
Replaces the direct Finished verify_data equality check with `hmac.compare_digest()` so verification uses constant-time comparison. Adds focused unittest coverage for the secure comparison path and mismatch behavior.

## Acceptance criteria
- [x] `verify_finished()` uses `hmac.compare_digest(computed_verify, received_verify)` instead of `==`
- [x] The `hmac` module is already imported; no new imports needed
- [x] Return value is still bool (True on match, False otherwise)
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Validation
```powershell
python -m unittest test_tls_handshake
```

Note: this is a non-UI Python security fix; the regression test output demonstrates the behavior in place of a UI demo video.