### PR TITLE
fix(scripts): add missing shebang to cleanup.sh

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # cleanup.sh - Log file cleanup utility
 # Removes old log files and compresses recent ones


### PR DESCRIPTION
Fixes #318

Added `#!/bin/bash` as the first line. Without a shebang the script relies on the parent shell and may execute with the wrong interpreter.

🤖 AI-assisted PR