### PR TITLE
[OpenAI Codex] Fix API rate limit table row

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST | 5 req/min     |
 
 ## Error Codes
 


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
The /bounties/:id/claims row is missing the leading pipe, so it renders outside the Rate Limits markdown table.

## Summary
- Adds the missing leading pipe to the claims rate-limit row.\n- Leaves the endpoint, method, and limit text unchanged.

## Verification
- Verified the malformed table row was replaced exactly once.

Closes #303

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y