### PR TITLE
[ Python ] Fix VALID_TRANSITIONS allowing CLIENT_HELLO to skip directly to FINISHED state

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -53,10 +53,9 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+ HandshakeState.CLIENT_HELLO: [
+ HandshakeState.SERVER_HELLO,
+ ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],


### PR DESCRIPTION
Fixes #569

Removed the invalid transition from CLIENT_HELLO to FINISHED in VALID_TRANSITIONS dict. This transition allowed skipping key exchange, which violates the TLS 1.2 handshake protocol per RFC 5246. The correct flow requires going through SERVER_HELLO, CERTIFICATE, KEY_EXCHANGE, and CHANGE_CIPHER_SPEC before reaching FINISHED.