### PR TITLE
Fix API reference rate limit table

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST | 5 req/min     |
 
 ## Error Codes
 


### PR DESCRIPTION
## Summary

Fixes the broken Markdown table row in `docs/api-reference.md` so `/bounties/:id/claims` renders as part of the Rate Limits table.

## Testing

- Documentation-only change; verified the table row now starts with a leading pipe.

Closes #303
