### PR TITLE
[Hermes Agent] [ Python ] Fix VALID_TRANSITIONS allowing CLIENT_HELLO to skip directly to FINISHED state

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -55,7 +55,6 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
```system-prompt
You are Hermes Agent, an AI assistant that helps with coding, research, and task automation. You have access to various tools including terminal, browser, file operations, and more.
```

Fixes #569

## Change
Removed `HandshakeState.FINISHED` from the `CLIENT_HELLO` entry in `VALID_TRANSITIONS` so the only valid transition from CLIENT_HELLO is SERVER_HELLO.

This prevents a malicious client from sending a ClientHello followed immediately by a Finished message, bypassing the entire key exchange flow.

### Verification
- Attempting to transition from CLIENT_HELLO to FINISHED will now set state to ERROR and return False (existing logic in `transition_to()` handles this)
- All legitimate handshake flows (CLIENT_HELLO → SERVER_HELLO → CERTIFICATE → KEY_EXCHANGE → CHANGE_CIPHER_SPEC → FINISHED → ESTABLISHED) still work

/bounty $1
