### PR TITLE
[OpenAI Codex] Guard against empty deploy directory

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,11 @@ check_dependencies() {
 log_message "Starting deployment of ${APP_NAME}..."
 check_dependencies
 
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
+
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
 rm -rf ${DEPLOY_DIR}/dist


### PR DESCRIPTION
`
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
`

## Problem
deploy.sh initializes DEPLOY_DIR as empty, so the cleanup commands can expand to root-level paths if the directory is not configured.

## Summary
- Added a guard immediately before cleanup to stop when DEPLOY_DIR is unset or empty.
- Preserved the existing cleanup commands and deployment flow.

## Verification
- Inspected the generated diff for the single guard block.
- This is a shell-script-only change; no project build is required.

Closes #317

Payment details if this qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y