### PR TITLE
fix(config): remove trailing comma in app json

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
## Issue
Closes #308

/claim #308

## Summary
Remove the trailing comma after the `allowed_origins` array so `config/app.json` is valid JSON.

## Acceptance criteria
- [x] The trailing comma after the `allowed_origins` line is removed
- [x] The file is valid JSON (parseable without errors)
- [x] All other content in the file remains unchanged

## Verification
- [x] `jq empty config/app.json`
- [x] `git diff --check`

Demo video not applicable for this config-only syntax fix.