### PR TITLE
Fix missing nginx proxy header semicolon

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
## Summary

- Adds the missing semicolon to the X-Forwarded-For proxy_set_header directive.

## Verification

- `git diff --check`

/claim #311