### PR TITLE
[OpenAI Codex] Use EMS PRF label when negotiated

### DIFF
--- a/python/test_extended_master_secret.py
+++ b/python/test_extended_master_secret.py
@@ -1,0 +1,23 @@
+import unittest
+
+from tls_handshake import TLSHandshake
+
+
+class ExtendedMasterSecretTests(unittest.TestCase):
+    def test_ems_uses_extended_master_secret_label(self):
+        labels = []
+        handshake = TLSHandshake()
+        handshake.negotiated_ems = True
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        handshake._pre_master_secret = b"p" * 48
+        handshake._prf = lambda secret, label, seed, length: labels.append(label) or (b"m" * length)
+
+        handshake._derive_master_secret()
+
+        self.assertEqual([b"extended master secret"], labels)
+        self.assertEqual(b"m" * 48, handshake.master_secret)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
The EMS branch still uses the standard master secret PRF label, so negotiating EMS does not affect derivation.

## Summary
- Uses b"extended master secret" when negotiated_ems is true.\n- Adds a unittest that records the label passed into _prf.

## Verification
- Added python/test_extended_master_secret.py for the EMS label regression case.

Closes #21

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y