### PR TITLE
[OpenAI Codex] Check TLS payload length before dispatch

### DIFF
--- a/assembly/test_truncated_payload.sh
+++ b/assembly/test_truncated_payload.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+nasm -f elf64 tls_record_parser.asm -o tls_record_parser.o
+ld tls_record_parser.o -o tls_record_parser
+output=$(printf '\x16\x03\x03\x01\xf4' | ./tls_record_parser)
+printf '%s\n' "$output" | grep -q 'Error: record payload truncated'

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -162,9 +162,10 @@ parse_tls_record:
     ja .invalid_length
 
     ; --- Read payload data ---
-    ; BUG: No check that r12 (bytes in buffer) >= r15 + 5
-    ; If the record claims a large payload but we only read a few
-    ; bytes, we'll process past the end of valid data
+    ; Ensure the buffer contains the declared payload length.
+    lea eax, [r15d+5]
+    cmp eax, r12d
+    ja .invalid_length
     lea rdi, [rsi+5]            ; rdi = start of payload
     mov ecx, r15d               ; ecx = payload length
 


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
parse_tls_record dispatches to handlers without checking whether the buffer contains the declared payload length.

## Summary
- Adds a r15d + 5 versus r12d bounds check before payload dispatch.\n- Adds a shell regression test for a truncated handshake record.

## Verification
- Added assembly/test_truncated_payload.sh.\n- nasm/ld are not installed in this Windows workspace, so the assembly test could not be run locally.

Closes #2

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y