### PR TITLE
fix(config): remove trailing comma in app.json

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
Fixes #308

Removes trailing comma in the `allowed_origins` array in `config/app.json`. Trailing commas are not valid in strict JSON and cause parsing errors.