### PR TITLE
fix: guard deploy cleanup path

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,6 +28,10 @@ log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
 # Clean previous deployment artifacts
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
 log_message "Cleaning previous build artifacts..."
 rm -rf ${DEPLOY_DIR}/dist
 rm -rf ${DEPLOY_DIR}/node_modules/.cache


### PR DESCRIPTION
Closes #317.

Adds the requested guard before the deployment cleanup `rm -rf` commands so the script exits with a clear error when `DEPLOY_DIR` is unset or empty. All other content remains unchanged.

Validation:
- `git diff --check`
