### PR TITLE
Fix zero-length COBOL certificate chains

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -160,38 +160,67 @@
            DISPLAY 'TLSVAL-I001: VALIDATION STARTED'
            .
        2000-VALIDATE-CERT-CHAIN.
-           IF WS-CHAIN-LENGTH = 0
-               SET WS-CHAIN-IS-INVALID TO TRUE
-               GO TO 2000-EXIT
+           IF WS-CHAIN-LENGTH > 0
+               PERFORM VARYING WS-CHAIN-INDEX FROM 1 BY 1
+                   UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH
+                   MOVE WS-CHN-SERIAL(WS-CHAIN-INDEX)
+                       TO CS-CERT-SERIAL
+                   READ CERT-STORE-FILE
+                       INVALID KEY
+                           DISPLAY 'TLSVAL-E011: UNKNOWN CERT '
+                               WS-CHN-SERIAL(WS-CHAIN-INDEX)
+                           SET WS-CHAIN-IS-INVALID TO TRUE
+                           GO TO 2000-EXIT
+                   END-READ
+                   IF WS-CHAIN-INDEX = WS-CHAIN-LENGTH
+                       IF NOT CS-IS-TRUST-ANCHOR
+                           SET WS-CHAIN-IS-INVALID TO TRUE
+                           GO TO 2000-EXIT
+                       END-IF
+                   END-IF
+                   IF WS-CHAIN-INDEX > 1
+                       IF WS-CHN-ISSUER(WS-CHAIN-INDEX - 1)
+                           NOT = WS-CHN-SUBJECT(WS-CHAIN-INDEX)
+                           SET WS-CHAIN-IS-INVALID TO TRUE
+                           GO TO 2000-EXIT
+                       END-IF
+                   END-IF
+                   SET WS-CHN-IS-VERIFIED(WS-CHAIN-INDEX) TO TRUE
+               END-PERFORM
+           ELSE
+               PERFORM 2100-VALIDATE-SELF-SIGNED-CERT
            END-IF
-           PERFORM VARYING WS-CHAIN-INDEX FROM 1 BY 1
-               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH + 1
-               MOVE WS-CHN-SERIAL(WS-CHAIN-INDEX)
-                   TO CS-CERT-SERIAL
-               READ CERT-STORE-FILE
-                   INVALID KEY
-                       DISPLAY 'TLSVAL-E011: UNKNOWN CERT '
-                           WS-CHN-SERIAL(WS-CHAIN-INDEX)
-                       SET WS-CHAIN-IS-INVALID TO TRUE
-                       GO TO 2000-EXIT
-               END-READ
-               IF WS-CHAIN-INDEX = WS-CHAIN-LENGTH
-                   IF NOT CS-IS-TRUST-ANCHOR
-                       SET WS-CHAIN-IS-INVALID TO TRUE
-                       GO TO 2000-EXIT
-                   END-IF
-               END-IF
-               IF WS-CHAIN-INDEX > 1
-                   IF WS-CHN-ISSUER(WS-CHAIN-INDEX - 1)
-                       NOT = WS-CHN-SUBJECT(WS-CHAIN-INDEX)
-                       SET WS-CHAIN-IS-INVALID TO TRUE
-                       GO TO 2000-EXIT
-                   END-IF
-               END-IF
-               SET WS-CHN-IS-VERIFIED(WS-CHAIN-INDEX) TO TRUE
-           END-PERFORM
            .
        2000-EXIT.
+           EXIT.
+       2100-VALIDATE-SELF-SIGNED-CERT.
+           SET WS-CHAIN-IS-INVALID TO TRUE
+           DISPLAY 'TLSVAL-W010: EMPTY CERTIFICATE CHAIN '
+               WS-CERT-SERIAL-NUM
+           MOVE WS-CERT-SERIAL-NUM TO CS-CERT-SERIAL
+           READ CERT-STORE-FILE
+               INVALID KEY
+                   DISPLAY 'TLSVAL-E010: SELF-SIGNED CERT NOT TRUSTED '
+                       WS-CERT-SERIAL-NUM
+                   MOVE 'SELF-SIGNED CERT NOT TRUSTED'
+                       TO WS-VALIDATION-MSG
+                   SET WS-CHAIN-IS-INVALID TO TRUE
+                   GO TO 2100-EXIT
+           END-READ
+           IF CS-IS-TRUST-ANCHOR
+               AND CS-FINGERPRINT = WS-CERT-FINGERPRINT
+               SET WS-CHAIN-IS-VALID TO TRUE
+               DISPLAY 'TLSVAL-I010: TRUSTED SELF-SIGNED CERT '
+                   WS-CERT-SERIAL-NUM
+           ELSE
+               DISPLAY 'TLSVAL-E010: SELF-SIGNED CERT NOT TRUSTED '
+                   WS-CERT-SERIAL-NUM
+               MOVE 'SELF-SIGNED CERT NOT TRUSTED'
+                   TO WS-VALIDATION-MSG
+               SET WS-CHAIN-IS-INVALID TO TRUE
+           END-IF
+           .
+       2100-EXIT.
            EXIT.
        3000-CHECK-EXPIRY-DATE.
            MOVE WS-CERT-NOT-AFTER(1:2)  TO WS-EXP-YEAR-2D

--- a/tests/test_cobol_cert_chain.py
+++ b/tests/test_cobol_cert_chain.py
@@ -1,0 +1,89 @@
+import re
+import unittest
+from pathlib import Path
+
+
+SOURCE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "cobol"
+    / "TLS-CERT-VALIDATOR.cbl"
+)
+
+
+def load_source():
+    return SOURCE_PATH.read_text(encoding="utf-8")
+
+
+def paragraph(source, name):
+    start = source.index(f"       {name}.")
+    match = re.search(
+        r"^       \d{4}-[A-Z0-9-]+\.",
+        source[start + len(name) + 9 :],
+        re.MULTILINE,
+    )
+    if not match:
+        return source[start:]
+    end = start + len(name) + 9 + match.start()
+    return source[start:end]
+
+
+class CobolCertificateChainTests(unittest.TestCase):
+    def test_zero_length_chain_uses_self_signed_handler_before_loop(self):
+        source = load_source()
+        validate_chain = paragraph(source, "2000-VALIDATE-CERT-CHAIN")
+
+        positive_length_guard = validate_chain.index("IF WS-CHAIN-LENGTH > 0")
+        handler_call = validate_chain.index(
+            "PERFORM 2100-VALIDATE-SELF-SIGNED-CERT"
+        )
+        chain_loop = validate_chain.index("PERFORM VARYING WS-CHAIN-INDEX")
+
+        self.assertLess(positive_length_guard, chain_loop)
+        self.assertLess(chain_loop, handler_call)
+        self.assertNotIn("IF WS-CHAIN-LENGTH = 0", validate_chain)
+
+    def test_self_signed_cert_is_only_valid_when_trusted(self):
+        source = load_source()
+        self_signed_handler = paragraph(
+            source, "2100-VALIDATE-SELF-SIGNED-CERT"
+        )
+
+        expected_fragments = [
+            "TLSVAL-W010: EMPTY CERTIFICATE CHAIN",
+            "MOVE WS-CERT-SERIAL-NUM TO CS-CERT-SERIAL",
+            "READ CERT-STORE-FILE",
+            "INVALID KEY",
+            "TLSVAL-E010: SELF-SIGNED CERT NOT TRUSTED",
+            "SET WS-CHAIN-IS-INVALID TO TRUE",
+            "CS-IS-TRUST-ANCHOR",
+            "CS-FINGERPRINT = WS-CERT-FINGERPRINT",
+            "SET WS-CHAIN-IS-VALID TO TRUE",
+        ]
+
+        for fragment in expected_fragments:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, self_signed_handler)
+
+        mark_invalid = self_signed_handler.index(
+            "SET WS-CHAIN-IS-INVALID TO TRUE"
+        )
+        audit_message = self_signed_handler.index(
+            "TLSVAL-W010: EMPTY CERTIFICATE CHAIN"
+        )
+        trust_store_read = self_signed_handler.index("READ CERT-STORE-FILE")
+
+        self.assertLess(mark_invalid, trust_store_read)
+        self.assertLess(audit_message, trust_store_read)
+
+    def test_chain_loop_stops_at_declared_chain_length(self):
+        source = load_source()
+        validate_chain = paragraph(source, "2000-VALIDATE-CERT-CHAIN")
+        loop_start = validate_chain.index("PERFORM VARYING WS-CHAIN-INDEX")
+        loop_body = validate_chain[loop_start:]
+
+        self.assertIn("UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH", loop_body)
+        self.assertNotIn("WS-CHAIN-LENGTH + 1", loop_body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #516

## Summary

Fixes the zero-length certificate-chain path in `TLS-CERT-VALIDATOR.cbl`.

- Adds the requested `IF WS-CHAIN-LENGTH > 0` guard before the chain `PERFORM VARYING` loop.
- Routes empty chains to an explicit self-signed certificate handler before the OCCURS table can read `WS-CHN-SERIAL(1)`.
- Immediately marks empty chains invalid and emits `TLSVAL-W010: EMPTY CERTIFICATE CHAIN` for audit visibility.
- Validates self-signed certificates against `CERT-STORE-FILE` and only accepts them when the store record is a trust anchor with a matching fingerprint.
- Keeps normal chain validation bounded to `WS-CHAIN-LENGTH` instead of probing `WS-CHAIN-LENGTH + 1`.
- Adds a focused regression test that verifies zero-length chains use the self-signed handler and that the chain loop no longer contains the off-by-one bound.

## Demo / Validation

Demo video:
https://github.com/DeepankerSeth/Bounty-Hunters/releases/download/bounty-516-demo-20260514-deepankerseth/unsafe-labs-516-empty-chain-demo.mp4

Release page:
https://github.com/DeepankerSeth/Bounty-Hunters/releases/tag/bounty-516-demo-20260514-deepankerseth

```text
$ python3 -m unittest tests/test_cobol_cert_chain.py
...
----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK
```

`git diff --check` also passes.

## Acceptance Criteria Mapping

- Adds `IF WS-CHAIN-LENGTH > 0` before the `PERFORM VARYING` loop.
- For `WS-CHAIN-LENGTH = 0`, no OCCURS entry is read before trust-store handling.
- Empty chains are marked invalid and logged with an explicit audit message before the trust-store exception can make a trusted self-signed cert valid.
- Self-signed certificates are rejected unless their serial resolves in `CERT-STORE-FILE`, the store entry is a trust anchor, and the fingerprint matches.
- Adds regression coverage for the `WS-CHAIN-LENGTH = 0` case.
