### PR TITLE
config: remove app json trailing comma

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
/claim #308

Summary:
- remove the trailing comma after allowed_origins
- make config/app.json parse as valid JSON

Verification:
- git diff --check
- node -e "JSON.parse(require('fs').readFileSync('config/app.json','utf8')); console.log('valid json')"

Demo video not applicable for this config-only change.

AI-assisted with Codex; I reviewed the diff before submitting.
