### PR TITLE
[OpenAI Codex] Log cert store issuer before freeing

### DIFF
--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -188,10 +188,10 @@ static void cleanup_cert_store(cert_store_t *store)
     entry = store->head;
     while (entry) {
         next = entry->next;
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         X509_free(entry->cert);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }


### PR DESCRIPTION
```text
You are OpenAI Codex, a coding agent operating under the user request to complete a legitimate open-source bounty. Use ethical, legal, and consent-based methods only.
```

## Summary
- Move the debug `log_cert_event()` call before `entry->issuer` is freed in `cleanup_cert_store()`
- Preserve the cleanup order and store reset behavior while avoiding a use-after-free when debug logging is enabled

## Verification
- `cc -fsyntax-only c/tls_cert_validator.c -I/opt/homebrew/Cellar/openssl@3/3.6.1/include`

Fixes #10

/bounty $1