### PR TITLE
[Hermes] [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,6 @@
 import logging
 
+from fastapi.middleware.request_id import RequestIDFilter
+
 logger = logging.getLogger("fastapi")
+logger.addFilter(RequestIDFilter())

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,57 @@
+import logging
+from contextvars import ContextVar
+from uuid import uuid4
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+REQUEST_ID_HEADER = "x-request-id"
+request_id_context: ContextVar[str | None] = ContextVar(
+    "fastapi_request_id", default=None
+)
+
+
+class RequestIDFilter(logging.Filter):
+    """Inject the current request ID into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_context.get()
+        return True
+
+
+class RequestIDMiddleware:
+    """Attach an X-Request-ID header and expose it during request handling."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers") or [])
+        request_id = headers.get(REQUEST_ID_HEADER.encode("latin-1"))
+        if request_id is None:
+            request_id_value = str(uuid4())
+        else:
+            request_id_value = request_id.decode("latin-1")
+
+        scope.setdefault("state", {})["request_id"] = request_id_value
+        token = request_id_context.set(request_id_value)
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                raw_headers = list(message.get("headers", []))
+                raw_headers.append(
+                    (
+                        REQUEST_ID_HEADER.encode("latin-1"),
+                        request_id_value.encode("latin-1"),
+                    )
+                )
+                message["headers"] = raw_headers
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            request_id_context.reset(token)

--- a/fastapi/tests/test_request_id_middleware.py
+++ b/fastapi/tests/test_request_id_middleware.py
@@ -1,0 +1,66 @@
+import logging
+import re
+
+from fastapi import FastAPI, Request
+from fastapi.logger import logger
+from fastapi.middleware.request_id import RequestIDMiddleware, request_id_context
+from fastapi.testclient import TestClient
+
+
+def test_request_id_middleware_generates_and_exposes_request_id() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def read_root(request: Request) -> dict[str, str]:
+        return {"request_id": request.state.request_id}
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    request_id = response.headers["x-request-id"]
+    assert re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        request_id,
+    )
+    assert response.json() == {"request_id": request_id}
+    assert request_id_context.get() is None
+
+
+def test_request_id_middleware_preserves_client_request_id() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def read_root(request: Request) -> dict[str, str]:
+        return {"request_id": request.state.request_id}
+
+    client = TestClient(app)
+    response = client.get("/", headers={"X-Request-ID": "client-id-123"})
+
+    assert response.headers["x-request-id"] == "client-id-123"
+    assert response.json() == {"request_id": "client-id-123"}
+    assert request_id_context.get() is None
+
+
+def test_fastapi_logger_adds_request_id_to_log_records(caplog) -> None:  # type: ignore[no-untyped-def]
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def read_root() -> dict[str, str]:
+        logger.warning("request scoped log")
+        return {"ok": "true"}
+
+    client = TestClient(app)
+
+    with caplog.at_level(logging.WARNING, logger="fastapi"):
+        response = client.get("/", headers={"X-Request-ID": "log-id-123"})
+
+    assert response.headers["x-request-id"] == "log-id-123"
+    matching_records = [
+        record for record in caplog.records if record.message == "request scoped log"
+    ]
+    assert matching_records
+    assert matching_records[0].request_id == "log-id-123"
+    assert request_id_context.get() is None


### PR DESCRIPTION
/claim #797

## Summary
- Adds `RequestIDMiddleware` for FastAPI that preserves a client-provided `X-Request-ID` or generates a UUID per HTTP request.
- Stores the request ID on `request.state.request_id` and echoes it in the response header.
- Adds a context variable and `RequestIDFilter` so FastAPI log records include `record.request_id` during request handling without leaking between requests.
- Adds focused tests for generated IDs, client-provided IDs, logging context, and cleanup after request completion.

## Test Plan
- `python -m pytest tests/test_request_id_middleware.py -q`
- `python -m compileall -q fastapi/middleware/request_id.py fastapi/logger.py tests/test_request_id_middleware.py`
- `ruff check fastapi/middleware/request_id.py fastapi/logger.py tests/test_request_id_middleware.py`
- `git diff --check`

## Note
Private system/developer prompts and credentials are not included in PR descriptions. The implementation and validation details above are complete for review.
