### PR TITLE
fix(scripts): use arithmetic context for comparison in cleanup.sh

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -35,7 +35,7 @@ done
 echo ""
 
 # Check total disk usage of log directories
-if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]; then
+if (( MAX_AGE_DAYS > TOTAL_CLEANED )); then
     echo "WARNING: Retention period exceeds number of files cleaned"
     echo "Consider reducing MAX_AGE_DAYS (currently ${MAX_AGE_DAYS})"
 fi


### PR DESCRIPTION
Fixes #319

Changes the comparison from `[ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]` to `(( MAX_AGE_DAYS > TOTAL_CLEANED ))` to use proper arithmetic context instead of test command with string variables.

**Acceptance Criteria:**
- [x] Comparison uses proper arithmetic context `(( ))`
- [x] Logic remains correct
- [x] All other content remains unchanged

**Syntax Verification:**
```bash
bash -n scripts/cleanup.sh
# No errors - script parses correctly with arithmetic context
```

/claim #319