### PR TITLE
fix: reject untrusted empty certificate chains

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -161,11 +161,31 @@
            .
        2000-VALIDATE-CERT-CHAIN.
            IF WS-CHAIN-LENGTH = 0
-               SET WS-CHAIN-IS-INVALID TO TRUE
+               MOVE WS-CERT-SERIAL-NUM TO CS-CERT-SERIAL
+               READ CERT-STORE-FILE
+                   INVALID KEY
+                       DISPLAY 'TLSVAL-E010: EMPTY CERT CHAIN '
+                           WS-CERT-SERIAL-NUM
+                       MOVE 'SELF-SIGNED CERT NOT TRUSTED'
+                           TO WS-VALIDATION-MSG
+                       SET WS-CHAIN-IS-INVALID TO TRUE
+                       GO TO 2000-EXIT
+               END-READ
+               IF CS-IS-TRUST-ANCHOR
+                   DISPLAY 'TLSVAL-I010: TRUSTED SELF-SIGNED CERT '
+                       WS-CERT-SERIAL-NUM
+                   SET WS-CHAIN-IS-VALID TO TRUE
+               ELSE
+                   DISPLAY 'TLSVAL-E010: SELF-SIGNED CERT NOT TRUSTED '
+                       WS-CERT-SERIAL-NUM
+                   MOVE 'SELF-SIGNED CERT NOT TRUSTED'
+                       TO WS-VALIDATION-MSG
+                   SET WS-CHAIN-IS-INVALID TO TRUE
+               END-IF
                GO TO 2000-EXIT
            END-IF
            PERFORM VARYING WS-CHAIN-INDEX FROM 1 BY 1
-               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH + 1
+               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH
                MOVE WS-CHN-SERIAL(WS-CHAIN-INDEX)
                    TO CS-CERT-SERIAL
                READ CERT-STORE-FILE

--- a/cobol/tests/self-signed-empty-chain-test.md
+++ b/cobol/tests/self-signed-empty-chain-test.md
@@ -1,0 +1,46 @@
+# TLS-CERT-VALIDATOR empty chain regression case
+
+Regression target: issue #516, `WS-CHAIN-LENGTH = 0` for a self-signed certificate.
+
+## Case A — self-signed certificate absent from trust store
+
+Initial working-storage setup:
+
+- `WS-CERT-SERIAL-NUM = "SELF-SIGNED-UNTRUSTED-001"`
+- `WS-CHAIN-LENGTH = 0`
+- `CERT-STORE-FILE` has no record whose `CS-CERT-SERIAL` matches the current serial.
+
+Expected behavior:
+
+- `2000-VALIDATE-CERT-CHAIN` does not enter the chain-entry `PERFORM VARYING` loop.
+- No `WS-CHAIN-ENTRY(1)` field is referenced.
+- `WS-CHAIN-IS-INVALID` is set.
+- `WS-VALIDATION-MSG = "SELF-SIGNED CERT NOT TRUSTED"`.
+- Audit output includes `TLSVAL-E010: EMPTY CERT CHAIN`.
+
+## Case B — self-signed certificate present as trust anchor
+
+Initial working-storage setup:
+
+- `WS-CERT-SERIAL-NUM = "SELF-SIGNED-TRUSTED-001"`
+- `WS-CHAIN-LENGTH = 0`
+- `CERT-STORE-FILE` contains a matching record with `CS-TRUST-ANCHOR-FLAG = "Y"`.
+
+Expected behavior:
+
+- `2000-VALIDATE-CERT-CHAIN` does not enter the chain-entry `PERFORM VARYING` loop.
+- No `WS-CHAIN-ENTRY(1)` field is referenced.
+- `WS-CHAIN-IS-VALID` remains set.
+- Audit output includes `TLSVAL-I010: TRUSTED SELF-SIGNED CERT`.
+
+## Case C — normal non-empty chain
+
+Initial working-storage setup:
+
+- `WS-CHAIN-LENGTH > 0`.
+
+Expected behavior:
+
+- The loop runs only while `WS-CHAIN-INDEX <= WS-CHAIN-LENGTH`.
+- No `WS-CHAIN-ENTRY(WS-CHAIN-LENGTH + 1)` access occurs.
+- The last chain entry must still resolve to a trust anchor.


### PR DESCRIPTION
Closes #516

## Summary
- Adds an explicit `WS-CHAIN-LENGTH = 0` path before the chain-entry loop.
- Trusts a self-signed/empty-chain certificate only when the current certificate serial is present in `CERT-STORE-FILE` as a trust anchor.
- Rejects untrusted empty chains with an audit message and validation message instead of touching `WS-CHAIN-ENTRY(1)`.
- Fixes the non-empty chain loop bound so it never reads `WS-CHAIN-ENTRY(WS-CHAIN-LENGTH + 1)`.
- Adds a regression test-case note for empty-chain trusted/untrusted behavior.

## Validation
- `git diff --check`
- Verified the chain loop now uses `UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH`.
- Added `cobol/tests/self-signed-empty-chain-test.md` covering the zero-chain and normal-chain cases.

## Notes
No private data, KYC, wallet action, or external service credential is involved.
