### PR TITLE
fix(python): decode SNI extension host names

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,37 @@
+import struct
+import unittest
+
+from tls_handshake import EXT_EXTENDED_MASTER_SECRET, EXT_SNI, TLSHandshake
+
+
+class SNIParsingTests(unittest.TestCase):
+    def test_parse_extensions_decodes_sni_host_name(self):
+        hostname = b"example.com"
+        sni_data = (
+            struct.pack("!H", len(hostname) + 3)
+            + b"\x00"
+            + struct.pack("!H", len(hostname))
+            + hostname
+        )
+        extension_data = (
+            struct.pack("!HH", EXT_SNI, len(sni_data))
+            + sni_data
+        )
+
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(extension_data)
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_no_sni_leaves_server_name_none(self):
+        extension_data = struct.pack("!HH", EXT_EXTENDED_MASTER_SECRET, 0)
+
+        handshake = TLSHandshake()
+        handshake.parse_extensions(extension_data)
+
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,20 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                if len(ext_data) >= 5:
+                    list_len = struct.unpack("!H", ext_data[0:2])[0]
+                    list_end = 2 + list_len
+                    if list_end <= len(ext_data) and ext_data[2] == 0:
+                        name_len = struct.unpack("!H", ext_data[3:5])[0]
+                        name_start = 5
+                        name_end = name_start + name_len
+                        if name_end <= list_end:
+                            ext.server_name = ext_data[
+                                name_start:name_end
+                            ].decode("utf-8")
+                            self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use


### PR DESCRIPTION
## Issue
Closes #17
/claim #17

## Summary
Adds SNI extension decoding for host_name entries and stores the decoded hostname on both the extension and handshake. Adds tests for SNI parsing and the no-SNI path.

## Acceptance criteria
- [x] `parse_extensions()` adds an elif branch for EXT_SNI that decodes the SNI list per RFC 6066 (name_type 0x00 = host_name)
- [x] After parsing, `ext.server_name` and `self.server_name` equal the decoded hostname string (e.g., example.com)
- [x] A ClientHello with no SNI extension leaves `self.server_name` as None
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Validation
```powershell
python -m unittest test_tls_handshake
```

Note: this is a non-UI Python parser fix; the regression test output demonstrates the behavior in place of a UI demo video.