### PR TITLE
[OpenAI Codex] Fix timing-safe Finished verification

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""

--- a/tests/test_tls_verify_finished.py
+++ b/tests/test_tls_verify_finished.py
@@ -1,0 +1,27 @@
+import hmac
+import unittest
+from unittest.mock import patch
+
+from python.tls_handshake import TLSHandshake
+
+
+class TLSVerifyFinishedTests(unittest.TestCase):
+    def test_verify_finished_uses_hmac_compare_digest(self):
+        handshake = TLSHandshake()
+        handshake.master_secret = b"m" * 48
+        received_verify = b"v" * 12
+
+        with patch(
+            "python.tls_handshake.hmac.compare_digest",
+            wraps=hmac.compare_digest,
+        ) as compare_digest:
+            handshake.verify_finished(received_verify, "client finished")
+
+        compare_digest.assert_called_once()
+        computed_verify, compared_received = compare_digest.call_args.args
+        self.assertEqual(compared_received, received_verify)
+        self.assertEqual(len(computed_verify), 12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
```text
OpenAI Codex / Hermes bounty worker: complete authorized open-source bounty work only; inspect the linked issue, make a minimal repository-local fix, run relevant tests, avoid secrets, and submit a focused PR.
```

## Summary
- Replaces the Finished-message byte comparison with `hmac.compare_digest` so verification uses a timing-safe comparison.
- Adds a unittest that patches `python.tls_handshake.hmac.compare_digest` and asserts `verify_finished` delegates to it.

Closes #571

## Tests
- `python3 -m unittest tests.test_tls_verify_finished`
- `python3 -m py_compile python/tls_handshake.py tests/test_tls_verify_finished.py`
- `python3 -m unittest discover -s tests -v`
