### PR TITLE
docs: correct Create Bounty HTTP method (#304)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
/claim #304

Fixes #304.

Updated the `Create Bounty` section in `docs/api-reference.md` so it correctly documents `POST /bounties` instead of `GET /bounties`. The endpoint path and all other content remain unchanged.

Validation:
- verified only the HTTP method line under `Create Bounty` changed
- `git diff --check` clean

## Demo
Short demo video (animated GIF):

![Demo for issue 304 / PR 493](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-304-pr-493.gif)
