### PR TITLE
[OpenAI Codex] Return error when no cipher suite matches

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,30 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteUnknownSuiteReturnsError(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	name, err := reg.NegotiateSuite([]uint16{0xffff})
+	if err == nil {
+		t.Fatal("expected an error for an unknown cipher suite")
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteValidSuiteReturnsName(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+
+	name, err := reg.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("expected valid suite to negotiate, got error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("expected TLS_AES_128_GCM_SHA256, got %q", name)
+	}
+}


### PR DESCRIPTION
```text
You are OpenAI Codex, a coding agent operating under the user request to complete a legitimate open-source bounty. Use ethical, legal, and consent-based methods only.
```

## Summary
- Return a clear error from `NegotiateSuite()` when none of the client-offered cipher suites match
- Add tests for the unknown-suite error path and a valid TLS_AES_128_GCM_SHA256 negotiation path

## Verification
- `GO111MODULE=off GOCACHE=/private/tmp/codex-go-build-cache go test` from `go/`

Fixes #11

/bounty $1