### PR TITLE
Use extended master secret PRF label

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,32 @@
+import unittest
+
+from tls_handshake import TLSHandshake
+
+
+class TLSHandshakeRegressionTests(unittest.TestCase):
+    def test_derive_master_secret_uses_ems_label_when_negotiated(self):
+        class RecordingHandshake(TLSHandshake):
+            def __init__(self, negotiated_ems):
+                super().__init__()
+                self.negotiated_ems = negotiated_ems
+                self._pre_master_secret = b"p" * 48
+                self.client_random = b"c" * 32
+                self.server_random = b"s" * 32
+                self.labels = []
+
+            def _prf(self, secret, label, seed, output_len):
+                self.labels.append(label)
+                return bytes([len(label) % 256]) * output_len
+
+        standard = RecordingHandshake(False)
+        standard._derive_master_secret()
+        ems = RecordingHandshake(True)
+        ems._derive_master_secret()
+
+        self.assertEqual(standard.labels[-1], b"master secret")
+        self.assertEqual(ems.labels[-1], b"extended master secret")
+        self.assertNotEqual(standard.master_secret, ems.master_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
/claim #21

## Summary
- use the RFC 7627 extended master secret label when EMS is negotiated
- keep the normal master secret label for non-EMS sessions
- add a regression test that records the PRF label and verifies different outputs

## Verification
- python python/test_tls_handshake.py