### PR TITLE
Guard empty deployment directory before cleanup

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,10 +27,15 @@ check_dependencies() {
 log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR must be set before cleaning deployment artifacts"
+    exit 1
+fi
+
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
-rm -rf ${DEPLOY_DIR}/dist
-rm -rf ${DEPLOY_DIR}/node_modules/.cache
+rm -rf "${DEPLOY_DIR}/dist"
+rm -rf "${DEPLOY_DIR}/node_modules/.cache"
 
 # Pull latest code
 if [ -d "${DEPLOY_DIR}/.git" ]; then


### PR DESCRIPTION
Fixes #317.\n\nAdds a guard that stops deployment when DEPLOY_DIR is empty before any cleanup command runs, and quotes the cleanup paths so they cannot expand unexpectedly.\n\nValidation:\n\n```\nbash -n scripts/deploy.sh\ngit diff --check\n```