### PR TITLE
config: fix compose image tag typo

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
/claim #310

Summary:
- change the API image tag suffix from lastest to latest
- leave the rest of the compose file unchanged

Verification:
- git diff --check
- rg -n 'lastest|latest' config/docker-compose.yml

Demo video not applicable for this config-only change.

AI-assisted with Codex; I reviewed the diff before submitting.
