### PR TITLE
fix: repair rate limits markdown table (#303)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST | 5 req/min     |
 
 ## Error Codes
 


### PR DESCRIPTION
/claim #303

Closes #303.

## Summary
- add the missing leading pipe to the /bounties/:id/claims rate-limit row
- keep all other api-reference content unchanged

## Validation
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 303 / PR 512](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-303-pr-512.gif)
