### PR TITLE
fix(scripts): add missing set -e to deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 #
 # deploy.sh - Application deployment script
 # Pulls latest code, builds, and deploys to production


### PR DESCRIPTION
Fixes #316

Adds `set -e` after the shebang line so the script exits immediately when any command fails.

**Acceptance Criteria:**
- [x] `set -e` added after shebang line, before variable declarations
- [x] All other content remains unchanged

**Syntax Verification:**
```bash
bash -n scripts/deploy.sh
# No errors - script remains parseable after adding set -e
```

/claim #316