### PR TITLE
Fix CRL revocation detection

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -309,11 +309,9 @@
                    NOT AT END
                        IF CRL-REVOKED-SERIAL =
                            WS-CERT-SERIAL-NUM
-                           IF WS-CRL-NOT-LOADED
-                               SET WS-CERT-IS-REVOKED TO TRUE
-                               MOVE 'CERTIFICATE ON CRL'
-                                   TO WS-VALIDATION-MSG
-                           END-IF
+                           SET WS-CERT-IS-REVOKED TO TRUE
+                           MOVE 'CERTIFICATE ON CRL'
+                               TO WS-VALIDATION-MSG
                        END-IF
                END-READ
            END-PERFORM


### PR DESCRIPTION
Closes #376

/claim #376

Summary:
- Remove the unreachable WS-CRL-NOT-LOADED guard inside the loaded CRL loop.
- Mark certificates as revoked whenever their serial appears in the CRL.

Verification:
- git diff --check