### PR TITLE
[OpenAI Codex] Fix cleanup arithmetic comparison

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -4,7 +4,7 @@
 #
 
 LOG_DIRS="/var/log/app /var/log/nginx /var/log/services"
-MAX_AGE_DAYS="14"
+MAX_AGE_DAYS=14
 COMPRESS_AGE_DAYS="3"
 TOTAL_CLEANED=0
 
@@ -35,7 +35,7 @@ done
 echo ""
 
 # Check total disk usage of log directories
-if [ $MAX_AGE_DAYS -gt $TOTAL_CLEANED ]; then
+if (( MAX_AGE_DAYS > TOTAL_CLEANED )); then
     echo "WARNING: Retention period exceeds number of files cleaned"
     echo "Consider reducing MAX_AGE_DAYS (currently ${MAX_AGE_DAYS})"
 fi


### PR DESCRIPTION
`
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
`

## Problem
cleanup.sh assigns MAX_AGE_DAYS as a string and then compares it with TOTAL_CLEANED using the test builtin's arithmetic operator.

## Summary
- Changed MAX_AGE_DAYS to an unquoted numeric assignment.
- Switched the final comparison to Bash arithmetic evaluation with (( ... )).

## Verification
- git diff --check
- ash -n scripts/cleanup.sh was attempted locally, but WSL/bash interpreted the Windows checkout with CRLF line endings and reported CRLF-related syntax noise. The edited syntax itself is standard Bash arithmetic syntax.

Closes #319

Payment details if this qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y