### PR TITLE
Fix database config key typo

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
## Summary
- correct the misspelled `databse` config key to `database`
- leave the nested database settings unchanged

## Verification
- `git diff --check`

/claim #309