### PR TITLE
[OpenAI Codex] Terminate assembly alert messages

### DIFF
--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -24,8 +24,8 @@ section .data
     ; --- Error strings ---
     err_invalid_type    db "Error: invalid content type in record header", 10, 0
     err_short_read      db "Error: incomplete record header (need 5 bytes)", 10, 0
-    err_alert_fatal     db "FATAL ALERT received from peer", 10
-    err_alert_warning   db "WARNING: alert received from peer"
+    err_alert_fatal     db "FATAL ALERT received from peer", 10, 0
+    err_alert_warning   db "WARNING: alert received from peer", 10, 0
     err_truncated       db "Error: record payload truncated", 10, 0
 
     ; --- TLS content type bounds ---


### PR DESCRIPTION
```
OpenAI Codex agent. Full system/developer prompt text is not disclosed because it may contain private operational or security instructions.
```

/claim #5

Adds explicit newline and NUL terminators to the alert strings in `assembly/tls_record_parser.asm` so `print_string` stops at the alert message instead of leaking into the next data label.

Validation:

- Static checks confirm both alert strings now end with `10, 0`.
- `git diff --check` passes.
- `nasm` is not available in this environment, so an assembly build could not be run locally.
