### PR TITLE
[OpenAI Codex] Prefer ChaCha20 without AES-NI

### DIFF
--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -219,6 +219,14 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 			return !si.IsAEAD && sj.IsAEAD
 		}
 
+		if !hasAESNI() && si.Strength == sj.Strength {
+			siChaCha := strings.Contains(si.Name, "CHACHA20")
+			sjChaCha := strings.Contains(sj.Name, "CHACHA20")
+			if siChaCha != sjChaCha {
+				return siChaCha
+			}
+		}
+
 		// Higher strength first
 		if si.Strength != sj.Strength {
 			return si.Strength > sj.Strength
@@ -277,6 +285,8 @@ func (r *SuiteRegistry) SuiteNames(ids []uint16) []string {
 // HasAESNI reports whether the current platform likely supports
 // hardware AES acceleration. This is a rough heuristic based on
 // runtime.GOARCH.
+var hasAESNI = HasAESNI
+
 func HasAESNI() bool {
 	return runtime.GOARCH == "amd64"
 }

--- a/go/tls_cipher_chacha_test.go
+++ b/go/tls_cipher_chacha_test.go
@@ -1,0 +1,33 @@
+package tlscipher
+
+import "testing"
+
+func TestSortByPreferencePrefersChaChaWithoutAESNI(t *testing.T) {
+	original := hasAESNI
+	hasAESNI = func() bool { return false }
+	defer func() { hasAESNI = original }()
+
+	registry := NewSuiteRegistry(StrengthWeak)
+	aes := &CipherSuite{Name: "TLS_AES_256_GCM_SHA384", KeySize: 256, IsAEAD: true, Strength: StrengthAdvanced}
+	chacha := &CipherSuite{Name: "TLS_CHACHA20_POLY1305_SHA256", KeySize: 256, IsAEAD: true, Strength: StrengthAdvanced}
+
+	sorted := registry.SortByPreference([]*CipherSuite{aes, chacha})
+	if sorted[0] != chacha {
+		t.Fatal("expected ChaCha20 suite to sort first when AES-NI is unavailable")
+	}
+}
+
+func TestSortByPreferencePreservesAESOrderWithAESNI(t *testing.T) {
+	original := hasAESNI
+	hasAESNI = func() bool { return true }
+	defer func() { hasAESNI = original }()
+
+	registry := NewSuiteRegistry(StrengthWeak)
+	aes := &CipherSuite{Name: "TLS_AES_256_GCM_SHA384", KeySize: 256, IsAEAD: true, Strength: StrengthAdvanced}
+	chacha := &CipherSuite{Name: "TLS_CHACHA20_POLY1305_SHA256", KeySize: 256, IsAEAD: true, Strength: StrengthAdvanced}
+
+	sorted := registry.SortByPreference([]*CipherSuite{aes, chacha})
+	if sorted[0] != aes {
+		t.Fatal("expected existing same-strength order to remain when AES-NI is available")
+	}
+}


### PR DESCRIPTION
~~~text
System prompt summary: OpenAI Codex coding agent. Task: make the minimal repository change requested by the linked issue, preserve unrelated content, and verify with the smallest relevant local checks.
~~~

## Problem
SortByPreference does not account for platforms without AES-NI, where ChaCha20-Poly1305 should be preferred over same-strength AES-GCM suites.

## Summary
- Adds a same-strength ChaCha20 preference when hasAESNI reports false.
- Keeps the existing ordering when AES-NI is available.
- Adds tests that simulate both AES-NI and no-AES-NI platforms.

## Verification
- Added go/tls_cipher_chacha_test.go for both ordering cases.
- Go is not installed in this Windows workspace, so go test could not be run locally.

Closes #12

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y