### PR TITLE
[OpenAI Codex] Filter RC4 and 3DES cipher suites

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -194,7 +194,10 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 
 	result := make([]*CipherSuite, 0, len(suites))
 	for _, s := range suites {
-		if s.KeySize >= minKeyBits {
+		name := strings.ToUpper(s.Name)
+		if s.KeySize >= minKeyBits &&
+			!strings.Contains(name, "RC4") &&
+			!strings.Contains(name, "3DES") {
 			result = append(result, s)
 		}
 	}

--- a/go/tls_cipher_filter_test.go
+++ b/go/tls_cipher_filter_test.go
@@ -1,0 +1,26 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestFilterWeakSuitesRejectsRC4And3DES(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	filtered := registry.FilterWeakSuites(registry.knownSuites)
+
+	seen := map[uint16]bool{}
+	for _, suite := range filtered {
+		seen[suite.ID] = true
+	}
+
+	if seen[0x0005] {
+		t.Fatal("expected RC4 suite to be filtered")
+	}
+	if seen[0x000a] {
+		t.Fatal("expected 3DES suite to be filtered")
+	}
+	if !seen[tls.TLS_AES_128_GCM_SHA256] {
+		t.Fatal("expected modern AES-GCM suite to remain")
+	}
+}


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
FilterWeakSuites only checks key size, allowing RC4 and 3DES suites through despite their weak algorithms.

## Summary
- Rejects suite names containing RC4 or 3DES in addition to the existing key-size check.\n- Adds a test that verifies RC4 and 3DES are removed while AES-GCM remains.

## Verification
- Added go/tls_cipher_filter_test.go for the weak-suite filtering regression.\n- Go is not installed in this Windows workspace, so go test could not be run locally.

Closes #13

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y