### PR TITLE
fix(scripts): add missing shebang to cleanup.sh

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # cleanup.sh - Log file cleanup utility
 # Removes old log files and compresses recent ones


### PR DESCRIPTION
Fixes #318

Adds `#!/bin/bash` as the very first line of cleanup.sh.

**Acceptance Criteria:**
- [x] `#!/bin/bash` added as very first line
- [x] All other content remains unchanged

**Syntax Verification:**
```bash
bash -n scripts/cleanup.sh
# No errors - script parses correctly with added shebang
```

/claim #318