### PR TITLE
Add missing environment setup step

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -33,7 +33,13 @@ pip install bounty-hunter
 
 This will install the core package and all required dependencies.
 
-### Step 5: Configure the Database
+### Step 4: Set Up Environment Variables
+
+```bash
+cp .env.example .env
+```
+
+### Step 6: Configure the Database
 
 Create a `config.yml` file in the project root:
 
@@ -56,13 +62,13 @@ server:
   debug: true
 ```
 
-### Step 6: Run Migrations
+### Step 7: Run Migrations
 
 ```bash
 python manage.py migrate
 ```
 
-### Step 7: Start the Development Server
+### Step 8: Start the Development Server
 
 ```bash
 python manage.py runserver


### PR DESCRIPTION
Closes #305

/claim #305

Summary:
- Add Step 4 for copying .env.example to .env.
- Renumber the following setup steps so the installation flow is sequential.

Verification:
- git diff --check