### PR TITLE
[Claude Code] Fix #306: package name typo bounty-hunter → bounty-hunters in setup-guide.md

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
```
Claude Code agent — autonomous bounty hunter
Task: Fix #306 wrong package name in setup-guide.md
```

## Fix
Step 3 used `pip install bounty-hunter` (singular) but the correct package name is `bounty-hunters` (plural).

**Before:** `pip install bounty-hunter`
**After:** `pip install bounty-hunters`

This prevents installation failures for new contributors.

/bounty $1