### PR TITLE
[OpenAI Codex] Avoid panic for missing Rust session tickets

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -134,9 +134,7 @@ impl SessionCache {
     ///
     /// Returns the ticket if it exists **and** has not expired.
     pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
-        // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
-        // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+        let ticket = self.cache.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;

--- a/rust/tls_session_get_session_test.rs
+++ b/rust/tls_session_get_session_test.rs
@@ -1,0 +1,39 @@
+#[path = "tls_session.rs"]
+mod tls_session;
+
+use tls_session::{CipherSuite, SessionCache, SessionTicket};
+
+fn test_ticket(ticket_id: &str, issued_at: u64, lifetime_secs: u64) -> SessionTicket {
+    SessionTicket {
+        ticket_id: ticket_id.to_string(),
+        cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+        master_secret: vec![1, 2, 3, 4],
+        issued_at,
+        lifetime_secs,
+        encrypted_state: vec![],
+        creation_time: 0,
+    }
+}
+
+#[test]
+fn missing_ticket_returns_none_instead_of_panicking() {
+    let cache = SessionCache::new(vec![0xaa; 32]);
+
+    assert!(cache.get_session("missing_ticket").is_none());
+}
+
+#[test]
+fn existing_unexpired_ticket_is_returned() {
+    let mut cache = SessionCache::new(vec![0xaa; 32]);
+    cache.store_session(test_ticket("tkt_1_12345", 10, 7200)).unwrap();
+
+    assert!(cache.get_session("tkt_1_12345").is_some());
+}
+
+#[test]
+fn existing_expired_ticket_returns_none_without_panicking() {
+    let mut cache = SessionCache::new(vec![0xaa; 32]);
+    cache.store_session(test_ticket("expired", 7201, 7200)).unwrap();
+
+    assert!(cache.get_session("expired").is_none());
+}


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
SessionCache::get_session unwraps the cache lookup result, so missing ticket ids panic instead of returning None.

## Summary
- Replaces the unwrap with the ? operator to return None for missing tickets.\n- Adds tests for missing, present, and expired ticket lookups.

## Verification
- Added rust/tls_session_get_session_test.rs for the lookup cases.\n- Rust is not installed in this Windows workspace, so rustc/cargo tests could not be run locally.

Closes #22

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y