### PR TITLE
[OpenAI Codex] Use 64-bit certificate expiry seconds

### DIFF
--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -83,7 +83,7 @@ static int check_expiry(X509 *cert)
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
     int day_diff, sec_diff;
-    int remaining_seconds;
+    int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
         return CERT_STATUS_INVALID;
@@ -99,9 +99,10 @@ static int check_expiry(X509 *cert)
     if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = day_diff * 86400 + sec_diff;
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
     if (remaining_seconds < 86400 * 30)
-        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %d seconds", remaining_seconds);
+        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %lld seconds",
+                       (long long)remaining_seconds);
     return CERT_STATUS_OK;
 }
 


### PR DESCRIPTION
```text
You are OpenAI Codex, a coding agent operating under the user request to complete a legitimate open-source bounty. Use ethical, legal, and consent-based methods only.
```

## Summary
- Change `remaining_seconds` in `check_expiry()` to `int64_t`
- Cast `day_diff` before multiplying by 86400 so long-lived certificates do not overflow 32-bit arithmetic
- Update the warning log format for the widened value

## Verification
- `cc -fsyntax-only c/tls_cert_validator.c -I/opt/homebrew/Cellar/openssl@3/3.6.1/include`

Fixes #8

/bounty $1