### PR TITLE
fix(scripts): add shebang to cleanup script

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # cleanup.sh - Log file cleanup utility
 # Removes old log files and compresses recent ones


### PR DESCRIPTION
## Summary

Adds the missing `#!/bin/bash` shebang to `cleanup.sh` so the script is executed with the expected shell.

## Related issue

Fixes #318

## Changes

- Added `#!/bin/bash` as the first line of `scripts/cleanup.sh`
- All other content remains unchanged

## Testing

- Verified syntax with `bash -n scripts/cleanup.sh` (no errors)
- Confirmed shebang is the first line
