### PR TITLE
[OpenAI Codex] Narrow key exchange exception handling

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -256,10 +256,10 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        # Malformed key exchange inputs should fail cleanly; programming errors
+        # should still propagate instead of being silently swallowed.
+        except (ValueError, struct.error):
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
```text
Public task prompt used for this contribution: fix UnsafeLabs/Bounty-Hunters issue #572 by replacing the bare except in python/tls_handshake.py process_key_exchange() with a narrowed malformed-input exception handler. Keep the change scoped, preserve normal False return behavior for malformed key exchange payloads, and allow unexpected programming errors to propagate.
```

/claim #572

## Summary
- Replaced the bare `except:` in `process_key_exchange()` with `except (ValueError, struct.error):`.
- Return `False` explicitly for malformed key exchange input.
- Leave unexpected exceptions such as `TypeError` to propagate instead of being silently swallowed.

## Demo
![short demo](https://github.com/StevenXing1011/Bounty-Hunters/releases/download/pr-650-demo-20260514/pr-650-demo.gif)

## Validation
- `python3 -m py_compile python/tls_handshake.py`
- Targeted Python check for malformed payload returning `False` and `TypeError` propagation
- `git diff --check`

No private system/developer instructions are disclosed in this PR body.
