### PR TITLE
fix: add host binding for API port (#312)

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080"
+      - "8080:8080"
       - "9090:9090"
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
/claim #312

Closes #312.

## Summary
- change the api port mapping from 8080 to 8080:8080
- leave the 9090:9090 mapping unchanged
- keep all other docker-compose content unchanged

## Validation
- parsed config/docker-compose.yml with PyYAML
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 312 / PR 508](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-312-pr-508.gif)
