### PR TITLE
fix: [ Laravel ] Add caching layer to config loading and fix cache store conn

### DIFF
--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:status';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run the cache health check and display results';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \App\Services\CacheHealthCheck  $healthCheck
+     * @return int
+     */
+    public function handle(CacheHealthCheck $healthCheck)
+    {
+        $this->info('Running cache health check...');
+
+        $results = $healthCheck->check();
+
+        $this->table(
+            ['Field', 'Value'],
+            [
+                ['Driver', $results['driver']],
+                ['Available', $results['available'] ? 'Yes' : 'No'],
+                ['Latency (ms)', $results['latency_ms']],
+            ]
+        );
+
+        if (!$results['available']) {
+            $this->error('Cache store is unavailable!');
+            return 1;
+        }
+
+        $this->info('Cache store is healthy.');
+        return 0;
+    }
+}
+

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+
+class CacheHealthCheck
+{
+    /**
+     * Test the connection for the active cache store and return status results.
+     *
+     * @return array{available: bool, driver: string, latency_ms: float}
+     */
+    public function check(): array
+    {
+        $store = Config::get('cache.default');
+        $driver = Config::get("cache.stores.{$store}.driver", $store);
+        $start = microtime(true);
+        $available = false;
+        $testKey = '_health_check_' . uniqid('', true);
+        $testValue = true;
+
+        try {
+            Cache::put($testKey, $testValue, 10);
+            $available = Cache::get($testKey) === $testValue;
+        } catch (\Exception $e) {
+            Log::error('Cache health check failed for driver [' . $driver . ']: ' . $e->getMessage());
+        } finally {
+            try {
+                Cache::forget($testKey);
+            } catch (\Exception $e) {
+                // Ignore cleanup errors — do not mask the original failure
+            }
+        }
+
+        $latency = round((microtime(true) - $start) * 1000, 2);
+
+        return [
+            'available' => $available,
+            'driver' => $driver,
+            'latency_ms' => $latency,
+        ];
+    }
+}
+

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -133,4 +133,20 @@ return [
 
     'serializable_classes' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Health Check Settings
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the settings for the cache health check system.
+    | The interval determines how often (in seconds) the check should
+    | be performed in scheduled tasks or external monitoring.
+    |
+    */
+
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
 ];
+

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,20 @@
 <?php
 
+use App\Services\CacheHealthCheck;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    if (!Config::get('cache.health_check_enabled', true)) {
+        return response()->json(['error' => 'Health check disabled'], 404);
+    }
+
+    $results = $healthCheck->check();
+
+    return response()->json($results, $results['available'] ? 200 : 503);
+});
+

--- a/laravel/tests/Feature/CacheHealthTest.php
+++ b/laravel/tests/Feature/CacheHealthTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class CacheHealthTest extends TestCase
+{
+    /**
+     * Test health check endpoint returns success when cache is available.
+     */
+    public function test_health_check_endpoint_returns_success_when_cache_is_available()
+    {
+        Cache::shouldReceive('put')->once()->andReturn(true);
+        Cache::shouldReceive('get')->once()->andReturn(true);
+        Cache::shouldReceive('forget')->once()->andReturn(true);
+        Config::set('cache.default', 'file');
+        Config::set('cache.health_check_enabled', true);
+
+        $response = $this->get('/health/cache');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure(['available', 'driver', 'latency_ms'])
+                 ->assertJson(['available' => true, 'driver' => 'file']);
+    }
+
+    /**
+     * Test health check endpoint returns 503 when cache is unavailable.
+     */
+    public function test_health_check_endpoint_returns_503_when_cache_is_unavailable()
+    {
+        Cache::shouldReceive('put')->once()->andThrow(new \Exception('Connection failed'));
+        Cache::shouldReceive('forget')->once()->andReturn(true);
+        Config::set('cache.default', 'redis');
+        Config::set('cache.health_check_enabled', true);
+
+        $response = $this->get('/health/cache');
+
+        $response->assertStatus(503)
+                 ->assertJson(['available' => false, 'driver' => 'redis']);
+    }
+
+    /**
+     * Test health check endpoint returns 404 when disabled.
+     */
+    public function test_health_check_endpoint_returns_404_when_disabled()
+    {
+        Config::set('cache.health_check_enabled', false);
+
+        $response = $this->get('/health/cache');
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * Test cache status command outputs correctly.
+     */
+    public function test_cache_status_command_outputs_correctly()
+    {
+        Cache::shouldReceive('put')->andReturn(true);
+        Cache::shouldReceive('get')->andReturn(true);
+        Cache::shouldReceive('forget')->andReturn(true);
+        Config::set('cache.default', 'file');
+
+        $this->artisan('cache:status')
+             ->expectsOutput('Running cache health check...')
+             ->assertExitCode(0);
+    }
+}
+

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    /**
+     * Test the check method returns available true on success.
+     */
+    public function test_check_returns_available_true_on_success()
+    {
+        Cache::shouldReceive('put')->once()->andReturn(true);
+        Cache::shouldReceive('get')->once()->andReturn(true);
+        Cache::shouldReceive('forget')->once()->andReturn(true);
+        Config::set('cache.default', 'file');
+
+        $service = new CacheHealthCheck();
+        $results = $service->check();
+
+        $this->assertTrue($results['available']);
+        $this->assertEquals('file', $results['driver']);
+        $this->assertIsFloat($results['latency_ms']);
+    }
+
+    /**
+     * Test the check method returns available false on failure.
+     */
+    public function test_check_returns_available_false_on_failure()
+    {
+        Cache::shouldReceive('put')->once()->andThrow(new \Exception('Fail'));
+        Cache::shouldReceive('forget')->once()->andReturn(true);
+        Config::set('cache.default', 'redis');
+
+        $service = new CacheHealthCheck();
+        $results = $service->check();
+
+        $this->assertFalse($results['available']);
+        $this->assertEquals('redis', $results['driver']);
+    }
+}
+


### PR DESCRIPTION
Fixes #747

---

**Summary of fixes:**

| # | File | Issue | Fix |
|---|------|-------|-----|
| 1 | `CacheHealthCheck.php` | Static key `health_check_ping` → stale key causes false positive | `'_health_check_' . uniqid('', true)` |
| 2 | `CacheHealthCheck.php` | `$driver` held store alias, not actual driver type | Read `cache.stores.{store}.driver` |
| 3 | `CacheHealthCheck.php` | `Cache::forget` skipped on read-mismatch | `finally` block always cleans up |
| 4 | `CacheHealthCheckTest.php` | Failure test missing `forget` expectation | Added `Cache::shouldReceive('forget')` |
| 5 | `CacheHealthTest.php` | 

## Changed Files
- `laravel/config/cache.php`
- `laravel/routes/web.php`
- `laravel/app/Console/`
- `laravel/app/Services/`
- `laravel/tests/Feature/CacheHealthTest.php`
- `laravel/tests/Unit/CacheHealthCheckTest.php`

## Test Results
```
('No test suite detected.', False)
```
