### PR TITLE
fix(config): remove trailing comma in app.json

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
## Summary

Removes the trailing comma after the `allowed_origins` array so `config/app.json` is valid JSON.

## Related issue

Fixes #308

## Changes

- Removed the trailing comma after the last property in the `features` object
- All other content remains unchanged

## Testing

- Verified JSON validity with `python3 -m json.tool config/app.json`
