### PR TITLE
fix(go): return error from NegotiateSuite when no suite matches

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module tlscipher
+
+go 1.26.3

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,9 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually-supported cipher suite found")
+	}
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,55 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+)
+
+func TestNegotiateSuite_ReturnsErrorWhenNoMatch(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	name, err := reg.NegotiateSuite([]uint16{0xFFFF})
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil (name=%q)", name)
+	}
+	if name != "" {
+		t.Errorf("expected empty name on no-match, got %q", name)
+	}
+}
+
+func TestNegotiateSuite_ReturnsNameOnMatch(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Errorf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}
+
+func TestNegotiateSuite_ErrorsOnEmptyClientSuites(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	name, err := reg.NegotiateSuite(nil)
+	if err == nil {
+		t.Fatalf("expected error on empty client suites, got name=%q", name)
+	}
+	if !strings.Contains(err.Error(), "no cipher suites") {
+		t.Errorf("expected 'no cipher suites' in error, got %q", err.Error())
+	}
+}
+
+func TestNegotiateSuite_NoPanicOnUnknownIDs(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NegotiateSuite panicked on unknown IDs: %v", r)
+		}
+	}()
+
+	_, _ = reg.NegotiateSuite([]uint16{0xFFFF, 0xFFFE, 0xDEAD})
+}


### PR DESCRIPTION
## Issue
Closes #11

/claim #11

## Summary
`NegotiateSuite` previously dereferenced `selectedSuite.Name` even when the matching loop left it `nil` (e.g. client offered only unknown IDs like `0xFFFF`), causing a runtime panic. Add an explicit nil check and return `("", error)` instead, matching the function's documented `(string, error)` contract.

## Acceptance criteria
- [x] `NegotiateSuite([]uint16{0xFFFF})` returns `("", non-nil error)`, no panic
- [x] `NegotiateSuite` with a valid ID like `TLS_AES_128_GCM_SHA256` still returns its name
- [x] All existing tests still pass (no existing tests in the package prior to this change)
- [x] Added new tests covering the fix in `go/tls_cipher_test.go`

## Diff (production change)
```diff
-	// BUG(1): nil dereference when no suite matched
-	return selectedSuite.Name, nil
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually-supported cipher suite found")
+	}
+	return selectedSuite.Name, nil
```

## Files touched
- `go/tls_cipher.go` — nil check + error return
- `go/tls_cipher_test.go` — new test file
- `go/go.mod` — module declaration so `go test` resolves the package

## Tests added
`go/tls_cipher_test.go` covers:
- `TestNegotiateSuite_ReturnsErrorWhenNoMatch` — `[]uint16{0xFFFF}` returns `("", non-nil error)`
- `TestNegotiateSuite_ReturnsNameOnMatch` — known suite `TLS_AES_128_GCM_SHA256` is returned by name
- `TestNegotiateSuite_ErrorsOnEmptyClientSuites` — pre-existing empty-input error path preserved
- `TestNegotiateSuite_NoPanicOnUnknownIDs` — explicit `recover()` guard around the no-match call

## Validation
```
$ cd go && go test -v ./...
=== RUN   TestNegotiateSuite_ReturnsErrorWhenNoMatch
--- PASS: TestNegotiateSuite_ReturnsErrorWhenNoMatch (0.00s)
=== RUN   TestNegotiateSuite_ReturnsNameOnMatch
--- PASS: TestNegotiateSuite_ReturnsNameOnMatch (0.00s)
=== RUN   TestNegotiateSuite_ErrorsOnEmptyClientSuites
--- PASS: TestNegotiateSuite_ErrorsOnEmptyClientSuites (0.00s)
=== RUN   TestNegotiateSuite_NoPanicOnUnknownIDs
--- PASS: TestNegotiateSuite_NoPanicOnUnknownIDs (0.00s)
PASS
ok  	tlscipher
```