### PR TITLE
[OpenAI Codex] Add missing setup environment step

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -33,7 +33,13 @@ pip install bounty-hunter
 
 This will install the core package and all required dependencies.
 
-### Step 5: Configure the Database
+### Step 4: Set Up Environment Variables
+
+`ash
+cp .env.example .env
+`
+
+### Step 6: Configure the Database
 
 Create a `config.yml` file in the project root:
 
@@ -56,13 +62,13 @@ server:
   debug: true
 ```
 
-### Step 6: Run Migrations
+### Step 7: Run Migrations
 
 ```bash
 python manage.py migrate
 ```
 
-### Step 7: Start the Development Server
+### Step 8: Start the Development Server
 
 ```bash
 python manage.py runserver


### PR DESCRIPTION
`
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
`

## Problem
The setup guide skips from Step 3 to Step 5, leaving out the environment variable setup step.

## Summary
- Added Step 4: Set Up Environment Variables.
- Included cp .env.example .env.
- Renumbered the following steps to 6, 7, and 8.

## Verification
- Inspected the generated markdown diff for the requested section and renumbering.

Closes #305

Payment details if this qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y