### PR TITLE
Fix API port mapping in compose config

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080"
+      - "8080:8080"
       - "9090:9090"
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
## Summary

- Maps host port 8080 to container port 8080 for the API service.

## Verification

- `git diff --check`

/claim #312