### PR TITLE
fix(config): fix port mapping for api service

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8080"
+      - "8080:8080"
       - "9090:9090"
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
Fixes #312

Changes the api service port mapping from \8080\ to \8080:8080\ to properly map host port to container port.

**Acceptance Criteria:**
- [x] The ports entry \8080\ changed to \8080:8080\
- [x] The other port mapping \9090:9090\ remains unchanged
- [x] All other content remains unchanged

**Validation:**
```bash
\$ docker compose -f config/docker-compose.yml config
name: config
services:
  api:
    ports:
      - mode: ingress
        target: 8080
        published: 8080
        protocol: tcp
      - mode: ingress
        target: 9090
        published: 9090
        protocol: tcp
# Warning: DB_PASSWORD variable not set (expected, env-specific)
# Warning: version attribute obsolete (pre-existing, not in scope)
# Compose file parses successfully with correct port mapping
```

/claim #312