### PR TITLE
[Fix #13] Filter RC4 and 3DES cipher suites in FilterWeakSuites

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters/go
+
+go 1.26.3

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,6 +194,9 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
+		if strings.Contains(s.Name, "RC4") || strings.Contains(s.Name, "3DES") {
+			continue
+		}
 		if s.KeySize >= minKeyBits {
 			result = append(result, s)
 		}

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,42 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestFilterWeakSuites_RemovesRC4(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	rc4Suite := &CipherSuite{ID: 0x0005, Name: "TLS_RSA_WITH_RC4_128_SHA", KeySize: 128}
+	aeadSuite := &CipherSuite{ID: tls.TLS_AES_128_GCM_SHA256, Name: "TLS_AES_128_GCM_SHA256", KeySize: 128, IsAEAD: true}
+	result := reg.FilterWeakSuites([]*CipherSuite{rc4Suite, aeadSuite})
+	for _, s := range result {
+		if s.Name == "TLS_RSA_WITH_RC4_128_SHA" {
+			t.Error("RC4 suite should be filtered out")
+		}
+	}
+	if len(result) != 1 || result[0].Name != "TLS_AES_128_GCM_SHA256" {
+		t.Errorf("expected only AEAD suite, got %v", result)
+	}
+}
+
+func TestFilterWeakSuites_Removes3DES(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	des3Suite := &CipherSuite{ID: 0x000a, Name: "TLS_RSA_WITH_3DES_EDE_CBC_SHA", KeySize: 168}
+	aeadSuite := &CipherSuite{ID: tls.TLS_AES_128_GCM_SHA256, Name: "TLS_AES_128_GCM_SHA256", KeySize: 128, IsAEAD: true}
+	result := reg.FilterWeakSuites([]*CipherSuite{des3Suite, aeadSuite})
+	for _, s := range result {
+		if s.Name == "TLS_RSA_WITH_3DES_EDE_CBC_SHA" {
+			t.Error("3DES suite should be filtered out")
+		}
+	}
+}
+
+func TestFilterWeakSuites_KeepsAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	aeadSuite := &CipherSuite{ID: tls.TLS_AES_128_GCM_SHA256, Name: "TLS_AES_128_GCM_SHA256", KeySize: 128, IsAEAD: true}
+	result := reg.FilterWeakSuites([]*CipherSuite{aeadSuite})
+	if len(result) != 1 {
+		t.Errorf("AEAD suite with KeySize 128 should be kept, got %d results", len(result))
+	}
+}


### PR DESCRIPTION
Closes #13

## Problem
FilterWeakSuites() only checks s.KeySize >= 128. TLS_RSA_WITH_RC4_128_SHA has KeySize 128 and TLS_RSA_WITH_3DES_EDE_CBC_SHA has KeySize 168, so both pass the filter despite being cryptographically broken algorithms.

## Fix
Added name-based checks to reject suites whose Name contains "RC4" or "3DES", before the KeySize check. These algorithms are considered weak regardless of their key size.

## Tests
- TestFilterWeakSuites_RemovesRC4 — verifies RC4 (0x0005, KeySize 128) is removed
- TestFilterWeakSuites_Removes3DES — verifies 3DES (0x000a, KeySize 168) is removed
- TestFilterWeakSuites_KeepsAEAD — verifies TLS_AES_128_GCM_SHA256 (KeySize 128, AEAD) is kept
