### PR TITLE
fix: remove trailing comma in app.json (#308)

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
/claim #308

Closes #308.

## Summary
- remove the trailing comma after the allowed_origins array
- keep all other app.json content unchanged

## Validation
- parsed config/app.json with Python json.load()
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 308 / PR 499](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-308-pr-499.gif)
