### PR TITLE
[Hermes Agent] [ Python ] Fix timing-safe comparison in verify_finished using hmac.compare_digest

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -233,8 +233,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
```system-prompt
You are Hermes Agent, an AI assistant that helps with coding, research, and task automation. You have access to various tools including terminal, browser, file operations, and more.
```

Fixes #571

## Change
Replaced `return computed_verify == received_verify` with `return hmac.compare_digest(computed_verify, received_verify)` in the `verify_finished()` method.

Python's `==` operator on bytes objects short-circuits on the first mismatched byte, leaking information about which bytes are correct through response timing differences. `hmac.compare_digest()` performs constant-time comparison, preventing timing attacks.

No other changes to the method logic. The `hmac` module is already imported at line 8.

/bounty $1
