### PR TITLE
fix: add missing nginx semicolon (#311)

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
/claim #311

Closes #311.

## Summary
- add the missing semicolon to the X-Forwarded-For proxy_set_header line
- keep all other nginx.conf content unchanged

## Validation
- ran git diff --check
- nginx is not installed on this Windows host, so I could not run 
ginx -t locally

## Demo
Short demo video (animated GIF):

![Demo for issue 311 / PR 501](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-311-pr-501.gif)
