### PR TITLE
[Claude Code] [Scripts] Fix unquoted variable in backup.sh

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -21,9 +21,9 @@ log_message() {
 }
 
 # Check if backup directory exists
-if [ ! -d $BACKUP_DIR ]; then
+if [ ! -d "$BACKUP_DIR" ]; then
     echo "Creating backup directory..."
-    mkdir -p $BACKUP_DIR
+    mkdir -p "$BACKUP_DIR"
     if [ $? -ne 0 ]; then
         log_message "ERROR: Failed to create backup directory"
         exit 1
@@ -41,7 +41,7 @@ fi
 
 # Perform the backup
 log_message "Starting backup of ${DB_NAME}..."
-pg_dump -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -Fc "$DB_NAME" | gzip > $BACKUP_DIR/$BACKUP_FILE
+pg_dump -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -Fc "$DB_NAME" | gzip > "$BACKUP_DIR/$BACKUP_FILE"
 
 if [ $? -eq 0 ]; then
     FILESIZE=$(du -h "$BACKUP_DIR/$BACKUP_FILE" | cut -f1)
@@ -53,9 +53,9 @@ fi
 
 # Remove old backups beyond retention period
 log_message "Cleaning up backups older than ${RETENTION_DAYS} days..."
-find $BACKUP_DIR -name "*.sql.gz" -mtime +${RETENTION_DAYS} -delete
+find "$BACKUP_DIR" -name "*.sql.gz" -mtime +${RETENTION_DAYS} -delete
 
-REMAINING=$(ls -1 $BACKUP_DIR/*.sql.gz 2>/dev/null | wc -l)
+REMAINING=$(ls -1 "$BACKUP_DIR"/*.sql.gz 2>/dev/null | wc -l)
 log_message "Backup rotation complete. ${REMAINING} backups remaining."
 
 echo "Backup completed successfully."


### PR DESCRIPTION
```
You are an expert software engineer and open source contributor. You fix bugs, write clean code, and follow project conventions carefully.
```

This PR fixes the issue described in #315.

**Changes:**
fix: quote BACKUP_DIR variable to prevent word splitting

**Verification:**
- [x] Change is minimal and focused
- [x] Only modifies the specific issue
- [x] Follows existing code style

Closes #315
