### PR TITLE
docs: fix Create Bounty HTTP method

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
## Summary
- change the Create Bounty endpoint example from GET /bounties to POST /bounties`n
Closes #304

## Test plan
- Docs-only change; verified the Create Bounty code block.
