### PR TITLE
[OpenAI Codex] Guard Go suite cache with mutex

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -139,6 +139,9 @@ func (r *SuiteRegistry) loadDefaults() {
 // scan of knownSuites. Results are cached for faster repeated lookups.
 // BUG(5): suiteCache is read/written without holding r.mu.
 func (r *SuiteRegistry) lookupSuite(id uint16) *CipherSuite {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if cached, ok := r.suiteCache[id]; ok {
 		return cached
 	}

--- a/go/tls_cipher_cache_test.go
+++ b/go/tls_cipher_cache_test.go
@@ -1,0 +1,38 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestConcurrentLookupUsesLockedSuiteCache(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+	ids := make([]uint16, 100)
+	for i := range ids {
+		ids[i] = tls.TLS_AES_128_GCM_SHA256
+	}
+
+	results, err := registry.ConcurrentLookup(ids)
+	if err != nil {
+		t.Fatalf("ConcurrentLookup returned error: %v", err)
+	}
+	for i, suite := range results {
+		if suite == nil || suite.ID != tls.TLS_AES_128_GCM_SHA256 {
+			t.Fatalf("unexpected suite at index %d: %#v", i, suite)
+		}
+	}
+}
+
+func TestLookupSuiteReturnsCachedSuite(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	first := registry.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+	second := registry.lookupSuite(tls.TLS_AES_128_GCM_SHA256)
+
+	if first == nil || second == nil {
+		t.Fatal("expected suite lookup to succeed")
+	}
+	if first != second {
+		t.Fatal("expected cached lookup to return the same suite pointer")
+	}
+}


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
lookupSuite reads and writes the shared suiteCache map without holding the existing mutex, so ConcurrentLookup can race on the map.

## Summary
- Locks r.mu around suiteCache reads, knownSuites scan, and suiteCache writes in lookupSuite.
- Adds tests for concurrent lookup and cached lookup behavior.

## Verification
- Added go/tls_cipher_cache_test.go for the lookup regression cases.
- Go is not installed in this Windows workspace, so go test -race could not be run locally.

Closes #15

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y