### PR TITLE
fix(python): preserve key exchange errors

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,33 @@
+import unittest
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class TLSHandshakeKeyExchangeErrorTests(unittest.TestCase):
+    def test_process_key_exchange_returns_false_for_expected_errors(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00")
+
+        self.assertFalse(handshake.process_key_exchange(message))
+        self.assertEqual(handshake.last_error, "Key exchange payload too short")
+
+    def test_process_key_exchange_propagates_unexpected_errors(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30" + b"x" * 48)
+
+        with patch.object(
+            handshake,
+            "_decrypt_pre_master_secret",
+            side_effect=TypeError("unexpected decrypt failure"),
+        ):
+            with self.assertRaises(TypeError):
+                handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -111,6 +111,7 @@ class TLSHandshake:
         self.server_name: Optional[str] = None
         self._pre_master_secret: Optional[bytes] = None
         self.transcript: bytearray = bytearray()
+        self.last_error: Optional[str] = None
 
     def transition_to(self, new_state: HandshakeState) -> bool:
         """Attempt a state transition. Returns True if valid."""
@@ -238,6 +239,7 @@ class TLSHandshake:
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""
+        self.last_error = None
         try:
             payload = message.payload
             if len(payload) < 2:
@@ -256,10 +258,9 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error) as exc:
+            self.last_error = str(exc)
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
## Issue
Closes #20

## Summary
Replaces the bare exception handler in processkeyexchange with expected error handling for ValueError and struct.error preserving a diagnostic message while allowing unexpected exceptions to propagate. Adds unittest coverage for both paths.

## Acceptance criteria
- x The bare except is replaced with except ValueError struct.error to catch only expected failures
- - x Unexpected exceptions e.g. TypeError KeyboardInterrupt propagate normally
- - x processkeyexchange still returns False on expected errors but the error is logged or re-raised for diagnostics
- - x All existing tests still pass
- - x Add new tests covering the fixed bugs