### PR TITLE
Rework cipher negotiation no-match handling

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module bountyhunters/tlscipher
+
+go 1.22

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -156,8 +156,6 @@ func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
 // It iterates server-side preferences and returns the first match found
 // in the client's offered list.
 //
-// BUG(1): When no suite matches, selectedSuite remains nil and the
-// function dereferences it to build the return value.
 func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 	if len(clientSuites) == 0 {
 		return "", errors.New("tlscipher: client offered no cipher suites")
@@ -178,7 +176,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_negotiation_test.go
+++ b/go/tls_cipher_negotiation_test.go
@@ -1,0 +1,30 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteReturnsErrorForUnknownOffer(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	name, err := reg.NegotiateSuite([]uint16{0xffff})
+	if err == nil {
+		t.Fatalf("expected no-match error, got suite name %q", name)
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name for no match, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteReturnsNameForSupportedOffer(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthLegacy)
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("expected supported suite to negotiate successfully: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}


### PR DESCRIPTION
/claim #11

## Summary
- Reworked the previous submission after the bot closed it as incomplete.
- Added a Go module for the go package so the regression tests can run directly.
- Return an explicit error when no offered cipher suite matches instead of dereferencing nil.
- Added focused tests for both unsupported and valid client suite negotiation.

## Verification
- go test ./... from go/ passes locally: ok bountyhunters/tlscipher 1.731s