### PR TITLE
Fix misspelled database key in app.json

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
Fixes #309.

Corrects the `databse` key in `config/app.json` to `database` while preserving the existing nested configuration.