### PR TITLE
fix(english): complete missing sonnet lines

### DIFF
--- a/english/sonnets.md
+++ b/english/sonnets.md
@@ -13,13 +13,16 @@ A whispered prayer dissolving in the cloud.
 
 The moon ascends her throne of silver light,
 And casts her gaze upon the sleeping earth,
-[TODO: write lines 7-8 — must rhyme with "light" and "earth", ~10 syllables each, iambic pentameter]
+I seek one answering spark across the night,
+Yet find no sign to measure what I am worth.
 
 The rivers carry secrets to the sea,
 And mountains hold the memories of rain,
-[TODO: write lines 11-12 — must rhyme with "sea" and "rain", ~10 syllables each]
+Still silence draws its circle around me,
+And leaves my heart to name its ancient pain.
 
-[TODO: write closing couplet (lines 13-14) — must rhyme with each other, provide resolution to the theme of cosmic solitude]
+Yet dawn will thread the dark with tender fire,
+And turn my lonely gaze toward desire.
 
 ---
 


### PR DESCRIPTION
## Issue
Closes #202

## Summary
Completes the missing lines in Sonnet I while leaving Sonnet II unchanged.

## Acceptance criteria
- [x] Lines 7 and 5 rhyme (ABAB pattern: light/line7)
- [x] Lines 8 and 6 rhyme (ABAB pattern: earth/line8)
- [x] Lines 11 and 9 rhyme (EFEF pattern: sea/line11)
- [x] Lines 12 and 10 rhyme (EFEF pattern: rain/line12)
- [x] Lines 13 and 14 rhyme with each other (GG couplet)
- [x] Each new line is approximately 10 syllables in iambic pentameter
- [x] The closing couplet resolves the theme of cosmic solitude
- [x] All [TODO: ...] placeholders are fully replaced
- [x] "Sonnet II - Digital Garden" remains completely unchanged