### PR TITLE
fix: deploy.sh - dangerous rm -rf with empty variable guard

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,12 +25,32 @@ check_dependencies() {
 }
 
 log_message "Starting deployment of ${APP_NAME}..."
+
+# Safety: ensure DEPLOY_DIR is set before any destructive operations
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR must be set before deployment"
+    exit 1
+fi
+
+# Safety: validate DEPLOY_DIR exists and is a directory
+if [ ! -d "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR does not exist"
+    exit 1
+fi
+
+# Safety: prevent rm -rf on root or critical paths
+case "${DEPLOY_DIR}" in
+    /|/bin|/boot|/sbin|/lib|/usr|/etc|/var|/home|/root|/dev|/proc|/sys)
+        log_message "ERROR: Refusing to deploy to critical system directory: ${DEPLOY_DIR}"
+        exit 1
+        ;;
+esac
 check_dependencies
 
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
-rm -rf ${DEPLOY_DIR}/dist
-rm -rf ${DEPLOY_DIR}/node_modules/.cache
+rm -rf "${DEPLOY_DIR}/dist"
+rm -rf "${DEPLOY_DIR}/node_modules/.cache"
 
 # Pull latest code
 if [ -d "${DEPLOY_DIR}/.git" ]; then


### PR DESCRIPTION
Fixed dangerous rm -rf with empty DEPLOY_DIR:
- Added empty variable check with error and exit
- Added directory existence validation
- Added blocklist for critical system paths (/, /bin, /usr, etc.)
- Properly quoted all variables in rm -rf commands

Resolves #317
/claim #317