### PR TITLE
[OpenAI Codex] Parse SNI server_name from TLS extensions

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,11 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                ext.server_name = self._parse_sni_server_name(ext_data)
+                if ext.server_name is not None:
+                    self.server_name = ext.server_name
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use
@@ -216,6 +218,36 @@ class TLSHandshake:
             extensions.append(ext)
 
         return extensions
+
+    def _parse_sni_server_name(self, data: bytes) -> Optional[str]:
+        """Extract the first host_name entry from an RFC 6066 SNI extension."""
+        if len(data) < 2:
+            return None
+
+        list_len = struct.unpack("!H", data[:2])[0]
+        if list_len != len(data) - 2:
+            return None
+
+        offset = 2
+        end = 2 + list_len
+        while offset + 3 <= end:
+            name_type = data[offset]
+            name_len = struct.unpack("!H", data[offset + 1:offset + 3])[0]
+            offset += 3
+            if offset + name_len > end:
+                return None
+
+            name_bytes = data[offset:offset + name_len]
+            offset += name_len
+            if name_type == 0x00:
+                if not name_bytes:
+                    return None
+                try:
+                    return name_bytes.decode("idna")
+                except UnicodeError:
+                    return None
+
+        return None
 
     def verify_finished(self, received_verify: bytes, label: str) -> bool:
         """

--- a/test_tls_sni_parsing.py
+++ b/test_tls_sni_parsing.py
@@ -1,0 +1,79 @@
+import struct
+import unittest
+
+from python.tls_handshake import EXT_SNI, TLSHandshake
+
+
+def sni_extension(hostname: str) -> bytes:
+    name = hostname.encode("idna")
+    server_name = b"\x00" + struct.pack("!H", len(name)) + name
+    return struct.pack("!H", len(server_name)) + server_name
+
+
+def client_hello_with_extensions(extensions: bytes) -> bytes:
+    payload = bytearray()
+    payload.extend(b"\x03\x03")
+    payload.extend(bytes(range(32)))
+    payload.append(0)  # empty session id
+    payload.extend(struct.pack("!H", 2))
+    payload.extend(b"\x00/" )  # TLS_RSA_WITH_AES_128_CBC_SHA
+    payload.append(1)
+    payload.append(0)  # null compression
+    payload.extend(struct.pack("!H", len(extensions)))
+    payload.extend(extensions)
+    return bytes(payload)
+
+
+class SNITest(unittest.TestCase):
+    def test_parse_extensions_extracts_sni_host_name(self):
+        ext_data = sni_extension("example.com")
+        raw_extensions = struct.pack("!HH", EXT_SNI, len(ext_data)) + ext_data
+        handshake = TLSHandshake()
+
+        extensions = handshake.parse_extensions(raw_extensions)
+
+        self.assertEqual(1, len(extensions))
+        self.assertEqual("example.com", extensions[0].server_name)
+        self.assertEqual("example.com", handshake.server_name)
+        self.assertIs(handshake.extensions[EXT_SNI], extensions[0])
+
+    def test_parse_client_hello_populates_server_name(self):
+        ext_data = sni_extension("api.example.test")
+        raw_extensions = struct.pack("!HH", EXT_SNI, len(ext_data)) + ext_data
+        handshake = TLSHandshake()
+        message = type("Message", (), {})()
+        message.payload = client_hello_with_extensions(raw_extensions)
+        message.extensions = []
+
+        self.assertTrue(handshake.parse_client_hello(message))
+
+        self.assertEqual("api.example.test", handshake.server_name)
+        self.assertEqual("api.example.test", message.extensions[0].server_name)
+
+    def test_malformed_sni_does_not_set_server_name(self):
+        # Advertise a longer server_name_list than the extension contains.
+        malformed = b"\x00\x10\x00\x00\x0bexample.com"
+        raw_extensions = struct.pack("!HH", EXT_SNI, len(malformed)) + malformed
+        handshake = TLSHandshake()
+
+        extensions = handshake.parse_extensions(raw_extensions)
+
+        self.assertEqual(1, len(extensions))
+        self.assertIsNone(extensions[0].server_name)
+        self.assertIsNone(handshake.server_name)
+
+    def test_non_host_name_entries_are_ignored(self):
+        name = b"ignored"
+        server_name = b"\x01" + struct.pack("!H", len(name)) + name
+        ext_data = struct.pack("!H", len(server_name)) + server_name
+        raw_extensions = struct.pack("!HH", EXT_SNI, len(ext_data)) + ext_data
+        handshake = TLSHandshake()
+
+        extensions = handshake.parse_extensions(raw_extensions)
+
+        self.assertIsNone(extensions[0].server_name)
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
OpenAI Codex CLI agent working as GitHub user realkoreanbeef / Han Woojin.

Fixes #570.

Summary
-------
* Added RFC 6066 SNI host_name parsing for EXT_SNI in `parse_extensions()`.
* Populate both `TLSExtension.server_name` and `TLSHandshake.server_name` when a valid hostname is present.
* Added focused unit tests for extension parsing, ClientHello parsing, malformed SNI data, and non-host_name entries.

Verification
------------
* `python3 -m unittest -v test_tls_sni_parsing`
* `python3 -m compileall python test_tls_sni_parsing.py`
* `git diff --check`

/claim #570
