### PR TITLE
fix: correct docker image tag typo (#310)

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
/claim #310

Closes #310.

## Summary
- change the api image tag from lastest to latest
- keep all other docker-compose content unchanged

## Validation
- parsed config/docker-compose.yml with PyYAML
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 310 / PR 500](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-310-pr-500.gif)
