### PR TITLE
config: fix misspelled database key (#309)

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
/claim #309

Fixes #309.

Corrected the misspelled `databse` key to `database` in `config/app.json`. The value object under the key and the rest of the file are unchanged.

Validation:
- verified only the key name changed
- `git diff --check` clean

## Demo
Short demo video (animated GIF):

![Demo for issue 309 / PR 495](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-309-pr-495.gif)
