### PR TITLE
[Hermes] [ FastAPI ] Add concurrent task runner with semaphore limiting and timeout

### DIFF
--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -13,6 +13,74 @@ from starlette.concurrency import (  # noqa
 
 _T = TypeVar("_T")
 
+import asyncio
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more coroutines fail during concurrent execution."""
+
+    def __init__(self, errors, results=None):
+        self.errors = errors
+        self.results = results or []
+        message = f'{len(errors)} coroutine(s) failed during concurrent execution'
+        super().__init__(message)
+
+
+async def run_concurrently(*coroutines, max_concurrency=5, timeout=None):
+    """Run multiple coroutines concurrently with a semaphore-limited concurrency.
+
+    Args:
+        *coroutines: Awaitables to execute concurrently.
+        max_concurrency: Maximum number of coroutines to run at once (default 5).
+        timeout: Optional timeout in seconds.
+
+    Returns:
+        List of results in the same order as the input coroutines.
+
+    Raises:
+        ConcurrencyError: If any coroutine raises an exception.
+    """
+    if not coroutines:
+        return []
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results = [None] * len(coroutines)
+    errors = []
+
+    async def _run_one(index, coro):
+        async with semaphore:
+            try:
+                results[index] = await coro
+            except Exception as exc:
+                errors.append((index, exc))
+
+    tasks = [asyncio.create_task(_run_one(i, c)) for i, c in enumerate(coroutines)]
+
+    try:
+        if timeout is not None:
+            done, pending = await asyncio.wait(tasks, timeout=timeout)
+            if pending:
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                errors.append((-1, TimeoutError(f'run_concurrently timed out after {timeout}s')))
+        else:
+            await asyncio.gather(*tasks)
+    except Exception:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        raise
+
+    if errors:
+        errors.sort(key=lambda x: x[0])
+        raise ConcurrencyError(errors=[e for _, e in errors], results=results)
+
+    return results
+
+
+
+
 
 @asynccontextmanager
 async def contextmanager_in_threadpool(

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,101 @@
+
+import asyncio
+import pytest
+from fastapi.fastapi.concurrency import run_concurrently, ConcurrencyError
+
+
+class TestRunConcurrently:
+    async def test_empty_coroutines(self):
+        result = await run_concurrently()
+        assert result == []
+
+    async def test_single_coroutine(self):
+        async def f():
+            return 42
+        result = await run_concurrently(f())
+        assert result == [42]
+
+    async def test_multiple_coroutines_results_order(self):
+        async def f(val, delay):
+            await asyncio.sleep(delay)
+            return val
+        result = await run_concurrently(
+            f(1, 0.03), f(2, 0.01), f(3, 0.02)
+        )
+        assert result == [1, 2, 3]
+
+    async def test_max_concurrency_limits_execution(self):
+        running = 0
+        max_seen = 0
+
+        async def f():
+            nonlocal running, max_seen
+            running += 1
+            max_seen = max(max_seen, running)
+            await asyncio.sleep(0.01)
+            running -= 1
+            return 1
+
+        await run_concurrently(*[f() for _ in range(10)], max_concurrency=3)
+        assert max_seen <= 3
+
+    async def test_max_concurrency_1_sequential(self):
+        running = 0
+        max_seen = 0
+
+        async def f():
+            nonlocal running, max_seen
+            running += 1
+            max_seen = max(max_seen, running)
+            await asyncio.sleep(0.01)
+            running -= 1
+            return 1
+
+        await run_concurrently(*[f() for _ in range(5)], max_concurrency=1)
+        assert max_seen == 1
+
+    async def test_max_concurrency_exceeds_task_count(self):
+        result = await run_concurrently(
+            *[asyncio.sleep(0)] * 3, max_concurrency=10
+        )
+        assert result == [None, None, None]
+
+    async def test_error_collects_all_failures(self):
+        async def fail(msg):
+            raise ValueError(msg)
+
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(
+                fail('err1'), fail('err2'), fail('err3')
+            )
+        assert len(exc_info.value.errors) == 3
+        assert all(isinstance(e, ValueError) for e in exc_info.value.errors)
+
+    async def test_error_with_partial_results(self):
+        async def ok(val):
+            return val
+
+        async def fail():
+            raise RuntimeError('boom')
+
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(ok(1), fail(), ok(3), fail())
+        err = exc_info.value
+        assert len(err.errors) == 2
+        assert err.results[0] == 1
+        assert err.results[2] == 3
+
+    async def test_timeout_cancels_remaining(self):
+        async def slow():
+            await asyncio.sleep(10)
+            return 'never'
+
+        async def fast():
+            await asyncio.sleep(0.01)
+            return 'done'
+
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(fast(), slow(), timeout=0.05)
+        err = exc_info.value
+        assert err.results[0] == 'done'
+        assert any(isinstance(e, TimeoutError) for e in err.errors)


### PR DESCRIPTION
```
You are running as a scheduled cron job. There is no user present — you cannot ask questions, request clarification, or wait for follow-up. Execute the task fully and autonomously, making reasonable decisions where needed. Your final response is automatically delivered to the job's configured destination — put the primary content directly in your response.
```

/claim #803

## Summary

Added `run_concurrently` function to `fastapi/fastapi/concurrency.py` that runs multiple coroutines with a configurable concurrency limit, timeout support, and comprehensive error collection.

## Changes

- **`fastapi/fastapi/concurrency.py`**: Added `ConcurrencyError` exception class and `run_concurrently(*coroutines, max_concurrency=5, timeout=None)` function
- **`fastapi/tests/test_concurrency.py`**: Comprehensive test suite covering empty input, single coroutine, results ordering, concurrency limiting, sequential execution, error collection, partial results, and timeout behavior

## How it works

- Uses `asyncio.Semaphore` to limit concurrent coroutine execution
- Results maintain input order regardless of completion order via index tracking
- `ConcurrencyError` collects all failed task exceptions and partial results
- Timeout via `asyncio.wait` cancels remaining tasks and includes `TimeoutError`
- `max_concurrency=1` executes sequentially; values exceeding task count run all at once

## Demo

```python
from fastapi.fastapi.concurrency import run_concurrently, ConcurrencyError

# Basic usage
results = await run_concurrently(coro1(), coro2(), coro3(), max_concurrency=2)

# With timeout
try:
    results = await run_concurrently(slow_task(), fast_task(), timeout=5.0)
except ConcurrencyError as e:
    print(e.errors)  # [TimeoutError(...)]
    print(e.results) # [None, "done"]
```