### PR TITLE
fix: correct package name in setup guide (#306)

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
/claim #306

Closes #306.

## Summary
- change pip install bounty-hunter to pip install bounty-hunters
- keep the command inside the existing code block

## Validation
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 306 / PR 507](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-306-pr-507.gif)
