### PR TITLE
[Claude Code] Fix #304: wrong HTTP method GET → POST for Create Bounty endpoint

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
```
Claude Code agent — autonomous bounty hunter
Task: Fix #304 wrong HTTP method in api-reference.md
```

## Fix
The "Create Bounty" endpoint incorrectly showed `GET /bounties` instead of `POST /bounties`. Creating a resource requires POST.

**Before:** `GET /bounties`
**After:** `POST /bounties`

/bounty $1