### PR TITLE
fix: stop deploy script on command failure

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 #
 # deploy.sh - Application deployment script
 # Pulls latest code, builds, and deploys to production


### PR DESCRIPTION
Closes #316

## Summary
- Add `set -e` near the top of `scripts/deploy.sh` so deployment stops on failed commands instead of continuing in a broken state.

## Validation
- `bash -n scripts/deploy.sh`
