### PR TITLE
docs: fix setup package name

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
## Summary
- change the setup guide install command from ounty-hunter to ounty-hunters`n
Closes #306

## Test plan
- Docs-only change; verified the setup guide code block.
