### PR TITLE
fix: parse SNI server name in Python TLS handshake

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,12 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                server_name = self._parse_sni_extension(ext_data)
+                if server_name is not None:
+                    ext.server_name = server_name
+                    self.server_name = server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +219,34 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_extension(self, data: bytes) -> Optional[str]:
+        """Parse the first host_name entry from an RFC 6066 SNI extension."""
+        if len(data) < 5:
+            return None
+
+        name_list_len = struct.unpack("!H", data[:2])[0]
+        if name_list_len + 2 > len(data):
+            return None
+
+        offset = 2
+        end = offset + name_list_len
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            if offset + name_len > end:
+                return None
+
+            name_bytes = data[offset:offset + name_len]
+            offset += name_len
+            if name_type == 0x00:
+                try:
+                    return name_bytes.decode("ascii")
+                except UnicodeDecodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """

--- a/tests/test_tls_handshake_sni.py
+++ b/tests/test_tls_handshake_sni.py
@@ -1,0 +1,66 @@
+import struct
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from tls_handshake import EXT_SNI, TLSHandshake  # noqa: E402
+
+
+def sni_extension(hostname: str) -> bytes:
+    host_bytes = hostname.encode("ascii")
+    server_name = b"\x00" + struct.pack("!H", len(host_bytes)) + host_bytes
+    server_name_list = struct.pack("!H", len(server_name)) + server_name
+    return struct.pack("!HH", EXT_SNI, len(server_name_list)) + server_name_list
+
+
+def client_hello_record(hostname: str) -> bytes:
+    extensions = sni_extension(hostname)
+    payload = b"".join(
+        [
+            b"\x03\x03",  # client version
+            b"\x01" * 32,  # client random
+            b"\x00",  # empty session id
+            b"\x00\x02\x13\x01",  # one cipher suite
+            b"\x01\x00",  # null compression
+            struct.pack("!H", len(extensions)),
+            extensions,
+        ]
+    )
+    handshake = b"\x01" + len(payload).to_bytes(3, "big") + payload
+    return b"\x16\x03\x03" + struct.pack("!H", len(handshake)) + handshake
+
+
+class TLSHandshakeSNITest(unittest.TestCase):
+    def test_parse_extensions_extracts_sni_server_name(self):
+        handshake = TLSHandshake()
+
+        extensions = handshake.parse_extensions(sni_extension("example.com"))
+
+        self.assertEqual(len(extensions), 1)
+        self.assertEqual(extensions[0].server_name, "example.com")
+        self.assertEqual(handshake.server_name, "example.com")
+        self.assertEqual(handshake.extensions[EXT_SNI].server_name, "example.com")
+
+    def test_client_hello_state_info_reports_sni_server_name(self):
+        handshake = TLSHandshake()
+
+        ok, message = handshake.process_message(client_hello_record("api.example.com"))
+
+        self.assertTrue(ok, message)
+        self.assertEqual(handshake.get_state_info()["server_name"], "api.example.com")
+
+    def test_malformed_sni_extension_does_not_set_server_name(self):
+        malformed_sni = struct.pack("!HH", EXT_SNI, 4) + b"\x00\xff\x00\x01"
+        handshake = TLSHandshake()
+
+        extensions = handshake.parse_extensions(malformed_sni)
+
+        self.assertEqual(len(extensions), 1)
+        self.assertIsNone(extensions[0].server_name)
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AI agent/tool used: OpenAI Codex GPT-5.5 in OpenClaw.

## Summary
- parse RFC 6066 SNI host_name entries from ClientHello extensions
- store the decoded hostname on both `TLSExtension.server_name` and `TLSHandshake.server_name`
- add focused unittest coverage for direct extension parsing, full ClientHello state info, and malformed SNI data

Fixes #570.

## Verification
- `python3 -m compileall -q python tests`
- `python3 -m unittest -v tests.test_tls_handshake_sni`
