### PR TITLE
fix: address small bounty config and script issues

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,10 +1,11 @@
+#!/bin/bash
 #
 # cleanup.sh - Log file cleanup utility
 # Removes old log files and compresses recent ones
 #
 
 LOG_DIRS="/var/log/app /var/log/nginx /var/log/services"
-MAX_AGE_DAYS="14"
+MAX_AGE_DAYS=14
 COMPRESS_AGE_DAYS="3"
 TOTAL_CLEANED=0
 
@@ -35,7 +36,7 @@ done
 echo ""
 
 # Check total disk usage of log directories
-if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]; then
+if (( MAX_AGE_DAYS > TOTAL_CLEANED )); then
     echo "WARNING: Retention period exceeds number of files cleaned"
     echo "Consider reducing MAX_AGE_DAYS (currently ${MAX_AGE_DAYS})"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,11 @@ check_dependencies() {
 log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
+
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
 rm -rf ${DEPLOY_DIR}/dist


### PR DESCRIPTION
## Summary

Fixes five small bounty issues across config and shell scripts:

- Closes #308 by removing the trailing comma from `config/app.json`
- Closes #309 by correcting `databse` to `database`
- Closes #317 by guarding against an empty `DEPLOY_DIR` before destructive cleanup in `deploy.sh`
- Closes #318 by adding the missing `#!/bin/bash` shebang to `cleanup.sh`
- Closes #319 by using numeric shell values and arithmetic comparison for the cleanup retention check

## Validation

- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('config/app.json','utf8')); console.log('app.json valid')"`
- `bash -n scripts/deploy.sh`
- `bash -n scripts/cleanup.sh`
- `git diff --check`
