### PR TITLE
docs: document TLS source files

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -1,6 +1,13 @@
 ; tls_record_parser.asm
 ; TLS Record Layer Parser - x86_64 NASM
-; Parses TLS record headers and dispatches by content type
+;
+; Module role:
+;   This source file implements the TLS record-layer parsing entry point used by
+;   the example TLS stack. It reads one record from stdin, decodes the record
+;   header, validates the content type and payload length, dispatches to a
+;   content-type-specific handler, and provides small printing helpers for
+;   diagnostics.
+;
 ; Build: nasm -f elf64 tls_record_parser.asm -o tls_record_parser.o
 ;        ld tls_record_parser.o -o tls_record_parser
 
@@ -48,6 +55,16 @@ section .text
 ; ============================================================
 ; _start - entry point
 ; ============================================================
+; ---------------------------------------------------------------------------
+; _start
+; Purpose:
+;   Process entry point. Prints the banner, reads a TLS record into read_buf,
+;   verifies that at least the five-byte header is present, and invokes the
+;   record parser.
+; Register usage:
+;   rax = syscall number / read byte count, rdi = syscall fd or string pointer,
+;   rsi = input buffer pointer, rdx = read size, r12 = total bytes read.
+; ---------------------------------------------------------------------------
 _start:
     ; Print banner
     lea rdi, [rel msg_banner]
@@ -74,6 +91,9 @@ _start:
     xor rdi, rdi
     syscall
 
+; .err_short
+; Purpose: Report that stdin did not contain a complete TLS record header.
+; Register usage: rdi points to err_short_read; rax/rdi are then reused for exit.
 .err_short:
     lea rdi, [rel err_short_read]
     call print_string
@@ -87,6 +107,16 @@ _start:
 ;           r12 = total bytes available in buffer
 ;   Parses content type, version, length and dispatches
 ; ============================================================
+; ---------------------------------------------------------------------------
+; parse_tls_record
+; Purpose:
+;   Decode the TLS record header at rsi, print the parsed fields, validate the
+;   content type and payload length, and dispatch to the matching handler label.
+; Register usage:
+;   Input rsi = record buffer, r12 = total bytes available. Uses r13d for the
+;   content type, r14d for the version, r15d for payload length, rdi for the
+;   payload pointer, and ecx for payload length during handler dispatch.
+; ---------------------------------------------------------------------------
 parse_tls_record:
     push rbp
     mov rbp, rsp
@@ -111,6 +141,9 @@ parse_tls_record:
     ; is heartbeat. The jle here means we accept up to AND including
     ; 0x18 which is correct. But see the LOWER bound check below...
 
+; .type_ok
+; Purpose: Continue after content-type validation and print the type byte.
+; Register usage: r13d holds the content type; rsi is preserved across printing.
 .type_ok:
     ; Print content type
     push rsi
@@ -181,6 +214,9 @@ parse_tls_record:
     je .handle_heartbeat
     jmp .unknown_type
 
+; .handle_change_cipher
+; Purpose: Handle ChangeCipherSpec records and print the matching label.
+; Register usage: rdi is temporarily used for the output string and then restored.
 .handle_change_cipher:
     push rdi
     lea rdi, [rel lbl_change_cipher]
@@ -189,6 +225,9 @@ parse_tls_record:
     ; ChangeCipherSpec payload is 1 byte (value 0x01)
     jmp .parse_done
 
+; .handle_alert
+; Purpose: Handle Alert records, distinguishing fatal alerts from warnings.
+; Register usage: rdi points to alert payload, ecx holds payload length, eax is scratch.
 .handle_alert:
     push rdi
     lea rdi, [rel lbl_alert]
@@ -205,11 +244,17 @@ parse_tls_record:
     call print_string                  ; will print into err_truncated
     jmp .parse_done
 
+; .alert_fatal
+; Purpose: Print the fatal-alert diagnostic for alert level 2.
+; Register usage: rdi points to err_alert_fatal before calling print_string.
 .alert_fatal:
     lea rdi, [rel err_alert_fatal]
     call print_string
     jmp .parse_done
 
+; .handle_handshake
+; Purpose: Handle Handshake records and read the handshake message type byte.
+; Register usage: rdi points to the handshake payload, ecx holds payload length, eax is scratch.
 .handle_handshake:
     push rdi
     lea rdi, [rel lbl_handshake]
@@ -223,6 +268,9 @@ parse_tls_record:
     ; 0x01=ClientHello, 0x02=ServerHello, 0x0b=Certificate, etc.
     jmp .parse_done
 
+; .handle_application
+; Purpose: Handle encrypted application-data records by reporting their type.
+; Register usage: rdi is temporarily used for the output string and then restored.
 .handle_application:
     push rdi
     lea rdi, [rel lbl_application]
@@ -232,6 +280,9 @@ parse_tls_record:
     ; No TLS 1.3 inner content type detection is performed
     jmp .parse_done
 
+; .handle_heartbeat
+; Purpose: Handle heartbeat records by reporting their content type.
+; Register usage: rdi is temporarily used for the output string and then restored.
 .handle_heartbeat:
     push rdi
     lea rdi, [rel lbl_heartbeat]
@@ -239,20 +290,32 @@ parse_tls_record:
     pop rdi
     jmp .parse_done
 
+; .unknown_type
+; Purpose: Fallback handler for a content type with no explicit dispatch branch.
+; Register usage: rdi points to lbl_unknown before calling print_string.
 .unknown_type:
     lea rdi, [rel lbl_unknown]
     call print_string
     jmp .parse_done
 
+; .invalid_type
+; Purpose: Report a record content type outside the accepted TLS type range.
+; Register usage: rdi points to err_invalid_type before calling print_string.
 .invalid_type:
     lea rdi, [rel err_invalid_type]
     call print_string
     jmp .parse_done
 
+; .invalid_length
+; Purpose: Report a record whose declared payload length exceeds the TLS limit.
+; Register usage: rdi points to err_truncated before calling print_string.
 .invalid_length:
     lea rdi, [rel err_truncated]
     call print_string
 
+; .parse_done
+; Purpose: Common parser epilogue that restores saved registers and returns.
+; Register usage: pops r14, r13, rbx, and rbp saved by parse_tls_record.
 .parse_done:
     pop r14
     pop r13
@@ -264,17 +327,31 @@ parse_tls_record:
 ; print_string - write null-terminated string to stdout
 ;   Input: rdi = pointer to string
 ; ============================================================
+; ---------------------------------------------------------------------------
+; print_string
+; Purpose:
+;   Write a null-terminated string to stdout by first computing its length.
+; Register usage:
+;   Input rdi = string pointer. Uses rsi for traversal, rdx for length, rax/rdi
+;   for sys_write, and preserves rsi, rdx, and rcx for the caller.
+; ---------------------------------------------------------------------------
 print_string:
     push rsi
     push rdx
     push rcx
     mov rsi, rdi
     xor rdx, rdx
+; .strlen
+; Purpose: Count bytes until the terminating NUL byte of the current string.
+; Register usage: rsi points to string base, rdx accumulates length.
 .strlen:
     cmp byte [rsi + rdx], 0
     je .do_write
     inc rdx
     jmp .strlen
+; .do_write
+; Purpose: Issue sys_write for the string counted by .strlen.
+; Register usage: rax = SYS_write, rdi = stdout fd, rsi = buffer, rdx = length.
 .do_write:
     mov rax, 1                  ; sys_write
     mov rdi, 1                  ; stdout
@@ -288,6 +365,14 @@ print_string:
 ; print_hex_byte - print a byte value as 2 hex digits
 ;   Input: edi = byte value (low 8 bits used)
 ; ============================================================
+; ---------------------------------------------------------------------------
+; print_hex_byte
+; Purpose:
+;   Print the low byte of edi as two lowercase hexadecimal characters.
+; Register usage:
+;   Input edi = byte value. Uses eax for nibble extraction, rcx for hex table,
+;   rsi for hex_out, and rax/rdi/rdx for sys_write.
+; ---------------------------------------------------------------------------
 print_hex_byte:
     push rsi
     push rdx
@@ -315,6 +400,14 @@ print_hex_byte:
 ; print_hex_word - print a 16-bit value as 4 hex digits
 ;   Input: edi = word value (low 16 bits used)
 ; ============================================================
+; ---------------------------------------------------------------------------
+; print_hex_word
+; Purpose:
+;   Print the low 16 bits of edi as four hexadecimal characters.
+; Register usage:
+;   Input edi = word value. Calls print_hex_byte for high and low bytes while
+;   preserving the original edi on the stack between calls.
+; ---------------------------------------------------------------------------
 print_hex_word:
     push rdi
     mov eax, edi
@@ -331,6 +424,15 @@ print_hex_word:
 ; print_decimal - print a 32-bit unsigned integer in decimal
 ;   Input: edi = value
 ; ============================================================
+; ---------------------------------------------------------------------------
+; print_decimal
+; Purpose:
+;   Convert the unsigned integer in edi to decimal ASCII and write it to stdout.
+; Register usage:
+;   Input edi = value. Uses stack scratch space for digits, eax/edx/ecx for
+;   repeated division by 10, rsi for the output pointer, and rax/rdi/rdx for
+;   sys_write.
+; ---------------------------------------------------------------------------
 print_decimal:
     push rbp
     mov rbp, rsp
@@ -339,6 +441,10 @@ print_decimal:
     mov byte [rsi], 10          ; newline at end
     mov eax, edi
     mov ecx, 10
+; .dec_loop
+; Purpose: Generate decimal digits from least significant to most significant.
+; Register usage: eax holds the remaining quotient, edx receives the remainder,
+; ecx is the divisor 10, and rsi moves backward through the stack buffer.
 .dec_loop:
     xor edx, edx
     div ecx

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -1,5 +1,15 @@
-/* tls_cert_validator.c - TLS Certificate Chain Validator
- * Copyright (c) 2024 SecureNet Systems */
+/**
+ * @file tls_cert_validator.c
+ * @brief TLS certificate-chain validation support for the TLS stack.
+ *
+ * This component manages a small trusted-certificate store, verifies leaf and
+ * intermediate certificate lifetimes and signatures, optionally enforces leaf
+ * fingerprint pinning, and emits diagnostics for certificate validation paths.
+ * It is intended to sit between the TLS handshake parser and OpenSSL's X.509
+ * primitives.
+ *
+ * Copyright (c) 2024 SecureNet Systems
+ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,6 +60,14 @@ typedef struct chain_context {
 } chain_context_t;
 
 static int g_log_level = LOG_LEVEL_INFO;
+/**
+ * @brief Emit a certificate-validation log message.
+ *
+ * @param level Severity level; messages below the global threshold are ignored.
+ * @param fmt printf-style format string followed by matching arguments.
+ *
+ * @return Nothing.
+ */
 static void log_cert_event(int level, const char *fmt, ...)
 {
     if (level < g_log_level)
@@ -63,6 +81,15 @@ static void log_cert_event(int level, const char *fmt, ...)
     fprintf(stderr, "\n");
 }
 
+/**
+ * @brief Compute a SHA-256 fingerprint for a certificate.
+ *
+ * @param cert Certificate whose DER encoding should be hashed.
+ * @param out Destination buffer for the fingerprint bytes.
+ * @param out_len Length of the destination buffer in bytes.
+ *
+ * @return 0 on success, or -1 when the input is invalid or the buffer is too small.
+ */
 static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 {
     unsigned int len = 0;
@@ -73,11 +100,27 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
     return (len == FINGERPRINT_LEN) ? 0 : -1;
 }
 
+/**
+ * @brief Compare two fixed-size SHA-256 certificate fingerprints.
+ *
+ * @param fp1 First fingerprint buffer.
+ * @param fp2 Second fingerprint buffer.
+ *
+ * @return Non-zero when the fingerprints are byte-for-byte equal, otherwise 0.
+ */
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
     return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
+/**
+ * @brief Validate the certificate validity window against the current time.
+ *
+ * @param cert Certificate to inspect.
+ *
+ * @return CERT_STATUS_OK for a currently valid certificate, or a negative
+ * status code describing the validity failure.
+ */
 static int check_expiry(X509 *cert)
 {
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
@@ -105,6 +148,14 @@ static int check_expiry(X509 *cert)
     return CERT_STATUS_OK;
 }
 
+/**
+ * @brief Verify that an issuer certificate signed a child certificate.
+ *
+ * @param cert Child certificate whose signature should be checked.
+ * @param issuer Candidate issuer certificate providing the public key.
+ *
+ * @return CERT_STATUS_OK when verification succeeds, otherwise CERT_STATUS_INVALID.
+ */
 static int verify_signature(X509 *cert, X509 *issuer)
 {
     EVP_PKEY *issuer_key = X509_get0_pubkey(issuer);
@@ -120,6 +171,14 @@ static int verify_signature(X509 *cert, X509 *issuer)
     return CERT_STATUS_OK;
 }
 
+/**
+ * @brief Find a trusted-store entry whose subject matches a certificate issuer.
+ *
+ * @param store Trusted certificate store to search.
+ * @param cert Certificate requiring an issuer.
+ *
+ * @return Pointer to the matching store entry, or NULL when no issuer matches.
+ */
 static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
 {
     X509_NAME *issuer_name = X509_get_issuer_name(cert);
@@ -132,6 +191,14 @@ static cert_entry_t *find_issuer(cert_store_t *store, X509 *cert)
     return NULL;
 }
 
+/**
+ * @brief Validate a certificate chain against the configured trust context.
+ *
+ * @param ctx Chain validation context containing the presented chain, trusted
+ * store, optional pinned fingerprint, and OCSP configuration flag.
+ *
+ * @return CERT_STATUS_OK when the chain is trusted, otherwise a negative status code.
+ */
 static int validate_chain(chain_context_t *ctx)
 {
     int             i, rc;
@@ -179,6 +246,13 @@ static int validate_chain(chain_context_t *ctx)
     return CERT_STATUS_OK;
 }
 
+/**
+ * @brief Free all entries in a certificate store.
+ *
+ * @param store Store whose entries should be released. NULL is accepted.
+ *
+ * @return Nothing.
+ */
 static void cleanup_cert_store(cert_store_t *store)
 {
     cert_entry_t *entry, *next;
@@ -199,6 +273,14 @@ static void cleanup_cert_store(cert_store_t *store)
     store->count = 0;
 }
 
+/**
+ * @brief Add a certificate to the trusted certificate store.
+ *
+ * @param store Store that receives the duplicated certificate entry.
+ * @param cert OpenSSL certificate to duplicate and index by subject/issuer.
+ *
+ * @return 0 on success, or -1 on invalid input or allocation/fingerprint failure.
+ */
 int add_trusted_cert(cert_store_t *store, X509 *cert)
 {
     if (!store || !cert)
@@ -236,6 +318,15 @@ int add_trusted_cert(cert_store_t *store, X509 *cert)
     return 0;
 }
 
+/**
+ * @brief Allocate and initialize an empty certificate store.
+ *
+ * @param max_depth Maximum allowed certificate-chain depth; out-of-range values
+ * fall back to MAX_CHAIN_DEPTH.
+ * @param log_level Minimum severity emitted by the certificate logger.
+ *
+ * @return Newly allocated certificate store, or NULL on allocation failure.
+ */
 cert_store_t *init_cert_store(int max_depth, int log_level)
 {
     cert_store_t *store = calloc(1, sizeof(cert_store_t));

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -1,3 +1,9 @@
+// Package tlscipher implements TLS cipher-suite selection helpers.
+//
+// The package models the cipher-negotiation component of a TLS stack. It keeps
+// metadata for common suites, filters suites against a configured security
+// threshold, orders suites by server preference, and exposes helper functions
+// for diagnostics and platform capability reporting.
 package tlscipher
 
 import (

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -1,7 +1,13 @@
-"""
-TLS 1.2 Handshake State Machine
-Implements message parsing and state transitions for TLS handshake protocol.
-Reference: RFC 5246, RFC 7627 (Extended Master Secret)
+"""TLS 1.2 handshake parsing and state-management helpers.
+
+This module models the handshake portion of a TLS connection. It parses TLS
+record and handshake headers, tracks transcript hashes, extracts selected
+ClientHello extensions, and derives or verifies handshake secrets for the rest
+of the TLS stack. The implementation is intentionally small and test-oriented,
+so private-key operations are represented by deterministic placeholders rather
+than production cryptography.
+
+Reference: RFC 5246 and RFC 7627 (Extended Master Secret).
 """
 
 import hashlib
@@ -13,6 +19,8 @@ from typing import Optional, Dict, List, Tuple, Any
 
 
 class HandshakeState(Enum):
+    """High-level states used by the TLS handshake state machine."""
+
     IDLE = auto()
     CLIENT_HELLO = auto()
     SERVER_HELLO = auto()
@@ -25,6 +33,8 @@ class HandshakeState(Enum):
 
 
 class ContentType(Enum):
+    """TLS record-layer content type codes used by this parser."""
+
     CHANGE_CIPHER_SPEC = 20
     ALERT = 21
     HANDSHAKE = 22
@@ -32,6 +42,8 @@ class ContentType(Enum):
 
 
 class HandshakeType(Enum):
+    """Handshake message type codes defined by TLS 1.2."""
+
     CLIENT_HELLO = 1
     SERVER_HELLO = 2
     CERTIFICATE = 11
@@ -71,11 +83,22 @@ class TLSExtension:
     """Represents a parsed TLS extension."""
 
     def __init__(self, ext_type: int, data: bytes):
+        """Initialize a parsed extension container.
+
+        Args:
+            ext_type: Numeric TLS extension type identifier.
+            data: Raw extension payload bytes without the type/length header.
+        """
         self.ext_type = ext_type
         self.data = data
         self.server_name: Optional[str] = None
 
     def __repr__(self) -> str:
+        """Return a concise debugging representation of the extension.
+
+        Returns:
+            String containing the extension type and payload length.
+        """
         return f"TLSExtension(type=0x{self.ext_type:04x}, len={len(self.data)})"
 
 
@@ -83,6 +106,12 @@ class HandshakeMessage:
     """Parsed TLS handshake message."""
 
     def __init__(self, msg_type: HandshakeType, payload: bytes):
+        """Initialize a parsed handshake message.
+
+        Args:
+            msg_type: TLS handshake message type.
+            payload: Message body bytes without the handshake header.
+        """
         self.msg_type = msg_type
         self.payload = payload
         self.extensions: List[TLSExtension] = []
@@ -98,6 +127,12 @@ class TLSHandshake:
     """
 
     def __init__(self, is_server: bool = False):
+        """Create a new handshake tracker.
+
+        Args:
+            is_server: Whether this instance should verify peer Finished
+                messages using the server-side label. Defaults to client mode.
+        """
         self.state: HandshakeState = HandshakeState.IDLE
         self.is_server = is_server
         self.client_random: Optional[bytes] = None
@@ -113,7 +148,15 @@ class TLSHandshake:
         self.transcript: bytearray = bytearray()
 
     def transition_to(self, new_state: HandshakeState) -> bool:
-        """Attempt a state transition. Returns True if valid."""
+        """Attempt to advance the handshake state machine.
+
+        Args:
+            new_state: Candidate next state.
+
+        Returns:
+            True when the transition is allowed; otherwise False and the
+            state is changed to ERROR.
+        """
         allowed = VALID_TRANSITIONS.get(self.state, [])
         if new_state in allowed:
             self.state = new_state
@@ -122,7 +165,16 @@ class TLSHandshake:
         return False
 
     def parse_record(self, data: bytes) -> Optional[HandshakeMessage]:
-        """Parse a TLS record layer and extract the handshake message."""
+        """Parse a TLS record and extract a handshake message.
+
+        Args:
+            data: Complete TLS record bytes, including the five-byte record
+                header.
+
+        Returns:
+            Parsed HandshakeMessage when the record is a supported handshake
+            record; otherwise None.
+        """
         if len(data) < 5:
             return None
 
@@ -157,7 +209,16 @@ class TLSHandshake:
         return message
 
     def parse_client_hello(self, message: HandshakeMessage) -> bool:
-        """Parse ClientHello message fields."""
+        """Parse key ClientHello fields and advertised extensions.
+
+        Args:
+            message: HandshakeMessage whose payload contains a ClientHello
+                body.
+
+        Returns:
+            True when mandatory fields were present and parsed; False when the
+            payload is too short or malformed.
+        """
         payload = message.payload
         if len(payload) < 38:
             return False
@@ -191,7 +252,15 @@ class TLSHandshake:
         return True
 
     def parse_extensions(self, data: bytes) -> List[TLSExtension]:
-        """Parse TLS extensions from raw bytes."""
+        """Parse a sequence of TLS extension records.
+
+        Args:
+            data: Concatenated extension records from a ClientHello.
+
+        Returns:
+            List of parsed extensions. Recognized extensions also update the
+            handshake object's negotiation fields.
+        """
         extensions = []
         offset = 0
 
@@ -219,8 +288,15 @@ class TLSHandshake:
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """
-        Verify the Finished message using HMAC-based PRF.
-        Compares received verify_data against locally computed value.
+        Verify the Finished message using the TLS PRF.
+
+        Args:
+            received_verify: Verify-data bytes received from the peer.
+            label: PRF label, typically ``client finished`` or
+                ``server finished``.
+
+        Returns:
+            True when the computed verify data matches the received value.
         """
         if self.master_secret is None:
             return False
@@ -237,7 +313,16 @@ class TLSHandshake:
         return computed_verify == received_verify
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
-        """Process a ClientKeyExchange or ServerKeyExchange message."""
+        """Process key-exchange payload and derive the master secret.
+
+        Args:
+            message: Key-exchange handshake message containing the encoded
+                pre-master secret.
+
+        Returns:
+            True when the pre-master secret was recovered and the master
+            secret was derived; otherwise False.
+        """
         try:
             payload = message.payload
             if len(payload) < 2:
@@ -262,7 +347,11 @@ class TLSHandshake:
         return False
 
     def _derive_master_secret(self) -> None:
-        """Derive the master secret from pre-master secret and randoms."""
+        """Derive the TLS master secret from pre-master secret and randoms.
+
+        Raises:
+            ValueError: If the pre-master secret or either random is missing.
+        """
         if self._pre_master_secret is None:
             raise ValueError("No pre-master secret available")
         if self.client_random is None or self.server_random is None:
@@ -283,7 +372,17 @@ class TLSHandshake:
 
     def _prf(self, secret: bytes, label: bytes, seed: bytes,
              output_len: int) -> bytes:
-        """TLS 1.2 PRF using HMAC-SHA256 (P_SHA256)."""
+        """Run the TLS 1.2 HMAC-SHA256 PRF.
+
+        Args:
+            secret: Secret keying material for HMAC.
+            label: ASCII PRF label.
+            seed: PRF seed bytes.
+            output_len: Number of bytes to produce.
+
+        Returns:
+            Pseudo-random output truncated to ``output_len`` bytes.
+        """
         combined_seed = label + seed
         result = b""
         a_value = combined_seed  # A(0) = seed
@@ -299,8 +398,18 @@ class TLSHandshake:
 
     def _decrypt_pre_master_secret(self, encrypted: bytes) -> Optional[bytes]:
         """
-        Placeholder for RSA decryption of the pre-master secret.
-        In production, this would use the server's private key.
+        Recover the pre-master secret from an encrypted key-exchange blob.
+
+        Args:
+            encrypted: Encrypted pre-master secret bytes from the peer.
+
+        Returns:
+            A 48-byte pre-master secret for test inputs, or None when the
+            input cannot contain a valid TLS 1.2 pre-master secret.
+
+        Note:
+            In production, this placeholder would perform RSA or ECDHE secret
+            agreement using the configured server private key.
         """
         # Stub: return a deterministic value for testing
         if len(encrypted) < 48:
@@ -309,8 +418,13 @@ class TLSHandshake:
 
     def process_message(self, data: bytes) -> Tuple[bool, str]:
         """
-        Main entry point: parse a TLS record and advance the state machine.
-        Returns (success, status_message).
+        Parse one TLS record and advance the handshake state machine.
+
+        Args:
+            data: Complete TLS record bytes.
+
+        Returns:
+            Tuple of success flag and a human-readable status message.
         """
         message = self.parse_record(data)
         if message is None:
@@ -357,7 +471,12 @@ class TLSHandshake:
         return False, f"Unhandled message type: {message.msg_type}"
 
     def get_state_info(self) -> Dict[str, Any]:
-        """Return current handshake state for diagnostics."""
+        """Return diagnostic information about the current handshake.
+
+        Returns:
+            Dictionary containing state, negotiated parameters, extension IDs,
+            and whether a master secret has been derived.
+        """
         return {
             "state": self.state.name,
             "cipher_suite": self.cipher_suite,

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -1,3 +1,11 @@
+//! TLS session-ticket cache and placeholder ticket-protection helpers.
+//!
+//! This module represents the session-resumption component of a TLS stack. It
+//! stores issued session tickets, checks ticket lifetime, serializes ticket
+//! metadata for logging, and wraps ticket secrets with a simplified encryption
+//! routine used by the repository examples. Production code would replace the
+//! XOR placeholder with an AEAD construction and synchronize shared cache state.
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -9,13 +17,15 @@ const MAX_CACHE_SIZE: usize = 4096;
 const DEFAULT_TICKET_LIFETIME_SECS: u64 = 7200;
 
 /// Fixed nonce used for ticket encryption.
-const ENCRYPTION_NONCE: [u8; 12] = [0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x01];
+const ENCRYPTION_NONCE: [u8; 12] = [
+    0x4e, 0x6f, 0x6e, 0x63, 0x65, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+];
 
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
 
+/// Errors returned by session-cache and ticket-protection operations.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SessionError {
     TicketExpired { ticket_id: String },
@@ -45,6 +55,7 @@ impl std::error::Error for SessionError {}
 // Core data structures
 // ---------------------------------------------------------------------------
 
+/// Resumable TLS session state issued to a client as a ticket.
 #[derive(Debug, Clone)]
 pub struct SessionTicket {
     pub ticket_id: String,
@@ -56,6 +67,7 @@ pub struct SessionTicket {
     pub creation_time: u64,
 }
 
+/// Key metadata and raw material used to protect session tickets.
 #[derive(Debug, Clone)]
 pub struct EncryptionKey {
     pub key_id: u32,
@@ -63,6 +75,7 @@ pub struct EncryptionKey {
     pub created_at: u64,
 }
 
+/// In-memory cache of issued TLS session tickets.
 #[derive(Debug, Clone)]
 pub struct SessionCache {
     /// Thread-safe reference to the inner cache map.
@@ -73,6 +86,7 @@ pub struct SessionCache {
     max_size: usize,
 }
 
+/// TLS 1.3 cipher suites supported by the ticket issuer.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CipherSuite {
     TlsAes128GcmSha256 = 0x1301,
@@ -85,6 +99,10 @@ pub enum CipherSuite {
 // ---------------------------------------------------------------------------
 
 impl EncryptionKey {
+    /// Construct a new encryption key with the current timestamp.
+    ///
+    /// The key is tagged with `key_id` so tickets can be associated with the
+    /// material that protected them.
     pub fn new(key_id: u32, material: Vec<u8>) -> Self {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -105,6 +123,9 @@ impl EncryptionKey {
 
 impl SessionCache {
     /// Create a new, empty session cache with a default encryption key.
+    ///
+    /// The cache uses `key_material` to initialize key id 1 and applies the
+    /// module default maximum cache size.
     pub fn new(key_material: Vec<u8>) -> Self {
         let key = EncryptionKey::new(1, key_material);
         SessionCache {
@@ -115,6 +136,9 @@ impl SessionCache {
     }
 
     /// Store a session ticket in the cache.
+    ///
+    /// Expired tickets are evicted before insertion. If the cache is still at
+    /// capacity after eviction, `SessionError::CacheFull` is returned.
     pub fn store_session(&mut self, ticket: SessionTicket) -> Result<(), SessionError> {
         let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
 
@@ -146,12 +170,16 @@ impl SessionCache {
     }
 
     /// Remove a specific ticket from the cache.
+    ///
+    /// Returns the removed ticket when it existed and the cache can be mutated.
     pub fn remove_session(&mut self, ticket_id: &str) -> Option<SessionTicket> {
         let inner = Arc::get_mut(&mut self.cache)?;
         inner.remove(ticket_id)
     }
 
     /// Return the number of cached sessions.
+    ///
+    /// This count includes expired tickets until an eviction pass runs.
     pub fn session_count(&self) -> usize {
         self.cache.len()
     }
@@ -192,6 +220,10 @@ impl SessionCache {
 
 impl SessionCache {
     /// Issue a new session ticket for the given cipher suite and secret.
+    ///
+    /// The generated ticket id embeds the key id and issue timestamp, the
+    /// master secret is encrypted, and the resulting ticket is inserted into
+    /// the cache before being returned.
     pub fn issue_ticket(
         &mut self,
         cipher_suite: CipherSuite,
@@ -250,6 +282,9 @@ impl SessionCache {
     }
 
     /// Decrypt ticket data using the current encryption key.
+    ///
+    /// The first 12 bytes are interpreted as the nonce prefix and the remaining
+    /// bytes are XOR-decoded with the configured key material.
     pub fn decrypt_ticket(&self, ciphertext: &[u8]) -> Result<Vec<u8>, SessionError> {
         if ciphertext.len() < 12 {
             return Err(SessionError::DecryptionFailed(
@@ -288,6 +323,8 @@ impl std::fmt::Display for SessionTicket {
 
 impl SessionCache {
     /// Return a summary line for logging / diagnostics.
+    ///
+    /// The summary intentionally excludes key material and ticket secrets.
     pub fn summary(&self) -> String {
         format!(
             "SessionCache {{ sessions: {}, key_id: {}, max: {} }}",


### PR DESCRIPTION
## Summary
- Add module-level documentation describing each TLS component's role in the stack
- Expand Python public class/method docstrings using Google-style sections
- Add Rust doc comments for public structs, enums, and public functions
- Ensure Go exported type/function comments follow godoc naming conventions
- Add Doxygen-style comments for C functions and purpose/register blocks for assembly labels

## Validation
- PYTHONPYCACHEPREFIX=/private/tmp/pycache python3 -m py_compile Bounty-Hunters/python/tls_handshake.py
- git -C Bounty-Hunters diff --check
- Lightweight doc coverage checks for Python public docstrings, Rust public API docs, Go godoc prefixes, and assembly label comment blocks

## Demo
Documentation-only change; no runtime behavior changed. The diff itself demonstrates the completed documentation coverage.

/claim #334
Closes #334
