### PR TITLE
scripts: guard deploy cleanup when DEPLOY_DIR is empty (#317)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,11 @@ check_dependencies() {
 log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
+
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
 rm -rf ${DEPLOY_DIR}/dist


### PR DESCRIPTION
/claim #317

Fixes #317.

Added a guard before the cleanup step in `scripts/deploy.sh` so the script exits with an error when `DEPLOY_DIR` is unset or empty, instead of letting `rm -rf ${DEPLOY_DIR}/dist` collapse to `/dist`. All other script behavior is unchanged.

Validation:
- verified the guard runs before the `rm -rf` commands
- `git diff --check` clean

## Demo
Short demo video (animated GIF):

![Demo for issue 317 / PR 496](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-317-pr-496.gif)
