### PR TITLE
docs: add issue 270 open PR triage report

### DIFF
--- a/docs/issue-270-open-pr-triage-2026-05-14.md
+++ b/docs/issue-270-open-pr-triage-2026-05-14.md
@@ -1,0 +1,100 @@
+# Issue 270 Open PR Triage Report
+
+Snapshot time: 2026-05-14 18:38 UTC
+
+This report records the open pull request triage pass performed for issue 270.
+At the time of verification, the repository had 54 open pull requests. Each
+open pull request had one submitted GitHub review from `kkudumu` that starts
+with `[OpenAI Codex]` and ends with the disclosed task-specific reviewer prompt.
+
+The disclosed prompt used for the review pass was:
+
+```text
+You are OpenAI Codex PR Triage Reviewer. Review one GitHub pull request against its linked issue, changed files, and acceptance criteria. State what is correct, what needs improvement, and at least one actionable suggestion. If the PR lacks a linked issue, request one. If it changes files outside the linked issue scope, flag that clearly. Be concise, professional, and do not claim tests passed unless evidence is inspected.
+```
+
+## Method
+
+- Started work on issue 270 with `/attempt #270`.
+- Refreshed the open pull request list from GitHub.
+- Reviewed each pull request against its linked issue or claim context, changed
+  files, and visible acceptance criteria.
+- Submitted one non-approving GitHub review comment per open pull request.
+- Rechecked the live open pull request list after new PRs appeared during the
+  first pass and covered the additional PRs too.
+- Verified that all 51 current open pull requests have a matching review comment
+  from `kkudumu`.
+
+## Verification
+
+Commands used:
+
+```bash
+gh pr list --repo UnsafeLabs/Bounty-Hunters --state open --limit 100 --json number,title,url,body,files
+gh pr view <number> --repo UnsafeLabs/Bounty-Hunters --json reviews
+```
+
+Verification result:
+
+```text
+current_open_prs=54
+matching_reviews_from_kkudumu=54
+missing_required_reviews=0
+```
+
+## Pull Requests Covered
+
+- [PR 626](https://github.com/UnsafeLabs/Bounty-Hunters/pull/626) - Create Bounty HTTP method documentation
+- [PR 625](https://github.com/UnsafeLabs/Bounty-Hunters/pull/625) - issue 270 triage report claim
+- [PR 624](https://github.com/UnsafeLabs/Bounty-Hunters/pull/624) - limerick completion claim with extra out-of-scope files
+- [PR 623](https://github.com/UnsafeLabs/Bounty-Hunters/pull/623) - Sonnet I completion in `english/sonnets.md`
+- [PR 622](https://github.com/UnsafeLabs/Bounty-Hunters/pull/622) - limerick completions in `english/limericks.md`
+- [PR 621](https://github.com/UnsafeLabs/Bounty-Hunters/pull/621) - haiku completions in `english/haikus.md`
+- [PR 619](https://github.com/UnsafeLabs/Bounty-Hunters/pull/619) - contributor/context registry change in `knowledge-base/context.json`
+- [PR 618](https://github.com/UnsafeLabs/Bounty-Hunters/pull/618) - haiku completions in `english/haikus.md`
+- [PR 617](https://github.com/UnsafeLabs/Bounty-Hunters/pull/617) - Sonnet I completion in `english/sonnets.md`
+- [PR 616](https://github.com/UnsafeLabs/Bounty-Hunters/pull/616) - song completions in `english/songs.md`
+- [PR 615](https://github.com/UnsafeLabs/Bounty-Hunters/pull/615) - limerick completions in `english/limericks.md`
+- [PR 614](https://github.com/UnsafeLabs/Bounty-Hunters/pull/614) - haiku completions in `english/haikus.md`
+- [PR 610](https://github.com/UnsafeLabs/Bounty-Hunters/pull/610) - EMS PRF label change in `python/tls_handshake.py`
+- [PR 609](https://github.com/UnsafeLabs/Bounty-Hunters/pull/609) - constant-time Finished comparison in `python/tls_handshake.py`
+- [PR 608](https://github.com/UnsafeLabs/Bounty-Hunters/pull/608) - TLS transition guard in `python/tls_handshake.py`
+- [PR 607](https://github.com/UnsafeLabs/Bounty-Hunters/pull/607) - song completions in `english/songs.md`
+- [PR 606](https://github.com/UnsafeLabs/Bounty-Hunters/pull/606) - sonnet line completions in `english/sonnets.md`
+- [PR 605](https://github.com/UnsafeLabs/Bounty-Hunters/pull/605) - limerick line completions in `english/limericks.md`
+- [PR 604](https://github.com/UnsafeLabs/Bounty-Hunters/pull/604) - database key typo in `config/app.json`
+- [PR 603](https://github.com/UnsafeLabs/Bounty-Hunters/pull/603) - COBOL expiry rounding
+- [PR 601](https://github.com/UnsafeLabs/Bounty-Hunters/pull/601) - changelog date ordering
+- [PR 600](https://github.com/UnsafeLabs/Bounty-Hunters/pull/600) - Create Bounty HTTP method documentation
+- [PR 599](https://github.com/UnsafeLabs/Bounty-Hunters/pull/599) - COBOL four-digit year handling
+- [PR 598](https://github.com/UnsafeLabs/Bounty-Hunters/pull/598) - COBOL CRL guard cleanup
+- [PR 597](https://github.com/UnsafeLabs/Bounty-Hunters/pull/597) - COBOL tally counter resets
+- [PR 596](https://github.com/UnsafeLabs/Bounty-Hunters/pull/596) - COBOL certificate chain loop bound
+- [PR 595](https://github.com/UnsafeLabs/Bounty-Hunters/pull/595) - acrostic completions in `english/acrostics.md`
+- [PR 594](https://github.com/UnsafeLabs/Bounty-Hunters/pull/594) - Docker image tag typo
+- [PR 593](https://github.com/UnsafeLabs/Bounty-Hunters/pull/593) - trailing comma in `config/app.json`
+- [PR 592](https://github.com/UnsafeLabs/Bounty-Hunters/pull/592) - setup package name documentation
+- [PR 591](https://github.com/UnsafeLabs/Bounty-Hunters/pull/591) - setup environment step documentation
+- [PR 590](https://github.com/UnsafeLabs/Bounty-Hunters/pull/590) - deploy directory guard in `scripts/deploy.sh`
+- [PR 589](https://github.com/UnsafeLabs/Bounty-Hunters/pull/589) - arithmetic comparison in `scripts/cleanup.sh`
+- [PR 588](https://github.com/UnsafeLabs/Bounty-Hunters/pull/588) - SNI server name extraction in `python/tls_handshake.py`
+- [PR 587](https://github.com/UnsafeLabs/Bounty-Hunters/pull/587) - TLS invalid transition prevention
+- [PR 586](https://github.com/UnsafeLabs/Bounty-Hunters/pull/586) - Extended Master Secret derivation
+- [PR 585](https://github.com/UnsafeLabs/Bounty-Hunters/pull/585) - narrowed key exchange exception handling
+- [PR 584](https://github.com/UnsafeLabs/Bounty-Hunters/pull/584) - SNI parser implementation and tests
+- [PR 583](https://github.com/UnsafeLabs/Bounty-Hunters/pull/583) - constant-time Finished comparison
+- [PR 581](https://github.com/UnsafeLabs/Bounty-Hunters/pull/581) - setup Step 4 documentation
+- [PR 580](https://github.com/UnsafeLabs/Bounty-Hunters/pull/580) - issue 270 triage report
+- [PR 574](https://github.com/UnsafeLabs/Bounty-Hunters/pull/574) - issue 270 triage report
+- [PR 568](https://github.com/UnsafeLabs/Bounty-Hunters/pull/568) - issue 270 triage report
+- [PR 567](https://github.com/UnsafeLabs/Bounty-Hunters/pull/567) - COBOL audit log overflow guard
+- [PR 561](https://github.com/UnsafeLabs/Bounty-Hunters/pull/561) - rate limits table row documentation
+- [PR 560](https://github.com/UnsafeLabs/Bounty-Hunters/pull/560) - COBOL fingerprint comparison
+- [PR 559](https://github.com/UnsafeLabs/Bounty-Hunters/pull/559) - COBOL empty certificate chain handling
+- [PR 558](https://github.com/UnsafeLabs/Bounty-Hunters/pull/558) - cleanup arithmetic context
+- [PR 557](https://github.com/UnsafeLabs/Bounty-Hunters/pull/557) - cleanup shebang
+- [PR 556](https://github.com/UnsafeLabs/Bounty-Hunters/pull/556) - deploy directory guard
+- [PR 555](https://github.com/UnsafeLabs/Bounty-Hunters/pull/555) - deploy `set -e`
+- [PR 554](https://github.com/UnsafeLabs/Bounty-Hunters/pull/554) - quoted `BACKUP_DIR` references
+- [PR 553](https://github.com/UnsafeLabs/Bounty-Hunters/pull/553) - compose port mapping
+- [PR 552](https://github.com/UnsafeLabs/Bounty-Hunters/pull/552) - nginx semicolon fix


### PR DESCRIPTION
/claim #270

Summary:
- Posted GitHub review comments on every open pull request in the live issue 270 snapshot.
- Each review starts with `[OpenAI Codex]` and ends with the disclosed task-specific reviewer prompt block.
- Added `docs/issue-270-open-pr-triage-2026-05-14.md` with the covered PR list, method, prompt, and verification result.

Verification:
- `gh pr list --repo UnsafeLabs/Bounty-Hunters --state open --limit 100 --json number,title,url,body,files`
- `gh pr view <number> --repo UnsafeLabs/Bounty-Hunters --json reviews`
- Result at 2026-05-14 18:38 UTC: `current_open_prs=54`, `matching_reviews_from_kkudumu=54`, `missing_required_reviews=0`.

Demo/evidence:
- The report includes the exact prompt block and all PR links reviewed.
- The GitHub review history on each covered PR contains the posted review comment.
