### PR TITLE
[OpenAI Codex] Return error when no Go TLS cipher suite matches

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_negotiate_test.go
+++ b/go/tls_cipher_negotiate_test.go
@@ -1,0 +1,30 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNegotiateSuiteReturnsErrorWhenNoSuiteMatches(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	name, err := registry.NegotiateSuite([]uint16{0xffff})
+	if err == nil {
+		t.Fatal("expected an error when no offered suite matches")
+	}
+	if name != "" {
+		t.Fatalf("expected empty suite name on failure, got %q", name)
+	}
+}
+
+func TestNegotiateSuiteReturnsMatchedSuite(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	name, err := registry.NegotiateSuite([]uint16{tls.TLS_AES_128_GCM_SHA256})
+	if err != nil {
+		t.Fatalf("expected valid suite to negotiate, got error: %v", err)
+	}
+	if name != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected negotiated suite %q", name)
+	}
+}


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
NegotiateSuite can leave selectedSuite nil and then dereference selectedSuite.Name when the client offers no known suites.

## Summary
- Returns an explicit error and empty suite name when no mutually supported suite is found.\n- Adds tests for the no-match path and a valid negotiation path.

## Verification
- Added go/tls_cipher_negotiate_test.go for the regression cases.\n- Go is not installed in this Windows workspace, so go test could not be run locally.

Closes #11

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y