### PR TITLE
[ Python ] Fix bare except clause silently swallowing errors in process_key_exchange

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -256,10 +256,11 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+ except (ValueError, struct.error) as e:
+ # Catch specific exceptions: ValueError for data validation,
+ # struct.error for unpacking failures. Avoid bare except to ensure
+ # unexpected errors are not silently swallowed.
+ return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
Fixes #572

Replaced the bare except:pass with except (ValueError, struct.error) as e. The bare except clause was silently swallowing all errors including KeyboardInterrupt and SystemExit, making debugging impossible. Now only the relevant exceptions (ValueError for data validation, struct.error for unpacking failures) are caught, and the function still returns False on error.