### PR TITLE
[Claude Code] [ FastAPI ] Add rate limiting to API key authentication

### DIFF
--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -1,6 +1,7 @@
 from .api_key import APIKeyCookie as APIKeyCookie
 from .api_key import APIKeyHeader as APIKeyHeader
 from .api_key import APIKeyQuery as APIKeyQuery
+from .api_key import APIKeyWithRateLimit as APIKeyWithRateLimit
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials

--- a/fastapi/fastapi/security/api_key.py
+++ b/fastapi/fastapi/security/api_key.py
@@ -1,3 +1,8 @@
+import math
+import threading
+import time
+from collections import defaultdict, deque
+from collections.abc import Iterable
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -5,7 +10,8 @@ from fastapi.openapi.models import APIKey, APIKeyIn
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.responses import Response
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class APIKeyBase(SecurityBase):
@@ -230,6 +236,120 @@ class APIKeyHeader(APIKeyBase):
     async def __call__(self, request: Request) -> str | None:
         api_key = request.headers.get(self.model.name)
         return self.check_api_key(api_key)
+
+
+class APIKeyWithRateLimit(APIKeyHeader):
+    def __init__(
+        self,
+        *,
+        name: Annotated[str, Doc("Header name.")],
+        rate_limit: Annotated[
+            str,
+            Doc('Rate limit in the form "100/minute" or "1000/hour".'),
+        ],
+        deprecated_keys: Annotated[
+            Iterable[str] | None,
+            Doc("API keys that still authenticate but return a deprecation warning."),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if the header is not provided, `APIKeyWithRateLimit` will
+                automatically cancel the request and send the client an error.
+
+                If `auto_error` is set to `False`, when the header is not available,
+                instead of erroring out, the dependency result will be `None`.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            name=name,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.limit, self.window_seconds = self._parse_rate_limit(rate_limit)
+        self.deprecated_keys = set(deprecated_keys or ())
+        self._requests: defaultdict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def _parse_rate_limit(self, rate_limit: str) -> tuple[int, int]:
+        try:
+            limit_value, period = rate_limit.split("/", 1)
+            limit = int(limit_value)
+        except ValueError as exc:
+            raise ValueError(
+                'rate_limit must use the form "100/minute" or "1000/hour"'
+            ) from exc
+
+        periods = {
+            "second": 1,
+            "minute": 60,
+            "hour": 60 * 60,
+            "day": 24 * 60 * 60,
+        }
+        period = period.lower()
+        if period.endswith("s"):
+            period = period[:-1]
+        if limit < 1 or period not in periods:
+            raise ValueError(
+                'rate_limit must use a positive limit and period "second", '
+                '"minute", "hour", or "day"'
+            )
+        return limit, periods[period]
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _check_rate_limit(self, api_key: str) -> None:
+        now = self._now()
+        with self._lock:
+            requests = self._requests[api_key]
+            while requests and now - requests[0] >= self.window_seconds:
+                requests.popleft()
+            if len(requests) >= self.limit:
+                retry_after = max(
+                    1, math.ceil(self.window_seconds - (now - requests[0]))
+                )
+                raise HTTPException(
+                    status_code=HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Rate limit exceeded",
+                    headers={"Retry-After": str(retry_after)},
+                )
+            requests.append(now)
+
+    async def __call__(self, request: Request, response: Response) -> str | None:
+        api_key = request.headers.get(self.model.name)
+        api_key = self.check_api_key(api_key)
+        if api_key is None:
+            return None
+
+        self._check_rate_limit(api_key)
+        if api_key in self.deprecated_keys:
+            response.headers["Warning"] = '299 - "API key is deprecated"'
+        return api_key
 
 
 class APIKeyCookie(APIKeyBase):

--- a/fastapi/tests/test_security_api_key_with_rate_limit.py
+++ b/fastapi/tests/test_security_api_key_with_rate_limit.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+from fastapi.security import APIKeyWithRateLimit
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+def make_request(key: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/users/me",
+            "headers": [(b"key", key.encode())],
+            "query_string": b"",
+        }
+    )
+
+
+def call_api_key(api_key: APIKeyWithRateLimit, key: str) -> tuple[str | None, Response]:
+    response = Response()
+    result = asyncio.run(api_key(make_request(key), response))
+    return result, response
+
+
+def make_api_key(
+    *,
+    rate_limit: str = "2/minute",
+    deprecated_keys: set[str] | None = None,
+) -> APIKeyWithRateLimit:
+    return APIKeyWithRateLimit(
+        name="key", rate_limit=rate_limit, deprecated_keys=deprecated_keys
+    )
+
+
+def test_api_key_rate_limit_enforced(monkeypatch):
+    now = 1000.0
+    monkeypatch.setattr(APIKeyWithRateLimit, "_now", lambda self: now)
+    api_key = make_api_key()
+
+    result, _ = call_api_key(api_key, "secret")
+    assert result == "secret"
+    result, _ = call_api_key(api_key, "secret")
+    assert result == "secret"
+
+    with pytest.raises(HTTPException) as exc_info:
+        call_api_key(api_key, "secret")
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail == "Rate limit exceeded"
+    assert exc_info.value.headers == {"Retry-After": "60"}
+
+
+def test_api_key_rate_limit_window_resets(monkeypatch):
+    now = 1000.0
+    monkeypatch.setattr(APIKeyWithRateLimit, "_now", lambda self: now)
+    api_key = make_api_key()
+
+    assert call_api_key(api_key, "secret")[0] == "secret"
+    assert call_api_key(api_key, "secret")[0] == "secret"
+    with pytest.raises(HTTPException):
+        call_api_key(api_key, "secret")
+
+    now = 1060.0
+    result, _ = call_api_key(api_key, "secret")
+    assert result == "secret"
+
+
+def test_api_key_deprecated_warning_header():
+    api_key = make_api_key(rate_limit="10/minute", deprecated_keys={"old-secret"})
+
+    result, response = call_api_key(api_key, "old-secret")
+    assert result == "old-secret"
+    assert response.headers["Warning"] == '299 - "API key is deprecated"'
+
+    result, response = call_api_key(api_key, "new-secret")
+    assert result == "new-secret"
+    assert "Warning" not in response.headers


### PR DESCRIPTION
```text
System prompt: Implement issue #768 in UnsafeLabs/Bounty-Hunters with minimal changes: add APIKeyWithRateLimit extending APIKeyHeader with rate_limit parsing, concurrency-safe sliding window rate limiting, 429 Retry-After, deprecated_keys Warning header, add focused tests, run tests, and provide demo link.
```

/claim #768

Adds `APIKeyWithRateLimit` in `fastapi/fastapi/security/api_key.py`:
- `rate_limit` parsing (e.g. `100/minute`, `1000/hour`)
- Per-key in-memory sliding window rate limiting (thread-safe)
- 429 response includes `Retry-After` (seconds)
- `deprecated_keys` emit a `Warning` header but still authenticate

Verification:
```bash
pytest -q -c /dev/null fastapi/tests/test_security_api_key_with_rate_limit.py
# 3 passed
```

## Demo video
https://asciinema.org/a/rodBKM01QqC2Ru7P
