### PR TITLE
Filter weak RC4 and 3DES suites

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,7 +194,10 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
+		name := strings.ToUpper(s.Name)
+		if s.KeySize >= minKeyBits &&
+			!strings.Contains(name, "RC4") &&
+			!strings.Contains(name, "3DES") {
 			result = append(result, s)
 		}
 	}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,39 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestFilterWeakSuitesRejectsRC4And3DESByName(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	suites := []*CipherSuite{
+		{
+			ID:       0x0005,
+			Name:     "TLS_RSA_WITH_RC4_128_SHA",
+			KeySize:  128,
+			Strength: StrengthWeak,
+		},
+		{
+			ID:       0x000a,
+			Name:     "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+			KeySize:  168,
+			Strength: StrengthWeak,
+		},
+		{
+			ID:       tls.TLS_AES_128_GCM_SHA256,
+			Name:     "TLS_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+	}
+
+	got := reg.FilterWeakSuites(suites)
+	if len(got) != 1 {
+		t.Fatalf("expected one acceptable suite, got %d", len(got))
+	}
+	if got[0].ID != tls.TLS_AES_128_GCM_SHA256 {
+		t.Fatalf("expected modern AES-GCM suite, got %s", got[0].Name)
+	}
+}


### PR DESCRIPTION
/claim #13

## Summary
- Updated FilterWeakSuites to reject RC4 and 3DES suites by cipher name even when key size is at least 128 bits.
- Added a focused test that rejects RC4 and 3DES while keeping a modern AES-GCM suite.

## Proof
- Not run locally: Go toolchain is not installed in this Codex environment.