### PR TITLE
[OpenAI Codex] Parse SNI extension hostnames

### DIFF
--- a/python/test_sni_extension.py
+++ b/python/test_sni_extension.py
@@ -1,0 +1,30 @@
+import struct
+import unittest
+
+from tls_handshake import EXT_EXTENDED_MASTER_SECRET, EXT_SNI, TLSHandshake
+
+
+class SNIExtensionParsingTests(unittest.TestCase):
+    def test_parse_extensions_decodes_sni_hostname(self):
+        hostname = b"example.com"
+        server_name = b"\x00" + struct.pack("!H", len(hostname)) + hostname
+        sni_data = struct.pack("!H", len(server_name)) + server_name
+        extension_block = struct.pack("!HH", EXT_SNI, len(sni_data)) + sni_data
+
+        handshake = TLSHandshake()
+        extensions = handshake.parse_extensions(extension_block)
+
+        self.assertEqual("example.com", extensions[0].server_name)
+        self.assertEqual("example.com", handshake.server_name)
+
+    def test_parse_extensions_without_sni_leaves_server_name_unset(self):
+        extension_block = struct.pack("!HH", EXT_EXTENDED_MASTER_SECRET, 0)
+
+        handshake = TLSHandshake()
+        handshake.parse_extensions(extension_block)
+
+        self.assertIsNone(handshake.server_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -203,9 +203,27 @@ class TLSHandshake:
 
             ext = TLSExtension(ext_type, ext_data)
 
-            # BUG 2: SNI extension (type 0x0000) is parsed but the server_name
-            # field is never extracted from the extension data
-            if ext_type == EXT_EXTENDED_MASTER_SECRET:
+            if ext_type == EXT_SNI:
+                if len(ext_data) >= 2:
+                    list_len = struct.unpack("!H", ext_data[:2])[0]
+                    offset_in_list = 2
+                    list_end = min(len(ext_data), 2 + list_len)
+                    while offset_in_list + 3 <= list_end:
+                        name_type = ext_data[offset_in_list]
+                        name_len = struct.unpack(
+                            "!H", ext_data[offset_in_list + 1:offset_in_list + 3]
+                        )[0]
+                        offset_in_list += 3
+                        name_end = offset_in_list + name_len
+                        if name_end > list_end:
+                            break
+                        name_bytes = ext_data[offset_in_list:name_end]
+                        offset_in_list = name_end
+                        if name_type == 0x00:
+                            ext.server_name = name_bytes.decode("ascii")
+                            self.server_name = ext.server_name
+                            break
+            elif ext_type == EXT_EXTENDED_MASTER_SECRET:
                 self.negotiated_ems = True
             elif ext_type == EXT_SIGNATURE_ALGORITHMS:
                 pass  # stored in ext.data for later use


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
parse_extensions stores SNI extension bytes but never decodes the host_name entry into TLSExtension.server_name or TLSHandshake.server_name.

## Summary
- Adds RFC 6066 host_name parsing for EXT_SNI.\n- Adds tests for decoded SNI and non-SNI extension behavior.

## Verification
- Added python/test_sni_extension.py for SNI parsing and no-SNI behavior.\n- Ran python -m unittest discover -s python -p test_*.py locally after opening the branch.

Closes #17

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y