### PR TITLE
[OpenAI Codex] Null-terminate warning alert message

### DIFF
--- a/assembly/test_warning_alert.sh
+++ b/assembly/test_warning_alert.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+nasm -f elf64 tls_record_parser.asm -o tls_record_parser.o
+ld tls_record_parser.o -o tls_record_parser
+output=$(printf '\x15\x03\x03\x00\x02\x01\x00' | ./tls_record_parser)
+printf '%s\n' "$output" | grep -q '^WARNING: alert received from peer$'
+if printf '%s\n' "$output" | grep -q 'record payload truncated'; then
+  echo "warning output leaked into truncated error" >&2
+  exit 1
+fi

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -25,7 +25,7 @@ section .data
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
     err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
err_alert_warning lacks a newline and null terminator, so print_string can read into the next error string.

## Summary
- Adds newline and null terminator bytes to err_alert_warning.\n- Adds a shell regression test for warning alert output.

## Verification
- Added assembly/test_warning_alert.sh.\n- nasm/ld are not installed in this Windows workspace, so the assembly test could not be run locally.

Closes #5

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y