### PR TITLE
fix: correct api port mapping

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080"
+      - "8080:8080"
       - "9090:9090"
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
## Summary
- Changes the api service port mapping from `"8080"` to `"8080:8080"`.
- Leaves the existing `"9090:9090"` mapping unchanged.

## Verification
- `python3` + PyYAML parse of `config/docker-compose.yml` ✅
- `git diff --check` ✅

/claim #312
