### PR TITLE
[OpenAI Codex] Fix setup guide package name

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
`
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
`

## Problem
Step 3 uses the singular package name `bounty-hunter`, which does not match the expected `bounty-hunters` package.

## Summary
- Changed the install command from `pip install bounty-hunter` to `pip install bounty-hunters`.

## Verification
- Inspected the generated markdown diff for the single package-name change.

Closes #306

Payment details if this qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y