### PR TITLE
[OpenAI Codex] Fix COBOL hostname tally reset

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -255,6 +255,7 @@
        4000-EXIT.
            EXIT.
        5000-MATCH-HOSTNAME.
+           MOVE 0 TO WS-HOSTNAME-TALLY
            INSPECT WS-SUBJECT-COMMON-NAME
                TALLYING WS-HOSTNAME-TALLY FOR ALL '*'
            IF WS-HOSTNAME-TALLY > 0
@@ -269,6 +270,7 @@
                        TO WS-VALIDATION-MSG
                END-IF
            END-IF
+           MOVE 0 TO WS-DOT-COUNT
            INSPECT WS-EXPECTED-HOSTNAME
                TALLYING WS-DOT-COUNT FOR ALL '.'
            IF WS-DOT-COUNT < 1
@@ -278,6 +280,7 @@
            END-IF
            .
        5100-WILDCARD-MATCH.
+           MOVE 0 TO WS-WILDCARD-POS
            INSPECT WS-SUBJECT-COMMON-NAME
                TALLYING WS-WILDCARD-POS
                FOR CHARACTERS BEFORE INITIAL '*'


### PR DESCRIPTION
```
OpenAI Codex agent. Full system/developer prompt text is not disclosed because it may contain private operational or security instructions.
```

/claim #374

Resets each COBOL `INSPECT TALLYING` counter before reuse in `5000-MATCH-HOSTNAME` / `5100-WILDCARD-MATCH`:

- `WS-HOSTNAME-TALLY`
- `WS-DOT-COUNT`
- `WS-WILDCARD-POS`

Validation:

- Static checks confirm each reset is immediately before its corresponding `INSPECT`.
- `git diff --check` passes.
- `cobc` is not available in this environment.
