### PR TITLE
[OpenAI Codex] Use constant-time fingerprint comparison

### DIFF
--- a/c/test_match_fingerprint.c
+++ b/c/test_match_fingerprint.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <string.h>
+
+#include "tls_cert_validator.c"
+
+int main(void) {
+    unsigned char a[FINGERPRINT_LEN] = {0};
+    unsigned char b[FINGERPRINT_LEN] = {0};
+
+    assert(match_fingerprint(a, b));
+    b[FINGERPRINT_LEN - 1] = 1;
+    assert(!match_fingerprint(a, b));
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
match_fingerprint uses memcmp, which can leak matching prefix length through timing.

## Summary
- Replaces memcmp with OpenSSL CRYPTO_memcmp while preserving boolean match semantics.\n- Adds a small regression test for matching and mismatching fingerprints.

## Verification
- Added c/test_match_fingerprint.c for match/mismatch behavior.\n- C/OpenSSL build tools are not installed in this Windows workspace, so the C test could not be compiled locally.

Closes #6

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y