### PR TITLE
fix(python): reject early Finished transition

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,22 @@
+import unittest
+
+from tls_handshake import HandshakeState, TLSHandshake, VALID_TRANSITIONS
+
+
+class StateTransitionTests(unittest.TestCase):
+    def test_client_hello_can_only_transition_to_server_hello(self):
+        self.assertEqual(
+            VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO],
+            [HandshakeState.SERVER_HELLO],
+        )
+
+    def test_client_hello_to_finished_is_rejected(self):
+        handshake = TLSHandshake()
+        handshake.state = HandshakeState.CLIENT_HELLO
+
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -55,7 +55,6 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
## Issue
Closes #16
/claim #16

## Summary
Removes the invalid `CLIENT_HELLO -> FINISHED` transition so the state machine cannot skip the expected server hello, certificate, and key exchange states. Adds regression tests for the allowed transition list and rejected early Finished transition.

## Acceptance criteria
- [x] `VALID_TRANSITIONS[CLIENT_HELLO]` contains only `[HandshakeState.SERVER_HELLO]`
- [x] `transition_to(HandshakeState.FINISHED)` returns False when state is CLIENT_HELLO
- [x] Attempting CLIENT_HELLO -> FINISHED sets state to HandshakeState.ERROR
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Validation
```powershell
python -m unittest test_tls_handshake
```

Note: this is a non-UI Python state-machine fix; the regression test output demonstrates the behavior in place of a UI demo video.