### PR TITLE
Return error when no cipher suite matches

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,32 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteReturnsErrorWhenNoSuiteMatches(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	name, err := registry.NegotiateSuite([]uint16{0xffff})
+
+	if err == nil {
+		t.Fatal("expected an error for unknown client suite")
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name on failure, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteReturnsValidSuiteName(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	name, err := registry.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+
+	if err != nil {
+		t.Fatalf("expected valid suite negotiation, got error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected negotiated suite name: %q", name)
+	}
+}


### PR DESCRIPTION
/claim #11

## Summary
- return an explicit error when NegotiateSuite finds no mutually supported cipher suite
- keep successful negotiation behavior unchanged
- add focused tests for unknown and valid offered suites

## Verification
- Select-String -Pattern 'selectedSuite\\.Name' -Path go/tls_cipher.go -Context 3,3
- git diff --check

Note: Go is not installed in this environment, so I could not run go test locally.