### PR TITLE
fix(config): fix port mapping and typo in docker-compose

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,12 +2,12 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080"
+      - "8080:8080"
       - "9090:9090"
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
Fixes #312

- Changed `ports: - "8080"` to `"8080:8080"` for proper host-to-container mapping
- Fixed image tag typo `lastest` → `latest`

🤖 AI-assisted PR