### PR TITLE
[ Python ] Fix timing-safe comparison in verify_finished using hmac.compare_digest

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,8 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+ # Use hmac.compare_digest for constant-time comparison to prevent timing attacks
+ return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
Fixes #571

Replaced the == comparison in verify_finished with hmac.compare_digest() for constant-time comparison. Using == enables timing attacks where an attacker can gradually discover the correct verify_data by measuring response times. hmac.compare_digest() ensures the comparison takes the same amount of time regardless of where the first difference occurs.