### PR TITLE
Fix Create Bounty HTTP method in API reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
## Summary

- Correct the Create Bounty endpoint method from `GET /bounties` to `POST /bounties`
- Leave the list/get/claim endpoints unchanged

## Verification

- Checked `docs/api-reference.md` to confirm `List Bounties` remains `GET /bounties`
- Confirmed `Create Bounty` now reads `POST /bounties`

Fixes #304