### PR TITLE
[OpenAI Codex] Prevent expiry seconds integer overflow

### DIFF
--- a/c/test_expiry_seconds_overflow.c
+++ b/c/test_expiry_seconds_overflow.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main(void) {
+    int day_diff = 25000;
+    int sec_diff = 0;
+    int64_t remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
+
+    assert(remaining_seconds == 2160000000LL);
+    assert(remaining_seconds >= (int64_t)86400 * 30);
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -83,7 +83,7 @@ static int check_expiry(X509 *cert)
     const ASN1_TIME *not_before = X509_get0_notBefore(cert);
     const ASN1_TIME *not_after  = X509_get0_notAfter(cert);
     int day_diff, sec_diff;
-    int remaining_seconds;
+    int64_t remaining_seconds;
     if (!not_before || !not_after) {
         log_cert_event(LOG_LEVEL_ERROR, "certificate missing validity dates");
         return CERT_STATUS_INVALID;
@@ -99,9 +99,9 @@ static int check_expiry(X509 *cert)
     if (!ASN1_TIME_diff(&day_diff, &sec_diff, NULL, not_after))
         return CERT_STATUS_INVALID;
 
-    remaining_seconds = day_diff * 86400 + sec_diff;
+    remaining_seconds = (int64_t)day_diff * 86400 + sec_diff;
     if (remaining_seconds < 86400 * 30)
-        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %d seconds", remaining_seconds);
+        log_cert_event(LOG_LEVEL_WARN, "certificate expires in %lld seconds", (long long)remaining_seconds);
     return CERT_STATUS_OK;
 }
 


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
check_expiry stores day_diff * 86400 in an int, which can overflow for long-lived certificates.

## Summary
- Stores remaining_seconds as int64_t.\n- Casts day_diff before multiplication.\n- Logs the widened value safely.

## Verification
- Added c/test_expiry_seconds_overflow.c for the 25000-day arithmetic case.\n- C/OpenSSL build tools are not installed in this Windows workspace, so the C test could not be compiled locally.

Closes #8

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y