### PR TITLE
Fix cleanup file count comparison

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -35,9 +35,8 @@ done
 echo ""
 
 # Check total disk usage of log directories
-if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]; then
-    echo "WARNING: Retention period exceeds number of files cleaned"
-    echo "Consider reducing MAX_AGE_DAYS (currently ${MAX_AGE_DAYS})"
+if [ "$TOTAL_CLEANED" -eq 0 ]; then
+    echo "INFO: No log files older than ${MAX_AGE_DAYS} days were removed"
 fi
 
 echo ""


### PR DESCRIPTION
Fixes #319.\n\nReplaces the misleading comparison between retention days and cleaned file count with a count-based check that reports when no old log files were removed.\n\nValidation:\n\n```\nbash -n scripts/cleanup.sh\ngit diff --check\n```