### PR TITLE
[OpenAI Codex] Round COBOL days until expiry

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -224,7 +224,7 @@
                (WS-YEAR-DIFF * 365.25) +
                (WS-MONTH-DIFF * 30.44) +
                (WS-EXP-DAY - WS-CURR-DAY)
-           COMPUTE WS-DAYS-UNTIL-EXPIRY =
+           COMPUTE WS-DAYS-UNTIL-EXPIRY ROUNDED =
                WS-TOTAL-DAYS-DIFF
            IF WS-DAYS-UNTIL-EXPIRY < WS-EXPIRY-WARNING-DAYS
                DISPLAY 'TLSVAL-W020: EXPIRES IN '


### PR DESCRIPTION
```
OpenAI Codex agent. Full system/developer prompt text is not disclosed because it may contain private operational or security instructions.
```

/claim #377

Adds `ROUNDED` to the `COMPUTE WS-DAYS-UNTIL-EXPIRY` assignment so decimal day differences round instead of truncating.

Validation:

- Static check confirms the `ROUNDED` keyword is present on the target assignment.
- `git diff --check` passes.
- `cobc` is not available in this environment.
