### PR TITLE
docs: add environment setup step

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -33,6 +33,12 @@ pip install bounty-hunter
 
 This will install the core package and all required dependencies.
 
+### Step 4: Set Up Environment Variables
+
+```bash
+cp .env.example .env
+```
+
 ### Step 5: Configure the Database
 
 Create a `config.yml` file in the project root:


### PR DESCRIPTION
/claim #305

Summary:
- add the missing environment-variable setup step
- keep the setup guide numbering continuous

Verification:
- git diff --check
- rg -n '^### Step [0-9]:' docs/setup-guide.md

Demo video not applicable for this docs-only change.

AI-assisted with Codex; I reviewed the diff before submitting.
