### PR TITLE
fix(docs): repair api reference rate limit table

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST | 5 req/min     |
 
 ## Error Codes
 


### PR DESCRIPTION
## Issue
Closes #303
/claim #303

## Summary
Adds the missing leading pipe on the `/bounties/:id/claims` rate-limit row so it renders as part of the markdown table.

## Acceptance criteria
- [x] The row starts with a pipe character like all other rows in the table
- [x] The table renders correctly with all four endpoints visible
- [x] All other content in the file remains unchanged

## Validation
- [x] `git diff --check`
- [x] Manually inspected the Rate Limits table rows in `docs/api-reference.md`