### PR TITLE
fix: correct database config key

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
Closes #309

## Summary
- Corrects the misspelled `databse` key in `config/app.json` to `database`.
- Leaves the nested database config object unchanged.
- Leaves all other file content unchanged.

## Validation
- `git diff --check`

