### PR TITLE
fix(scripts): exit deploy script on command failure

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 #
 # deploy.sh - Application deployment script
 # Pulls latest code, builds, and deploys to production


### PR DESCRIPTION
## Summary

Adds `set -e` after the shebang so the deployment script exits immediately when any command fails, preventing broken deployments.

## Related issue

Fixes #316

## Changes

- Added `set -e` on line 2 (after shebang, before comments)
- All other content remains unchanged

## Testing

- Verified syntax with `bash -n scripts/deploy.sh` (no errors)
- Confirmed `set -e` is positioned correctly
