### PR TITLE
fix(scripts): guard deploy cleanup against empty directory

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,8 +29,12 @@ check_dependencies
 
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
-rm -rf ${DEPLOY_DIR}/dist
-rm -rf ${DEPLOY_DIR}/node_modules/.cache
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
+rm -rf "${DEPLOY_DIR}/dist"
+rm -rf "${DEPLOY_DIR}/node_modules/.cache"
 
 # Pull latest code
 if [ -d "${DEPLOY_DIR}/.git" ]; then


### PR DESCRIPTION
## Summary

Adds a guard check to verify `DEPLOY_DIR` is non-empty before executing `rm -rf` commands, preventing accidental deletion of root-level directories.

## Related issue

Fixes #317

## Changes

- Added validation check before cleanup: exits with error if `DEPLOY_DIR` is unset or empty
- Quoted `${DEPLOY_DIR}` in rm commands for safety
- All other content remains unchanged

## Testing

- Verified syntax with `bash -n scripts/deploy.sh` (no errors)
- Confirmed guard prevents dangerous rm when DEPLOY_DIR is empty
