### PR TITLE
fix(python): parse sni host names

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,32 @@
+import struct
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tls_handshake import EXT_SNI, TLSHandshake
+
+
+class TLSHandshakeSniExtensionTests(unittest.TestCase):
+    def test_parse_sni_extension_sets_server_name(self):
+        hostname = b"example.com"
+        server_name = b"\x00" + struct.pack("!H", len(hostname)) + hostname
+        ext_data = struct.pack("!H", len(server_name)) + server_name
+        extension = struct.pack("!HH", EXT_SNI, len(ext_data)) + ext_data
+
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(extension)
+
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+
+    def test_parse_extensions_without_sni_leaves_server_name_unset(self):
+        handshake = TLSHandshake()
+
+        self.assertEqual(handshake.parse_extensions(b""), [])
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,9 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                self._parse_sni_extension(ext)
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +216,34 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_extension(self, ext: TLSExtension) -> None:
+        """Decode the first host_name entry from an SNI extension."""
+        data = ext.data
+        if len(data) < 2:
+            return
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        offset = 2
+        end = min(len(data), offset + list_len)
+
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+
+            if offset + name_len > end:
+                return
+
+            if name_type == 0:
+                try:
+                    ext.server_name = data[offset:offset + name_len].decode("ascii")
+                except UnicodeDecodeError:
+                    return
+                self.server_name = ext.server_name
+                return
+
+            offset += name_len
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """


### PR DESCRIPTION
## Issue
Closes #17

## Summary
Adds SNI host_name decoding for TLS extensions and records the decoded hostname on both the extension and handshake. Adds unittest coverage for SNI and no-SNI cases.

## Acceptance criteria
- [x] parse_extensions() adds an elif branch for EXT_SNI that decodes the SNI list per RFC 6066 (name_type 0x00 = host_name)
- [x] After parsing, ext.server_name and self.server_name equal the decoded hostname string (e.g., "example.com")
- [x] A ClientHello with no SNI extension leaves self.server_name as None
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs