### PR TITLE
docs: fix Create Bounty HTTP method

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
## Summary
- Change the Create Bounty endpoint example from `GET /bounties` to `POST /bounties`.
- Keep the List Bounties endpoint as `GET /bounties`.

## Verification
- `git diff --check`
- `rg -n "List Bounties|Create Bounty|GET /bounties|POST /bounties" docs/api-reference.md`

/claim #304