### PR TITLE
[Hermes] [ Laravel ] Fix User model password cast not applying bcrypt rounds from config

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,20 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Hash the password with the configured bcrypt rounds.
+     *
+     * Replaces the generic 'hashed' cast so that config('hashing.bcrypt.rounds')
+     * is respected instead of always using the default 10 rounds.
+     */
+    protected function setPasswordAttribute(?string $value): void
+    {
+        if ($value !== null) {
+            $rounds = (int) config('hashing.bcrypt.rounds', 10);
+            $this->attributes['password'] = Hash::make($value, ['rounds' => $rounds]);
+        }
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    'driver' => 'bcrypt',
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 10),
+    ],
+
+    'argon' => [
+        'memory' => 65536,
+        'threads' => 1,
+        'time' => 4,
+    ],
+
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -28,7 +28,10 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$password ??= Hash::make(
+                'password',
+                ['rounds' => (int) config('hashing.bcrypt.rounds', 10)]
+            ),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/PasswordHashingTest.php
+++ b/laravel/tests/Unit/PasswordHashingTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class PasswordHashingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Password hashing respects the configured bcrypt rounds.
+     */
+    public function test_password_hashing_uses_configured_rounds(): void
+    {
+        $configuredRounds = (int) config('hashing.bcrypt.rounds', 10);
+
+        $user = User::factory()->create([
+            'password' => 'secret123',
+        ]);
+
+        $hashedPassword = $user->password;
+
+        // bcrypt hashes start with $2y$ followed by the round count
+        $this->assertStringStartsWith('$2y$', $hashedPassword);
+
+        // Extract the round count from the hash
+        // Format: $2y$<rounds>$<salt><hash>
+        $parts = explode('$', $hashedPassword);
+        $actualRounds = (int) ($parts[2] ?? 0);
+
+        $this->assertEquals(
+            $configuredRounds,
+            $actualRounds,
+            "Password should be hashed with {$configuredRounds} rounds, got {$actualRounds}"
+        );
+    }
+
+    /**
+     * Password verification still works with the custom mutator.
+     */
+    public function test_password_verification_works(): void
+    {
+        $user = User::factory()->create([
+            'password' => 'secret123',
+        ]);
+
+        $this->assertTrue(
+            Hash::check('secret123', $user->password),
+            'Hash::check should return true for the correct password'
+        );
+
+        $this->assertFalse(
+            Hash::check('wrongpassword', $user->password),
+            'Hash::check should return false for an incorrect password'
+        );
+    }
+}


### PR DESCRIPTION
```
You are running as a scheduled cron job. There is no user present — you cannot ask questions, request clarification, or wait for follow-up. Execute the task fully and autonomously, making reasonable decisions where needed. Your final response is automatically delivered to the job's configured destination — put the primary content directly in your response.

If the user asks about configuring, setting up, or using Hermes Agent itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') before answering. Docs: https://hermes-agent.nousresearch.com/docs
```

/claim #745

## Summary

The User model used the generic `hashed` cast for passwords, which always uses the default 10 bcrypt rounds regardless of `BCRYPT_ROUNDS=12` being set in `.env`. This PR replaces the cast with a custom mutator that reads `config('hashing.bcrypt.rounds')` and passes it to `Hash::make()`.

## Changes

### 1. `laravel/config/hashing.php` (new)
- Standard Laravel hashing config with `bcrypt.rounds` from `BCRYPT_ROUNDS` env (default 10)

### 2. `laravel/app/Models/User.php`
- Removed `password => hashed` from casts
- Added `setPasswordAttribute()` mutator that calls `Hash::make($value, ['rounds' => config('hashing.bcrypt.rounds')])`
- Added `use Illuminate\Support\Facades\Hash` import

### 3. `laravel/database/factories/UserFactory.php`
- Updated `Hash::make('password')` to include `['rounds' => config('hashing.bcrypt.rounds')]`

### 4. `laravel/tests/Unit/PasswordHashingTest.php` (new)
- Test: password hash uses configured round count (parses $2y$ hash)
- Test: `Hash::check()` still works for verification
- Uses `RefreshDatabase`

## Backward Compatibility
Bcrypt embeds the round count in the hash itself ($2y$XX$...), so old passwords hashed with 10 rounds continue to verify correctly with `Hash::check()`. No migration needed.