### PR TITLE
[OpenAI Codex] Log cert store entry before freeing issuer

### DIFF
--- a/c/test_cleanup_cert_store.c
+++ b/c/test_cleanup_cert_store.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tls_cert_validator.c"
+
+static cert_entry_t *entry_with_issuer(const char *issuer) {
+    cert_entry_t *entry = calloc(1, sizeof(*entry));
+    assert(entry != NULL);
+    entry->subject = strdup("subject");
+    entry->issuer = strdup(issuer);
+    assert(entry->subject != NULL);
+    assert(entry->issuer != NULL);
+    return entry;
+}
+
+int main(void) {
+    cert_store_t store = {0};
+    g_log_level = LOG_LEVEL_DEBUG;
+
+    store.head = entry_with_issuer("issuer-1");
+    store.head->next = entry_with_issuer("issuer-2");
+    store.count = 2;
+
+    cleanup_cert_store(&store);
+
+    assert(store.head == NULL);
+    assert(store.count == 0);
+    return 0;
+}

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -188,10 +188,10 @@ static void cleanup_cert_store(cert_store_t *store)
     entry = store->head;
     while (entry) {
         next = entry->next;
+        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         X509_free(entry->cert);
         free(entry->subject);
         free(entry->issuer);
-        log_cert_event(LOG_LEVEL_DEBUG, "freed cert store entry: %s", entry->issuer);
         free(entry);
         entry = next;
     }


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
cleanup_cert_store frees entry->issuer and then logs it at debug level, causing a use-after-free.

## Summary
- Moves the debug log before X509/free calls so issuer remains valid.\n- Adds a small cleanup regression test covering debug logging with multiple entries.

## Verification
- Added c/test_cleanup_cert_store.c for cleanup behavior.\n- C/OpenSSL build tools are not installed in this Windows workspace, so the C test could not be compiled locally.

Closes #10

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y