### PR TITLE
[OpenAI Codex] Fix trailing comma in app.json

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
`
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
`

## Problem
`config/app.json` has a trailing comma after the final `allowed_origins` property, making the JSON invalid.

## Summary
- Removed the trailing comma after `allowed_origins`.

## Verification
- Parsed the updated JSON with PowerShell `ConvertFrom-Json`.

Closes #308

Payment details if this qualifies for the bounty:
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y