### PR TITLE
Fix broken rate limits table row

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST   | 5 req/min       |
 
 ## Error Codes
 


### PR DESCRIPTION
## Summary
- Fixes the broken Markdown row in the Rate Limits table.
- Keeps the change limited to the `/bounties/:id/claims` row.
- No other API reference rows or content were changed.

## Validation
- Reviewed the Markdown table diff locally.

Closes #303