### PR TITLE
fix(python): use ems master secret label

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,52 @@
+import unittest
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tls_handshake import TLSHandshake
+
+
+class TLSHandshakeMasterSecretTests(unittest.TestCase):
+    def _configured_handshake(self, negotiated_ems):
+        handshake = TLSHandshake()
+        handshake._pre_master_secret = b"p" * 48
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        handshake.negotiated_ems = negotiated_ems
+        return handshake
+
+    def test_ems_uses_extended_master_secret_label(self):
+        handshake = self._configured_handshake(negotiated_ems=True)
+
+        with patch.object(handshake, "_prf", return_value=b"x" * 48) as prf:
+            handshake._derive_master_secret()
+
+        self.assertEqual(prf.call_args.args[1], b"extended master secret")
+
+    def test_non_ems_keeps_standard_master_secret_label(self):
+        handshake = self._configured_handshake(negotiated_ems=False)
+
+        with patch.object(handshake, "_prf", return_value=b"x" * 48) as prf:
+            handshake._derive_master_secret()
+
+        self.assertEqual(prf.call_args.args[1], b"master secret")
+
+    def test_ems_and_non_ems_generate_different_master_secrets(self):
+        ems_handshake = self._configured_handshake(negotiated_ems=True)
+        standard_handshake = self._configured_handshake(negotiated_ems=False)
+
+        ems_handshake._derive_master_secret()
+        standard_handshake._derive_master_secret()
+
+        self.assertEqual(len(ems_handshake.master_secret), 48)
+        self.assertEqual(len(standard_handshake.master_secret), 48)
+        self.assertNotEqual(
+            ems_handshake.master_secret,
+            standard_handshake.master_secret,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
## Issue
Closes #21

## Summary
Uses the RFC 7627 extended master secret label when EMS is negotiated while preserving the standard label otherwise. Adds unittest coverage for both labels and different derived master secrets.

## Acceptance criteria
- [x] When self.negotiated_ems is True, label is b"extended master secret"
- [x] When self.negotiated_ems is False, label remains b"master secret"
- [x] _prf() receives the correct label, producing different 48-byte master_secret values for EMS vs non-EMS
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs