### PR TITLE
fix(python): use constant-time comparison in verify_finished

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,48 @@
+"""Tests for tls_handshake.verify_finished() constant-time comparison."""
+
+import hashlib
+import hmac
+
+from tls_handshake import TLSHandshake
+
+
+def _expected_verify(handshake: TLSHandshake, label: str) -> bytes:
+    transcript_hash = handshake.handshake_hash.copy().digest()
+    return handshake._prf(
+        handshake.master_secret,
+        label.encode("ascii"),
+        transcript_hash,
+        12,
+    )
+
+
+def test_verify_finished_returns_true_on_match() -> None:
+    handshake = TLSHandshake(is_server=False)
+    handshake.master_secret = b"\x11" * 48
+    expected = _expected_verify(handshake, "client finished")
+
+    assert handshake.verify_finished(expected, "client finished") is True
+
+
+def test_verify_finished_returns_false_on_mismatch() -> None:
+    handshake = TLSHandshake(is_server=False)
+    handshake.master_secret = b"\x22" * 48
+    expected = _expected_verify(handshake, "client finished")
+    tampered = bytes([expected[0] ^ 0x01]) + expected[1:]
+
+    assert handshake.verify_finished(tampered, "client finished") is False
+
+
+def test_verify_finished_uses_constant_time_comparison() -> None:
+    """The fix replaces == with hmac.compare_digest(); verify the source reflects that."""
+    import inspect
+
+    source = inspect.getsource(TLSHandshake.verify_finished)
+    assert "hmac.compare_digest" in source
+    assert "computed_verify == received_verify" not in source
+
+
+def test_verify_finished_returns_false_when_master_secret_missing() -> None:
+    handshake = TLSHandshake(is_server=True)
+    assert handshake.master_secret is None
+    assert handshake.verify_finished(b"\x00" * 12, "server finished") is False

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Issue
Closes #18

/claim #18

## Summary
Replace the `==` byte-string comparison in `TLSHandshake.verify_finished()` with `hmac.compare_digest()` so the verify_data comparison runs in constant time and does not leak per-byte timing information usable to forge a valid Finished MAC.

The `hmac` module is already imported, so no new imports were added.

## Acceptance criteria
- [x] `verify_finished()` uses `hmac.compare_digest(computed_verify, received_verify)` instead of `==`
- [x] The `hmac` module is already imported; no new imports needed
- [x] Return value is still `bool` (`True` on match, `False` otherwise)
- [x] All existing tests still pass (no existing test files in the repo prior to this change)
- [x] Added new tests covering the fix in `python/test_tls_handshake.py`

## Diff (production change)
```diff
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
```

## Tests added
`python/test_tls_handshake.py` covers:
- `test_verify_finished_returns_true_on_match` — matching verify_data returns `True`
- `test_verify_finished_returns_false_on_mismatch` — single-byte tampered verify_data returns `False`
- `test_verify_finished_uses_constant_time_comparison` — source inspection confirms `hmac.compare_digest` is in use and the `==` path is gone
- `test_verify_finished_returns_false_when_master_secret_missing` — early-return path preserved

## Validation
```
$ python3 -c "import sys; sys.path.insert(0, 'python'); \
    import test_tls_handshake as t; \
    t.test_verify_finished_returns_true_on_match(); \
    t.test_verify_finished_returns_false_on_mismatch(); \
    t.test_verify_finished_uses_constant_time_comparison(); \
    t.test_verify_finished_returns_false_when_master_secret_missing(); \
    print('ALL PASS')"
ALL PASS
```