### PR TITLE
fix: reset COBOL hostname tally counters

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -255,6 +255,7 @@
        4000-EXIT.
            EXIT.
        5000-MATCH-HOSTNAME.
+           MOVE 0 TO WS-HOSTNAME-TALLY
            INSPECT WS-SUBJECT-COMMON-NAME
                TALLYING WS-HOSTNAME-TALLY FOR ALL '*'
            IF WS-HOSTNAME-TALLY > 0
@@ -269,6 +270,7 @@
                        TO WS-VALIDATION-MSG
                END-IF
            END-IF
+           MOVE 0 TO WS-DOT-COUNT
            INSPECT WS-EXPECTED-HOSTNAME
                TALLYING WS-DOT-COUNT FOR ALL '.'
            IF WS-DOT-COUNT < 1
@@ -278,6 +280,7 @@
            END-IF
            .
        5100-WILDCARD-MATCH.
+           MOVE 0 TO WS-WILDCARD-POS
            INSPECT WS-SUBJECT-COMMON-NAME
                TALLYING WS-WILDCARD-POS
                FOR CHARACTERS BEFORE INITIAL '*'


### PR DESCRIPTION
Closes #374.

## Summary
- Reset `WS-HOSTNAME-TALLY` before the wildcard `INSPECT` in `5000-MATCH-HOSTNAME`.
- Reset `WS-DOT-COUNT` before counting dots in `WS-EXPECTED-HOSTNAME`.
- Reset `WS-WILDCARD-POS` before the wildcard-position `INSPECT` in `5100-WILDCARD-MATCH`.

## Verification
- Static assertion confirmed each `MOVE 0` appears immediately before the corresponding `INSPECT`.
- Diff is limited to the requested three reset statements.
