### PR TITLE
config: add nginx header semicolon

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
/claim #311

Summary:
- add the missing semicolon on the X-Forwarded-For proxy header directive
- leave all other nginx config lines unchanged

Verification:
- git diff --check
- rg -n 'X-Forwarded-For' config/nginx.conf

Demo video not applicable for this config-only change.

AI-assisted with Codex; I reviewed the diff before submitting.
