### PR TITLE
[ Hermes Agent ] [ FastAPI ] Add StreamingCSVResponse for large dataset exports

### DIFF
--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,5 +1,7 @@
+import csv
 import importlib
-from typing import Any, Protocol, cast
+from io import StringIO
+from typing import Any, AsyncGenerator, Protocol, Sequence, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
@@ -95,4 +97,96 @@ class ORJSONResponse(JSONResponse):
         assert orjson is not None, "orjson must be installed to use ORJSONResponse"
         return orjson.dumps(
             content, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
+        )
+
+
+def _escape_csv_value(value: Any, delimiter: str) -> str:
+    """Escape a single CSV value per RFC 4180."""
+    s = str(value) if value is not None else ""
+    needs_quoting = (
+        delimiter in s
+        or '"' in s
+        or "\n" in s
+        or "\r" in s
+        or "," in s
+    )
+    if needs_quoting:
+        escaped = s.replace('"', '""')
+        s = f'"{escaped}"'
+    return s
+
+
+async def _csv_row_generator(
+    headers: Sequence[str] | None,
+    rows: AsyncGenerator[Sequence[Any], None],
+    delimiter: str,
+) -> AsyncGenerator[bytes, None]:
+    """Generate CSV content as bytes from an async row generator."""
+    if headers:
+        header_line = delimiter.join(_escape_csv_value(h, delimiter) for h in headers)
+        yield (header_line + "\r\n").encode("utf-8")
+
+    async for row in rows:
+        values = [_escape_csv_value(v, delimiter) for v in row]
+        line = delimiter.join(values)
+        yield (line + "\r\n").encode("utf-8")
+
+
+class StreamingCSVResponse(StreamingResponse):
+    """
+    A streaming CSV response for large dataset exports.
+
+    Streams rows as CSV without loading the entire dataset into memory.
+    Supports RFC 4180 escaping, custom delimiters, and configurable filenames.
+
+    ## Example
+
+    ```python
+    from fastapi.responses import StreamingCSVResponse
+
+
+    async def generate_rows():
+        for i in range(1000000):
+            yield [i, f"item-{i}", "description"]
+
+    @app.get("/export.csv")
+    async def export_csv():
+        return StreamingCSVResponse(
+            rows=generate_rows(),
+            headers=["id", "name", "description"],
+            filename="export.csv",
+        )
+    ```
+    """
+
+    MEDIA_TYPE = "text/csv"
+
+    def __init__(
+        self,
+        rows: AsyncGenerator[Sequence[Any], None],
+        headers: Sequence[str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        **kwargs: Any,
+    ):
+        """
+        Create a streaming CSV response.
+
+        Args:
+            rows: Async generator yielding sequences (lists/tuples) of row values.
+            headers: Optional list of column names written as the first row.
+            filename: Filename in the Content-Disposition header.
+            delimiter: CSV delimiter character (default: comma).
+            status_code: HTTP status code (default: 200).
+        """
+        content = _csv_row_generator(headers, rows, delimiter)
+        super().__init__(
+            content=content,
+            status_code=status_code,
+            media_type=self.MEDIA_TYPE,
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+            },
+            **kwargs,
         )

--- a/tests/test_streaming_csv_response.py
+++ b/tests/test_streaming_csv_response.py
@@ -1,0 +1,132 @@
+"""Tests for StreamingCSVResponse."""
+
+from typing import Any, AsyncGenerator, Sequence
+
+import pytest
+from fastapi.responses import StreamingCSVResponse
+
+
+async def _async_rows(
+    rows: list[Sequence[Any]],
+) -> AsyncGenerator[Sequence[Any], None]:
+    for row in rows:
+        yield row
+
+
+class TestStreamingCSVResponse:
+    """Test suite for StreamingCSVResponse."""
+
+    @pytest.mark.asyncio
+    async def test_basic_csv_output(self):
+        """Basic CSV with headers produces correct output."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([[1, "Alice"], [2, "Bob"]]),
+            headers=["id", "name"],
+        )
+        content = b"".join([chunk async for chunk in response.body_iterator])
+        expected = b"id,name\r\n1,Alice\r\n2,Bob\r\n"
+        assert content == expected
+
+    @pytest.mark.asyncio
+    async def test_no_headers(self):
+        """CSV without headers works correctly."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([["a", 1], ["b", 2]]),
+        )
+        content = b"".join([chunk async for chunk in response.body_iterator])
+        expected = b"a,1\r\nb,2\r\n"
+        assert content == expected
+
+    @pytest.mark.asyncio
+    async def test_comma_in_value_is_quoted(self):
+        """Values containing commas are wrapped in double quotes."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([["hello, world", 42]]),
+            headers=["greeting", "number"],
+        )
+        content = b"".join([chunk async for chunk in response.body_iterator])
+        expected = b'greeting,number\r\n"hello, world",42\r\n'
+        assert content == expected
+
+    @pytest.mark.asyncio
+    async def test_quotes_in_value_are_escaped(self):
+        """Values containing double quotes have them escaped by doubling."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([['say "hello"', 42]]),
+            headers=["text", "value"],
+        )
+        content = b"".join([chunk async for chunk in response.body_iterator])
+        expected = b'text,value\r\n"say ""hello""",42\r\n'
+        assert content == expected
+
+    @pytest.mark.asyncio
+    async def test_newlines_in_value_are_quoted(self):
+        """Values containing newlines are wrapped in quotes."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([["line1\nline2", 99]]),
+            headers=["text", "num"],
+        )
+        content = b"".join([chunk async for chunk in response.body_iterator])
+        expected = b'text,num\r\n"line1\nline2",99\r\n'
+        assert content == expected
+
+    @pytest.mark.asyncio
+    async def test_custom_delimiter(self):
+        """Custom delimiter works correctly."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([["a", "b"], ["c", "d"]]),
+            headers=["col1", "col2"],
+            delimiter=";",
+        )
+        content = b"".join([chunk async for chunk in response.body_iterator])
+        expected = b"col1;col2\r\na;b\r\nc;d\r\n"
+        assert content == expected
+
+    @pytest.mark.asyncio
+    async def test_content_disposition_filename(self):
+        """Filename in Content-Disposition header is configurable."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([[1]]),
+            filename="my-export.csv",
+        )
+        assert response.headers["Content-Disposition"] == 'attachment; filename="my-export.csv"'
+
+    @pytest.mark.asyncio
+    async def test_content_type(self):
+        """Content-Type is set to text/csv."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([[1]]),
+        )
+        assert response.media_type == "text/csv"
+
+    @pytest.mark.asyncio
+    async def test_none_values_handled(self):
+        """None values are converted to empty strings."""
+        response = StreamingCSVResponse(
+            rows=_async_rows([[1, None, 3]]),
+            headers=["a", "b", "c"],
+        )
+        content = b"".join([chunk async for chunk in response.body_iterator])
+        expected = b"a,b,c\r\n1,,3\r\n"
+        assert content == expected
+
+    @pytest.mark.asyncio
+    async def test_streaming_no_full_load(self):
+        """Rows are streamed without loading entire dataset in memory."""
+        # Verify by creating a large generator and checking it's iterated lazily
+        called = 0
+
+        async def lazy_rows() -> AsyncGenerator[Sequence[Any], None]:
+            nonlocal called
+            for i in range(10):
+                called += 1
+                yield [i]
+
+        response = StreamingCSVResponse(
+            rows=lazy_rows(),
+            headers=["num"],
+        )
+        # Read only first chunk
+        async for chunk in response.body_iterator:
+            assert called <= 2  # Only first row(s) materialized
+            break


### PR DESCRIPTION
/claim #799

## Issue
Closes #799

## Summary
Add StreamingCSVResponse class for streaming CSV exports without loading entire datasets in memory.

## Acceptance criteria
- [x] StreamingCSVResponse streams rows without loading entire dataset in memory
- [x] Column headers are written as the first row when provided
- [x] Values containing commas are wrapped in double quotes
- [x] Values containing double quotes have them escaped by doubling
- [x] Custom delimiters work correctly
- [x] Filename in Content-Disposition header is configurable
- [x] Tests verify streaming behavior, escaping, and header output

## Demo
All 10 tests pass covering: basic CSV, no headers, comma escaping, quote escaping, newline handling, custom delimiters, Content-Disposition, Content-Type, None values, streaming behavior.