### PR TITLE
Fix API port mapping in compose config

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080"
+      - "8080:8080"
       - "9090:9090"
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
Fixes #312

/claim #312

Validation:
- verified the API service maps 8080:8080 and leaves 9090:9090 unchanged