### PR TITLE
scripts: stop deploy on command failure

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,8 @@
 # Pulls latest code, builds, and deploys to production
 #
 
+set -e
+
 APP_NAME="webapp"
 DEPLOY_DIR=""
 REPO_URL="git@github.com:org/webapp.git"


### PR DESCRIPTION
/claim #316

Summary:
- add set -e near the top of deploy.sh
- keep the rest of the deploy script unchanged

Verification:
- git diff --check
- bash -n scripts/deploy.sh

Demo video not applicable for this shell-script change.

AI-assisted with Codex; I reviewed the diff before submitting.
