### PR TITLE
fix(scripts): guard against unset DEPLOY_DIR in deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,8 +29,12 @@ check_dependencies
 
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
-rm -rf ${DEPLOY_DIR}/dist
-rm -rf ${DEPLOY_DIR}/node_modules/.cache
+if [ -z "$DEPLOY_DIR" ]; then
+    log_message "ERROR: DEPLOY_DIR is not set"
+    exit 1
+fi
+rm -rf "${DEPLOY_DIR}/dist"
+rm -rf "${DEPLOY_DIR}/node_modules/.cache"
 
 # Pull latest code
 if [ -d "${DEPLOY_DIR}/.git" ]; then


### PR DESCRIPTION
Fixes #317

`rm -rf ${DEPLOY_DIR}/dist` is dangerous when DEPLOY_DIR is empty. Added a guard to check it's set before cleanup, and quoted the variable.

🤖 AI-assisted PR