### PR TITLE
[ Python ] Fix Extended Master Secret using wrong PRF label in _derive_master_secret

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -270,12 +270,11 @@ class TLSHandshake:
 
         seed = self.client_random + self.server_random
 
-        if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
-        else:
-            label = b"master secret"
+ if self.negotiated_ems:
+ # Use "extended master secret" label per RFC 7627
+ label = b"extended master secret"
+ else:
+ label = b"master secret"
 
         self.master_secret = self._prf(
             self._pre_master_secret, label, seed, 48


### PR DESCRIPTION
Fixes #573

Fixed the PRF label in _derive_master_secret: when negotiated_ems is True, the label should be "extended master secret" per RFC 7627, not "master secret". The previous code used the same label for both cases, which defeats the purpose of the Extended Master Secret extension and makes the connection vulnerable to triple handshake attacks.
