### PR TITLE
[OpenAI Codex] Narrow key exchange exception handling

### DIFF
--- a/python/test_key_exchange_errors.py
+++ b/python/test_key_exchange_errors.py
@@ -1,0 +1,25 @@
+import struct
+import unittest
+
+from tls_handshake import HandshakeMessage, HandshakeType, TLSHandshake
+
+
+class ProcessKeyExchangeErrorTests(unittest.TestCase):
+    def test_expected_key_exchange_errors_return_false(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00")
+
+        with self.assertLogs("tls_handshake", level="DEBUG"):
+            self.assertFalse(handshake.process_key_exchange(message))
+
+    def test_unexpected_key_exchange_errors_propagate(self):
+        handshake = TLSHandshake()
+        message = HandshakeMessage(HandshakeType.CLIENT_KEY_EXCHANGE, b"\x00\x30" + (b"a" * 48))
+        handshake._decrypt_pre_master_secret = lambda encrypted: (_ for _ in ()).throw(TypeError("boom"))
+
+        with self.assertRaises(TypeError):
+            handshake.process_key_exchange(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -6,6 +6,7 @@ Reference: RFC 5246, RFC 7627 (Extended Master Secret)
 
 import hashlib
 import hmac
+import logging
 import struct
 import os
 from enum import Enum, auto
@@ -49,6 +50,9 @@ EXT_EXTENDED_MASTER_SECRET = 0x0017
 EXT_SIGNATURE_ALGORITHMS = 0x000D
 EXT_SUPPORTED_VERSIONS = 0x002B
 EXT_KEY_SHARE = 0x0033
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
@@ -256,10 +260,9 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except (ValueError, struct.error) as exc:
+            _LOGGER.debug("key exchange failed: %s", exc)
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
process_key_exchange uses a bare except that swallows expected validation failures and unexpected runtime errors alike.

## Summary
- Catches only ValueError and struct.error, logging expected failures.\n- Lets unexpected exceptions propagate for diagnostics.\n- Adds regression tests for both paths.

## Verification
- Added python/test_key_exchange_errors.py for expected and unexpected exception behavior.\n- Ran python -m unittest discover -s python -p test_*.py locally after opening the branch.

Closes #20

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y