### PR TITLE
Guard suite cache lookups with mutex

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -137,8 +137,10 @@ func (r *SuiteRegistry) loadDefaults() {
 
 // lookupSuite retrieves a suite from the cache, falling back to a linear
 // scan of knownSuites. Results are cached for faster repeated lookups.
-// BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,42 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestConcurrentLookupUsesCacheWithoutErrors(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	ids := make([]uint16, 100)
+	for i := range ids {
+		ids[i] = tls.TLS_AES_128_GCM_SHA256
+	}
+
+	results, err := registry.ConcurrentLookup(ids)
+
+	if err != nil {
+		t.Fatalf("ConcurrentLookup returned error: %v", err)
+	}
+	for i, result := range results {
+		if result == nil {
+			t.Fatalf("result %d was nil", i)
+		}
+		if result.Name != "TLS_AES_128_GCM_SHA256" {
+			t.Fatalf("result %d used unexpected suite %q", i, result.Name)
+		}
+	}
+}
+
+func TestLookupSuiteCachesKnownSuite(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	first := registry.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+	second := registry.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+
+	if first == nil || second == nil {
+		t.Fatal("expected known suite lookup to succeed")
+	}
+	if first != second {
+		t.Fatal("expected repeated lookup to return cached suite pointer")
+	}
+}


### PR DESCRIPTION
/claim #15

## Summary
- lock lookupSuite before reading or writing the shared suiteCache map
- add concurrent lookup and cache-hit tests for known suite IDs

## Verification
- Select-String -Pattern 'r\\.mu\\.Lock\\(\\)|suiteCache\\[id\\]' -Path go/tls_cipher.go -Context 2,2
- git diff --check

Note: Go is not installed in this environment, so I could not run go test locally.