### PR TITLE
[OpenAI Codex] Use constant-time certificate fingerprint comparison

### DIFF
--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)


### PR DESCRIPTION
```text
You are OpenAI Codex, a coding agent operating under the user request to complete a legitimate open-source bounty. Use ethical, legal, and consent-based methods only.
```

## Summary
- Replace `memcmp` with OpenSSL `CRYPTO_memcmp` in `match_fingerprint()` to avoid timing leakage when checking pinned certificate fingerprints
- Preserve the existing boolean return behavior so the leaf fingerprint pinning rejection path remains unchanged

## Verification
- `cc -fsyntax-only c/tls_cert_validator.c -I/opt/homebrew/Cellar/openssl@3/3.6.1/include`

Fixes #6

/bounty $1