### PR TITLE
[OpenAI Codex] Remove unreachable CRL revoked branch guard

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -309,11 +309,9 @@
                    NOT AT END
                        IF CRL-REVOKED-SERIAL =
                            WS-CERT-SERIAL-NUM
-                           IF WS-CRL-NOT-LOADED
-                               SET WS-CERT-IS-REVOKED TO TRUE
-                               MOVE 'CERTIFICATE ON CRL'
-                                   TO WS-VALIDATION-MSG
-                           END-IF
+                           SET WS-CERT-IS-REVOKED TO TRUE
+                           MOVE 'CERTIFICATE ON CRL'
+                               TO WS-VALIDATION-MSG
                        END-IF
                END-READ
            END-PERFORM


### PR DESCRIPTION
``text
OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
``

## Problem
The revocation loop only runs after a CRL is loaded, but the matching serial branch checks WS-CRL-NOT-LOADED before marking a certificate revoked, making the revoked handling unreachable.

## Summary
- Removes the impossible WS-CRL-NOT-LOADED guard inside the matching CRL serial branch.\n- Leaves the outer no-CRL early exit unchanged.

## Verification
- Verified only the inner unreachable guard is removed.\n- COBOL compiler was not available in this Windows workspace, so no compile was run.

Closes #376

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y