### PR TITLE
[OpenAI Codex] Fix Python TLS transition bypass

### DIFF
--- a/python/test_tls_handshake_transitions.py
+++ b/python/test_tls_handshake_transitions.py
@@ -1,0 +1,16 @@
+import unittest
+
+from tls_handshake import HandshakeState, TLSHandshake
+
+
+class TLSHandshakeTransitionTests(unittest.TestCase):
+    def test_client_hello_cannot_skip_to_finished(self):
+        handshake = TLSHandshake()
+
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(HandshakeState.ERROR, handshake.state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -53,10 +53,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
CLIENT_HELLO can transition directly to FINISHED, skipping the expected TLS handshake states.

## Summary
- Restricts CLIENT_HELLO transitions to SERVER_HELLO only.\n- Adds a unittest covering the rejected CLIENT_HELLO to FINISHED transition.

## Verification
- Added python/test_tls_handshake_transitions.py for the transition regression case.

Closes #16

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y