### PR TITLE
Fix AEAD cipher preference ordering

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -214,9 +214,8 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,56 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePrefersAEADOverNonAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	suites := []*CipherSuite{
+		{
+			ID:       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+			KeySize:  128,
+			IsAEAD:   false,
+			Strength: StrengthLegacy,
+		},
+		{
+			ID:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+	}
+
+	got := reg.SortByPreference(suites)
+	if got[0].ID != tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
+		t.Fatalf("expected AEAD suite first, got %s", got[0].Name)
+	}
+}
+
+func TestSortByPreferenceOrdersAEADByStrength(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	suites := []*CipherSuite{
+		{
+			ID:       tls.TLS_AES_128_GCM_SHA256,
+			Name:     "TLS_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+		{
+			ID:       tls.TLS_AES_256_GCM_SHA384,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	}
+
+	got := reg.SortByPreference(suites)
+	if got[0].ID != tls.TLS_AES_256_GCM_SHA384 {
+		t.Fatalf("expected stronger AEAD suite first, got %s", got[0].Name)
+	}
+}


### PR DESCRIPTION
/claim #14

## Summary
- Corrected SortByPreference so AEAD cipher suites are ranked ahead of non-AEAD suites.
- Added focused tests for AEAD-before-non-AEAD ordering and strength ordering among AEAD suites.

## Proof
- Not run locally: Go toolchain is not installed in this Codex environment.