### PR TITLE
fix: quote backup directory check (#315)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -21,7 +21,7 @@ log_message() {
 }
 
 # Check if backup directory exists
-if [ ! -d $BACKUP_DIR ]; then
+if [ ! -d "$BACKUP_DIR" ]; then
     echo "Creating backup directory..."
     mkdir -p $BACKUP_DIR
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
/claim #315

Closes #315.

## Summary
- wrap the BACKUP_DIR existence check in double quotes
- keep all other backup.sh content unchanged

## Validation
- ran bash -n scripts/backup.sh
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 315 / PR 502](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-315-pr-502.gif)
