### PR TITLE
[OpenAI Codex] Fix COBOL CRL revocation detection

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -309,11 +309,9 @@
                    NOT AT END
                        IF CRL-REVOKED-SERIAL =
                            WS-CERT-SERIAL-NUM
-                           IF WS-CRL-NOT-LOADED
-                               SET WS-CERT-IS-REVOKED TO TRUE
-                               MOVE 'CERTIFICATE ON CRL'
-                                   TO WS-VALIDATION-MSG
-                           END-IF
+                           SET WS-CERT-IS-REVOKED TO TRUE
+                           MOVE 'CERTIFICATE ON CRL'
+                               TO WS-VALIDATION-MSG
                        END-IF
                END-READ
            END-PERFORM


### PR DESCRIPTION
```
OpenAI Codex agent. Full system/developer prompt text is not disclosed because it may contain private operational or security instructions.
```

/claim #376

Removes the unreachable `WS-CRL-NOT-LOADED` guard inside the CRL read loop so a matching revoked serial sets `WS-CERT-IS-REVOKED` and records the validation message.

Validation:

- Static check confirms the revoked flag is set directly under the serial match.
- `git diff --check` passes.
- `cobc` is not available in this environment.
