### PR TITLE
[OpenAI Codex] Calculate Rust session ticket age from current time

### DIFF
--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -166,10 +166,12 @@ impl SessionCache {
 
     /// Calculate the age of a ticket in seconds.
     fn calculate_ticket_age(&self, ticket: &SessionTicket) -> u64 {
-        // BUG(trap4): subtracts creation_time from issued_at instead of
-        // computing `now - issued_at`.  The result is a fixed delta that
-        // never grows, so tickets effectively never expire.
-        ticket.issued_at.saturating_sub(ticket.creation_time)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+
+        now.saturating_sub(ticket.issued_at)
     }
 
     /// Evict all expired sessions from the map.

--- a/rust/tls_session_ticket_age_test.rs
+++ b/rust/tls_session_ticket_age_test.rs
@@ -1,0 +1,40 @@
+#[path = "tls_session.rs"]
+mod tls_session;
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tls_session::{CipherSuite, SessionCache, SessionTicket};
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+
+fn test_ticket(ticket_id: &str, issued_at: u64, lifetime_secs: u64) -> SessionTicket {
+    SessionTicket {
+        ticket_id: ticket_id.to_string(),
+        cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+        master_secret: vec![1, 2, 3, 4],
+        issued_at,
+        lifetime_secs,
+        encrypted_state: vec![],
+        creation_time: issued_at,
+    }
+}
+
+#[test]
+fn ticket_older_than_lifetime_is_expired() {
+    let mut cache = SessionCache::new(vec![0xaa; 32]);
+    cache.store_session(test_ticket("old", now_secs() - 7201, 7200)).unwrap();
+
+    assert!(cache.get_session("old").is_none());
+}
+
+#[test]
+fn recent_ticket_is_not_expired() {
+    let mut cache = SessionCache::new(vec![0xaa; 32]);
+    cache.store_session(test_ticket("recent", now_secs() - 100, 7200)).unwrap();
+
+    assert!(cache.get_session("recent").is_some());
+}


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
calculate_ticket_age subtracts creation_time from issued_at, so ticket age does not grow over time and tickets do not expire correctly.

## Summary
- Computes ticket age as current Unix time minus issued_at.\n- Adds tests for expired and recent tickets.

## Verification
- Added rust/tls_session_ticket_age_test.rs for ticket expiry behavior.\n- Rust is not installed in this Windows workspace, so rustc/cargo tests could not be run locally.

Closes #25

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y