### PR TITLE
Add open PR triage report

### DIFF
--- a/triage-reports/open-pr-review-2026-05-14.md
+++ b/triage-reports/open-pr-review-2026-05-14.md
@@ -1,0 +1,43 @@
+# Open PR Review Report
+
+Issue: 270
+Reviewer: hobyt-aluzar
+Review window: 2026-05-14 UTC
+
+## Scope
+
+I reviewed every pull request that was open when this triage pass started.
+Each review compared the patch against the linked issue's acceptance criteria
+and left constructive feedback on the pull request.
+
+## Reviewed Pull Requests
+
+- PR 444, issue 312: port mapping fix reviewed; suggested compose validation.
+- PR 446, issue 311: semicolon fix reviewed; flagged indentation drift.
+- PR 449, issue 310: Docker tag typo fix reviewed; suggested compose validation.
+- PR 450, issue 309: database key typo fix reviewed; suggested JSON validation.
+- PR 453, issue 377: COBOL rounding fix reviewed; suggested behavior validation.
+- PR 454, issue 311: nginx semicolon fix reviewed; suggested removing payout identity from the PR body.
+- PR 456, issue 304: Create Bounty method fix reviewed; noted clear claim linkage.
+- PR 457, issue 309: database key typo fix reviewed; suggested JSON validation.
+- PR 458, issue 310: Docker tag typo fix reviewed; suggested compose validation.
+- PR 459, issue 311: nginx semicolon fix reviewed; noted it preserves formatting.
+- PR 460, issue 318: cleanup shebang fix reviewed; suggested shell syntax validation.
+- PR 461, issue 304: HTTP method fix reviewed; requested linking the real issue instead of another PR.
+- PR 462, issue 316: deploy `set -e` fix reviewed; noted duplicate overlap.
+- PR 463, issue 316: deploy `set -e` fix reviewed; suggested shell syntax validation.
+- PR 464, issue 315: backup path quoting fix reviewed; flagged remaining unquoted `mkdir -p` usage.
+- PR 465, issue 307: changelog ordering fix reviewed; suggested validation note.
+
+## Summary
+
+The strongest candidates are the PRs that make the requested one-line change
+while preserving surrounding formatting and linking the correct issue. Several
+PRs are duplicate solutions for the same issue, so maintainers should merge only
+one per issue to avoid duplicate/conflicting claims.
+
+Two PRs need direct follow-up before merge:
+
+- PR 446 should preserve the original nginx indentation while adding the semicolon.
+- PR 464 should quote the later `mkdir -p "$BACKUP_DIR"` usage too, because the
+  issue requires the backup script to handle paths with spaces.


### PR DESCRIPTION
## Summary
- Reviewed every pull request that was open at the start of this triage pass.
- Left one constructive review on each pull request with acceptance-criteria notes and actionable follow-up.
- Added a concise triage report listing the reviewed pull requests and the main findings.

## Verification
- Posted 16 GitHub pull request reviews.
- Ran `git diff --check` before committing the report.

/claim #270