### PR TITLE
fix(go): rank AEAD cipher suites above non-AEAD in SortByPreference

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module tlscipher
+
+go 1.26.3

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -214,9 +214,8 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,83 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreference_AEADRanksAboveNonAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	aead := &CipherSuite{
+		ID:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		KeySize:  128,
+		IsAEAD:   true,
+		Strength: StrengthModern,
+	}
+	nonAEAD := &CipherSuite{
+		ID:       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+		KeySize:  128,
+		IsAEAD:   false,
+		Strength: StrengthLegacy,
+	}
+
+	sorted := reg.SortByPreference([]*CipherSuite{nonAEAD, aead})
+	if len(sorted) != 2 {
+		t.Fatalf("expected 2 suites, got %d", len(sorted))
+	}
+	if !sorted[0].IsAEAD {
+		t.Fatalf("expected AEAD suite first, got %q (IsAEAD=%v)", sorted[0].Name, sorted[0].IsAEAD)
+	}
+	if sorted[0].Name != aead.Name {
+		t.Errorf("expected %q first, got %q", aead.Name, sorted[0].Name)
+	}
+	if sorted[1].Name != nonAEAD.Name {
+		t.Errorf("expected %q second, got %q", nonAEAD.Name, sorted[1].Name)
+	}
+}
+
+func TestSortByPreference_AmongAEADStrengthAdvancedAboveModern(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	modern := &CipherSuite{
+		ID:       tls.TLS_AES_128_GCM_SHA256,
+		Name:     "TLS_AES_128_GCM_SHA256",
+		KeySize:  128,
+		IsAEAD:   true,
+		Strength: StrengthModern,
+	}
+	advanced := &CipherSuite{
+		ID:       tls.TLS_AES_256_GCM_SHA384,
+		Name:     "TLS_AES_256_GCM_SHA384",
+		KeySize:  256,
+		IsAEAD:   true,
+		Strength: StrengthAdvanced,
+	}
+
+	sorted := reg.SortByPreference([]*CipherSuite{modern, advanced})
+	if sorted[0].Strength != StrengthAdvanced {
+		t.Fatalf("expected StrengthAdvanced first, got %v (%s)", sorted[0].Strength, sorted[0].Name)
+	}
+	if sorted[1].Strength != StrengthModern {
+		t.Fatalf("expected StrengthModern second, got %v (%s)", sorted[1].Strength, sorted[1].Name)
+	}
+}
+
+func TestSortByPreference_DefaultsKeepAEADBeforeLegacy(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	sorted := reg.SortByPreference(reg.knownSuites)
+
+	seenNonAEAD := false
+	for _, s := range sorted {
+		if !s.IsAEAD {
+			seenNonAEAD = true
+			continue
+		}
+		if seenNonAEAD {
+			t.Fatalf("AEAD suite %q appeared after a non-AEAD suite", s.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Issue
Closes #14

/claim #14

## Summary
The AEAD branch of the `SortByPreference` comparator returned `!si.IsAEAD && sj.IsAEAD`, which placed non-AEAD suites (e.g. `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`) ahead of AEAD suites (e.g. `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`). Flip it to `si.IsAEAD && !sj.IsAEAD` so AEAD sorts first, matching the documented intent of the function.

## Acceptance criteria
- [x] `SortByPreference` places `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` (IsAEAD true) before `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256` (IsAEAD false)
- [x] Among AEAD-only suites, `StrengthAdvanced` still sorts above `StrengthModern`
- [x] All existing tests still pass (no existing tests in the package prior to this change)
- [x] Added new tests covering the fix in `go/tls_cipher_test.go`

## Diff (production change)
```diff
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
```

## Files touched
- `go/tls_cipher.go` — single-line comparator flip
- `go/tls_cipher_test.go` — new test file
- `go/go.mod` — module declaration so `go test` resolves the package

## Tests added
`go/tls_cipher_test.go` covers:
- `TestSortByPreference_AEADRanksAboveNonAEAD` — AEAD `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` sorts ahead of non-AEAD `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
- `TestSortByPreference_AmongAEADStrengthAdvancedAboveModern` — `StrengthAdvanced` sorts above `StrengthModern` among AEAD suites
- `TestSortByPreference_DefaultsKeepAEADBeforeLegacy` — full-registry invariant: no AEAD suite ever appears after a non-AEAD suite

## Validation
```
$ cd go && go test -v ./...
=== RUN   TestSortByPreference_AEADRanksAboveNonAEAD
--- PASS: TestSortByPreference_AEADRanksAboveNonAEAD (0.00s)
=== RUN   TestSortByPreference_AmongAEADStrengthAdvancedAboveModern
--- PASS: TestSortByPreference_AmongAEADStrengthAdvancedAboveModern (0.00s)
=== RUN   TestSortByPreference_DefaultsKeepAEADBeforeLegacy
--- PASS: TestSortByPreference_DefaultsKeepAEADBeforeLegacy (0.00s)
PASS
ok  	tlscipher
```