### PR TITLE
[OpenAI Codex] Fix key exchange exception handling

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -256,10 +256,8 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error):
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""

--- a/tests/test_tls_key_exchange_errors.py
+++ b/tests/test_tls_key_exchange_errors.py
@@ -1,0 +1,36 @@
+import struct
+import unittest
+from unittest.mock import patch
+
+from python.tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class TLSProcessKeyExchangeTests(unittest.TestCase):
+    def test_malformed_key_exchange_returns_false_for_value_error(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30short")
+
+        self.assertFalse(handshake.process_key_exchange(message))
+
+    def test_struct_error_returns_false(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30" + b"x" * 48)
+
+        with patch("python.tls_handshake.struct.unpack", side_effect=struct.error):
+            self.assertFalse(handshake.process_key_exchange(message))
+
+    def test_unexpected_type_error_propagates(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30" + b"x" * 48)
+
+        with patch.object(
+            handshake,
+            "_decrypt_pre_master_secret",
+            side_effect=TypeError("programming error"),
+        ):
+            with self.assertRaises(TypeError):
+                handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
```text
OpenAI Codex / Hermes bounty worker: complete authorized open-source bounty work only; inspect the linked issue, make a minimal repository-local fix, run relevant tests, avoid secrets, and submit a focused PR.
```

## Summary
- Narrows `process_key_exchange` error handling to only catch `ValueError` and `struct.error`.
- Returns `False` explicitly for malformed key-exchange input while allowing unexpected programming errors to propagate.
- Adds unittest coverage for malformed input, `struct.error`, and uncaught `TypeError` propagation.

Closes #572

## Tests
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile python/tls_handshake.py tests/test_tls_key_exchange_errors.py`
