### PR TITLE
Fix misspelled database config key

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
## Issue

Closes #309

## Summary

Corrects the misspelled `databse` key in `config/app.json` to `database`, preserving the existing nested database configuration and leaving unrelated content unchanged.

## Acceptance criteria

- [x] `config/app.json` uses the `database` key
- [x] The misspelled `databse` key is removed
- [x] The database configuration object values are unchanged
- [x] Diff is scoped to the single requested key rename

## Validation

```bash
python3 - <<'PY'
from pathlib import Path
text = Path('config/app.json').read_text()
assert '"database": {' in text
assert '"databse": {' not in text
print('targeted database key validation passed')
PY
git diff --check
```

Result: targeted database key validation passed; `git diff --check` passed.

Note: full JSON parsing is still blocked by the pre-existing trailing comma tracked separately in issue #308; this PR intentionally changes only issue #309.

/claim #309
