### PR TITLE
[OpenAI Codex] Reset COBOL tally counters before INSPECT

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -255,6 +255,7 @@
        4000-EXIT.
            EXIT.
        5000-MATCH-HOSTNAME.
+           MOVE 0 TO WS-HOSTNAME-TALLY
            INSPECT WS-SUBJECT-COMMON-NAME
                TALLYING WS-HOSTNAME-TALLY FOR ALL '*'
            IF WS-HOSTNAME-TALLY > 0
@@ -269,6 +270,7 @@
                        TO WS-VALIDATION-MSG
                END-IF
            END-IF
+           MOVE 0 TO WS-DOT-COUNT
            INSPECT WS-EXPECTED-HOSTNAME
                TALLYING WS-DOT-COUNT FOR ALL '.'
            IF WS-DOT-COUNT < 1
@@ -278,6 +280,7 @@
            END-IF
            .
        5100-WILDCARD-MATCH.
+           MOVE 0 TO WS-WILDCARD-POS
            INSPECT WS-SUBJECT-COMMON-NAME
                TALLYING WS-WILDCARD-POS
                FOR CHARACTERS BEFORE INITIAL '*'


### PR DESCRIPTION
``text
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
``

## Problem
COBOL INSPECT TALLYING increments the existing tally value, so hostname, dot, and wildcard counters can leak values from previous validations.

## Summary
- Resets WS-HOSTNAME-TALLY before counting wildcard characters.\n- Resets WS-DOT-COUNT before checking the expected hostname FQDN.\n- Resets WS-WILDCARD-POS before locating wildcard position.

## Verification
- Verified each reset is inserted before its corresponding INSPECT statement.\n- COBOL compiler was not available in this Windows workspace, so no compile was run.

Closes #374

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y