### PR TITLE
fix(config): correct database key spelling

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
## Issue
Closes #309

/claim #309

## Summary
Correct the misspelled `databse` key in `config/app.json` to `database` while leaving the nested object unchanged.

## Acceptance criteria
- [x] The key `databse` is corrected to `database`
- [x] The value object under the key remains unchanged
- [x] All other content in the file remains unchanged

## Verification
- [x] `rg -n '"database"|"databse"' config/app.json`
- [x] `git diff --check`

Note: `jq empty config/app.json` still fails on upstream `main` because issue #308 is a separate pre-existing trailing-comma bug; this PR intentionally does not bundle that fix.

Demo video not applicable for this config-only spelling fix.
