### PR TITLE
Fix AEAD cipher suite preference

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters/go
+
+go 1.22.2

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -204,9 +204,6 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 // SortByPreference returns a copy of the slice ordered by server
 // preference. AEAD suites should be preferred over non-AEAD, and
 // higher strength suites should come first within each group.
-//
-// BUG(4): The AEAD comparison is inverted — non-AEAD suites end up
-// ranked above AEAD suites.
 func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sorted := make([]*CipherSuite, len(suites))
 	copy(sorted, suites)
@@ -214,9 +211,8 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		si, sj := sorted[i], sorted[j]
 
-		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,66 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePrefersAEADOverNonAEAD(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthLegacy)
+
+	nonAEAD := &CipherSuite{
+		ID:       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		Name:     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+		KeySize:  128,
+		IsAEAD:   false,
+		Strength: StrengthModern,
+	}
+	aead := &CipherSuite{
+		ID:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		Name:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		KeySize:  128,
+		IsAEAD:   true,
+		Strength: StrengthModern,
+	}
+
+	sorted := registry.SortByPreference([]*CipherSuite{nonAEAD, aead})
+
+	if got := sorted[0].Name; got != aead.Name {
+		t.Fatalf("expected AEAD suite first, got %s", got)
+	}
+	if got := sorted[1].Name; got != nonAEAD.Name {
+		t.Fatalf("expected non-AEAD suite second, got %s", got)
+	}
+}
+
+func TestSortByPreferenceOrdersAEADByStrengthThenKeySize(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthLegacy)
+
+	modern256 := &CipherSuite{
+		Name:     "modern-256-aead",
+		KeySize:  256,
+		IsAEAD:   true,
+		Strength: StrengthModern,
+	}
+	advanced128 := &CipherSuite{
+		Name:     "advanced-128-aead",
+		KeySize:  128,
+		IsAEAD:   true,
+		Strength: StrengthAdvanced,
+	}
+	modern128 := &CipherSuite{
+		Name:     "modern-128-aead",
+		KeySize:  128,
+		IsAEAD:   true,
+		Strength: StrengthModern,
+	}
+
+	sorted := registry.SortByPreference([]*CipherSuite{modern128, modern256, advanced128})
+
+	want := []string{"advanced-128-aead", "modern-256-aead", "modern-128-aead"}
+	for i, name := range want {
+		if sorted[i].Name != name {
+			t.Fatalf("sorted[%d] = %s, want %s", i, sorted[i].Name, name)
+		}
+	}
+}


### PR DESCRIPTION
## Issue

Closes #14

## Summary

Fixes `SortByPreference` so AEAD cipher suites are ranked before non-AEAD suites. The previous comparator returned `!si.IsAEAD && sj.IsAEAD`, which inverted the intended ordering.

## Changes

- Correct the AEAD comparator to return `si.IsAEAD && !sj.IsAEAD`.
- Remove the stale BUG(4) comments from the fixed code path.
- Add regression coverage for the reported AEAD-vs-non-AEAD ordering.
- Add coverage that AEAD-only suites still sort by strength first, then key size.
- Add a minimal Go module in `go/` so the package tests can run reproducibly.

## Validation

```bash
cd go
go test ./...
```

Result: `ok github.com/UnsafeLabs/Bounty-Hunters/go`.

/claim #14
