### PR TITLE
[Hermes] [ FastAPI ] Fix jsonable_encoder TypeError on bytes and memoryview objects

### DIFF
--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+import base64
 from collections import defaultdict, deque
 from collections.abc import Callable
 from decimal import Decimal
@@ -82,7 +83,8 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
+    # bytes is handled explicitly in jsonable_encoder with bytes_encoding support
+    memoryview: lambda o: base64.b64encode(bytes(o)).decode(),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -203,6 +205,18 @@ def jsonable_encoder(
             """
         ),
     ] = None,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding to use for bytes and memoryview objects.
+
+            Options:
+            - `"base64"` (default): Encode as base64 string
+            - `"hex"`: Encode as hexadecimal string
+            """
+        ),
+    ] = "base64",
     sqlalchemy_safe: Annotated[
         bool,
         Doc(
@@ -331,6 +345,15 @@ def jsonable_encoder(
             )
         return encoded_list
 
+    if isinstance(obj, bytes):
+        if bytes_encoding == "hex":
+            return obj.hex()
+        return base64.b64encode(obj).decode()
+    if isinstance(obj, memoryview):
+        b = bytes(obj)
+        if bytes_encoding == "hex":
+            return b.hex()
+        return base64.b64encode(b).decode()
     if type(obj) in ENCODERS_BY_TYPE:
         return ENCODERS_BY_TYPE[type(obj)](obj)
     for encoder, classes_tuple in encoders_by_class_tuples.items():


### PR DESCRIPTION
```
You are running as a scheduled cron job. There is no user present — you cannot ask questions, request clarification, or wait for follow-up. Execute the task fully and autonomously, making reasonable decisions where needed. Your final response is automatically delivered to the job's configured destination — put the primary content directly in your response.

If the user asks about configuring, setting up, or using Hermes Agent itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') before answering. Docs: https://hermes-agent.nousresearch.com/docs
```

/claim #759

## Summary

Updated `jsonable_encoder` to properly handle `bytes` and `memoryview` objects, which previously caused `TypeError` (bytes tried to `.decode()` as UTF-8, which fails on binary data, and memoryview wasn't handled at all).

## Changes

- **bytes**: Now encodes as base64 string by default instead of calling `.decode()` (which only works for UTF-8 text)
- **memoryview**: Added support — converts to bytes first, then base64 encodes
- **bytes_encoding parameter**: Added to `jsonable_encoder` with `"base64"` default and `"hex"` option
- Removed the old `bytes: lambda o: o.decode()` entry from `ENCODERS_BY_TYPE` (replaced with inline handling that respects the encoding parameter)
- All existing encoder behavior for other types (int, str, dict, list, datetime, Decimal, Enum, etc.) is unchanged

## Examples

```python
# bytes -> base64 (default)
jsonable_encoder(b"hello")  # "aGVsbG8="

# bytes -> hex
jsonable_encoder(b"hello", bytes_encoding="hex")  # "68656c6c6f"

# memoryview -> base64
jsonable_encoder(memoryview(b"test"))  # "dGVzdA=="
```