### PR TITLE
Guard empty deploy directory cleanup

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,9 +28,14 @@ log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
 # Clean previous deployment artifacts
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
+
 log_message "Cleaning previous build artifacts..."
-rm -rf ${DEPLOY_DIR}/dist
-rm -rf ${DEPLOY_DIR}/node_modules/.cache
+rm -rf "${DEPLOY_DIR}/dist"
+rm -rf "${DEPLOY_DIR}/node_modules/.cache"
 
 # Pull latest code
 if [ -d "${DEPLOY_DIR}/.git" ]; then


### PR DESCRIPTION
Closes #317

/claim #317

Summary:
- Add an explicit DEPLOY_DIR guard before cleanup.
- Quote the cleanup targets so paths with spaces are handled safely.

Verification:
- git diff --check