### PR TITLE
fix(python): reject finished after client hello

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,26 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tls_handshake import HandshakeState, TLSHandshake, VALID_TRANSITIONS
+
+
+class TLSHandshakeStateTransitionTests(unittest.TestCase):
+    def test_client_hello_only_allows_server_hello_next(self):
+        self.assertEqual(
+            VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO],
+            [HandshakeState.SERVER_HELLO],
+        )
+
+    def test_client_hello_cannot_transition_directly_to_finished(self):
+        handshake = TLSHandshake()
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -55,7 +55,6 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
## Issue
Closes #16

## Summary
Removes the invalid CLIENT_HELLO -> FINISHED transition so the handshake cannot skip SERVER_HELLO, CERTIFICATE, and KEY_EXCHANGE. Adds unittest coverage for the allowed transition list and rejected direct Finished transition.

## Acceptance criteria
- [x] VALID_TRANSITIONS[CLIENT_HELLO] contains only [HandshakeState.SERVER_HELLO]
- [x] transition_to(HandshakeState.FINISHED) returns False when state is CLIENT_HELLO
- [x] Attempting CLIENT_HELLO -> FINISHED sets state to HandshakeState.ERROR
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs