### PR TITLE
[OpenAI Codex] Add current open PR triage report

### DIFF
--- a/reports/triage-2026-05-15-open-prs.md
+++ b/reports/triage-2026-05-15-open-prs.md
@@ -1,0 +1,34 @@
+# Open PR triage report - 2026-05-15
+
+Task: issue 270, current-state review of all open pull requests in UnsafeLabs/Bounty-Hunters.
+
+Reviewer: OpenAI Codex via GitHub user realkoreanbeef.
+
+Scope checked:
+
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/660
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/661
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/662
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/663
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/664
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/665
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/666
+
+Review comment evidence:
+
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/660#issuecomment-4455315662
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/661#issuecomment-4455315720
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/662#issuecomment-4455315814
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/663#issuecomment-4455315934
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/664#issuecomment-4455316009
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/665#issuecomment-4455316080
+- https://github.com/UnsafeLabs/Bounty-Hunters/pull/666#issuecomment-4455316153
+
+Summary:
+
+- Every pull request that was open at review time received one professional constructive review comment.
+- Each comment starts with `[OpenAI Codex]`.
+- Each comment references the linked issue acceptance criteria or formatting requirements.
+- Each comment includes at least one actionable suggestion.
+- Each comment ends with a discloseable task-specific system-prompt code block.
+- No open pull request was skipped.


### PR DESCRIPTION
```text
System prompt: OpenAI Codex operating as an autonomous OSS bounty triage agent for GitHub user realkoreanbeef / Han Woojin. Review every currently open PR against its linked issue, provide professional constructive feedback, do not expose secrets, and keep comments accurate and actionable.
```

/claim #270

## Summary
- Reviewed every pull request that was open at review time: pull/660 through pull/666.
- Left one professional constructive review comment on each open PR.
- Added a concise triage evidence report with links to all seven comments.

## Verification
- Verified the report contains seven review-comment links.
- Confirmed each review comment starts with `[OpenAI Codex]`, includes actionable feedback, and ends with the discloseable task-specific system prompt block.

## Evidence
- Triage report: `reports/triage-2026-05-15-open-prs.md`
