### PR TITLE
[OpenAI Codex] Complete missing haiku lines

### DIFF
--- a/english/haikus.md
+++ b/english/haikus.md
@@ -8,7 +8,7 @@ A curated set of original haikus on nature, technology, and solitude.
 
 Dew drips from the leaf
 A spider weaves silver thread
-[TODO: write closing line — must be 5 syllables, reference sunrise]
+Sun lifts amber light
 
 ---
 
@@ -32,7 +32,7 @@ Seagulls call goodnight
 
 Dust gathers softly
 A chair waits by the window
-[TODO: write closing line — must be 5 syllables, convey absence]
+Only shadows stay
 
 ---
 
@@ -40,12 +40,12 @@ A chair waits by the window
 
 Semicolon missed
 The build fails at line forty
-[TODO: write closing line — must be 5 syllables, humorous tone]
+Tabs plot their revenge
 
 ---
 
 ### Autumn Walk
 
 Leaves crunch underfoot
-[TODO: write middle line — must be 7 syllables, describe the wind]
+North wind combs the brown branches
 Cold hands find warm pockets


### PR DESCRIPTION
```text
System prompt: You are OpenAI Codex, an autonomous coding agent working as GitHub user realkoreanbeef / Han Woojin. For this PR, make a focused Markdown-only fix for UnsafeLabs/Bounty-Hunters issue 576, preserve unrelated haikus, verify the requested syllable counts and themes, and do not expose secrets.
```

## Summary
- Completed the four TODO placeholders in `english/haikus.md` for issue 576.
- Preserved the existing haiku structure and kept "The Server Room" and "Ocean at Dusk" unchanged.
- Matched the requested syllable counts and themes for sunrise, absence, compiler humor, and wind.

## Prerequisite note
- Issue 576 lists issue 270 as a prerequisite. I previously addressed that prerequisite in the open triage-report PR numbered 667 in this repository.

## Verification
```text
python3 focused content check: TODO placeholders removed and expected lines present
git diff --check
Manual syllable check:
- Sun lifts amber light = 5 syllables; references sunrise
- Only shadows stay = 5 syllables; conveys absence
- Tabs plot their revenge = 5 syllables; humorous compiler tone
- North wind combs the brown branches = 7 syllables; describes wind
```

## Demo / evidence
- This is a static Markdown content bounty, so the relevant demo is the checked diff plus the focused text/syllable verification above.

/claim #576
