### PR TITLE
[OpenAI Codex] Fix Create Bounty API method

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
Fixes #304.

## Summary
- Correct the Create Bounty endpoint method from `GET /bounties` to `POST /bounties`.

## Verification
- `python3 - <<'PY' ...` verified the Create Bounty section contains `POST /bounties` and no longer contains `GET /bounties`.
