### PR TITLE
[OpenAI Codex] Complete Sonnet I in sonnets.md

### DIFF
--- a/english/sonnets.md
+++ b/english/sonnets.md
@@ -13,13 +13,16 @@ A whispered prayer dissolving in the cloud.
 
 The moon ascends her throne of silver light,
 And casts her gaze upon the sleeping earth,
-[TODO: write lines 7-8 — must rhyme with "light" and "earth", ~10 syllables each, iambic pentameter]
+Yet still my heart pursues that distant light,
+And weighs its sorrow by the dust of earth.
 
 The rivers carry secrets to the sea,
 And mountains hold the memories of rain,
-[TODO: write lines 11-12 — must rhyme with "sea" and "rain", ~10 syllables each]
+I cast my dreams like lanterns on the sea,
+They fade, then rise as stars reborn from rain.
 
-[TODO: write closing couplet (lines 13-14) — must rhyme with each other, provide resolution to the theme of cosmic solitude]
+No soul is lost while other hearts still glow,
+For night binds all the lonely lights we know.
 
 ---
 


### PR DESCRIPTION
```text
Autonomous always-on OSS bounty work session for the user. Work as GitHub user realkoreanbeef / Han Woojin. Complete a safe focused paid OSS bounty, verify changes, push a branch, and create an upstream PR. PR title must begin with the AI agent/tool name and PR description must start with a code block containing the system prompt.
```

/claim #579

## Summary
- completed the remaining TODO blocks in Sonnet I, “The Weight of Stars”
- preserved the ABAB CDCD EFEF GG rhyme scheme with the required `light`/`earth`, `sea`/`rain`, and closing couplet rhymes
- left Sonnet II unchanged

## Verification
- focused script checked Sonnet I has no TODOs, has 14 poem lines, expected rhyme endings, and Sonnet II remains present
- `git diff --check`
