### PR TITLE
Handle missing negotiated cipher suite

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,30 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteReturnsErrorWhenNoSuiteMatches(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	name, err := reg.NegotiateSuite([]uint16{0xffff})
+	if err == nil {
+		t.Fatal("expected error for unknown cipher suite")
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteReturnsMatchingSuiteName(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("expected successful negotiation, got %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}


### PR DESCRIPTION
/claim #11

## Summary
- Return an explicit error when no mutually supported cipher suite is found instead of dereferencing nil.
- Added focused tests for the unknown-suite error path and successful negotiation with TLS_AES_128_GCM_SHA256.

## Proof
- Not run locally: Go toolchain is not installed in this Codex environment.