### PR TITLE
Fix setup package name

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
Closes #306

/claim #306

Summary:
- Update the setup guide install command to use the correct bounty-hunters package name.

Verification:
- git diff --check