### PR TITLE
[Fix #14] Flip AEAD comparison in SortByPreference so AEAD ranks first

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/UnsafeLabs/Bounty-Hunters/go
+
+go 1.26.3

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -216,7 +216,7 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,33 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreference_AEADBeforeNonAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	nonAEAD := &CipherSuite{ID: tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, Name: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", KeySize: 128, IsAEAD: false, Strength: StrengthLegacy}
+	aead := &CipherSuite{ID: tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, Name: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", KeySize: 128, IsAEAD: true, Strength: StrengthModern}
+	result := reg.SortByPreference([]*CipherSuite{nonAEAD, aead})
+	if len(result) < 2 {
+		t.Fatal("expected at least 2 suites")
+	}
+	if !result[0].IsAEAD {
+		t.Errorf("AEAD suite should come first, got %q (IsAEAD=%v)", result[0].Name, result[0].IsAEAD)
+	}
+}
+
+func TestSortByPreference_StrengthOrderWithinAEAD(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	modern := &CipherSuite{ID: tls.TLS_AES_128_GCM_SHA256, Name: "TLS_AES_128_GCM_SHA256", KeySize: 128, IsAEAD: true, Strength: StrengthModern}
+	advanced := &CipherSuite{ID: tls.TLS_AES_256_GCM_SHA384, Name: "TLS_AES_256_GCM_SHA384", KeySize: 256, IsAEAD: true, Strength: StrengthAdvanced}
+	result := reg.SortByPreference([]*CipherSuite{modern, advanced})
+	if len(result) < 2 {
+		t.Fatal("expected at least 2 suites")
+	}
+	if result[0].Strength < result[1].Strength {
+		t.Errorf("higher strength AEAD should come first, got %q (%d) before %q (%d)",
+			result[0].Name, result[0].Strength, result[1].Name, result[1].Strength)
+	}
+}


### PR DESCRIPTION
Closes #14

## Problem
In SortByPreference(), the comparator returns !si.IsAEAD && sj.IsAEAD, which ranks non-AEAD suites (e.g., TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256) above AEAD suites (e.g., TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256).

## Fix
Changed the condition from !si.IsAEAD && sj.IsAEAD to si.IsAEAD && !sj.IsAEAD so that AEAD suites correctly sort before non-AEAD suites.

## Tests
- TestSortByPreference_AEADBeforeNonAEAD — verifies AEAD suite comes before non-AEAD
- TestSortByPreference_StrengthOrderWithinAEAD — verifies StrengthAdvanced sorts before StrengthModern within AEAD group
