### PR TITLE
Exit deploy script on command failure

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 #
 # deploy.sh - Application deployment script
 # Pulls latest code, builds, and deploys to production


### PR DESCRIPTION
Closes #316

/claim #316

Summary:
- Add set -e immediately after the deploy script shebang.
- Ensure deployment stops when any command fails instead of continuing in a broken state.

Verification:
- git diff --check