### PR TITLE
test: cover certificate validity checks

### DIFF
--- a/javascript/tls_handshake_client.js
+++ b/javascript/tls_handshake_client.js
@@ -236,6 +236,8 @@ class TLSHandshakeClient {
       throw new TLSError('Empty certificate chain', 42);
     }
 
+    const now = new Date();
+
     for (let i = 0; i < certChain.length; i++) {
       const cert = certChain[i];
 
@@ -244,7 +246,6 @@ class TLSHandshakeClient {
       }
 
       // Check certificate expiry — both notBefore and notAfter
-      const now = new Date();
       if (cert.notBefore && now < new Date(cert.notBefore)) {
         throw new TLSError(`Certificate at index ${i} is not yet valid`, 45);
       }

--- a/javascript/tls_handshake_client_certificate.test.js
+++ b/javascript/tls_handshake_client_certificate.test.js
@@ -83,3 +83,15 @@ test('verifyServerCertificate checks intermediate certificate validity', () => {
     /expired/,
   );
 });
+
+test('verifyServerCertificate rejects not-yet-valid intermediate certificates', () => {
+  const client = new TLSHandshakeClient({ hostname: 'example.com' });
+
+  assertValidityError(
+    () => client.verifyServerCertificate([
+      certificate(),
+      rootCertificate({ notBefore: '2999-01-01T00:00:00Z' }),
+    ]),
+    /not yet valid/,
+  );
+});

--- a/javascript/tls_handshake_client_certificate.test.js
+++ b/javascript/tls_handshake_client_certificate.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { TLSError, TLSHandshakeClient } = require('./tls_handshake_client.js');
+
+const VALID_FROM = '2020-01-01T00:00:00Z';
+const VALID_TO = '2099-01-01T00:00:00Z';
+
+function certificate(overrides = {}) {
+  return {
+    subject: 'example.com',
+    issuer: 'Example Root CA',
+    subjectAltNames: ['example.com'],
+    notBefore: VALID_FROM,
+    notAfter: VALID_TO,
+    ...overrides,
+  };
+}
+
+function rootCertificate(overrides = {}) {
+  return certificate({
+    subject: 'Example Root CA',
+    issuer: 'Example Root CA',
+    subjectAltNames: [],
+    ...overrides,
+  });
+}
+
+function assertValidityError(fn, pattern) {
+  assert.throws(
+    fn,
+    (error) => (
+      error instanceof TLSError
+      && error.alertCode === 45
+      && pattern.test(error.message)
+    ),
+  );
+}
+
+test('verifyServerCertificate accepts certificates inside their validity period', () => {
+  const client = new TLSHandshakeClient({ hostname: 'example.com' });
+
+  assert.equal(
+    client.verifyServerCertificate([certificate(), rootCertificate()]),
+    true,
+  );
+});
+
+test('verifyServerCertificate rejects expired leaf certificates', () => {
+  const client = new TLSHandshakeClient({ hostname: 'example.com' });
+
+  assertValidityError(
+    () => client.verifyServerCertificate([
+      certificate({ notAfter: '2001-01-01T00:00:00Z' }),
+      rootCertificate(),
+    ]),
+    /expired/,
+  );
+});
+
+test('verifyServerCertificate rejects not-yet-valid leaf certificates', () => {
+  const client = new TLSHandshakeClient({ hostname: 'example.com' });
+
+  assertValidityError(
+    () => client.verifyServerCertificate([
+      certificate({ notBefore: '2999-01-01T00:00:00Z' }),
+      rootCertificate(),
+    ]),
+    /not yet valid/,
+  );
+});
+
+test('verifyServerCertificate checks intermediate certificate validity', () => {
+  const client = new TLSHandshakeClient({ hostname: 'example.com' });
+
+  assertValidityError(
+    () => client.verifyServerCertificate([
+      certificate(),
+      rootCertificate({ notAfter: '2001-01-01T00:00:00Z' }),
+    ]),
+    /expired/,
+  );
+});


### PR DESCRIPTION
## Summary
- computes `now` once per `verifyServerCertificate()` call so all certificates in a chain are checked against a stable timestamp
- adds a separate Node regression test file for valid, expired, not-yet-valid, and intermediate/root validity-period checks
- verifies validity failures throw `TLSError` with alert code 45

## Validation
- `node --test javascript/tls_handshake_client_certificate.test.js`
- `git diff --check`

/claim #392