### PR TITLE
fix(config): add missing semicolon to X-Forwarded-For directive

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
Fixes #311

Adds the missing trailing semicolon to the `proxy_set_header X-Forwarded-For` directive in nginx.conf.

**Acceptance Criteria:**
- [x] Semicolon added at end of X-Forwarded-For proxy_set_header line
- [x] All other content remains unchanged

**Validation:**
nginx is not available in the local environment, however the directive syntax follows the standard nginx proxy module documentation format. The fix is a single character addition (semicolon) on a well-defined directive line.

/claim #311