### PR TITLE
Prefer AEAD suites in preference sorting

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -214,9 +214,8 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,51 @@
+package tlscipher
+
+import "testing"
+
+func TestSortByPreferenceRanksAeadBeforeNonAead(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	sorted := registry.SortByPreference([]*CipherSuite{
+		{
+			ID:       0x003c,
+			Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+			KeySize:  128,
+			IsAEAD:   false,
+			Strength: StrengthModern,
+		},
+		{
+			ID:       0xc02b,
+			Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+	})
+
+	if !sorted[0].IsAEAD {
+		t.Fatalf("expected AEAD suite first, got %s", sorted[0].Name)
+	}
+}
+
+func TestSortByPreferenceKeepsStrengthOrderingWithinAead(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	sorted := registry.SortByPreference([]*CipherSuite{
+		{
+			ID:       0x1301,
+			Name:     "TLS_AES_128_GCM_SHA256",
+			KeySize:  128,
+			IsAEAD:   true,
+			Strength: StrengthModern,
+		},
+		{
+			ID:       0x1302,
+			Name:     "TLS_AES_256_GCM_SHA384",
+			KeySize:  256,
+			IsAEAD:   true,
+			Strength: StrengthAdvanced,
+		},
+	})
+
+	if sorted[0].Strength != StrengthAdvanced {
+		t.Fatalf("expected advanced AEAD suite first, got %s", sorted[0].Name)
+	}
+}


### PR DESCRIPTION
/claim #14

## Summary
- fix SortByPreference so AEAD suites sort before non-AEAD suites
- preserve strength ordering among AEAD suites
- add focused tests for AEAD priority and strength ordering

## Verification
- Select-String -Pattern 'si\\.IsAEAD|!si\\.IsAEAD' -Path go/tls_cipher.go -Context 3,3
- git diff --check

Note: Go is not installed in this environment, so I could not run go test locally.