### PR TITLE
[Hermes] [ FastAPI ] Fix hardcoded CDN URLs in Swagger UI and ReDoc HTML generation

### DIFF
--- a/fastapi/fastapi/applications.py
+++ b/fastapi/fastapi/applications.py
@@ -761,6 +761,61 @@ class FastAPI(Starlette):
                 """
             ),
         ] = None,
+        swagger_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI JavaScript.
+
+                It is normally set to a CDN URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = None,
+        swagger_css_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI CSS.
+
+                It is normally set to a CDN URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = None,
+        swagger_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the favicon to use for Swagger UI. It is normally shown in the browser tab.
+                """
+            ),
+        ] = None,
+        redoc_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the ReDoc JavaScript.
+
+                It is normally set to a CDN URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = None,
+        redoc_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the favicon to use for ReDoc. It is normally shown in the browser tab.
+                """
+            ),
+        ] = None,
         generate_unique_id_function: Annotated[
             Callable[[routing.APIRoute], str],
             Doc(
@@ -885,6 +940,11 @@ class FastAPI(Starlette):
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
         self.swagger_ui_parameters = swagger_ui_parameters
+        self.swagger_js_url = swagger_js_url
+        self.swagger_css_url = swagger_css_url
+        self.swagger_favicon_url = swagger_favicon_url
+        self.redoc_js_url = redoc_js_url
+        self.redoc_favicon_url = redoc_favicon_url
         self.servers = servers or []
         self.separate_input_output_schemas = separate_input_output_schemas
         self.openapi_external_docs = openapi_external_docs
@@ -1128,6 +1188,9 @@ class FastAPI(Starlette):
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                     swagger_ui_parameters=self.swagger_ui_parameters,
+                    swagger_js_url=self.swagger_js_url,
+                    swagger_css_url=self.swagger_css_url,
+                    swagger_favicon_url=self.swagger_favicon_url,
                 )
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
@@ -1148,7 +1211,9 @@ class FastAPI(Starlette):
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 return get_redoc_html(
-                    openapi_url=openapi_url, title=f"{self.title} - ReDoc"
+                    openapi_url=openapi_url, title=f"{self.title} - ReDoc",
+                    redoc_js_url=self.redoc_js_url,
+                    redoc_favicon_url=self.redoc_favicon_url,
                 )
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)


### PR DESCRIPTION
```
You are running as a scheduled cron job. There is no user present — you cannot ask questions, request clarification, or wait for follow-up. Execute the task fully and autonomously, making reasonable decisions where needed. Your final response is automatically delivered to the job's configured destination — put the primary content directly in your response.

If the user asks about configuring, setting up, or using Hermes Agent itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') before answering. Docs: https://hermes-agent.nousresearch.com/docs
```

/claim #762

## Summary

Wired the `swagger_js_url`, `swagger_css_url`, `swagger_favicon_url`, `redoc_js_url`, and `redoc_favicon_url` parameters through the FastAPI application class so users can override CDN URLs at the app level.

## Changes

- Added `swagger_js_url`, `swagger_css_url`, `swagger_favicon_url` parameters to `FastAPI.__init__` with proper `Annotated`/`Doc` documentation
- Added `redoc_js_url`, `redoc_favicon_url` parameters similarly
- Stored all as `self.*` attributes
- Passed them through in the `swagger_ui_html` and `redoc_html` endpoint handlers
- All parameters default to `None`, preserving full backward compatibility — when not provided, `get_swagger_ui_html()` and `get_redoc_html()` use their own defaults

## Usage

```python
app = FastAPI(
    swagger_js_url="https://cdn.example.com/swagger-ui-bundle.js",
    swagger_css_url="https://cdn.example.com/swagger-ui.css",
    redoc_js_url="https://cdn.example.com/redoc.standalone.js",
)
```