### PR TITLE
fix(scripts): guard DEPLOY_DIR before rm -rf

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,8 +29,12 @@ check_dependencies
 
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
-rm -rf ${DEPLOY_DIR}/dist
-rm -rf ${DEPLOY_DIR}/node_modules/.cache
+if [ -z "$DEPLOY_DIR" ]; then
+    log_message "ERROR: DEPLOY_DIR is not set or empty"
+    exit 1
+fi
+rm -rf "${DEPLOY_DIR}/dist"
+rm -rf "${DEPLOY_DIR}/node_modules/.cache"
 
 # Pull latest code
 if [ -d "${DEPLOY_DIR}/.git" ]; then


### PR DESCRIPTION
Fixes #317

Adds a guard check before the rm -rf commands to verify DEPLOY_DIR is non-empty. Also quotes the paths in the rm commands for additional safety.

**Acceptance Criteria:**
- [x] Guard check added before rm commands
- [x] Script exits with error if DEPLOY_DIR is unset or empty
- [x] All other content remains unchanged

**Note:** The quoting of ${DEPLOY_DIR} in the rm lines is included because those are the exact delete paths being guarded - the quoting ensures the guard protects against spaces too.

**Syntax Verification:**
```bash
bash -n scripts/deploy.sh
# No errors - script remains parseable after adding guard + quoting
```

/claim #317