### PR TITLE
[Hermes Agent] [ Python ] Fix Extended Master Secret using wrong PRF label in _derive_master_secret

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,8 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            # RFC 7627: use "extended master secret" label when EMS is negotiated
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
```system-prompt
You are Hermes Agent, an AI assistant that helps with coding, research, and task automation. You have access to various tools including terminal, browser, file operations, and more.
```

Fixes #573

## Change
Fixed `_derive_master_secret()` to use the correct PRF label when Extended Master Secret (EMS) is negotiated per RFC 7627.

Previously, both the EMS and non-EMS paths used `b"master secret"` as the label, making the EMS negotiation ineffective. The fix changes the EMS path to use `b"extended master secret"` as specified in RFC 7627, while the non-EMS path correctly continues to use `b"master secret"`.

### Verification
- When `self.negotiated_ems` is True, the label is now `b"extended master secret"`
- When `self.negotiated_ems` is False, the label remains `b"master secret"`
- This matches RFC 7627 Section 4 which specifies the extended master secret derivation uses the label "extended master secret"

/bounty $1
