### PR TITLE
[OpenAI Codex] Fix COBOL certificate chain loop bound

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -165,7 +165,7 @@
                GO TO 2000-EXIT
            END-IF
            PERFORM VARYING WS-CHAIN-INDEX FROM 1 BY 1
-               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH + 1
+               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH
                MOVE WS-CHN-SERIAL(WS-CHAIN-INDEX)
                    TO CS-CERT-SERIAL
                READ CERT-STORE-FILE


### PR DESCRIPTION
```
OpenAI Codex agent. Full system/developer prompt text is not disclosed because it may contain private operational or security instructions.
```

/claim #375

Fixes the certificate chain loop bound so `WS-CHAIN-INDEX` iterates from 1 through `WS-CHAIN-LENGTH` without accessing one past the `OCCURS` table.

Validation:

- Static check confirms the loop condition is now `UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH`.
- `git diff --check` passes.
- `cobc` is not available in this environment.
