### PR TITLE
[OpenAI Codex] Fix Extended Master Secret derivation

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -268,14 +268,12 @@ class TLSHandshake:
         if self.client_random is None or self.server_random is None:
             raise ValueError("Client/server random not set")
 
-        seed = self.client_random + self.server_random
-
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
+            seed = self.handshake_hash.copy().digest()
         else:
             label = b"master secret"
+            seed = self.client_random + self.server_random
 
         self.master_secret = self._prf(
             self._pre_master_secret, label, seed, 48

--- a/tests/test_tls_extended_master_secret.py
+++ b/tests/test_tls_extended_master_secret.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+from python.tls_handshake import TLSHandshake
+
+
+class TLSExtendedMasterSecretTests(unittest.TestCase):
+    def _handshake(self):
+        handshake = TLSHandshake()
+        handshake._pre_master_secret = b"p" * 48
+        handshake.client_random = b"c" * 32
+        handshake.server_random = b"s" * 32
+        handshake.handshake_hash.update(b"client/server transcript")
+        return handshake
+
+    def test_ems_uses_extended_master_secret_label_and_session_hash_seed(self):
+        handshake = self._handshake()
+        handshake.negotiated_ems = True
+        session_hash = handshake.handshake_hash.copy().digest()
+
+        with patch.object(handshake, "_prf", return_value=b"m" * 48) as prf:
+            handshake._derive_master_secret()
+
+        prf.assert_called_once_with(
+            handshake._pre_master_secret,
+            b"extended master secret",
+            session_hash,
+            48,
+        )
+
+    def test_non_ems_uses_master_secret_label_and_random_seed(self):
+        handshake = self._handshake()
+        handshake.negotiated_ems = False
+
+        with patch.object(handshake, "_prf", return_value=b"m" * 48) as prf:
+            handshake._derive_master_secret()
+
+        prf.assert_called_once_with(
+            handshake._pre_master_secret,
+            b"master secret",
+            handshake.client_random + handshake.server_random,
+            48,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
```text
OpenAI Codex / Hermes bounty worker: complete authorized open-source bounty work only; inspect the linked issue, make a minimal repository-local fix, run relevant tests, avoid secrets, and submit a focused PR.
```

## Summary
- Uses the RFC 7627 `extended master secret` PRF label when EMS is negotiated.
- Uses the handshake transcript session hash as the EMS seed.
- Preserves the non-EMS `master secret` label with `client_random + server_random` seed.
- Adds unittest coverage for both EMS and non-EMS derivation inputs.

Closes #573

## Tests
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile python/tls_handshake.py tests/test_tls_extended_master_secret.py`
