### PR TITLE
fix(python): use EMS label for master secret

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,55 @@
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tls_handshake import TLSHandshake
+
+
+class MasterSecretDerivationTests(unittest.TestCase):
+    def _handshake(self, negotiated_ems=False):
+        handshake = TLSHandshake()
+        handshake.negotiated_ems = negotiated_ems
+        handshake._pre_master_secret = bytes(range(48))
+        handshake.client_random = bytes(range(32))
+        handshake.server_random = bytes(range(32, 64))
+        return handshake
+
+    def test_non_ems_uses_standard_master_secret_label(self):
+        handshake = self._handshake(negotiated_ems=False)
+
+        handshake._derive_master_secret()
+
+        expected = handshake._prf(
+            handshake._pre_master_secret,
+            b"master secret",
+            handshake.client_random + handshake.server_random,
+            48,
+        )
+        self.assertEqual(handshake.master_secret, expected)
+        self.assertEqual(len(handshake.master_secret), 48)
+
+    def test_ems_uses_extended_master_secret_label(self):
+        handshake = self._handshake(negotiated_ems=True)
+
+        handshake._derive_master_secret()
+
+        expected = handshake._prf(
+            handshake._pre_master_secret,
+            b"extended master secret",
+            handshake.client_random + handshake.server_random,
+            48,
+        )
+        standard = handshake._prf(
+            handshake._pre_master_secret,
+            b"master secret",
+            handshake.client_random + handshake.server_random,
+            48,
+        )
+        self.assertEqual(handshake.master_secret, expected)
+        self.assertNotEqual(handshake.master_secret, standard)
+        self.assertEqual(len(handshake.master_secret), 48)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Issue
Closes #21

## Summary
Fixes Extended Master Secret derivation so the EMS path uses the RFC 7627 `extended master secret` PRF label instead of the standard `master secret` label. Adds focused unit tests for both EMS and non-EMS derivation paths.

## Acceptance criteria
- [x] When self.negotiated_ems is True, label is b"extended master secret"
- [x] When self.negotiated_ems is False, label remains b"master secret"
- [x] _prf() receives the correct label, producing different 48-byte master_secret values for EMS vs non-EMS
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Tests
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest python.test_tls_handshake`

/claim #21