### PR TITLE
Fix certificate chain loop bound

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -165,7 +165,7 @@
                GO TO 2000-EXIT
            END-IF
            PERFORM VARYING WS-CHAIN-INDEX FROM 1 BY 1
-               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH + 1
+               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH
                MOVE WS-CHN-SERIAL(WS-CHAIN-INDEX)
                    TO CS-CERT-SERIAL
                READ CERT-STORE-FILE


### PR DESCRIPTION
Closes #375

/claim #375

Summary:
- Remove the extra + 1 from the certificate chain PERFORM termination condition.
- Keep iteration bounded to indexes 1 through WS-CHAIN-LENGTH.

Verification:
- git diff --check