### PR TITLE
docs: fix setup package name

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
## Summary
- correct the setup guide package install command from `bounty-hunter` to `bounty-hunters`

Fixes #306

## Verification
- git diff --check