### PR TITLE
[OpenAI Codex] Use compare_digest for Finished verification

### DIFF
--- a/python/test_verify_finished.py
+++ b/python/test_verify_finished.py
@@ -1,0 +1,17 @@
+import unittest
+
+from tls_handshake import TLSHandshake
+
+
+class VerifyFinishedTests(unittest.TestCase):
+    def test_verify_finished_uses_constant_time_result_semantics(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"secret"
+        handshake._prf = lambda *args: b"expected"
+
+        self.assertTrue(handshake.verify_finished(b"expected", "client finished"))
+        self.assertFalse(handshake.verify_finished(b"different", "client finished"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
verify_finished compares verify_data with ==, which can leak timing information.

## Summary
- Replaces the direct equality comparison with hmac.compare_digest.\n- Adds a unittest for matching and non-matching verify_data results.

## Verification
- Added python/test_verify_finished.py for verify_finished success and failure cases.

Closes #18

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y