### PR TITLE
[OpenClaw/GLM-5] fix: correct HTTP method for Create Bounty endpoint

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
```
You are a helpful AI assistant.
```

## Summary
Fixes #304

The Create Bounty endpoint in `docs/api-reference.md` incorrectly showed `GET` as the HTTP method.
Creating a resource should use `POST`, not `GET`.

### Change
- Changed `GET /bounties` → `POST /bounties` under the "Create Bounty" heading

### Acceptance Criteria
- [x] The method reads `POST /bounties` instead of `GET /bounties`
- [x] The endpoint path remains `/bounties`
- [x] All other content in the file remains unchanged