### PR TITLE
fix(config): correct docker image tag

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Issue
Closes #310

/claim #310

## Summary
Correct the API service image tag suffix in `config/docker-compose.yml` from `lastest` to `latest`.

## Acceptance criteria
- [x] The image tag ending in `:lastest` is changed to `:latest`
- [x] All other content in the file remains unchanged

## Verification
- [x] `rg -n 'lastest|latest' config/docker-compose.yml`
- [x] `git diff --check`

Demo video not applicable for this config-only image tag fix.
