### PR TITLE
fix(python): constrain key exchange error handling

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class KeyExchangeErrorHandlingTests(unittest.TestCase):
+    def test_expected_value_error_returns_false(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00")
+
+        self.assertFalse(handshake.process_key_exchange(message))
+
+    def test_unexpected_exception_propagates(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(
+            HandshakeType.CLIENT_KEY_EXCHANGE,
+            b"\x00\x30" + b"e" * 48,
+        )
+
+        with patch.object(
+            handshake,
+            "_decrypt_pre_master_secret",
+            side_effect=TypeError("unexpected"),
+        ):
+            with self.assertRaises(TypeError):
+                handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,10 +6,14 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
 from typing import Optional, Dict, List, Tuple, Any
+
+
+logger = logging.getLogger(__name__)
 
 
 class HandshakeState(Enum):
@@ -256,9 +260,8 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
+        except (ValueError, struct.error) as exc:
+            logger.debug("Key exchange failed: %s", exc)
         return False
 
     def _derive_master_secret(self) -> None:


### PR DESCRIPTION
## Issue
Closes #20
/claim #20

## Summary
Replaces the bare exception handler in `process_key_exchange()` with expected `ValueError` and `struct.error` handling, logging those failures while allowing unexpected exceptions to propagate. Adds regression tests for both paths.

## Acceptance criteria
- [x] The bare except is replaced with `except (ValueError, struct.error)` to catch only expected failures
- [x] Unexpected exceptions (e.g., TypeError, KeyboardInterrupt) propagate normally
- [x] `process_key_exchange()` still returns False on expected errors, but the error is logged or re-raised for diagnostics
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Validation
```powershell
python -m unittest test_tls_handshake
```

Note: this is a non-UI Python error-handling fix; the regression test output demonstrates the behavior in place of a UI demo video.