### PR TITLE
[Claude Code] [ FastAPI ] Implement dynamic CORS origin validation

### DIFF
--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,136 @@
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+AllowOriginFunc = Callable[[str], bool | Awaitable[bool]]
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        allow_origins: Sequence[str] = (),
+        allow_methods: Sequence[str] = ("GET",),
+        allow_headers: Sequence[str] = (),
+        allow_credentials: bool = False,
+        allow_origin_regex: str | None = None,
+        allow_private_network: bool = False,
+        expose_headers: Sequence[str] = (),
+        allow_origin_func: AllowOriginFunc | None = None,
+        cors_max_age: int = 600,
+    ) -> None:
+        super().__init__(
+            app=app,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=allow_origin_regex,
+            allow_private_network=allow_private_network,
+            expose_headers=expose_headers,
+            max_age=cors_max_age,
+        )
+        self.allow_origin_func = allow_origin_func
+        if allow_origin_func is not None:
+            self.simple_headers.pop("Access-Control-Allow-Origin", None)
+            self.preflight_headers.pop("Access-Control-Allow-Origin", None)
+            self.preflight_headers["Vary"] = "Origin"
+            self.preflight_explicit_allow_origin = True
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":  # pragma: no cover
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+
+        if origin is None:
+            await self.app(scope, receive, send)
+            return
+
+        if method == "OPTIONS" and "access-control-request-method" in headers:
+            response = await self.preflight_response_async(request_headers=headers)
+            await response(scope, receive, send)
+            return
+
+        await self.simple_response(scope, receive, send, request_headers=headers)
+
+    async def is_allowed_origin_async(self, origin: str) -> bool:
+        if self.allow_origin_func is None:
+            return self.is_allowed_origin(origin=origin)
+
+        allowed = self.allow_origin_func(origin)
+        if inspect.isawaitable(allowed):
+            allowed = await allowed
+        return bool(allowed)
+
+    async def preflight_response_async(self, request_headers: Headers) -> Response:
+        requested_origin = request_headers["origin"]
+        requested_method = request_headers["access-control-request-method"]
+        requested_headers = request_headers.get("access-control-request-headers")
+        requested_private_network = request_headers.get(
+            "access-control-request-private-network"
+        )
+
+        headers = dict(self.preflight_headers)
+        failures: list[str] = []
+
+        if await self.is_allowed_origin_async(origin=requested_origin):
+            if self.preflight_explicit_allow_origin:
+                headers["Access-Control-Allow-Origin"] = requested_origin
+        else:
+            failures.append("origin")
+
+        if requested_method not in self.allow_methods:
+            failures.append("method")
+
+        if self.allow_all_headers and requested_headers is not None:
+            headers["Access-Control-Allow-Headers"] = requested_headers
+        elif requested_headers is not None:
+            for header in [h.lower() for h in requested_headers.split(",")]:
+                if header.strip() not in self.allow_headers:
+                    failures.append("headers")
+                    break
+
+        if requested_private_network is not None:
+            if self.allow_private_network:
+                headers["Access-Control-Allow-Private-Network"] = "true"
+            else:
+                failures.append("private-network")
+
+        if failures:
+            failure_text = "Disallowed CORS " + ", ".join(failures)
+            return PlainTextResponse(failure_text, status_code=400, headers=headers)
+
+        return PlainTextResponse("OK", status_code=200, headers=headers)
+
+    async def send(
+        self, message: Message, send: Send, request_headers: Headers
+    ) -> None:
+        if message["type"] != "http.response.start":
+            await send(message)
+            return
+
+        message.setdefault("headers", [])
+        headers = MutableHeaders(scope=message)
+        headers.update(self.simple_headers)
+        origin = request_headers["Origin"]
+        has_cookie = "cookie" in request_headers
+
+        if self.allow_origin_func is not None:
+            if await self.is_allowed_origin_async(origin=origin):
+                self.allow_explicit_origin(headers, origin)
+        elif self.allow_all_origins and has_cookie:
+            self.allow_explicit_origin(headers, origin)
+        elif not self.allow_all_origins and await self.is_allowed_origin_async(
+            origin=origin
+        ):
+            self.allow_explicit_origin(headers, origin)
+
+        await send(message)

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -65,9 +65,13 @@ class DynamicCORSMiddleware(CORSMiddleware):
         if self.allow_origin_func is None:
             return self.is_allowed_origin(origin=origin)
 
-        allowed = self.allow_origin_func(origin)
-        if inspect.isawaitable(allowed):
-            allowed = await allowed
+        try:
+            allowed = self.allow_origin_func(origin)
+            if inspect.isawaitable(allowed):
+                allowed = await allowed
+        except Exception:
+            # If the callback fails, treat as deny (secure-by-default).
+            return False
         return bool(allowed)
 
     async def preflight_response_async(self, request_headers: Headers) -> Response:
@@ -124,6 +128,8 @@ class DynamicCORSMiddleware(CORSMiddleware):
         has_cookie = "cookie" in request_headers
 
         if self.allow_origin_func is not None:
+            # Ensure caches don't serve a response computed for one Origin to another.
+            headers.add_vary_header("Origin")
             if await self.is_allowed_origin_async(origin=origin):
                 self.allow_explicit_origin(headers, origin)
         elif self.allow_all_origins and has_cookie:

--- a/fastapi/tests/test_dynamic_cors.py
+++ b/fastapi/tests/test_dynamic_cors.py
@@ -1,0 +1,118 @@
+import asyncio
+
+from fastapi.middleware.cors import DynamicCORSMiddleware
+from starlette.types import Message, Receive, Scope, Send
+
+
+async def app(scope: Scope, receive: Receive, send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Hello World"})
+
+
+def request(
+    middleware_options: dict[str, object],
+    origin: str,
+    method: str = "GET",
+    request_method: str | None = None,
+) -> tuple[int, dict[str, str]]:
+    sent: list[Message] = []
+    headers = [(b"origin", origin.encode())]
+    if request_method is not None:
+        headers.append((b"access-control-request-method", request_method.encode()))
+
+    async def receive() -> Message:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    async def run() -> None:
+        middleware = DynamicCORSMiddleware(app, **middleware_options)
+        scope: Scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "http",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": headers,
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "root_path": "",
+        }
+        await middleware(scope, receive, send)
+
+    asyncio.run(run())
+    response_start = sent[0]
+    response_headers = {
+        key.decode().lower(): value.decode()
+        for key, value in response_start["headers"]
+    }
+    return response_start["status"], response_headers
+
+
+def test_dynamic_allow() -> None:
+    status_code, headers = request(
+        {"allow_origin_func": lambda origin: origin == "https://allowed.com"},
+        "https://allowed.com",
+    )
+
+    assert status_code == 200
+    assert headers["access-control-allow-origin"] == "https://allowed.com"
+
+
+def test_dynamic_deny() -> None:
+    status_code, headers = request(
+        {"allow_origin_func": lambda origin: origin == "https://allowed.com"},
+        "https://denied.com",
+    )
+
+    assert status_code == 200
+    assert "access-control-allow-origin" not in headers
+
+
+def test_async_callback() -> None:
+    async def allow_origin(origin: str) -> bool:
+        return origin == "https://async-allowed.com"
+
+    status_code, headers = request(
+        {"allow_origin_func": allow_origin},
+        "https://async-allowed.com",
+    )
+
+    assert status_code == 200
+    assert headers["access-control-allow-origin"] == "https://async-allowed.com"
+
+
+def test_fallback_to_static_allow_origins() -> None:
+    status_code, headers = request(
+        {"allow_origins": ["https://static-allowed.com"]},
+        "https://static-allowed.com",
+    )
+
+    assert status_code == 200
+    assert headers["access-control-allow-origin"] == "https://static-allowed.com"
+
+
+def test_preflight_sets_access_control_max_age() -> None:
+    def callback(origin: str) -> bool:
+        return origin == "https://allowed.com"
+
+    status_code, headers = request(
+        {"allow_origin_func": callback, "cors_max_age": 3600},
+        "https://allowed.com",
+        method="OPTIONS",
+        request_method="GET",
+    )
+
+    assert status_code == 200
+    assert headers["access-control-max-age"] == "3600"
+    assert headers["access-control-allow-origin"] == "https://allowed.com"

--- a/fastapi/tests/test_dynamic_cors.py
+++ b/fastapi/tests/test_dynamic_cors.py
@@ -67,6 +67,7 @@ def test_dynamic_allow() -> None:
 
     assert status_code == 200
     assert headers["access-control-allow-origin"] == "https://allowed.com"
+    assert "origin" in headers.get("vary", "").lower()
 
 
 def test_dynamic_deny() -> None:


### PR DESCRIPTION
```text
System prompt: Implement issue #763 in UnsafeLabs/Bounty-Hunters with minimal changes: add DynamicCORSMiddleware with sync/async origin callback and cors_max_age, keep CORSMiddleware unchanged, add focused tests for allow/deny/async/fallback/max-age, run tests, and provide demo link.
```

/claim #763

Implements `DynamicCORSMiddleware` in `fastapi/fastapi/middleware/cors.py`:
- Supports `allow_origin_func` (sync or async) to dynamically allow/deny per Origin.
- Falls back to the existing static `allow_origins` behavior when `allow_origin_func` is not provided.
- Adds `cors_max_age` to control `Access-Control-Max-Age` for preflight.

Verification:
```bash
pytest -q -c /dev/null fastapi/tests/test_dynamic_cors.py
# 5 passed
```

## Demo video
https://asciinema.org/a/k9Ptm5gcFrAINxzE
