### PR TITLE
[OpenAI Codex] Fix COBOL certificate chain loop bound

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -165,7 +165,7 @@
                GO TO 2000-EXIT
            END-IF
            PERFORM VARYING WS-CHAIN-INDEX FROM 1 BY 1
-               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH + 1
+               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH
                MOVE WS-CHN-SERIAL(WS-CHAIN-INDEX)
                    TO CS-CERT-SERIAL
                READ CERT-STORE-FILE


### PR DESCRIPTION
``text
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
``

## Problem
The certificate chain loop stops only after WS-CHAIN-INDEX exceeds WS-CHAIN-LENGTH + 1, so it can iterate one entry past the populated chain.

## Summary
- Removes the extra + 1 from the PERFORM VARYING termination condition.\n- Keeps the rest of the certificate chain validation logic unchanged.

## Verification
- Verified the target expression is replaced exactly once.\n- COBOL compiler was not available in this Windows workspace, so no compile was run.

Closes #375

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y