### PR TITLE
fix: correct database key typo

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
## Summary
- changes the misspelled `databse` key to `database` in `config/app.json`
- leaves the nested value and all other content unchanged

/claim #309

## Verification
```sh
rg '"database"|"databse"' config/app.json
```

Checked against the branch content via GitHub API: `"database"` is present and `"databse"` is absent.