### PR TITLE
[Hermes Agent with DeepSeek V4 Flash] [ T3 Code ] Enable SQLite WAL mode and add Effect.Pool connection pooling

### DIFF
--- a/t3code/apps/server/src/__tests__/DatabaseService.test.ts
+++ b/t3code/apps/server/src/__tests__/DatabaseService.test.ts
@@ -1,0 +1,202 @@
+/**
+ * DatabaseService tests — pool lifecycle, concurrent queries, WAL mode check.
+ */
+import { it, describe, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+
+import {
+  DatabaseService,
+  makeDatabaseServiceLayer,
+} from "../services/DatabaseService.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a test layer backed by an in-memory SQLite database with a pool of 2. */
+const testLayer = (poolSize = 2) =>
+  makeDatabaseServiceLayer({ filename: ":memory:", poolSize });
+
+/** Run a query via the service and return rows. */
+const runQuery = (sql: string, params?: ReadonlyArray<unknown>) =>
+  Effect.flatMap(
+    DatabaseService,
+    (svc) => svc.query(sql, params),
+  );
+
+/** Execute a statement via the service. */
+const runExec = (sql: string, params?: ReadonlyArray<unknown>) =>
+  Effect.flatMap(
+    DatabaseService,
+    (svc) => svc.exec(sql, params),
+  );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DatabaseService", () => {
+  describe("pool lifecycle", () => {
+    it.effect("should create a pool, execute queries, and shut down gracefully", () =>
+      Effect.gen(function* () {
+        const result = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const scope = yield* Effect.scope;
+            const layer = testLayer(2);
+            yield* Scope.extend(layer, scope);
+            yield* Scope.addFinalizer(scope, Layer.toRuntime(layer).pipe(Effect.asVoid));
+
+            // Use the pool
+            yield* runExec("CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, name TEXT)");
+            yield* runExec("INSERT INTO test (name) VALUES (?)", ["hello"]);
+
+            const rows = yield* runQuery("SELECT * FROM test");
+            expect(rows).toEqual([{ id: 1, name: "hello" }]);
+
+            return "ok";
+          }),
+        );
+        expect(result).toBe("ok");
+      }),
+    );
+
+    it.effect("should handle graceful shutdown without errors", () =>
+      Effect.gen(function* () {
+        const result = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const scope = yield* Effect.scope;
+            const layer = testLayer(3);
+            yield* Scope.extend(layer, scope);
+
+            yield* runExec("CREATE TABLE IF NOT EXISTS graceful (id INTEGER PRIMARY KEY)");
+            yield* runExec("INSERT INTO graceful DEFAULT VALUES");
+
+            // Scope closing will trigger pool shutdown
+            return "shutdown-ok";
+          }),
+        );
+        expect(result).toBe("shutdown-ok");
+      }),
+    );
+  });
+
+  describe("concurrent queries", () => {
+    it.effect("should handle multiple concurrent queries", () =>
+      Effect.gen(function* () {
+        const results = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const scope = yield* Effect.scope;
+            const layer = testLayer(4);
+            yield* Scope.extend(layer, scope);
+
+            yield* runExec("CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, value TEXT)");
+            yield* runExec("INSERT INTO items (value) VALUES ('a')");
+            yield* runExec("INSERT INTO items (value) VALUES ('b')");
+            yield* runExec("INSERT INTO items (value) VALUES ('c')");
+
+            // Fire 3 concurrent queries
+            const queries = Effect.all(
+              [
+                runQuery("SELECT value FROM items WHERE id = 1"),
+                runQuery("SELECT value FROM items WHERE id = 2"),
+                runQuery("SELECT value FROM items WHERE id = 3"),
+              ],
+              { concurrency: 3 },
+            );
+
+            return yield* queries;
+          }),
+        );
+
+        expect(results).toHaveLength(3);
+        expect(results[0]).toEqual([{ value: "a" }]);
+        expect(results[1]).toEqual([{ value: "b" }]);
+        expect(results[2]).toEqual([{ value: "c" }]);
+      }),
+    );
+
+    it.effect("should handle concurrent writes in WAL mode", () =>
+      Effect.gen(function* () {
+        const count = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const scope = yield* Effect.scope;
+            const layer = testLayer(4);
+            yield* Scope.extend(layer, scope);
+
+            yield* runExec("CREATE TABLE IF NOT EXISTS conwrite (id INTEGER PRIMARY KEY, val TEXT)");
+
+            // Concurrent inserts
+            yield* Effect.all(
+              [1, 2, 3, 4, 5].map((i) =>
+                runExec("INSERT INTO conwrite (val) VALUES (?)", [`item-${i}`])
+              ),
+              { concurrency: 5 },
+            );
+
+            const rows = yield* runQuery("SELECT COUNT(*) as count FROM conwrite");
+            return rows[0]!.count as number;
+          }),
+        );
+        expect(count).toBe(5);
+      }),
+    );
+  });
+
+  describe("WAL mode", () => {
+    it.effect("should have WAL journal mode enabled", () =>
+      Effect.gen(function* () {
+        const rows = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const scope = yield* Effect.scope;
+            const layer = testLayer(1);
+            yield* Scope.extend(layer, scope);
+
+            return yield* runQuery("PRAGMA journal_mode");
+          }),
+        );
+
+        // `journal_mode` returns the current mode as a single-row result.
+        // WAL is always enabled by the service.
+        const mode = String(rows[0]?.journal_mode ?? rows[0]?.mode ?? "");
+        expect(mode.toLowerCase()).toBe("wal");
+      }),
+    );
+
+    it.effect("should have foreign keys enabled", () =>
+      Effect.gen(function* () {
+        const rows = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const scope = yield* Effect.scope;
+            const layer = testLayer(1);
+            yield* Scope.extend(layer, scope);
+
+            return yield* runQuery("PRAGMA foreign_keys");
+          }),
+        );
+
+        const fk = Number(rows[0]?.foreign_keys ?? rows[0]?.fk ?? 0);
+        expect(fk).toBe(1);
+      }),
+    );
+  });
+
+  describe("error handling", () => {
+    it.effect("should return DatabaseError on bad SQL", () =>
+      Effect.gen(function* () {
+        const error = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const scope = yield* Effect.scope;
+            const layer = testLayer(1);
+            yield* Scope.extend(layer, scope);
+
+            return yield* runExec("INVALID SQL HERE").pipe(Effect.flip);
+          }),
+        );
+
+        expect(error._tag).toBe("DatabaseError");
+      }),
+    );
+  });
+});

--- a/t3code/apps/server/src/services/DatabaseService.ts
+++ b/t3code/apps/server/src/services/DatabaseService.ts
@@ -1,0 +1,162 @@
+/**
+ * DatabaseService — Effect.Pool-based SQLite connection pooling with WAL mode.
+ *
+ * Provides a pool of `node:sqlite` connections for concurrent read/write access
+ * in WAL mode. Supports configurable pool size and graceful shutdown via
+ * Effect's Scope-based resource management.
+ *
+ * Each connection in the pool enables WAL journal mode and foreign keys.
+ * Pool lifecycle is fully managed by Effect.Scope — when the owning scope
+ * closes, all connections are gracefully closed.
+ *
+ * @module DatabaseService
+ */
+
+import * as Config from "effect/Config";
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Pool from "effect/Pool";
+import type * as Scope from "effect/Scope";
+import { DatabaseSync } from "node:sqlite";
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Service interface & tag
+// ---------------------------------------------------------------------------
+
+export interface DatabaseService {
+  /** Execute a SQL statement (INSERT, UPDATE, DELETE, DDL, PRAGMA, etc.). */
+  readonly exec: (
+    sql: string,
+    params?: ReadonlyArray<unknown>,
+  ) => Effect.Effect<void, DatabaseError>;
+
+  /** Run a SELECT query and return all rows as plain objects. */
+  readonly query: <T = Record<string, unknown>>(
+    sql: string,
+    params?: ReadonlyArray<unknown>,
+  ) => Effect.Effect<Array<T>, DatabaseError>;
+}
+
+export const DatabaseService = Context.Service<DatabaseService>(
+  "t3/DatabaseService",
+);
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface DatabaseServiceConfig {
+  readonly filename: string;
+  readonly poolSize: number;
+}
+
+export const DatabaseServiceConfig = Config.all({
+  filename: Config.string("DB_PATH").pipe(Config.withDefault(":memory:")),
+  poolSize: Config.integer("DB_POOL_SIZE").pipe(Config.withDefault(5)),
+});
+
+// ---------------------------------------------------------------------------
+// Layer constructor
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a `DatabaseService` layer backed by an Effect.Pool of `node:sqlite`
+ * connections.  Each connection enables WAL journal mode and foreign keys.
+ *
+ * Pool lifecycle is managed by Effect.Scope — when the scope closes all
+ * underlying `DatabaseSync` handles are closed via the release action of
+ * `Effect.acquireRelease`.
+ */
+export const makeDatabaseServiceLayer = (
+  config: DatabaseServiceConfig,
+): Layer.Layer<DatabaseService> =>
+  Layer.scopedContext(
+    Effect.map(
+      Pool.make({
+        acquire: Effect.acquireRelease(
+          Effect.sync(() => {
+            const db = new DatabaseSync(config.filename);
+            db.exec("PRAGMA journal_mode = WAL;");
+            db.exec("PRAGMA foreign_keys = ON;");
+            return db;
+          }),
+          (db) =>
+            Effect.sync(() => {
+              db.close();
+            }),
+        ),
+        size: config.poolSize,
+      }),
+      (pool): Context.Context<DatabaseService> => {
+        const service: DatabaseService = {
+          exec: (sql, params) =>
+            Effect.scoped(
+              Effect.flatMap(
+                Pool.get(pool),
+                (conn): Effect.Effect<void, DatabaseError> =>
+                  Effect.try({
+                    try: () => {
+                      if (params && params.length > 0) {
+                        conn.prepare(sql).run(...params);
+                      } else {
+                        conn.exec(sql);
+                      }
+                    },
+                    catch: (cause) =>
+                      new DatabaseError({
+                        message: "Failed to execute SQL",
+                        cause,
+                      }),
+                  }),
+              ),
+            ),
+
+          query: (sql, params) =>
+            Effect.scoped(
+              Effect.flatMap(
+                Pool.get(pool),
+                (conn): Effect.Effect<Array<Record<string, unknown>>, DatabaseError> =>
+                  Effect.try({
+                    try: () => {
+                      const stmt = conn.prepare(sql);
+                      if (params && params.length > 0) {
+                        return stmt.all(...params) as Array<Record<string, unknown>>;
+                      }
+                      return stmt.all() as Array<Record<string, unknown>>;
+                    },
+                    catch: (cause) =>
+                      new DatabaseError({
+                        message: "Failed to query SQL",
+                        cause,
+                      }),
+                  }),
+              ),
+            ),
+        };
+        return Context.make(DatabaseService, service);
+      },
+    ),
+  );
+
+/**
+ * Convenience layer that reads config from environment variables:
+ * - `DB_PATH` (default `:memory:`)
+ * - `DB_POOL_SIZE` (default `5`)
+ */
+export const DatabaseServiceLive: Layer.Layer<
+  DatabaseService,
+  Config.ConfigError
+> = Layer.unwrapEffect(
+  Effect.map(DatabaseServiceConfig, (cfg) => makeDatabaseServiceLayer(cfg)),
+);


### PR DESCRIPTION
```system
You are an expert TypeScript developer working on T3 Code, a minimal web GUI for coding agents. You specialize in Effect-TS v4 and SQLite optimization.
```

## Summary

Adds `DatabaseService` — an Effect.Pool-based SQLite connection pooling service for the T3 Code server.

### Changes

- **`DatabaseService.ts`** (new): Effect.Pool-backed SQLite connection pool using Node.js built-in `node:sqlite` (`DatabaseSync`)
- **`__tests__/DatabaseService.test.ts`** (new): Comprehensive test suite

### Features

- **Effect.Pool connection pooling** — configurable pool size (default: 5) for concurrent read/write access
- **WAL mode enabled** — every pooled connection runs `PRAGMA journal_mode = WAL` on creation
- **Foreign keys enforced** — `PRAGMA foreign_keys = ON` on every connection
- **Graceful shutdown** — pool lifecycle managed by Effect.Scope with `acquireRelease` finalizers that close all `DatabaseSync` handles
- **Error handling** — typed `DatabaseError` using `Data.TaggedError`

### API

```typescript
// Service tag
DatabaseService

// Methods
svc.exec(sql: string, params?: ReadonlyArray<unknown>): Effect<void, DatabaseError>
svc.query<T>(sql: string, params?: ReadonlyArray<unknown>): Effect<T[], DatabaseError>
```

### Configuration

| Environment Variable | Default | Description |
|---------------------|---------|-------------|
| `DB_PATH` | `:memory:` | Path to the SQLite database file |
| `DB_POOL_SIZE` | `5` | Number of connections in the pool |

### Tests

- Pool lifecycle (create, use, graceful shutdown)
- Concurrent queries (3 concurrent reads, 5 concurrent writes)
- WAL mode verification (`PRAGMA journal_mode` returns `"wal"`)
- Foreign keys enabled check
- Error handling (bad SQL returns `DatabaseError`)

Closes #858