### PR TITLE
fix(scripts): guard empty deploy directory

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,11 @@ check_dependencies() {
 log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
+
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
 rm -rf ${DEPLOY_DIR}/dist


### PR DESCRIPTION
## Issue
Closes #317
/claim #317

## Summary
Adds a guard before deployment cleanup so `DEPLOY_DIR` must be set and non-empty before any `rm -rf` path is expanded.

## Acceptance criteria
- [x] A guard check is added before the rm commands to verify DEPLOY_DIR is non-empty
- [x] The script exits with an error if DEPLOY_DIR is unset or empty
- [x] All other content in the file remains unchanged

## Validation
- [x] `bash -n scripts/deploy.sh`
- [x] `git diff --check`