### PR TITLE
docs: fix create bounty HTTP method

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
Closes #304.

## Summary
- Updates the Create Bounty endpoint example from `GET /bounties` to `POST /bounties`.
- Keeps the endpoint path and surrounding documentation unchanged.

## Validation
- `git diff --check`
