### PR TITLE
fix(config): bind api host port

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080"
+      - "8080:8080"
       - "9090:9090"
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
## Issue
Closes #312

/claim #312

## Summary
Bind the API service host port by changing the Docker Compose port entry from `8080` to `8080:8080`.

## Acceptance criteria
- [x] The ports entry `8080` is changed to `8080:8080`
- [x] The other port mapping `9090:9090` remains unchanged
- [x] All other content in the file remains unchanged

## Verification
- [x] `rg -n '8080|9090' config/docker-compose.yml`
- [x] `git diff --check`

Demo video not applicable for this config-only port mapping fix.
