### PR TITLE
fix: use arithmetic comparison in cleanup script (#319)

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -35,7 +35,7 @@ done
 echo ""
 
 # Check total disk usage of log directories
-if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]; then
+if (( MAX_AGE_DAYS > TOTAL_CLEANED )); then
     echo "WARNING: Retention period exceeds number of files cleaned"
     echo "Consider reducing MAX_AGE_DAYS (currently ${MAX_AGE_DAYS})"
 fi


### PR DESCRIPTION
/claim #319

Closes #319.

## Summary
- switch the final MAX_AGE_DAYS vs TOTAL_CLEANED check to an explicit arithmetic comparison
- keep the surrounding cleanup logic unchanged

## Validation
- ran bash -n scripts/cleanup.sh
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 319 / PR 514](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-319-pr-514.gif)
