### PR TITLE
fix(config): correct docker image latest tag typo

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

Corrects the Docker image tag typo from `lastest` to `latest` so the image can be pulled successfully.

## Related issue

Fixes #310

## Changes

- Fixed image tag: `lastest` → `latest`
- All other content remains unchanged

## Testing

- Verified the tag is now correctly spelled
