### PR TITLE
fix(python): use 'extended master secret' label when EMS is negotiated

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,47 @@
+"""Tests for tls_handshake._derive_master_secret() EMS label handling (RFC 7627)."""
+
+from tls_handshake import TLSHandshake
+
+
+def _setup_handshake(ems: bool) -> TLSHandshake:
+    handshake = TLSHandshake(is_server=False)
+    handshake._pre_master_secret = b"\xaa" * 48
+    handshake.client_random = b"\xcc" * 32
+    handshake.server_random = b"\xdd" * 32
+    handshake.negotiated_ems = ems
+    return handshake
+
+
+def test_ems_branch_uses_extended_master_secret_label() -> None:
+    handshake = _setup_handshake(ems=True)
+    handshake._derive_master_secret()
+    assert isinstance(handshake.master_secret, bytes)
+    assert len(handshake.master_secret) == 48
+
+
+def test_non_ems_branch_uses_master_secret_label() -> None:
+    handshake = _setup_handshake(ems=False)
+    handshake._derive_master_secret()
+    assert isinstance(handshake.master_secret, bytes)
+    assert len(handshake.master_secret) == 48
+
+
+def test_ems_and_non_ems_produce_different_master_secrets() -> None:
+    """The whole point of EMS: a different label must yield a different secret."""
+    ems = _setup_handshake(ems=True)
+    non_ems = _setup_handshake(ems=False)
+
+    ems._derive_master_secret()
+    non_ems._derive_master_secret()
+
+    assert ems.master_secret != non_ems.master_secret
+
+
+def test_derive_raises_without_pre_master_secret() -> None:
+    handshake = TLSHandshake()
+    try:
+        handshake._derive_master_secret()
+    except ValueError as exc:
+        assert "pre-master secret" in str(exc)
+    else:
+        raise AssertionError("expected ValueError when pre-master secret is missing")

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Issue
Closes #21

/claim #21

## Summary
Per RFC 7627 §4, when the Extended Master Secret extension has been negotiated, the master_secret must be derived with the PRF label `"extended master secret"` rather than `"master secret"`. Previously both branches of `_derive_master_secret()` used the same label, so the EMS extension had no effect on the derived key material.

## Acceptance criteria
- [x] When `self.negotiated_ems` is `True`, `label` is `b"extended master secret"`
- [x] When `self.negotiated_ems` is `False`, `label` remains `b"master secret"`
- [x] `_prf()` receives the correct label, producing different 48-byte master_secret values for EMS vs non-EMS
- [x] All existing tests still pass (no pre-existing test files)
- [x] Added new tests covering the fix in `python/test_tls_handshake.py`

## Diff (production change)
```diff
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
```

## Tests added
`python/test_tls_handshake.py` covers:
- `test_ems_branch_uses_extended_master_secret_label` — derivation succeeds and yields a 48-byte master_secret on the EMS path
- `test_non_ems_branch_uses_master_secret_label` — non-EMS path remains 48 bytes
- `test_ems_and_non_ems_produce_different_master_secrets` — the whole point of EMS: different label ⇒ different secret
- `test_derive_raises_without_pre_master_secret` — error path preserved

## Validation
All four tests pass:
```
OK: ems_uses_extended_label
OK: non_ems_uses_master_secret
OK: different_secrets
OK: raises_without_pms
ALL PASS
```