### PR TITLE
Guard empty deploy directory before cleanup

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,6 +28,11 @@ log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
 # Clean previous deployment artifacts
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
+
 log_message "Cleaning previous build artifacts..."
 rm -rf ${DEPLOY_DIR}/dist
 rm -rf ${DEPLOY_DIR}/node_modules/.cache


### PR DESCRIPTION
Closes #317

/claim #317

Summary:
- Add a DEPLOY_DIR empty-value guard before destructive cleanup commands.
- Exit with an error before rm commands can expand against an unintended absolute path.

Verification:
- git diff --check