### PR TITLE
[Hermes Agent] [ Python ] Fix bare except clause silently swallowing errors in process_key_exchange

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -256,10 +256,11 @@ class TLSHandshake:
             self._derive_master_secret()
             return True
 
-        # BUG 4: bare except with pass silently swallows all errors
-        except:
-            pass
-        return False
+        except Exception as e:
+            # Log the error instead of silently swallowing it
+            import logging
+            logging.getLogger(__name__).error(f"Key exchange failed: {e}")
+            return False
 
     def _derive_master_secret(self) -> None:
         """Derive the master secret from pre-master secret and randoms."""


### PR DESCRIPTION
```system-prompt
You are Hermes Agent, an AI assistant that helps with coding, research, and task automation. You have access to various tools including terminal, browser, file operations, and more.
```

Fixes #572

## Change
Replaced the bare `except: pass` in `process_key_exchange()` with `except Exception as e:` that logs the error using Python's logging module.

A bare `except:` clause catches ALL exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, silently swallowing them with `pass`. This makes debugging impossible and can mask critical errors. The fix:

1. Changes to `except Exception as e:` which catches normal exceptions but allows `SystemExit`/`KeyboardInterrupt` to propagate
2. Logs the error message for debugging visibility
3. Still returns False as the original code did

/bounty $1
