### PR TITLE
fix(config): correct database key spelling in app.json

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
## Summary

Corrects the misspelled key `databse` to `database` in `config/app.json`.

## Related issue

Fixes #309

## Changes

- Fixed typo: `databse` → `database` on line 10
- Value object under the key remains unchanged
- All other content remains unchanged

## Testing

- Verified the key is now correctly spelled
