### PR TITLE
docs: add missing environment setup step (#305)

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -33,7 +33,13 @@ pip install bounty-hunter
 
 This will install the core package and all required dependencies.
 
-### Step 5: Configure the Database
+### Step 4: Set Up Environment Variables
+
+```bash
+cp .env.example .env
+```
+
+### Step 6: Configure the Database
 
 Create a `config.yml` file in the project root:
 
@@ -56,13 +62,13 @@ server:
   debug: true
 ```
 
-### Step 6: Run Migrations
+### Step 7: Run Migrations
 
 ```bash
 python manage.py migrate
 ```
 
-### Step 7: Start the Development Server
+### Step 8: Start the Development Server
 
 ```bash
 python manage.py runserver


### PR DESCRIPTION
/claim #305

Closes #305.

## Summary
- add a new Step 4 for copying .env.example to .env
- renumber the later setup sections from 5/6/7 to 6/7/8
- keep the rest of the guide unchanged

## Validation
- ran git diff --check

## Demo
Short demo video (animated GIF):

![Demo for issue 305 / PR 513](https://raw.githubusercontent.com/MizuCiaossu/Bounty-Hunters/e1ccadd1820b803e64ee78033710c15614fe444a/demo/unsafe/unsafe-305-pr-513.gif)
