### PR TITLE
Fix rate limit table row

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST   | 5 req/min       |
 
 ## Error Codes
 


### PR DESCRIPTION
Closes #303

/claim #303

Summary:
- Add the missing leading pipe to the /bounties/:id/claims rate-limit row.
- Align the row with the rest of the markdown table.

Verification:
- git diff --check