### PR TITLE
fix: remove app json trailing comma

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
## Summary
- removes the trailing comma after `allowed_origins` in `config/app.json`
- leaves all other config content unchanged

/claim #308

## Verification
```sh
jq empty config/app.json
rg 'allowed_origins|databse|database' config/app.json
```

Checked against the branch content via GitHub API: `jq empty` passes and the diff is scoped to the trailing comma.