### PR TITLE
docs: fix bounty setup and create endpoint examples

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
## Summary
- correct the setup guide package name to ounty-hunters`n- correct the Create Bounty API example to POST /bounties`n
Closes #304
Closes #306

## Test plan
- Docs-only change; verified the edited code blocks in docs/api-reference.md and docs/setup-guide.md.
