### PR TITLE
Filter RC4 and 3DES cipher suites

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,7 +194,9 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
+		if s.KeySize >= minKeyBits &&
+			!strings.Contains(s.Name, "RC4") &&
+			!strings.Contains(s.Name, "3DES") {
 			result = append(result, s)
 		}
 	}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,33 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestFilterWeakSuitesRejectsBrokenAlgorithms(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	filtered := registry.FilterWeakSuites(registry.knownSuites)
+
+	for _, suite := range filtered {
+		if suite.ID == 0x0005 {
+			t.Fatalf("RC4 suite was not filtered: %s", suite.Name)
+		}
+		if suite.ID == 0x000a {
+			t.Fatalf("3DES suite was not filtered: %s", suite.Name)
+		}
+	}
+}
+
+func TestFilterWeakSuitesKeepsModernAeadSuite(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	filtered := registry.FilterWeakSuites(registry.knownSuites)
+
+	for _, suite := range filtered {
+		if suite.ID == tls.TLS_AES_128_GCM_SHA256 {
+			return
+		}
+	}
+
+	t.Fatal("expected TLS_AES_128_GCM_SHA256 to remain after filtering")
+}


### PR DESCRIPTION
/claim #13

## Summary
- reject RC4 and 3DES suites in FilterWeakSuites even when key size is >= 128 bits
- keep modern AEAD suites passing through the filter
- add focused tests for the broken algorithm exclusions

## Verification
- Select-String -Pattern 'RC4|3DES|KeySize >= minKeyBits' -Path go/tls_cipher.go -Context 2,2
- git diff --check

Note: Go is not installed in this environment, so I could not run go test locally.