### PR TITLE
OpenAI Codex [ FastAPI ] Implement standardized pagination support

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -18,6 +18,9 @@ from .param_functions import Header as Header
 from .param_functions import Path as Path
 from .param_functions import Query as Query
 from .param_functions import Security as Security
+from .pagination import PaginatedResponse as PaginatedResponse
+from .pagination import Paginator as Paginator
+from .pagination import paginate as paginate
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import math
+from collections.abc import Iterable, Sequence
+from typing import Annotated, Any, Generic, Literal, TypeVar, cast
+
+from pydantic import BaseModel
+
+from .exceptions import HTTPException
+from .param_functions import Query
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+class Paginator:
+    def __init__(
+        self,
+        page: int = 1,
+        page_size: int = 50,
+        cursor: str | None = None,
+        max_page_size: int = 100,
+    ) -> None:
+        if page < 1:
+            raise ValueError("page must be greater than or equal to 1")
+        if page_size < 1:
+            raise ValueError("page_size must be greater than or equal to 1")
+        if max_page_size < 1:
+            raise ValueError("max_page_size must be greater than or equal to 1")
+        if page_size > max_page_size:
+            raise ValueError(f"page_size must be less than or equal to {max_page_size}")
+
+        self.page = page
+        self.page_size = page_size
+        self.cursor = cursor
+        self.max_page_size = max_page_size
+        self._cursor_offset = self.decode_cursor(cursor) if cursor else None
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    @staticmethod
+    def encode_cursor(offset: int) -> str:
+        if offset < 0:
+            raise ValueError("cursor offset must be greater than or equal to 0")
+        payload = json.dumps({"offset": offset}, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+    @staticmethod
+    def decode_cursor(cursor: str) -> int:
+        try:
+            padded_cursor = cursor + "=" * (-len(cursor) % 4)
+            decoded = base64.urlsafe_b64decode(padded_cursor.encode("ascii"))
+            payload = json.loads(decoded.decode("utf-8"))
+            offset = payload["offset"]
+        except (
+            binascii.Error,
+            KeyError,
+            TypeError,
+            ValueError,
+            UnicodeDecodeError,
+        ) as exc:
+            raise ValueError("cursor must be a valid encoded pagination cursor") from exc
+
+        if not isinstance(offset, int) or offset < 0:
+            raise ValueError("cursor offset must be greater than or equal to 0")
+        return offset
+
+    def paginate(
+        self,
+        data_source: Sequence[T] | Iterable[T] | Any,
+        *,
+        total: int | None = None,
+        mode: Literal["offset", "cursor"] = "offset",
+        session: Any | None = None,
+    ) -> PaginatedResponse[T]:
+        if mode == "cursor":
+            return self.paginate_cursor(data_source, total=total, session=session)
+        if mode == "offset":
+            return self.paginate_offset(data_source, total=total, session=session)
+        raise ValueError("mode must be either 'offset' or 'cursor'")
+
+    def paginate_offset(
+        self,
+        data_source: Sequence[T] | Iterable[T] | Any,
+        *,
+        total: int | None = None,
+        session: Any | None = None,
+    ) -> PaginatedResponse[T]:
+        items, total_items = self._page_items(
+            data_source,
+            offset=self.offset,
+            limit=self.limit,
+            total=total,
+            session=session,
+        )
+        return self._build_response(
+            items=items,
+            total=total_items,
+            offset=self.offset,
+            next_cursor=None,
+            previous_cursor=None,
+        )
+
+    def paginate_cursor(
+        self,
+        data_source: Sequence[T] | Iterable[T] | Any,
+        *,
+        total: int | None = None,
+        session: Any | None = None,
+    ) -> PaginatedResponse[T]:
+        offset = self._cursor_offset if self._cursor_offset is not None else self.offset
+        items, total_items = self._page_items(
+            data_source,
+            offset=offset,
+            limit=self.limit,
+            total=total,
+            session=session,
+        )
+        next_offset = offset + self.page_size
+        previous_offset = max(offset - self.page_size, 0)
+        return self._build_response(
+            items=items,
+            total=total_items,
+            offset=offset,
+            next_cursor=(
+                self.encode_cursor(next_offset) if next_offset < total_items else None
+            ),
+            previous_cursor=(
+                self.encode_cursor(previous_offset) if offset > 0 else None
+            ),
+        )
+
+    def _build_response(
+        self,
+        *,
+        items: list[T],
+        total: int,
+        offset: int,
+        next_cursor: str | None,
+        previous_cursor: str | None,
+    ) -> PaginatedResponse[T]:
+        total_pages = math.ceil(total / self.page_size) if total else 0
+        page = (offset // self.page_size) + 1
+        return PaginatedResponse[T](
+            items=items,
+            total=total,
+            page=page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=offset + self.page_size < total,
+            has_previous=offset > 0,
+            next_cursor=next_cursor,
+            previous_cursor=previous_cursor,
+        )
+
+    def _page_items(
+        self,
+        data_source: Sequence[T] | Iterable[T] | Any,
+        *,
+        offset: int,
+        limit: int,
+        total: int | None,
+        session: Any | None,
+    ) -> tuple[list[T], int]:
+        if session is not None:
+            return self._page_sqlalchemy_select(
+                data_source, offset=offset, limit=limit, total=total, session=session
+            )
+
+        if self._is_sqlalchemy_query(data_source):
+            query = cast(Any, data_source)
+            total_items = total if total is not None else int(query.count())
+            return list(query.offset(offset).limit(limit).all()), total_items
+
+        if isinstance(data_source, Sequence):
+            total_items = total if total is not None else len(data_source)
+            return list(data_source[offset : offset + limit]), total_items
+
+        items = list(data_source)
+        total_items = total if total is not None else len(items)
+        return items[offset : offset + limit], total_items
+
+    def _page_sqlalchemy_select(
+        self,
+        statement: Any,
+        *,
+        offset: int,
+        limit: int,
+        total: int | None,
+        session: Any,
+    ) -> tuple[list[T], int]:
+        result = session.execute(statement.offset(offset).limit(limit))
+        rows = result.scalars() if hasattr(result, "scalars") else result
+        items = list(rows.all() if hasattr(rows, "all") else rows)
+        return items, total if total is not None else self._count_sqlalchemy_select(
+            statement, session=session
+        )
+
+    @staticmethod
+    def _count_sqlalchemy_select(statement: Any, *, session: Any) -> int:
+        try:
+            from sqlalchemy import func, select
+        except ImportError:
+            return 0
+
+        count_statement = select(func.count()).select_from(
+            statement.order_by(None).subquery()
+        )
+        return int(session.execute(count_statement).scalar_one())
+
+    @staticmethod
+    def _is_sqlalchemy_query(data_source: Any) -> bool:
+        return all(
+            callable(getattr(data_source, method, None))
+            for method in ("count", "offset", "limit", "all")
+        )
+
+
+def paginate(
+    page: Annotated[
+        int,
+        Query(
+            ge=1,
+            description="One-based page number used for offset pagination.",
+        ),
+    ] = 1,
+    page_size: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=100,
+            description="Number of items to return per page.",
+        ),
+    ] = 50,
+    cursor: Annotated[
+        str | None,
+        Query(
+            description="Encoded cursor returned by a previous cursor-paginated page.",
+        ),
+    ] = None,
+) -> Paginator:
+    try:
+        return Paginator(page=page, page_size=page_size, cursor=cursor)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,233 @@
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.pagination import PaginatedResponse, Paginator, paginate
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String, create_engine, select
+from sqlalchemy.orm import Session, declarative_base
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+ITEMS = [Item(id=index, name=f"item-{index}") for index in range(1, 8)]
+
+app = FastAPI()
+
+
+@app.get("/items", response_model=PaginatedResponse[Item])
+def read_items(paginator: Annotated[Paginator, Depends(paginate)]):
+    return paginator.paginate(ITEMS)
+
+
+@app.get("/cursor-items", response_model=PaginatedResponse[Item])
+def read_cursor_items(paginator: Annotated[Paginator, Depends(paginate)]):
+    return paginator.paginate(ITEMS, mode="cursor")
+
+
+@app.get("/empty", response_model=PaginatedResponse[Item])
+def read_empty(paginator: Annotated[Paginator, Depends(paginate)]):
+    return paginator.paginate([])
+
+
+client = TestClient(app)
+
+
+class FakeQuery:
+    def __init__(
+        self, items: list[Item], offset_value: int = 0, limit_value: int | None = None
+    ) -> None:
+        self.items = items
+        self.offset_value = offset_value
+        self.limit_value = limit_value
+
+    def count(self) -> int:
+        return len(self.items)
+
+    def offset(self, value: int) -> "FakeQuery":
+        return FakeQuery(self.items, offset_value=value, limit_value=self.limit_value)
+
+    def limit(self, value: int) -> "FakeQuery":
+        return FakeQuery(self.items, offset_value=self.offset_value, limit_value=value)
+
+    def all(self) -> list[Item]:
+        end = None
+        if self.limit_value is not None:
+            end = self.offset_value + self.limit_value
+        return self.items[self.offset_value : end]
+
+
+Base = declarative_base()
+
+
+class DbItem(Base):
+    __tablename__ = "pagination_test_items"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+def test_offset_pagination_calculates_skip_limit_and_totals():
+    response = client.get("/items?page=2&page_size=3")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "items": [
+            {"id": 4, "name": "item-4"},
+            {"id": 5, "name": "item-5"},
+            {"id": 6, "name": "item-6"},
+        ],
+        "total": 7,
+        "page": 2,
+        "page_size": 3,
+        "total_pages": 3,
+        "has_next": True,
+        "has_previous": True,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_offset_pagination_handles_last_page_boundary():
+    response = client.get("/items?page=3&page_size=3")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["has_next"] is False
+    assert response.json()["has_previous"] is True
+    assert response.json()["items"] == [{"id": 7, "name": "item-7"}]
+
+
+def test_paginate_dependency_rejects_invalid_query_values():
+    assert client.get("/items?page=0").status_code == 422
+    assert client.get("/items?page=-1").status_code == 422
+    assert client.get("/items?page_size=0").status_code == 422
+
+
+def test_empty_results_have_zero_totals_and_no_boundaries():
+    response = client.get("/empty?page=1&page_size=10")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "page_size": 10,
+        "total_pages": 0,
+        "has_next": False,
+        "has_previous": False,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_cursor_pagination_uses_encoded_next_and_previous_cursors():
+    first = client.get("/cursor-items?page_size=3")
+
+    assert first.status_code == 200, first.text
+    first_payload = first.json()
+    assert [item["id"] for item in first_payload["items"]] == [1, 2, 3]
+    assert first_payload["has_next"] is True
+    assert first_payload["has_previous"] is False
+    assert first_payload["next_cursor"] is not None
+    assert first_payload["previous_cursor"] is None
+    assert Paginator.decode_cursor(first_payload["next_cursor"]) == 3
+
+    second = client.get(
+        f"/cursor-items?page_size=3&cursor={first_payload['next_cursor']}"
+    )
+
+    assert second.status_code == 200, second.text
+    second_payload = second.json()
+    assert [item["id"] for item in second_payload["items"]] == [4, 5, 6]
+    assert second_payload["page"] == 2
+    assert second_payload["has_next"] is True
+    assert second_payload["has_previous"] is True
+    assert Paginator.decode_cursor(second_payload["next_cursor"]) == 6
+    assert Paginator.decode_cursor(second_payload["previous_cursor"]) == 0
+
+
+def test_cursor_pagination_handles_final_page_boundary():
+    cursor = Paginator.encode_cursor(6)
+    response = client.get(f"/cursor-items?page_size=3&cursor={cursor}")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["items"] == [{"id": 7, "name": "item-7"}]
+    assert payload["has_next"] is False
+    assert payload["has_previous"] is True
+    assert payload["next_cursor"] is None
+    assert Paginator.decode_cursor(payload["previous_cursor"]) == 3
+
+
+def test_invalid_cursor_returns_validation_error():
+    response = client.get("/cursor-items?page_size=3&cursor=not-a-real-cursor")
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "cursor must be a valid encoded pagination cursor"
+
+
+def test_direct_paginator_validation_handles_invalid_edges():
+    with pytest.raises(ValueError, match="page must be greater"):
+        Paginator(page=0)
+    with pytest.raises(ValueError, match="page_size must be greater"):
+        Paginator(page_size=0)
+    with pytest.raises(ValueError, match="page_size must be less"):
+        Paginator(page_size=101)
+
+
+def test_paginated_response_is_generic_for_pydantic_models():
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    schema_name = "PaginatedResponse_Item_"
+    assert schema_name in response.json()["components"]["schemas"]
+    assert response.json()["components"]["schemas"][schema_name]["properties"][
+        "items"
+    ] == {
+        "items": {"$ref": "#/components/schemas/Item"},
+        "title": "Items",
+        "type": "array",
+    }
+
+
+def test_sqlalchemy_style_query_sources_use_offset_limit_and_count():
+    paginator = Paginator(page=2, page_size=2)
+
+    response = paginator.paginate(FakeQuery(ITEMS))
+
+    assert [item.id for item in response.items] == [3, 4]
+    assert response.total == 7
+    assert response.page == 2
+    assert response.total_pages == 4
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_sqlalchemy_select_sources_calculate_total_with_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add_all([DbItem(id=index, name=f"item-{index}") for index in range(1, 6)])
+        session.commit()
+
+        paginator = Paginator(page=2, page_size=2)
+        response = paginator.paginate(
+            select(DbItem).order_by(DbItem.id), session=session
+        )
+
+    assert [item.id for item in response.items] == [3, 4]
+    assert response.total == 5
+    assert response.total_pages == 3
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_invalid_pagination_mode_is_rejected():
+    paginator = Paginator()
+
+    with pytest.raises(ValueError, match="mode must be either"):
+        paginator.paginate(ITEMS, mode="unknown")


### PR DESCRIPTION
```text
Task-specific prompt used for this bounty implementation (sanitized to exclude private platform/developer instructions):
Act as an AI coding agent working on UnsafeLabs/Bounty-Hunters issue #802. Implement a focused FastAPI pagination utility that provides a Paginator class, dependency-backed page/page_size/cursor query parameters, a generic PaginatedResponse model, offset pagination, cursor pagination with encoded cursors, SQLAlchemy/Pydantic-friendly data source handling, and tests for boundaries and edge cases. Keep the patch self-contained and verify the acceptance criteria before submitting a PR that claims the bounty.
```

/claim #802

Summary:
- Added `fastapi.pagination` with `Paginator`, `PaginatedResponse[T]`, and the injectable `paginate` dependency.
- Implemented offset pagination with accurate `offset`, `limit`, total pages, and boundary flags.
- Implemented cursor pagination with encoded next/previous cursors while keeping the standardized response fields.
- Added support for sequences, iterables, legacy SQLAlchemy-style query objects, and SQLAlchemy `select()` statements with a session-backed count query.
- Re-exported the pagination helpers from `fastapi.__init__` for ergonomic imports.

Demo video:
- https://raw.githubusercontent.com/Bjvsquare/Bounty-Hunters/codex/fastapi-pagination-demo/bounty-802-demo.mp4

Verification:
- `uv run pytest tests/test_pagination.py` -> 12 passed
- `uv run pytest tests/test_pagination.py -q` -> 12 passed
- `uv run ruff check fastapi/pagination.py tests/test_pagination.py` -> All checks passed
- `uv run mypy fastapi/pagination.py` -> Success: no issues found
- `uv run python -c "from fastapi import PaginatedResponse, Paginator, paginate; print(PaginatedResponse.__name__, Paginator(page=2, page_size=10).offset, callable(paginate))"` -> import smoke test passed
- `git diff --check` -> no whitespace errors; Git only reported line-ending normalization warnings on Windows