### PR TITLE
Fix missing semicolon in nginx.conf

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
Fixes #311.

Adds the missing trailing semicolon to the `X-Forwarded-For` `proxy_set_header` directive in `config/nginx.conf`.