### PR TITLE
fix: correct api image tag typo

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- changes the API image tag suffix from `:lastest` to `:latest` in `config/docker-compose.yml`
- leaves the image name and all other compose content unchanged

/claim #310

## Verification
```sh
rg ':latest|:lastest' config/docker-compose.yml
```

Checked against the branch content via GitHub API: `:latest` is present and `:lastest` is absent.