### PR TITLE
fix(config): correct misspelled 'databse' key to 'database'

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -7,7 +7,7 @@
     "port": 8080,
     "timeout": 30000
   },
-  "databse": {
+  "database": {
     "host": "db.internal.local",
     "port": 5432,
     "name": "bounty_hunters",


### PR DESCRIPTION
Fixes #309

Corrects the misspelled JSON key `databse` to `database` in `config/app.json`. The typo causes the database configuration block to be ignored by the application.