### PR TITLE
[Fix #11] Prevent nil pointer dereference in NegotiateSuite

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters/go
+
+go 1.26.3

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,9 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,33 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuite_NoMatch_ReturnsError(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	name, err := reg.NegotiateSuite([]uint16{0xFFFF})
+	if err == nil {
+		t.Errorf("expected error when no suite matches, got name=%q", name)
+	}
+}
+
+func TestNegotiateSuite_ValidID_ReturnsName(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Errorf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}
+
+func TestNegotiateSuite_EmptyInput_ReturnsError(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	_, err := reg.NegotiateSuite([]uint16{})
+	if err == nil {
+		t.Error("expected error for empty client suites")
+	}
+}


### PR DESCRIPTION
Closes #11

## Problem
NegotiateSuite() dereferences selectedSuite.Name without a nil check. When clientSuites contains only unknown IDs (e.g. []uint16{0xFFFF}), no suite matches and selectedSuite stays nil, causing a runtime panic.

## Fix
Added a nil check for selectedSuite before dereferencing. When no mutually supported cipher suite is found, the function now returns ("", error) instead of panicking.

## Tests
- TestNegotiateSuite_NoMatch_ReturnsError — verifies []uint16{0xFFFF} returns error, no panic
- TestNegotiateSuite_ValidID_ReturnsName — verifies valid ID still returns correct name
- TestNegotiateSuite_EmptyInput_ReturnsError — verifies empty input returns error