### PR TITLE
fix(python): compare finished verify data safely

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tls_handshake import TLSHandshake
+
+
+class TLSHandshakeFinishedVerificationTests(unittest.TestCase):
+    def test_verify_finished_uses_constant_time_comparison(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"master secret for tests"
+        received_verify = b"\x00" * 12
+
+        with patch("tls_handshake.hmac.compare_digest", return_value=False) as compare_digest:
+            self.assertFalse(handshake.verify_finished(received_verify, "client finished"))
+
+        compare_digest.assert_called_once()
+        self.assertEqual(compare_digest.call_args.args[1], received_verify)
+
+    def test_verify_finished_returns_true_when_verify_data_matches(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"master secret for tests"
+        transcript_hash = handshake.handshake_hash.copy().digest()
+        expected_verify = handshake._prf(
+            handshake.master_secret,
+            b"client finished",
+            transcript_hash,
+            12,
+        )
+
+        self.assertTrue(handshake.verify_finished(expected_verify, "client finished"))
+        self.assertFalse(
+            handshake.verify_finished(b"\xff" + expected_verify[1:], "client finished")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Issue
Closes #18

## Summary
Replaces byte-string equality in Finished verification with hmac.compare_digest() to avoid timing leaks. Adds unittest coverage for the comparison call and bool behavior.

## Acceptance criteria
- [x] verify_finished() uses hmac.compare_digest(computed_verify, received_verify) instead of ==
- [x] The hmac module is already imported; no new imports needed
- [x] Return value is still bool (True on match, False otherwise)
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs