### PR TITLE
[Claude Code] [T3 Code] Add resizable sidebar width with drag handle and persisted width #840

### DIFF
--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -9,7 +9,9 @@ import {
 } from "../shortcutModifierState";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
-const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
+const THREAD_SIDEBAR_MIN_WIDTH = 200;
+const THREAD_SIDEBAR_MAX_WIDTH = 500;
+const THREAD_SIDEBAR_DEFAULT_WIDTH = 280;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
@@ -61,6 +63,8 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         className="border-r border-border bg-card text-foreground"
         resizable={{
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+          maxWidth: THREAD_SIDEBAR_MAX_WIDTH,
+          defaultWidth: THREAD_SIDEBAR_DEFAULT_WIDTH,
           shouldAcceptWidth: ({ nextWidth, wrapper }) =>
             wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
           storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,

--- a/t3code/apps/web/src/components/ui/sidebar.test.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.test.tsx
@@ -6,6 +6,8 @@ import {
   SidebarMenuButton,
   SidebarMenuSubButton,
   SidebarProvider,
+  clampSidebarWidth,
+  type SidebarResolvedResizableOptions,
 } from "./sidebar";
 
 function renderSidebarButton(className?: string) {
@@ -49,5 +51,34 @@ describe("sidebar interactive cursors", () => {
 
     expect(html).toContain('data-slot="sidebar-menu-sub-button"');
     expect(html).toContain("cursor-pointer");
+  });
+});
+
+describe("clampSidebarWidth", () => {
+  const makeOptions = (min: number, max: number): SidebarResolvedResizableOptions => ({
+    minWidth: min,
+    maxWidth: max,
+    defaultWidth: 280,
+    storageKey: null,
+  });
+
+  it("returns width when within min and max bounds", () => {
+    expect(clampSidebarWidth(300, makeOptions(200, 500))).toBe(300);
+  });
+
+  it("clamps to minWidth when width is below minimum", () => {
+    expect(clampSidebarWidth(100, makeOptions(200, 500))).toBe(200);
+  });
+
+  it("clamps to maxWidth when width is above maximum", () => {
+    expect(clampSidebarWidth(600, makeOptions(200, 500))).toBe(500);
+  });
+
+  it("returns minWidth when width equals the minimum", () => {
+    expect(clampSidebarWidth(200, makeOptions(200, 500))).toBe(200);
+  });
+
+  it("returns maxWidth when width equals the maximum", () => {
+    expect(clampSidebarWidth(500, makeOptions(200, 500))).toBe(500);
   });
 });

--- a/t3code/apps/web/src/components/ui/sidebar.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.tsx
@@ -41,6 +41,7 @@ type SidebarContextProps = {
 type SidebarResizableOptions = {
   maxWidth?: number;
   minWidth?: number;
+  defaultWidth?: number;
   onResize?: (width: number) => void;
   shouldAcceptWidth?: (context: {
     currentWidth: number;
@@ -56,6 +57,7 @@ type SidebarResizableOptions = {
 type SidebarResolvedResizableOptions = {
   maxWidth: number;
   minWidth: number;
+  defaultWidth: number;
   onResize?: (width: number) => void;
   shouldAcceptWidth?: (context: {
     currentWidth: number;
@@ -194,6 +196,7 @@ function Sidebar({
     return {
       maxWidth: options.maxWidth ?? Number.POSITIVE_INFINITY,
       minWidth: options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
+      defaultWidth: options.defaultWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
       storageKey: options.storageKey ?? null,
       ...(options.onResize ? { onResize: options.onResize } : {}),
       ...(options.shouldAcceptWidth ? { shouldAcceptWidth: options.shouldAcceptWidth } : {}),
@@ -331,7 +334,7 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
   );
 }
 
-function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptions): number {
+export function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptions): number {
   return Math.max(options.minWidth, Math.min(width, options.maxWidth));
 }
 
@@ -365,7 +368,7 @@ function SidebarRail({
   const resolvedResizable = sidebarInstance?.resizable ?? null;
   const canResize = resolvedResizable !== null && open;
   const railLabel = canResize ? "Resize Sidebar" : "Toggle Sidebar";
-  const railTitle = canResize ? "Drag to resize sidebar" : "Toggle Sidebar";
+  const railTitle = canResize ? "Drag to resize sidebar — double-click to reset" : "Toggle Sidebar";
 
   const stopResize = React.useCallback(
     (pointerId: number) => {
@@ -525,6 +528,21 @@ function SidebarRail({
     [endResizeInteraction, onPointerCancel],
   );
 
+  const handleDoubleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (!resolvedResizable || !open) return;
+      const wrapper = event.currentTarget.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
+      if (!wrapper) return;
+      const defaultWidth = clampSidebarWidth(resolvedResizable.defaultWidth, resolvedResizable);
+      wrapper.style.setProperty("--sidebar-width", `${defaultWidth}px`);
+      if (resolvedResizable.storageKey && typeof window !== "undefined") {
+        setLocalStorageItem(resolvedResizable.storageKey, defaultWidth, Schema.Finite);
+      }
+      resolvedResizable.onResize?.(defaultWidth);
+    },
+    [open, resolvedResizable],
+  );
+
   const handleClick = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       onClick?.(event);
@@ -576,17 +594,19 @@ function SidebarRail({
       aria-label={railLabel}
       className={cn(
         /* disable pointer events only when offcanvas sidebar is collapsed, that's when the rail sits over the native scrollbar on windows and linux. icon mode stays fully clickable. */
-        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex [[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none",
+        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex [[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none group-data-[collapsible=offcanvas]:active:after:bg-primary/40",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full",
+        "group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:active:bg-sidebar",
         "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        "hover:bg-sidebar-accent active:bg-sidebar-accent",
         className,
       )}
       data-sidebar="rail"
       data-slot="sidebar-rail"
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onPointerCancel={handlePointerCancel}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
@@ -999,3 +1019,4 @@ export {
   SidebarTrigger,
   useSidebar,
 };
+export type { SidebarResizableOptions, SidebarResolvedResizableOptions };


### PR DESCRIPTION
## Issue
Closes #840

## Summary
Adds resizable sidebar width support with 200–500px constraints, double-click to reset to 280px default, and hover/active visual feedback on the drag handle.

## Acceptance Criteria
- [x] Sidebar width is adjustable by dragging the right edge
- [x] Width is constrained between 200px min and 500px max
- [x] Width persists across page reloads via localStorage
- [x] Double-click resets to 280px default
- [x] Drag handle shows visual feedback on hover
- [x] Content reflows smoothly during drag without layout thrashing
- [x] Sidebar collapsed state is unaffected by this change
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

/claim #840