### PR TITLE
[OpenAI Codex] Prefer AEAD suites in Go cipher sorting

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -216,7 +216,7 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
-			return !si.IsAEAD && sj.IsAEAD
+			return si.IsAEAD && !sj.IsAEAD
 		}
 
 		// Higher strength first

--- a/go/tls_cipher_sort_test.go
+++ b/go/tls_cipher_sort_test.go
@@ -1,0 +1,25 @@
+package tlscipher
+
+import "testing"
+
+func TestSortByPreferencePrefersAEADSuites(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	aead := &CipherSuite{Name: "aead", KeySize: 128, IsAEAD: true, Strength: StrengthModern}
+	nonAEAD := &CipherSuite{Name: "cbc", KeySize: 256, IsAEAD: false, Strength: StrengthAdvanced}
+
+	sorted := registry.SortByPreference([]*CipherSuite{nonAEAD, aead})
+	if sorted[0] != aead {
+		t.Fatal("expected AEAD suite to sort before non-AEAD suite")
+	}
+}
+
+func TestSortByPreferenceKeepsStrengthOrderWithinAEAD(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	modern := &CipherSuite{Name: "modern", KeySize: 256, IsAEAD: true, Strength: StrengthModern}
+	advanced := &CipherSuite{Name: "advanced", KeySize: 128, IsAEAD: true, Strength: StrengthAdvanced}
+
+	sorted := registry.SortByPreference([]*CipherSuite{modern, advanced})
+	if sorted[0] != advanced {
+		t.Fatal("expected higher-strength AEAD suite to sort first")
+	}
+}


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
SortByPreference uses the inverted AEAD comparison, so non-AEAD suites can be ranked ahead of AEAD suites.

## Summary
- Flips the AEAD comparator to prefer AEAD suites.\n- Adds tests for AEAD-vs-non-AEAD ordering and strength ordering within AEAD suites.

## Verification
- Added go/tls_cipher_sort_test.go for the comparator regression cases.\n- Go is not installed in this Windows workspace, so go test could not be run locally.

Closes #14

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y