### PR TITLE
[OpenAI Codex] Prevent ClientHello from skipping to Finished

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -53,10 +53,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],

--- a/test_tls_handshake_state.py
+++ b/test_tls_handshake_state.py
@@ -1,0 +1,37 @@
+import unittest
+
+from python.tls_handshake import HandshakeState, TLSHandshake, VALID_TRANSITIONS
+
+
+class TLSHandshakeStateTransitionTests(unittest.TestCase):
+    def test_client_hello_cannot_skip_directly_to_finished(self):
+        self.assertNotIn(
+            HandshakeState.FINISHED,
+            VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO],
+        )
+
+        handshake = TLSHandshake()
+        self.assertTrue(handshake.transition_to(HandshakeState.CLIENT_HELLO))
+
+        self.assertFalse(handshake.transition_to(HandshakeState.FINISHED))
+        self.assertEqual(handshake.state, HandshakeState.ERROR)
+
+    def test_mandatory_intermediate_path_still_reaches_finished(self):
+        handshake = TLSHandshake()
+
+        for state in (
+            HandshakeState.CLIENT_HELLO,
+            HandshakeState.SERVER_HELLO,
+            HandshakeState.CERTIFICATE,
+            HandshakeState.KEY_EXCHANGE,
+            HandshakeState.CHANGE_CIPHER_SPEC,
+            HandshakeState.FINISHED,
+        ):
+            with self.subTest(state=state):
+                self.assertTrue(handshake.transition_to(state))
+
+        self.assertEqual(handshake.state, HandshakeState.FINISHED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
```text
OpenAI Codex CLI agent working autonomously as GitHub user realkoreanbeef / Han Woojin. Follow the issue requirements, keep the patch narrowly scoped, verify locally, and do not expose secrets.
```

Fixes #569.

## Summary
- removes the invalid direct `CLIENT_HELLO -> FINISHED` state transition
- adds a focused unittest proving the skip is rejected and the normal intermediate handshake path still reaches `FINISHED`

## Verification
- `python3 -m unittest -v test_tls_handshake_state`
- `python3 -m compileall python test_tls_handshake_state.py`
- `git diff --check`
