### PR TITLE
fix: terminate X-Forwarded-For nginx header directive

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
Closes #311.

## Summary
- Adds the missing trailing semicolon to the `X-Forwarded-For` `proxy_set_header` directive in `config/nginx.conf`.
- Leaves all other nginx configuration content unchanged.

## Validation
- Verified the diff is limited to the one requested line.
- Ran a lightweight directive check confirming every `proxy_set_header` line now ends with `;`.

```bash
python3 - <<'PY'
from pathlib import Path
bad=[]
for i,line in enumerate(Path('config/nginx.conf').read_text().splitlines(),1):
    if 'proxy_set_header' in line and not line.strip().endswith(';'):
        bad.append((i,line))
if bad:
    raise SystemExit(f'proxy_set_header lines missing semicolon: {bad}')
print('OK: all proxy_set_header directives end with semicolon')
PY
```

Payout identity: Nico Vale / HustlerOps
