### PR TITLE
fix(config): fix nginx listen directive and missing semicolon

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -25,14 +25,14 @@ http {
     # gzip_types text/plain application/json application/javascript text/css;
 
     server {
-        listen_port 80;
+        listen 80;
         server_name app.example.com;
 
         location / {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
Fixes #311

- Fixed `listen_port 80` → `listen 80` (wrong directive name)
- Added missing semicolon on `proxy_set_header X-Forwarded-For` line

🤖 AI-assisted PR