### PR TITLE
fix(scripts): quote variables in cleanup.sh comparison

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -35,7 +35,7 @@ done
 echo ""
 
 # Check total disk usage of log directories
-if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]; then
+if [ "$MAX_AGE_DAYS" -gt "$TOTAL_CLEANED" ]; then
     echo "WARNING: Retention period exceeds number of files cleaned"
     echo "Consider reducing MAX_AGE_DAYS (currently ${MAX_AGE_DAYS})"
 fi


### PR DESCRIPTION
Fixes #319

`if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]` used unquoted variables which can cause word splitting errors. Both are now quoted.

🤖 AI-assisted PR