### PR TITLE
Fix trailing comma in app.json

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
Fixes #308.

Removes the trailing comma after the `allowed_origins` array so `config/app.json` parses as valid JSON. Verified with `python3 -m json.tool config/app.json` and `git diff --check`.