### PR TITLE
fix(config): correct image tag typo lastest → latest in docker-compose.yml

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Fixed the Docker image tag typo that would cause pull failures:

- `bounty-hunters-api:lastest` → `bounty-hunters-api:latest`

Closes #310