### PR TITLE
fix(python): use EMS PRF label

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import patch
+
+from tls_handshake import TLSHandshake
+
+
+class MasterSecretDerivationTests(unittest.TestCase):
+    def setUp(self):
+        self.handshake = TLSHandshake()
+        self.handshake._pre_master_secret = b"p" * 48
+        self.handshake.client_random = b"c" * 32
+        self.handshake.server_random = b"s" * 32
+
+    def test_ems_uses_extended_master_secret_label(self):
+        self.handshake.negotiated_ems = True
+
+        with patch.object(self.handshake, "_prf", return_value=b"m" * 48) as prf:
+            self.handshake._derive_master_secret()
+
+        prf.assert_called_once_with(
+            self.handshake._pre_master_secret,
+            b"extended master secret",
+            self.handshake.client_random + self.handshake.server_random,
+            48,
+        )
+
+    def test_non_ems_uses_standard_master_secret_label(self):
+        self.handshake.negotiated_ems = False
+
+        with patch.object(self.handshake, "_prf", return_value=b"m" * 48) as prf:
+            self.handshake._derive_master_secret()
+
+        prf.assert_called_once_with(
+            self.handshake._pre_master_secret,
+            b"master secret",
+            self.handshake.client_random + self.handshake.server_random,
+            48,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
﻿## Issue
Closes #21
/claim #21

## Summary
Uses the RFC 7627 `extended master secret` PRF label when EMS is negotiated while keeping the standard `master secret` label for the non-EMS path. Adds tests that verify `_prf()` receives the correct label in both cases.

## Acceptance criteria
- [x] When `self.negotiated_ems` is True, label is `b"extended master secret"`
- [x] When `self.negotiated_ems` is False, label remains `b"master secret"`
- [x] `_prf()` receives the correct label, producing different 48-byte master_secret values for EMS vs non-EMS
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Validation
```powershell
python -m unittest test_tls_handshake
```

Note: this is a non-UI Python key-derivation fix; the regression test output demonstrates the behavior in place of a UI demo video.
