### PR TITLE
Fix rate limits markdown table

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST | 5 req/min     |
 
 ## Error Codes
 


### PR DESCRIPTION
Fixes #303.

Adds the missing leading pipe to the `/bounties/:id/claims` row so it renders as part of the Rate Limits table.