### PR TITLE
fix(scripts): compare retention values in arithmetic context

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -35,7 +35,7 @@ done
 echo ""
 
 # Check total disk usage of log directories
-if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]; then
+if (( MAX_AGE_DAYS > TOTAL_CLEANED )); then
     echo "WARNING: Retention period exceeds number of files cleaned"
     echo "Consider reducing MAX_AGE_DAYS (currently ${MAX_AGE_DAYS})"
 fi


### PR DESCRIPTION
## Issue
Closes #319

/claim #319

## Summary
Replace the `[ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]` comparison in `scripts/cleanup.sh` with `(( MAX_AGE_DAYS > TOTAL_CLEANED ))` so both operands are evaluated in proper arithmetic context, eliminating the string-vs-arithmetic mismatch caused by `MAX_AGE_DAYS="14"` being assigned as a string.

## Acceptance criteria
- [x] The comparison is corrected to use proper arithmetic context
- [x] The logic correctly compares numeric values without string/arithmetic mismatch
- [x] All other content in the file remains unchanged

## Validation
- [x] `bash -n scripts/cleanup.sh` — syntax OK
- [x] `git diff --check` — no whitespace errors
- [x] Diff is a single one-line change inside the existing `if`