### PR TITLE
Codex [ T3 Code ] Fix ProviderModelPicker persistence

### DIFF
--- a/t3code/apps/web/src/components/chat/ChatComposer.tsx
+++ b/t3code/apps/web/src/components/chat/ChatComposer.tsx
@@ -1,0 +1,2409 @@
+import type {
+  ApprovalRequestId,
+  EnvironmentId,
+  ModelSelection,
+  ProjectEntry,
+  ProviderApprovalDecision,
+  ProviderInteractionMode,
+  ResolvedKeybindingsConfig,
+  RuntimeMode,
+  ScopedThreadRef,
+  ServerProvider,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+} from "@t3tools/contracts";
+import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useDebouncedValue } from "@tanstack/react-pacer";
+import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
+import {
+  clampCollapsedComposerCursor,
+  type ComposerTrigger,
+  collapseExpandedComposerCursor,
+  detectComposerTrigger,
+  expandCollapsedComposerCursor,
+  replaceTextRange,
+} from "../../composer-logic";
+import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
+import {
+  type ComposerImageAttachment,
+  type DraftId,
+  type PersistedComposerImageAttachment,
+  useComposerDraftStore,
+  useComposerThreadDraft,
+  useEffectiveComposerModelState,
+} from "../../composerDraftStore";
+import {
+  type TerminalContextDraft,
+  type TerminalContextSelection,
+  insertInlineTerminalContextPlaceholder,
+  removeInlineTerminalContextPlaceholder,
+} from "../../lib/terminalContext";
+import {
+  shouldUseCompactComposerPrimaryActions,
+  shouldUseCompactComposerFooter,
+} from "../composerFooterLayout";
+import { type ComposerPromptEditorHandle, ComposerPromptEditor } from "../ComposerPromptEditor";
+import { ProviderModelPicker } from "./ProviderModelPicker";
+import { type ComposerCommandItem, ComposerCommandMenu } from "./ComposerCommandMenu";
+import { ComposerPendingApprovalActions } from "./ComposerPendingApprovalActions";
+import { CompactComposerControlsMenu } from "./CompactComposerControlsMenu";
+import { ComposerPrimaryActions } from "./ComposerPrimaryActions";
+import { ComposerPendingApprovalPanel } from "./ComposerPendingApprovalPanel";
+import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
+import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
+import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
+import { searchSlashCommandItems } from "./composerSlashCommandSearch";
+import {
+  getComposerProviderState,
+  renderProviderTraitsMenuContent,
+  renderProviderTraitsPicker,
+} from "./composerProviderState";
+import { ContextWindowMeter } from "./ContextWindowMeter";
+import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
+import { basenameOfPath } from "../../vscode-icons";
+import { cn, randomUUID } from "~/lib/utils";
+import { Separator } from "../ui/separator";
+import { Button } from "../ui/button";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { toastManager } from "../ui/toast";
+import {
+  BotIcon,
+  CircleAlertIcon,
+  ListTodoIcon,
+  type LucideIcon,
+  LockIcon,
+  LockOpenIcon,
+  PenLineIcon,
+  XIcon,
+} from "lucide-react";
+import { proposedPlanTitle } from "../../proposedPlan";
+import { getProviderInteractionModeToggle } from "../../providerModels";
+import {
+  deriveProviderInstanceEntries,
+  resolveProviderDriverKindForInstanceSelection,
+  sortProviderInstanceEntries,
+  type ProviderInstanceEntry,
+} from "../../providerInstances";
+import { type AppModelOption, getAppModelOptionsForInstance } from "../../modelSelection";
+import type { UnifiedSettings } from "@t3tools/contracts/settings";
+import type { SessionPhase, Thread } from "../../types";
+import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
+import type { PendingApproval, PendingUserInput } from "../../session-logic";
+import { deriveLatestContextWindowSnapshot } from "../../lib/contextWindow";
+import { formatProviderSkillDisplayName } from "../../providerSkillPresentation";
+import { searchProviderSkills } from "../../providerSkillSearch";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
+
+const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
+
+const runtimeModeConfig: Record<
+  RuntimeMode,
+  { label: string; description: string; icon: LucideIcon }
+> = {
+  "approval-required": {
+    label: "Supervised",
+    description: "Ask before commands and file changes.",
+    icon: LockIcon,
+  },
+  "auto-accept-edits": {
+    label: "Auto-accept edits",
+    description: "Auto-approve edits, ask before other actions.",
+    icon: PenLineIcon,
+  },
+  "full-access": {
+    label: "Full access",
+    description: "Allow commands and edits without prompts.",
+    icon: LockOpenIcon,
+  },
+};
+
+const runtimeModeOptions = Object.keys(runtimeModeConfig) as RuntimeMode[];
+const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
+const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
+const COMPOSER_FLOATING_LAYER_SELECTOR = [
+  '[data-slot="popover-popup"]',
+  '[data-slot="menu-popup"]',
+  '[data-slot="select-popup"]',
+  '[data-slot="combobox-popup"]',
+  '[data-slot="autocomplete-popup"]',
+].join(",");
+
+const extendReplacementRangeForTrailingSpace = (
+  text: string,
+  rangeEnd: number,
+  replacement: string,
+): number => {
+  if (!replacement.endsWith(" ")) {
+    return rangeEnd;
+  }
+  return text[rangeEnd] === " " ? rangeEnd + 1 : rangeEnd;
+};
+
+const syncTerminalContextsByIds = (
+  contexts: ReadonlyArray<TerminalContextDraft>,
+  ids: ReadonlyArray<string>,
+): TerminalContextDraft[] => {
+  const contextsById = new Map(contexts.map((context) => [context.id, context]));
+  return ids.flatMap((id) => {
+    const context = contextsById.get(id);
+    return context ? [context] : [];
+  });
+};
+
+const terminalContextIdListsEqual = (
+  contexts: ReadonlyArray<TerminalContextDraft>,
+  ids: ReadonlyArray<string>,
+): boolean =>
+  contexts.length === ids.length && contexts.every((context, index) => context.id === ids[index]);
+
+function isInsideComposerFloatingLayer(element: Element): boolean {
+  return element.closest(COMPOSER_FLOATING_LAYER_SELECTOR) !== null;
+}
+
+const ComposerFooterModeControls = memo(function ComposerFooterModeControls(props: {
+  showInteractionModeToggle: boolean;
+  interactionMode: ProviderInteractionMode;
+  runtimeMode: RuntimeMode;
+  showPlanToggle: boolean;
+  planSidebarLabel: string;
+  planSidebarOpen: boolean;
+  onToggleInteractionMode: () => void;
+  onRuntimeModeChange: (mode: RuntimeMode) => void;
+  onTogglePlanSidebar: () => void;
+}) {
+  const runtimeModeOption = runtimeModeConfig[props.runtimeMode];
+  const RuntimeModeIcon = runtimeModeOption.icon;
+
+  return (
+    <>
+      <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+
+      {props.showInteractionModeToggle ? (
+        <>
+          <Button
+            variant="ghost"
+            className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
+            size="sm"
+            type="button"
+            onClick={props.onToggleInteractionMode}
+            title={
+              props.interactionMode === "plan"
+                ? "Plan mode — click to return to normal build mode"
+                : "Default mode — click to enter plan mode"
+            }
+          >
+            <BotIcon />
+            <span className="sr-only sm:not-sr-only">
+              {props.interactionMode === "plan" ? "Plan" : "Build"}
+            </span>
+          </Button>
+
+          <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+        </>
+      ) : null}
+
+      <Select
+        value={props.runtimeMode}
+        onValueChange={(value) => props.onRuntimeModeChange(value!)}
+      >
+        <SelectTrigger
+          variant="ghost"
+          size="sm"
+          className="font-medium"
+          aria-label="Runtime mode"
+          title={runtimeModeOption.description}
+        >
+          <RuntimeModeIcon className="size-4" />
+          <SelectValue>{runtimeModeOption.label}</SelectValue>
+        </SelectTrigger>
+        <SelectPopup alignItemWithTrigger={false}>
+          {runtimeModeOptions.map((mode) => {
+            const option = runtimeModeConfig[mode];
+            const OptionIcon = option.icon;
+            return (
+              <SelectItem key={mode} value={mode} className="min-w-64 py-2">
+                <div className="grid min-w-0 gap-0.5">
+                  <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+                    <OptionIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                    {option.label}
+                  </span>
+                  <span className="text-muted-foreground text-xs leading-4">
+                    {option.description}
+                  </span>
+                </div>
+              </SelectItem>
+            );
+          })}
+        </SelectPopup>
+      </Select>
+
+      {props.showPlanToggle ? (
+        <>
+          <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+          <Button
+            variant="ghost"
+            className={cn(
+              "shrink-0 whitespace-nowrap px-2 sm:px-3",
+              props.planSidebarOpen
+                ? "text-blue-400 hover:text-blue-300"
+                : "text-muted-foreground/70 hover:text-foreground/80",
+            )}
+            size="sm"
+            type="button"
+            onClick={props.onTogglePlanSidebar}
+            title={
+              props.planSidebarOpen
+                ? `Hide ${props.planSidebarLabel.toLowerCase()} sidebar`
+                : `Show ${props.planSidebarLabel.toLowerCase()} sidebar`
+            }
+          >
+            <ListTodoIcon />
+            <span className="sr-only sm:not-sr-only">{props.planSidebarLabel}</span>
+          </Button>
+        </>
+      ) : null}
+    </>
+  );
+});
+
+const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(props: {
+  compact: boolean;
+  activeContextWindow: ReturnType<typeof deriveLatestContextWindowSnapshot>;
+  isPreparingWorktree: boolean;
+  pendingAction: {
+    questionIndex: number;
+    isLastQuestion: boolean;
+    canAdvance: boolean;
+    isResponding: boolean;
+    isComplete: boolean;
+  } | null;
+  isRunning: boolean;
+  showPlanFollowUpPrompt: boolean;
+  promptHasText: boolean;
+  isSendBusy: boolean;
+  isConnecting: boolean;
+  isEnvironmentUnavailable: boolean;
+  hasSendableContent: boolean;
+  preserveComposerFocusOnPointerDown?: boolean;
+  onPreviousPendingQuestion: () => void;
+  onInterrupt: () => void;
+  onImplementPlanInNewThread: () => void;
+}) {
+  return (
+    <>
+      {props.activeContextWindow ? <ContextWindowMeter usage={props.activeContextWindow} /> : null}
+      {props.isPreparingWorktree ? (
+        <span className="text-muted-foreground/70 text-xs">Preparing worktree...</span>
+      ) : null}
+      <ComposerPrimaryActions
+        compact={props.compact}
+        pendingAction={props.pendingAction}
+        isRunning={props.isRunning}
+        showPlanFollowUpPrompt={props.showPlanFollowUpPrompt}
+        promptHasText={props.promptHasText}
+        isSendBusy={props.isSendBusy}
+        isConnecting={props.isConnecting}
+        isEnvironmentUnavailable={props.isEnvironmentUnavailable}
+        isPreparingWorktree={props.isPreparingWorktree}
+        hasSendableContent={props.hasSendableContent}
+        preserveComposerFocusOnPointerDown={props.preserveComposerFocusOnPointerDown ?? false}
+        onPreviousPendingQuestion={props.onPreviousPendingQuestion}
+        onInterrupt={props.onInterrupt}
+        onImplementPlanInNewThread={props.onImplementPlanInNewThread}
+      />
+    </>
+  );
+});
+
+// --------------------------------------------------------------------------
+// Handle exposed to ChatView
+// --------------------------------------------------------------------------
+
+export interface ChatComposerHandle {
+  focusAtEnd: () => void;
+  focusAt: (cursor: number) => void;
+  openModelPicker: () => void;
+  toggleModelPicker: () => void;
+  isModelPickerOpen: () => boolean;
+  readSnapshot: () => {
+    value: string;
+    cursor: number;
+    expandedCursor: number;
+    terminalContextIds: string[];
+  };
+  /** Reset composer cursor/trigger/highlight after external prompt mutations (e.g. onSend). */
+  resetCursorState: (options?: {
+    cursor?: number;
+    prompt?: string;
+    detectTrigger?: boolean;
+  }) => void;
+  /** Insert a terminal context from the terminal drawer. */
+  addTerminalContext: (selection: TerminalContextSelection) => void;
+  /** Get the current prompt/effort/model state for use in send. */
+  getSendContext: () => {
+    prompt: string;
+    images: ComposerImageAttachment[];
+    terminalContexts: TerminalContextDraft[];
+    selectedPromptEffort: string | null;
+    selectedModelOptionsForDispatch: unknown;
+    selectedModelSelection: ModelSelection;
+    selectedProvider: ProviderDriverKind;
+    selectedModel: string;
+    selectedProviderModels: ReadonlyArray<ServerProvider["models"][number]>;
+  };
+}
+
+// --------------------------------------------------------------------------
+// Props
+// --------------------------------------------------------------------------
+
+export interface ChatComposerProps {
+  composerDraftTarget: ScopedThreadRef | DraftId;
+  environmentId: EnvironmentId;
+  routeKind: "server" | "draft";
+  routeThreadRef: ScopedThreadRef;
+  draftId: DraftId | null;
+
+  // Thread context
+  activeThreadId: ThreadId | null;
+  activeThreadEnvironmentId: EnvironmentId | undefined;
+  activeThread: Thread | undefined;
+  isServerThread: boolean;
+  isLocalDraftThread: boolean;
+
+  // Session phase
+  phase: SessionPhase;
+  isConnecting: boolean;
+  isSendBusy: boolean;
+  isPreparingWorktree: boolean;
+  environmentUnavailable: {
+    readonly label: string;
+    readonly connectionState: "connecting" | "disconnected" | "error";
+  } | null;
+
+  // Pending approvals / inputs
+  activePendingApproval: PendingApproval | null;
+  pendingApprovals: PendingApproval[];
+  pendingUserInputs: PendingUserInput[];
+  activePendingProgress: {
+    questionIndex: number;
+    isLastQuestion: boolean;
+    canAdvance: boolean;
+    customAnswer: string;
+    activeQuestion: { id: string; multiSelect?: boolean | undefined } | null;
+  } | null;
+  activePendingResolvedAnswers: Record<string, unknown> | null;
+  activePendingIsResponding: boolean;
+  activePendingDraftAnswers: Record<string, PendingUserInputDraftAnswer>;
+  activePendingQuestionIndex: number;
+  respondingRequestIds: ApprovalRequestId[];
+
+  // Plan
+  showPlanFollowUpPrompt: boolean;
+  activeProposedPlan: Thread["proposedPlans"][number] | null;
+  activePlan: { turnId?: TurnId } | null;
+  sidebarProposedPlan: { turnId?: TurnId } | null;
+  planSidebarLabel: string;
+  planSidebarOpen: boolean;
+
+  // Mode
+  runtimeMode: RuntimeMode;
+  interactionMode: ProviderInteractionMode;
+
+  // Provider / model
+  lockedProvider: ProviderDriverKind | null;
+  providerStatuses: ServerProvider[];
+  activeProjectDefaultModelSelection: ModelSelection | null | undefined;
+  activeThreadModelSelection: ModelSelection | null | undefined;
+
+  // Context window
+  activeThreadActivities: Thread["activities"] | undefined;
+
+  // Misc
+  resolvedTheme: "light" | "dark";
+  settings: UnifiedSettings;
+  keybindings: ResolvedKeybindingsConfig;
+  terminalOpen: boolean;
+  gitCwd: string | null;
+
+  // Refs the parent needs kept in sync
+  promptRef: React.RefObject<string>;
+  composerImagesRef: React.RefObject<ComposerImageAttachment[]>;
+  composerTerminalContextsRef: React.RefObject<TerminalContextDraft[]>;
+  composerRef: React.RefObject<ChatComposerHandle | null>;
+
+  // Scroll
+  shouldAutoScrollRef: React.RefObject<boolean>;
+  scheduleStickToBottom: () => void;
+
+  // Callbacks
+  onSend: (e?: { preventDefault: () => void }) => void;
+  onInterrupt: () => void;
+  onImplementPlanInNewThread: () => void;
+  onRespondToApproval: (
+    requestId: ApprovalRequestId,
+    decision: ProviderApprovalDecision,
+  ) => Promise<void>;
+  onSelectActivePendingUserInputOption: (questionId: string, optionLabel: string) => void;
+  onAdvanceActivePendingUserInput: () => void;
+  onPreviousActivePendingUserInputQuestion: () => void;
+  onChangeActivePendingUserInputCustomAnswer: (
+    questionId: string,
+    value: string,
+    nextCursor: number,
+    expandedCursor: number,
+    cursorAdjacentToMention: boolean,
+  ) => void;
+
+  onProviderModelSelect: (instanceId: ProviderInstanceId, model: string) => void;
+  toggleInteractionMode: () => void;
+  handleRuntimeModeChange: (mode: RuntimeMode) => void;
+  handleInteractionModeChange: (mode: ProviderInteractionMode) => void;
+  togglePlanSidebar: () => void;
+
+  focusComposer: () => void;
+  scheduleComposerFocus: () => void;
+  setThreadError: (threadId: ThreadId | null, error: string | null) => void;
+  onExpandImage: (preview: ExpandedImagePreview) => void;
+}
+
+// --------------------------------------------------------------------------
+// Component
+// --------------------------------------------------------------------------
+
+export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps) {
+  const {
+    composerDraftTarget,
+    environmentId,
+    routeKind,
+    routeThreadRef,
+    draftId,
+    activeThreadId,
+    activeThreadEnvironmentId: _activeThreadEnvironmentId,
+    activeThread,
+    isServerThread: _isServerThread,
+    isLocalDraftThread: _isLocalDraftThread,
+    phase,
+    isConnecting,
+    isSendBusy,
+    isPreparingWorktree,
+    environmentUnavailable,
+    activePendingApproval,
+    pendingApprovals,
+    pendingUserInputs,
+    activePendingProgress,
+    activePendingResolvedAnswers,
+    activePendingIsResponding,
+    activePendingDraftAnswers,
+    activePendingQuestionIndex,
+    respondingRequestIds,
+    showPlanFollowUpPrompt,
+    activeProposedPlan,
+    activePlan,
+    sidebarProposedPlan,
+    planSidebarLabel,
+    planSidebarOpen,
+    runtimeMode,
+    interactionMode,
+    lockedProvider,
+    providerStatuses,
+    activeProjectDefaultModelSelection,
+    activeThreadModelSelection,
+    activeThreadActivities,
+    resolvedTheme,
+    settings,
+    keybindings,
+    terminalOpen,
+    gitCwd,
+    promptRef,
+    composerRef,
+    composerImagesRef,
+    composerTerminalContextsRef,
+    shouldAutoScrollRef,
+    scheduleStickToBottom,
+    onSend,
+    onInterrupt,
+    onImplementPlanInNewThread,
+    onRespondToApproval,
+    onSelectActivePendingUserInputOption,
+    onAdvanceActivePendingUserInput,
+    onPreviousActivePendingUserInputQuestion,
+    onChangeActivePendingUserInputCustomAnswer,
+    onProviderModelSelect,
+    toggleInteractionMode,
+    handleRuntimeModeChange,
+    handleInteractionModeChange,
+    togglePlanSidebar,
+    focusComposer,
+    scheduleComposerFocus,
+    setThreadError,
+    onExpandImage,
+  } = props;
+
+  // ------------------------------------------------------------------
+  // Store subscriptions (prompt / images / terminal contexts)
+  // ------------------------------------------------------------------
+  const composerDraft = useComposerThreadDraft(composerDraftTarget);
+  const prompt = composerDraft.prompt;
+  const composerImages = composerDraft.images;
+  const composerTerminalContexts = composerDraft.terminalContexts;
+  const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
+
+  const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
+  const addComposerDraftImage = useComposerDraftStore((store) => store.addImage);
+  const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
+  const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
+  const insertComposerDraftTerminalContext = useComposerDraftStore(
+    (store) => store.insertTerminalContext,
+  );
+  const removeComposerDraftTerminalContext = useComposerDraftStore(
+    (store) => store.removeTerminalContext,
+  );
+  const setComposerDraftTerminalContexts = useComposerDraftStore(
+    (store) => store.setTerminalContexts,
+  );
+  const clearComposerDraftPersistedAttachments = useComposerDraftStore(
+    (store) => store.clearPersistedAttachments,
+  );
+  const syncComposerDraftPersistedAttachments = useComposerDraftStore(
+    (store) => store.syncPersistedAttachments,
+  );
+  const getComposerDraft = useComposerDraftStore((store) => store.getComposerDraft);
+
+  // ------------------------------------------------------------------
+  // Model state
+  // ------------------------------------------------------------------
+  // Instance-aware projection of the wire provider list. One entry per
+  // configured instance (default built-in + any custom `providerInstances.*`),
+  // sorted default-first per driver kind for a stable picker order.
+  const providerInstanceEntries = useMemo<ReadonlyArray<ProviderInstanceEntry>>(
+    () => sortProviderInstanceEntries(deriveProviderInstanceEntries(providerStatuses)),
+    [providerStatuses],
+  );
+  const selectedProviderByThreadId = composerDraft.activeProvider ?? null;
+  const threadProvider =
+    activeThread?.session?.providerInstanceId ??
+    activeThreadModelSelection?.instanceId ??
+    activeProjectDefaultModelSelection?.instanceId ??
+    null;
+  const explicitSelectedInstanceId = selectedProviderByThreadId ?? threadProvider;
+
+  const unlockedSelectedProvider =
+    resolveProviderDriverKindForInstanceSelection(
+      providerInstanceEntries,
+      providerStatuses,
+      explicitSelectedInstanceId,
+    ) ?? ProviderDriverKind.make("codex");
+  const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
+  const lockedContinuationGroupKey = useMemo((): string | null => {
+    if (!lockedProvider || !activeThread) return null;
+    const lockedInstanceId =
+      activeThread.session?.providerInstanceId ?? activeThreadModelSelection?.instanceId;
+    if (!lockedInstanceId) return null;
+    return (
+      providerInstanceEntries.find((entry) => entry.instanceId === lockedInstanceId)
+        ?.continuationGroupKey ?? null
+    );
+  }, [
+    activeThread,
+    activeThreadModelSelection?.instanceId,
+    lockedProvider,
+    providerInstanceEntries,
+  ]);
+
+  // Resolve which configured instance the composer is currently targeting.
+  // Priority:
+  //   1. The composer draft's `activeProvider` — the user's unsaved pick
+  //      from the model picker (must win, otherwise the UI appears to
+  //      ignore picker selections).
+  //   2. Thread's persisted instance id (server-side saved selection).
+  //   3. Project default's instance id.
+  //   4. First enabled entry matching the current driver kind.
+  //   5. First enabled entry overall / default instance for the kind.
+  //
+  const selectedInstanceId = useMemo<ProviderInstanceId>(() => {
+    const candidates: Array<string | null | undefined> = [
+      composerDraft.activeProvider,
+      activeThread?.session?.providerInstanceId,
+      activeThreadModelSelection?.instanceId,
+      activeProjectDefaultModelSelection?.instanceId,
+    ];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      const match = providerInstanceEntries.find(
+        (entry) => entry.instanceId === candidate && entry.enabled,
+      );
+      if (match) {
+        // When locked to a specific driver kind, ignore persisted instance
+        // ids from a different kind or continuation group.
+        if (lockedProvider && match.driverKind !== lockedProvider) continue;
+        if (
+          lockedContinuationGroupKey &&
+          match.continuationGroupKey !== lockedContinuationGroupKey
+        ) {
+          continue;
+        }
+        return match.instanceId;
+      }
+    }
+    if (explicitSelectedInstanceId) {
+      return ProviderInstanceId.make(explicitSelectedInstanceId);
+    }
+    const byKind = providerInstanceEntries.find(
+      (entry) =>
+        entry.enabled &&
+        entry.driverKind === selectedProvider &&
+        (!lockedContinuationGroupKey || entry.continuationGroupKey === lockedContinuationGroupKey),
+    );
+    if (byKind) return byKind.instanceId;
+    const anyEnabled = providerInstanceEntries.find((entry) => entry.enabled);
+    return (
+      anyEnabled?.instanceId ??
+      providerInstanceEntries[0]?.instanceId ??
+      activeThreadModelSelection?.instanceId ??
+      activeProjectDefaultModelSelection?.instanceId ??
+      ProviderInstanceId.make("codex")
+    );
+  }, [
+    activeProjectDefaultModelSelection?.instanceId,
+    activeThread?.session?.providerInstanceId,
+    activeThreadModelSelection?.instanceId,
+    composerDraft.activeProvider,
+    explicitSelectedInstanceId,
+    lockedContinuationGroupKey,
+    lockedProvider,
+    providerInstanceEntries,
+    selectedProvider,
+  ]);
+
+  const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({
+    threadRef: composerDraftTarget,
+    providers: providerStatuses,
+    selectedProvider,
+    selectedInstanceId,
+    threadModelSelection: activeThreadModelSelection,
+    projectModelSelection: activeProjectDefaultModelSelection,
+    settings,
+  });
+
+  // Resolve the active instance's snapshot by `instanceId` so a custom
+  // instance gets its own slash commands, skills, and model list — not
+  // the first snapshot for the same driver kind.
+  const selectedProviderEntry = useMemo(
+    () => providerInstanceEntries.find((entry) => entry.instanceId === selectedInstanceId),
+    [providerInstanceEntries, selectedInstanceId],
+  );
+  const selectedProviderStatus = useMemo(
+    () => selectedProviderEntry?.snapshot ?? null,
+    [selectedProviderEntry],
+  );
+  const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
+    () => selectedProviderEntry?.models ?? [],
+    [selectedProviderEntry],
+  );
+
+  const composerProviderState = useMemo(
+    () =>
+      getComposerProviderState({
+        provider: selectedProvider,
+        model: selectedModel,
+        models: selectedProviderModels,
+        prompt,
+        modelOptions: composerModelOptions?.[selectedProvider],
+      }),
+    [composerModelOptions, prompt, selectedModel, selectedProvider, selectedProviderModels],
+  );
+
+  const selectedPromptEffort = composerProviderState.promptEffort;
+  const selectedModelOptionsForDispatch = composerProviderState.modelOptionsForDispatch;
+  const composerProviderControls = useMemo(
+    () => ({
+      showInteractionModeToggle: getProviderInteractionModeToggle(
+        providerStatuses,
+        selectedProvider,
+      ),
+    }),
+    [providerStatuses, selectedProvider],
+  );
+  const selectedModelSelection = useMemo<ModelSelection>(
+    () => createModelSelection(selectedInstanceId, selectedModel, selectedModelOptionsForDispatch),
+    [selectedInstanceId, selectedModel, selectedModelOptionsForDispatch],
+  );
+  const selectedModelForPicker = selectedModel;
+  // Instance-keyed option list so the picker can show each configured
+  // instance (built-in + custom) as a first-class sidebar entry. The
+  // options are server-reported models plus that exact instance's
+  // configured custom models; selected slugs are not injected into lists.
+  const modelOptionsByInstance = useMemo<
+    ReadonlyMap<ProviderInstanceId, ReadonlyArray<AppModelOption>>
+  >(() => {
+    const out = new Map<ProviderInstanceId, ReadonlyArray<AppModelOption>>();
+    for (const entry of providerInstanceEntries) {
+      out.set(entry.instanceId, getAppModelOptionsForInstance(settings, entry));
+    }
+    return out;
+  }, [providerInstanceEntries, settings]);
+  const selectedModelForPickerWithCustomFallback = useMemo(() => {
+    const currentOptions = modelOptionsByInstance.get(selectedInstanceId) ?? [];
+    return currentOptions.some((option) => option.slug === selectedModelForPicker)
+      ? selectedModelForPicker
+      : (normalizeModelSlug(selectedModelForPicker, selectedProvider) ?? selectedModelForPicker);
+  }, [modelOptionsByInstance, selectedInstanceId, selectedModelForPicker, selectedProvider]);
+
+  // ------------------------------------------------------------------
+  // Context window
+  // ------------------------------------------------------------------
+  const activeContextWindow = useMemo(
+    () => deriveLatestContextWindowSnapshot(activeThreadActivities ?? []),
+    [activeThreadActivities],
+  );
+
+  // ------------------------------------------------------------------
+  // Composer-local state
+  // ------------------------------------------------------------------
+  const [composerCursor, setComposerCursor] = useState(() =>
+    collapseExpandedComposerCursor(prompt, prompt.length),
+  );
+  const [composerTrigger, setComposerTrigger] = useState<ComposerTrigger | null>(() =>
+    detectComposerTrigger(prompt, prompt.length),
+  );
+  const [composerHighlightedItemId, setComposerHighlightedItemId] = useState<string | null>(null);
+  const [composerHighlightedSearchKey, setComposerHighlightedSearchKey] = useState<string | null>(
+    null,
+  );
+  const [isDragOverComposer, setIsDragOverComposer] = useState(false);
+  const [isComposerFooterCompact, setIsComposerFooterCompact] = useState(false);
+  const [isComposerPrimaryActionsCompact, setIsComposerPrimaryActionsCompact] = useState(false);
+  const [isComposerModelPickerOpen, setIsComposerModelPickerOpen] = useState(false);
+  const [isComposerFocused, setIsComposerFocused] = useState(false);
+  const isMobileViewport = useMediaQuery("max-sm");
+  const isComposerCollapsedMobile = isMobileViewport && !isComposerFocused;
+
+  // ------------------------------------------------------------------
+  // Refs
+  // ------------------------------------------------------------------
+  const composerEditorRef = useRef<ComposerPromptEditorHandle>(null);
+  const composerFormRef = useRef<HTMLFormElement>(null);
+  const composerSurfaceRef = useRef<HTMLDivElement>(null);
+  const composerFormHeightRef = useRef(0);
+  const composerSelectLockRef = useRef(false);
+  const composerMenuOpenRef = useRef(false);
+  const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
+  const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
+  const composerBlurFrameRef = useRef<number | null>(null);
+  const mobileComposerExpandFrameRef = useRef<number | null>(null);
+  const mobileComposerExpandReleaseFrameRef = useRef<number | null>(null);
+  const mobileComposerExpandInFlightRef = useRef(false);
+  const dragDepthRef = useRef(0);
+
+  // ------------------------------------------------------------------
+  // Derived: composer send state
+  // ------------------------------------------------------------------
+  const composerSendState = useMemo(
+    () =>
+      deriveComposerSendState({
+        prompt,
+        imageCount: composerImages.length,
+        terminalContexts: composerTerminalContexts,
+      }),
+    [composerImages.length, composerTerminalContexts, prompt],
+  );
+
+  // ------------------------------------------------------------------
+  // Derived: composer trigger / menu
+  // ------------------------------------------------------------------
+  const composerTriggerKind = composerTrigger?.kind ?? null;
+  const pathTriggerQuery = composerTrigger?.kind === "path" ? composerTrigger.query : "";
+  const isPathTrigger = composerTriggerKind === "path";
+  const [debouncedPathQuery, composerPathQueryDebouncer] = useDebouncedValue(
+    pathTriggerQuery,
+    { wait: COMPOSER_PATH_QUERY_DEBOUNCE_MS },
+    (debouncerState) => ({ isPending: debouncerState.isPending }),
+  );
+  const effectivePathQuery = pathTriggerQuery.length > 0 ? debouncedPathQuery : "";
+  const workspaceEntriesQuery = useQuery(
+    projectSearchEntriesQueryOptions({
+      environmentId,
+      cwd: gitCwd,
+      query: effectivePathQuery,
+      enabled: isPathTrigger,
+      limit: 80,
+    }),
+  );
+  const workspaceEntries = workspaceEntriesQuery.data?.entries ?? EMPTY_PROJECT_ENTRIES;
+
+  const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
+    if (!composerTrigger) return [];
+    if (composerTrigger.kind === "path") {
+      return workspaceEntries.map((entry) => ({
+        id: `path:${entry.kind}:${entry.path}`,
+        type: "path",
+        path: entry.path,
+        pathKind: entry.kind,
+        label: basenameOfPath(entry.path),
+        description: entry.parentPath ?? "",
+      }));
+    }
+    if (composerTrigger.kind === "slash-command") {
+      const builtInSlashCommandItems = [
+        {
+          id: "slash:model",
+          type: "slash-command",
+          command: "model",
+          label: "/model",
+          description: "Switch response model for this thread",
+        },
+        {
+          id: "slash:plan",
+          type: "slash-command",
+          command: "plan",
+          label: "/plan",
+          description: "Switch this thread into plan mode",
+        },
+        {
+          id: "slash:default",
+          type: "slash-command",
+          command: "default",
+          label: "/default",
+          description: "Switch this thread back to normal build mode",
+        },
+      ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
+      const providerSlashCommandItems = (selectedProviderStatus?.slashCommands ?? []).map(
+        (command) => ({
+          id: `provider-slash-command:${selectedProvider}:${command.name}`,
+          type: "provider-slash-command" as const,
+          provider: selectedProvider,
+          command,
+          label: `/${command.name}`,
+          description: command.description ?? command.input?.hint ?? "Run provider command",
+        }),
+      );
+      const query = composerTrigger.query.trim().toLowerCase();
+      const slashCommandItems = [...builtInSlashCommandItems, ...providerSlashCommandItems];
+      if (!query) {
+        return slashCommandItems;
+      }
+      return searchSlashCommandItems(slashCommandItems, query);
+    }
+    if (composerTrigger.kind === "skill") {
+      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
+        (skill) => ({
+          id: `skill:${selectedProvider}:${skill.name}`,
+          type: "skill" as const,
+          provider: selectedProvider,
+          skill,
+          label: formatProviderSkillDisplayName(skill),
+          description:
+            skill.shortDescription ??
+            skill.description ??
+            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+        }),
+      );
+    }
+    return [];
+  }, [composerTrigger, selectedProvider, selectedProviderStatus, workspaceEntries]);
+
+  const composerMenuOpen = Boolean(composerTrigger);
+  const composerMenuSearchKey = composerTrigger
+    ? `${composerTrigger.kind}:${composerTrigger.query.trim().toLowerCase()}`
+    : null;
+  const activeComposerMenuItem = useMemo(() => {
+    const activeItemId = resolveComposerMenuActiveItemId({
+      items: composerMenuItems,
+      highlightedItemId: composerHighlightedItemId,
+      currentSearchKey: composerMenuSearchKey,
+      highlightedSearchKey: composerHighlightedSearchKey,
+    });
+    return composerMenuItems.find((item) => item.id === activeItemId) ?? null;
+  }, [
+    composerHighlightedItemId,
+    composerHighlightedSearchKey,
+    composerMenuItems,
+    composerMenuSearchKey,
+  ]);
+
+  composerMenuOpenRef.current = composerMenuOpen;
+  composerMenuItemsRef.current = composerMenuItems;
+  activeComposerMenuItemRef.current = activeComposerMenuItem;
+
+  const nonPersistedComposerImageIdSet = useMemo(
+    () => new Set(nonPersistedComposerImageIds),
+    [nonPersistedComposerImageIds],
+  );
+
+  const isComposerApprovalState = activePendingApproval !== null;
+  const activePendingUserInput = pendingUserInputs[0] ?? null;
+  const hasComposerHeader =
+    isComposerApprovalState ||
+    pendingUserInputs.length > 0 ||
+    (showPlanFollowUpPrompt && activeProposedPlan !== null);
+  const showCollapsedMobilePromptRow =
+    isComposerCollapsedMobile && !isComposerApprovalState && pendingUserInputs.length === 0;
+
+  const composerFooterHasWideActions = showPlanFollowUpPrompt || activePendingProgress !== null;
+  const showPlanSidebarToggle = Boolean(activePlan || sidebarProposedPlan || planSidebarOpen);
+  const composerFooterActionLayoutKey = useMemo(() => {
+    if (activePendingProgress) {
+      return `pending:${activePendingProgress.questionIndex}:${activePendingProgress.isLastQuestion}:${activePendingIsResponding}`;
+    }
+    if (phase === "running") {
+      return "running";
+    }
+    if (showPlanFollowUpPrompt) {
+      return prompt.trim().length > 0 ? "plan:refine" : "plan:implement";
+    }
+    return `idle:${composerSendState.hasSendableContent}:${isSendBusy}:${isConnecting}:${isPreparingWorktree}`;
+  }, [
+    activePendingIsResponding,
+    activePendingProgress,
+    composerSendState.hasSendableContent,
+    isConnecting,
+    isPreparingWorktree,
+    isSendBusy,
+    phase,
+    prompt,
+    showPlanFollowUpPrompt,
+  ]);
+
+  const isComposerMenuLoading =
+    composerTriggerKind === "path" &&
+    ((pathTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
+      workspaceEntriesQuery.isLoading ||
+      workspaceEntriesQuery.isFetching);
+  const composerMenuEmptyState = useMemo(() => {
+    if (composerTriggerKind === "skill") {
+      return "No skills found. Try / to browse provider commands.";
+    }
+    return composerTriggerKind === "path"
+      ? "No matching files or folders."
+      : "No matching command.";
+  }, [composerTriggerKind]);
+
+  // ------------------------------------------------------------------
+  // Provider traits UI
+  // ------------------------------------------------------------------
+  const setPromptFromTraits = useCallback(
+    (nextPrompt: string) => {
+      if (nextPrompt === promptRef.current) {
+        scheduleComposerFocus();
+        return;
+      }
+      promptRef.current = nextPrompt;
+      setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+      const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
+      setComposerCursor(nextCursor);
+      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
+      scheduleComposerFocus();
+    },
+    [composerDraftTarget, promptRef, scheduleComposerFocus, setComposerDraftPrompt],
+  );
+
+  const providerTraitsMenuContent = renderProviderTraitsMenuContent({
+    provider: selectedProvider,
+    ...(routeKind === "server" ? { threadRef: routeThreadRef } : {}),
+    ...(routeKind === "draft" && draftId ? { draftId } : {}),
+    model: selectedModel,
+    models: selectedProviderModels,
+    modelOptions: composerModelOptions?.[selectedProvider],
+    prompt,
+    onPromptChange: setPromptFromTraits,
+  });
+  const providerTraitsPicker = renderProviderTraitsPicker({
+    provider: selectedProvider,
+    ...(routeKind === "server" ? { threadRef: routeThreadRef } : {}),
+    ...(routeKind === "draft" && draftId ? { draftId } : {}),
+    model: selectedModel,
+    models: selectedProviderModels,
+    modelOptions: composerModelOptions?.[selectedProvider],
+    prompt,
+    onPromptChange: setPromptFromTraits,
+  });
+  const pendingPrimaryAction = useMemo(
+    () =>
+      activePendingProgress
+        ? {
+            questionIndex: activePendingProgress.questionIndex,
+            isLastQuestion: activePendingProgress.isLastQuestion,
+            canAdvance: activePendingProgress.canAdvance,
+            isResponding: activePendingIsResponding,
+            isComplete: Boolean(activePendingResolvedAnswers),
+          }
+        : null,
+    [activePendingIsResponding, activePendingProgress, activePendingResolvedAnswers],
+  );
+  const collapsedComposerPrimaryActionDisabled =
+    phase === "running" || isSendBusy || isConnecting || !composerSendState.hasSendableContent;
+  const collapsedComposerPrimaryActionLabel = "Send message";
+  const showMobilePendingAnswerActions =
+    isMobileViewport && !isComposerCollapsedMobile && pendingPrimaryAction !== null;
+
+  // ------------------------------------------------------------------
+  // Prompt helpers
+  // ------------------------------------------------------------------
+  const setPrompt = useCallback(
+    (nextPrompt: string) => {
+      setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+    },
+    [composerDraftTarget, setComposerDraftPrompt],
+  );
+
+  const addComposerImage = useCallback(
+    (image: ComposerImageAttachment) => {
+      addComposerDraftImage(composerDraftTarget, image);
+    },
+    [composerDraftTarget, addComposerDraftImage],
+  );
+
+  const addComposerImagesToDraft = useCallback(
+    (images: ComposerImageAttachment[]) => {
+      addComposerDraftImages(composerDraftTarget, images);
+    },
+    [composerDraftTarget, addComposerDraftImages],
+  );
+
+  const removeComposerImageFromDraft = useCallback(
+    (imageId: string) => {
+      removeComposerDraftImage(composerDraftTarget, imageId);
+    },
+    [composerDraftTarget, removeComposerDraftImage],
+  );
+
+  const removeComposerTerminalContextFromDraft = useCallback(
+    (contextId: string) => {
+      const contextIndex = composerTerminalContexts.findIndex(
+        (context) => context.id === contextId,
+      );
+      if (contextIndex < 0) return;
+      const removal = removeInlineTerminalContextPlaceholder(promptRef.current, contextIndex);
+      promptRef.current = removal.prompt;
+      setPrompt(removal.prompt);
+      removeComposerDraftTerminalContext(composerDraftTarget, contextId);
+      const nextCursor = collapseExpandedComposerCursor(removal.prompt, removal.cursor);
+      setComposerCursor(nextCursor);
+      setComposerTrigger(detectComposerTrigger(removal.prompt, removal.cursor));
+    },
+    [
+      composerDraftTarget,
+      composerTerminalContexts,
+      promptRef,
+      removeComposerDraftTerminalContext,
+      setPrompt,
+    ],
+  );
+
+  // ------------------------------------------------------------------
+  // Sync refs back to parent
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    promptRef.current = prompt;
+    setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
+  }, [prompt, promptRef]);
+
+  useEffect(() => {
+    composerImagesRef.current = composerImages;
+  }, [composerImages, composerImagesRef]);
+
+  useEffect(() => {
+    composerTerminalContextsRef.current = composerTerminalContexts;
+  }, [composerTerminalContexts, composerTerminalContextsRef]);
+
+  // ------------------------------------------------------------------
+  // Composer menu highlight sync
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    if (!composerMenuOpen) {
+      setComposerHighlightedItemId(null);
+      setComposerHighlightedSearchKey(null);
+      return;
+    }
+    const nextActiveItemId = resolveComposerMenuActiveItemId({
+      items: composerMenuItems,
+      highlightedItemId: composerHighlightedItemId,
+      currentSearchKey: composerMenuSearchKey,
+      highlightedSearchKey: composerHighlightedSearchKey,
+    });
+    setComposerHighlightedItemId((existing) =>
+      existing === nextActiveItemId ? existing : nextActiveItemId,
+    );
+    setComposerHighlightedSearchKey((existing) =>
+      existing === composerMenuSearchKey ? existing : composerMenuSearchKey,
+    );
+  }, [
+    composerHighlightedItemId,
+    composerHighlightedSearchKey,
+    composerMenuItems,
+    composerMenuOpen,
+    composerMenuSearchKey,
+  ]);
+
+  const lastSyncedPendingInputRef = useRef<{
+    requestId: string | null;
+    questionId: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    const nextCustomAnswer = activePendingProgress?.customAnswer;
+    if (typeof nextCustomAnswer !== "string") {
+      lastSyncedPendingInputRef.current = null;
+      return;
+    }
+
+    const nextRequestId = activePendingUserInput?.requestId ?? null;
+    const nextQuestionId = activePendingProgress?.activeQuestion?.id ?? null;
+    const questionChanged =
+      lastSyncedPendingInputRef.current?.requestId !== nextRequestId ||
+      lastSyncedPendingInputRef.current?.questionId !== nextQuestionId;
+    const textChangedExternally = promptRef.current !== nextCustomAnswer;
+
+    lastSyncedPendingInputRef.current = {
+      requestId: nextRequestId,
+      questionId: nextQuestionId,
+    };
+
+    if (!questionChanged && !textChangedExternally) {
+      return;
+    }
+
+    promptRef.current = nextCustomAnswer;
+    const nextCursor = collapseExpandedComposerCursor(nextCustomAnswer, nextCustomAnswer.length);
+    setComposerCursor(nextCursor);
+    setComposerTrigger(
+      detectComposerTrigger(
+        nextCustomAnswer,
+        expandCollapsedComposerCursor(nextCustomAnswer, nextCursor),
+      ),
+    );
+    setComposerHighlightedItemId(null);
+  }, [
+    activePendingProgress?.customAnswer,
+    activePendingProgress?.activeQuestion?.id,
+    activePendingUserInput?.requestId,
+    promptRef,
+  ]);
+
+  // ------------------------------------------------------------------
+  // Reset compositor state on thread/draft change
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    setComposerHighlightedItemId(null);
+    setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
+    setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
+    dragDepthRef.current = 0;
+    setIsDragOverComposer(false);
+  }, [draftId, activeThreadId, promptRef]);
+
+  // ------------------------------------------------------------------
+  // Footer compact layout observation
+  // ------------------------------------------------------------------
+  useLayoutEffect(() => {
+    const composerForm = composerFormRef.current;
+    if (!composerForm) return;
+    const measureComposerFormWidth = () => composerForm.clientWidth;
+    const measureFooterCompactness = () => {
+      const composerFormWidth = measureComposerFormWidth();
+      const footerCompact = shouldUseCompactComposerFooter(composerFormWidth, {
+        hasWideActions: composerFooterHasWideActions,
+      });
+      const primaryActionsCompact =
+        footerCompact &&
+        shouldUseCompactComposerPrimaryActions(composerFormWidth, {
+          hasWideActions: composerFooterHasWideActions,
+        });
+      return {
+        primaryActionsCompact,
+        footerCompact,
+      };
+    };
+
+    composerFormHeightRef.current = composerForm.getBoundingClientRect().height;
+    const initialCompactness = measureFooterCompactness();
+    setIsComposerPrimaryActionsCompact(initialCompactness.primaryActionsCompact);
+    setIsComposerFooterCompact(initialCompactness.footerCompact);
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver((entries) => {
+      const [entry] = entries;
+      if (!entry) return;
+      const nextCompactness = measureFooterCompactness();
+      setIsComposerPrimaryActionsCompact((previous) =>
+        previous === nextCompactness.primaryActionsCompact
+          ? previous
+          : nextCompactness.primaryActionsCompact,
+      );
+      setIsComposerFooterCompact((previous) =>
+        previous === nextCompactness.footerCompact ? previous : nextCompactness.footerCompact,
+      );
+      const nextHeight = entry.contentRect.height;
+      const previousHeight = composerFormHeightRef.current;
+      composerFormHeightRef.current = nextHeight;
+      if (previousHeight > 0 && Math.abs(nextHeight - previousHeight) < 0.5) return;
+      if (!shouldAutoScrollRef.current) return;
+      scheduleStickToBottom();
+    });
+
+    observer.observe(composerForm);
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    activeThreadId,
+    composerFooterActionLayoutKey,
+    composerFooterHasWideActions,
+    scheduleStickToBottom,
+    shouldAutoScrollRef,
+  ]);
+
+  // ------------------------------------------------------------------
+  // Image persist effect
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (composerImages.length === 0) {
+        clearComposerDraftPersistedAttachments(composerDraftTarget);
+        return;
+      }
+      const getPersistedAttachmentsForThread = () =>
+        getComposerDraft(composerDraftTarget)?.persistedAttachments ?? [];
+      try {
+        const currentPersistedAttachments = getPersistedAttachmentsForThread();
+        const existingPersistedById = new Map(
+          currentPersistedAttachments.map((attachment) => [attachment.id, attachment]),
+        );
+        const stagedAttachmentById = new Map<string, PersistedComposerImageAttachment>();
+        await Promise.all(
+          composerImages.map(async (image) => {
+            try {
+              const dataUrl = await readFileAsDataUrl(image.file);
+              stagedAttachmentById.set(image.id, {
+                id: image.id,
+                name: image.name,
+                mimeType: image.mimeType,
+                sizeBytes: image.sizeBytes,
+                dataUrl,
+              });
+            } catch {
+              const existingPersisted = existingPersistedById.get(image.id);
+              if (existingPersisted) {
+                stagedAttachmentById.set(image.id, existingPersisted);
+              }
+            }
+          }),
+        );
+        const serialized = Array.from(stagedAttachmentById.values());
+        if (cancelled) return;
+        syncComposerDraftPersistedAttachments(composerDraftTarget, serialized);
+      } catch {
+        const currentImageIds = new Set(composerImages.map((image) => image.id));
+        const fallbackPersistedAttachments = getPersistedAttachmentsForThread();
+        const fallbackPersistedIds = fallbackPersistedAttachments
+          .map((attachment) => attachment.id)
+          .filter((id) => currentImageIds.has(id));
+        const fallbackPersistedIdSet = new Set(fallbackPersistedIds);
+        const fallbackAttachments = fallbackPersistedAttachments.filter((attachment) =>
+          fallbackPersistedIdSet.has(attachment.id),
+        );
+        if (cancelled) return;
+        syncComposerDraftPersistedAttachments(composerDraftTarget, fallbackAttachments);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    composerDraftTarget,
+    clearComposerDraftPersistedAttachments,
+    composerImages,
+    getComposerDraft,
+    syncComposerDraftPersistedAttachments,
+  ]);
+
+  // ------------------------------------------------------------------
+  // Callbacks: prompt change
+  // ------------------------------------------------------------------
+  const onPromptChange = useCallback(
+    (
+      nextPrompt: string,
+      nextCursor: number,
+      expandedCursor: number,
+      cursorAdjacentToMention: boolean,
+      terminalContextIds: string[],
+    ) => {
+      if (activePendingProgress?.activeQuestion && pendingUserInputs.length > 0) {
+        setComposerCursor(nextCursor);
+        setComposerTrigger(
+          cursorAdjacentToMention ? null : detectComposerTrigger(nextPrompt, expandedCursor),
+        );
+        onChangeActivePendingUserInputCustomAnswer(
+          activePendingProgress.activeQuestion.id,
+          nextPrompt,
+          nextCursor,
+          expandedCursor,
+          cursorAdjacentToMention,
+        );
+        return;
+      }
+      promptRef.current = nextPrompt;
+      setPrompt(nextPrompt);
+      if (!terminalContextIdListsEqual(composerTerminalContexts, terminalContextIds)) {
+        setComposerDraftTerminalContexts(
+          composerDraftTarget,
+          syncTerminalContextsByIds(composerTerminalContexts, terminalContextIds),
+        );
+      }
+      setComposerCursor(nextCursor);
+      setComposerTrigger(
+        cursorAdjacentToMention ? null : detectComposerTrigger(nextPrompt, expandedCursor),
+      );
+    },
+    [
+      activePendingProgress?.activeQuestion,
+      pendingUserInputs.length,
+      onChangeActivePendingUserInputCustomAnswer,
+      promptRef,
+      setPrompt,
+      composerDraftTarget,
+      composerTerminalContexts,
+      setComposerDraftTerminalContexts,
+    ],
+  );
+
+  // ------------------------------------------------------------------
+  // Callbacks: prompt replacement / menu
+  // ------------------------------------------------------------------
+  const applyPromptReplacement = useCallback(
+    (
+      rangeStart: number,
+      rangeEnd: number,
+      replacement: string,
+      options?: { expectedText?: string; focusEditorAfterReplace?: boolean },
+    ): boolean => {
+      const currentText = promptRef.current;
+      const safeStart = Math.max(0, Math.min(currentText.length, rangeStart));
+      const safeEnd = Math.max(safeStart, Math.min(currentText.length, rangeEnd));
+      if (
+        options?.expectedText !== undefined &&
+        currentText.slice(safeStart, safeEnd) !== options.expectedText
+      ) {
+        return false;
+      }
+      const next = replaceTextRange(promptRef.current, rangeStart, rangeEnd, replacement);
+      const nextCursor = collapseExpandedComposerCursor(next.text, next.cursor);
+      const nextExpandedCursor = expandCollapsedComposerCursor(next.text, nextCursor);
+      promptRef.current = next.text;
+      const activePendingQuestion = activePendingProgress?.activeQuestion;
+      if (activePendingQuestion && activePendingUserInput) {
+        onChangeActivePendingUserInputCustomAnswer(
+          activePendingQuestion.id,
+          next.text,
+          nextCursor,
+          nextExpandedCursor,
+          false,
+        );
+      } else {
+        setPrompt(next.text);
+      }
+      setComposerCursor(nextCursor);
+      setComposerTrigger(detectComposerTrigger(next.text, nextExpandedCursor));
+      if (options?.focusEditorAfterReplace !== false) {
+        window.requestAnimationFrame(() => {
+          composerEditorRef.current?.focusAt(nextCursor);
+        });
+      }
+      return true;
+    },
+    [
+      activePendingProgress?.activeQuestion,
+      activePendingUserInput,
+      onChangeActivePendingUserInputCustomAnswer,
+      promptRef,
+      setPrompt,
+    ],
+  );
+
+  const readComposerSnapshot = useCallback((): {
+    value: string;
+    cursor: number;
+    expandedCursor: number;
+    terminalContextIds: string[];
+  } => {
+    const editorSnapshot = composerEditorRef.current?.readSnapshot();
+    if (editorSnapshot) {
+      return editorSnapshot;
+    }
+    return {
+      value: promptRef.current,
+      cursor: composerCursor,
+      expandedCursor: expandCollapsedComposerCursor(promptRef.current, composerCursor),
+      terminalContextIds: composerTerminalContexts.map((context) => context.id),
+    };
+  }, [composerCursor, composerTerminalContexts, promptRef]);
+
+  const resolveActiveComposerTrigger = useCallback((): {
+    snapshot: { value: string; cursor: number; expandedCursor: number };
+    trigger: ComposerTrigger | null;
+  } => {
+    const snapshot = readComposerSnapshot();
+    return {
+      snapshot,
+      trigger: detectComposerTrigger(snapshot.value, snapshot.expandedCursor),
+    };
+  }, [readComposerSnapshot]);
+
+  const onSelectComposerItem = useCallback(
+    (item: ComposerCommandItem) => {
+      if (composerSelectLockRef.current) return;
+      composerSelectLockRef.current = true;
+      window.requestAnimationFrame(() => {
+        composerSelectLockRef.current = false;
+      });
+      const { snapshot, trigger } = resolveActiveComposerTrigger();
+      if (!trigger) return;
+      if (item.type === "path") {
+        const replacement = `@${item.path} `;
+        const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+          snapshot.value,
+          trigger.rangeEnd,
+          replacement,
+        );
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          replacementRangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+        );
+        if (applied) {
+          setComposerHighlightedItemId(null);
+        }
+        return;
+      }
+      if (item.type === "slash-command") {
+        if (item.command === "model") {
+          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+            focusEditorAfterReplace: false,
+          });
+          if (applied) {
+            setComposerHighlightedItemId(null);
+            setIsComposerModelPickerOpen(true);
+          }
+          return;
+        }
+        void handleInteractionModeChange(item.command === "plan" ? "plan" : "default");
+        const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+          expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+        });
+        if (applied) {
+          setComposerHighlightedItemId(null);
+        }
+        return;
+      }
+      if (item.type === "provider-slash-command") {
+        const replacement = `/${item.command.name} `;
+        const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+          snapshot.value,
+          trigger.rangeEnd,
+          replacement,
+        );
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          replacementRangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+        );
+        if (applied) {
+          setComposerHighlightedItemId(null);
+        }
+        return;
+      }
+      if (item.type === "skill") {
+        const replacement = `$${item.skill.name} `;
+        const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+          snapshot.value,
+          trigger.rangeEnd,
+          replacement,
+        );
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          replacementRangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+        );
+        if (applied) {
+          setComposerHighlightedItemId(null);
+        }
+        return;
+      }
+    },
+    [applyPromptReplacement, handleInteractionModeChange, resolveActiveComposerTrigger],
+  );
+
+  const onComposerMenuItemHighlighted = useCallback(
+    (itemId: string | null) => {
+      setComposerHighlightedItemId(itemId);
+      setComposerHighlightedSearchKey(composerMenuSearchKey);
+    },
+    [composerMenuSearchKey],
+  );
+
+  const nudgeComposerMenuHighlight = useCallback(
+    (key: "ArrowDown" | "ArrowUp") => {
+      if (composerMenuItems.length === 0) return;
+      const highlightedIndex = composerMenuItems.findIndex(
+        (item) => item.id === composerHighlightedItemId,
+      );
+      const normalizedIndex =
+        highlightedIndex >= 0 ? highlightedIndex : key === "ArrowDown" ? -1 : 0;
+      const offset = key === "ArrowDown" ? 1 : -1;
+      const nextIndex =
+        (normalizedIndex + offset + composerMenuItems.length) % composerMenuItems.length;
+      const nextItem = composerMenuItems[nextIndex];
+      setComposerHighlightedItemId(nextItem?.id ?? null);
+    },
+    [composerHighlightedItemId, composerMenuItems],
+  );
+
+  const blurMobileComposerAfterSend = useCallback(() => {
+    if (!isMobileViewport) return;
+    if (composerBlurFrameRef.current !== null) {
+      window.cancelAnimationFrame(composerBlurFrameRef.current);
+      composerBlurFrameRef.current = null;
+    }
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement) {
+      activeElement.blur();
+    }
+    setIsComposerFocused(false);
+  }, [isMobileViewport]);
+
+  const shouldBlurMobileComposerOnSubmit = useCallback(() => {
+    if (!isMobileViewport) return false;
+    if (isSendBusy || isConnecting || phase === "running") return false;
+    if (activePendingProgress) {
+      return activePendingProgress.isLastQuestion && Boolean(activePendingResolvedAnswers);
+    }
+    return showPlanFollowUpPrompt || composerSendState.hasSendableContent;
+  }, [
+    activePendingProgress,
+    activePendingResolvedAnswers,
+    composerSendState.hasSendableContent,
+    isConnecting,
+    isMobileViewport,
+    isSendBusy,
+    phase,
+    showPlanFollowUpPrompt,
+  ]);
+
+  const submitComposer = useCallback(
+    (event?: { preventDefault: () => void }) => {
+      onSend(event);
+      if (shouldBlurMobileComposerOnSubmit()) {
+        blurMobileComposerAfterSend();
+      }
+    },
+    [blurMobileComposerAfterSend, onSend, shouldBlurMobileComposerOnSubmit],
+  );
+  const expandMobileComposer = useCallback(() => {
+    if (composerBlurFrameRef.current !== null) {
+      window.cancelAnimationFrame(composerBlurFrameRef.current);
+      composerBlurFrameRef.current = null;
+    }
+    if (mobileComposerExpandFrameRef.current !== null) {
+      window.cancelAnimationFrame(mobileComposerExpandFrameRef.current);
+    }
+    if (mobileComposerExpandReleaseFrameRef.current !== null) {
+      window.cancelAnimationFrame(mobileComposerExpandReleaseFrameRef.current);
+    }
+    mobileComposerExpandInFlightRef.current = true;
+    setIsComposerFocused(true);
+    mobileComposerExpandFrameRef.current = window.requestAnimationFrame(() => {
+      mobileComposerExpandFrameRef.current = null;
+      composerEditorRef.current?.focusAtEnd();
+      mobileComposerExpandReleaseFrameRef.current = window.requestAnimationFrame(() => {
+        mobileComposerExpandReleaseFrameRef.current = null;
+        mobileComposerExpandInFlightRef.current = false;
+      });
+    });
+  }, []);
+
+  // ------------------------------------------------------------------
+  // Callbacks: command key
+  // ------------------------------------------------------------------
+  const onComposerCommandKey = (
+    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
+    event: KeyboardEvent,
+  ) => {
+    if (key === "Tab" && event.shiftKey) {
+      toggleInteractionMode();
+      return true;
+    }
+    const { trigger } = resolveActiveComposerTrigger();
+    const menuIsActive = composerMenuOpenRef.current || trigger !== null;
+    if (menuIsActive) {
+      const currentItems = composerMenuItemsRef.current;
+      const selectedItem = activeComposerMenuItemRef.current ?? currentItems[0];
+      if (key === "ArrowDown" && currentItems.length > 0) {
+        nudgeComposerMenuHighlight("ArrowDown");
+        return true;
+      }
+      if (key === "ArrowUp" && currentItems.length > 0) {
+        nudgeComposerMenuHighlight("ArrowUp");
+        return true;
+      }
+      if ((key === "Enter" || key === "Tab") && selectedItem) {
+        onSelectComposerItem(selectedItem);
+        return true;
+      }
+    }
+    if (key === "Enter" && !event.shiftKey) {
+      submitComposer();
+      return true;
+    }
+    return false;
+  };
+
+  // ------------------------------------------------------------------
+  // Callbacks: images
+  // ------------------------------------------------------------------
+  const addComposerImages = (files: File[]) => {
+    if (!activeThreadId || files.length === 0) return;
+    if (pendingUserInputs.length > 0) {
+      toastManager.add({
+        type: "error",
+        title: "Attach images after answering plan questions.",
+      });
+      return;
+    }
+    const nextImages: ComposerImageAttachment[] = [];
+    let nextImageCount = composerImagesRef.current.length;
+    let error: string | null = null;
+    for (const file of files) {
+      if (!file.type.startsWith("image/")) {
+        error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
+        continue;
+      }
+      if (file.size > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+        error = `'${file.name}' exceeds the ${IMAGE_SIZE_LIMIT_LABEL} attachment limit.`;
+        continue;
+      }
+      if (nextImageCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
+        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`;
+        break;
+      }
+      const previewUrl = URL.createObjectURL(file);
+      nextImages.push({
+        type: "image",
+        id: randomUUID(),
+        name: file.name || "image",
+        mimeType: file.type,
+        sizeBytes: file.size,
+        previewUrl,
+        file,
+      });
+      nextImageCount += 1;
+    }
+    if (nextImages.length === 1 && nextImages[0]) {
+      addComposerImage(nextImages[0]);
+    } else if (nextImages.length > 1) {
+      addComposerImagesToDraft(nextImages);
+    }
+    setThreadError(activeThreadId, error);
+  };
+
+  const removeComposerImage = (imageId: string) => {
+    removeComposerImageFromDraft(imageId);
+  };
+
+  // ------------------------------------------------------------------
+  // Callbacks: paste / drag
+  // ------------------------------------------------------------------
+  const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
+    const files = Array.from(event.clipboardData.files);
+    if (files.length === 0) return;
+    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+    if (imageFiles.length === 0) return;
+    event.preventDefault();
+    addComposerImages(imageFiles);
+  };
+
+  const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    dragDepthRef.current += 1;
+    setIsDragOverComposer(true);
+  };
+
+  const onComposerDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setIsDragOverComposer(true);
+  };
+
+  const onComposerDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) {
+      setIsDragOverComposer(false);
+    }
+  };
+
+  const onComposerDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    dragDepthRef.current = 0;
+    setIsDragOverComposer(false);
+    const files = Array.from(event.dataTransfer.files);
+    addComposerImages(files);
+    focusComposer();
+  };
+  const handleInterruptPrimaryAction = useCallback(() => {
+    void onInterrupt();
+  }, [onInterrupt]);
+  const handleImplementPlanInNewThreadPrimaryAction = useCallback(() => {
+    void onImplementPlanInNewThread();
+  }, [onImplementPlanInNewThread]);
+  const scheduleComposerCollapseCheck = useCallback(() => {
+    if (!isMobileViewport) {
+      return;
+    }
+    if (mobileComposerExpandInFlightRef.current) {
+      return;
+    }
+    if (composerBlurFrameRef.current !== null) {
+      window.cancelAnimationFrame(composerBlurFrameRef.current);
+    }
+    composerBlurFrameRef.current = window.requestAnimationFrame(() => {
+      composerBlurFrameRef.current = null;
+      if (mobileComposerExpandInFlightRef.current) {
+        return;
+      }
+      const composerSurface = composerSurfaceRef.current;
+      const activeElement = document.activeElement;
+      if (activeElement instanceof Element && isInsideComposerFloatingLayer(activeElement)) {
+        return;
+      }
+      if (
+        composerSurface &&
+        activeElement instanceof Node &&
+        composerSurface.contains(activeElement)
+      ) {
+        return;
+      }
+      setIsComposerFocused(false);
+    });
+  }, [isMobileViewport]);
+
+  useEffect(() => {
+    return () => {
+      if (composerBlurFrameRef.current !== null) {
+        window.cancelAnimationFrame(composerBlurFrameRef.current);
+      }
+      if (mobileComposerExpandFrameRef.current !== null) {
+        window.cancelAnimationFrame(mobileComposerExpandFrameRef.current);
+      }
+      if (mobileComposerExpandReleaseFrameRef.current !== null) {
+        window.cancelAnimationFrame(mobileComposerExpandReleaseFrameRef.current);
+      }
+    };
+  }, []);
+
+  // ------------------------------------------------------------------
+  // Imperative handle
+  // ------------------------------------------------------------------
+  useImperativeHandle(
+    composerRef,
+    () => ({
+      focusAtEnd: () => {
+        composerEditorRef.current?.focusAtEnd();
+      },
+      focusAt: (cursor: number) => {
+        composerEditorRef.current?.focusAt(cursor);
+      },
+      openModelPicker: () => {
+        setIsComposerModelPickerOpen(true);
+      },
+      toggleModelPicker: () => {
+        setIsComposerModelPickerOpen((open) => !open);
+      },
+      isModelPickerOpen: () => isComposerModelPickerOpen,
+      readSnapshot: () => {
+        return readComposerSnapshot();
+      },
+      resetCursorState: (options?: {
+        cursor?: number;
+        prompt?: string;
+        detectTrigger?: boolean;
+      }) => {
+        const promptForState = options?.prompt ?? promptRef.current;
+        const cursor = clampCollapsedComposerCursor(promptForState, options?.cursor ?? 0);
+        setComposerHighlightedItemId(null);
+        setComposerCursor(cursor);
+        setComposerTrigger(
+          options?.detectTrigger
+            ? detectComposerTrigger(
+                promptForState,
+                expandCollapsedComposerCursor(promptForState, cursor),
+              )
+            : null,
+        );
+      },
+      addTerminalContext: (selection: TerminalContextSelection) => {
+        if (!activeThread) return;
+        const snapshot = composerEditorRef.current?.readSnapshot() ?? {
+          value: promptRef.current,
+          cursor: composerCursor,
+          expandedCursor: expandCollapsedComposerCursor(promptRef.current, composerCursor),
+          terminalContextIds: composerTerminalContexts.map((context) => context.id),
+        };
+        const insertion = insertInlineTerminalContextPlaceholder(
+          snapshot.value,
+          snapshot.expandedCursor,
+        );
+        const nextCollapsedCursor = collapseExpandedComposerCursor(
+          insertion.prompt,
+          insertion.cursor,
+        );
+        const inserted = insertComposerDraftTerminalContext(
+          composerDraftTarget,
+          insertion.prompt,
+          {
+            id: randomUUID(),
+            threadId: activeThread.id,
+            createdAt: new Date().toISOString(),
+            ...selection,
+          },
+          insertion.contextIndex,
+        );
+        if (!inserted) return;
+        promptRef.current = insertion.prompt;
+        setComposerCursor(nextCollapsedCursor);
+        setComposerTrigger(detectComposerTrigger(insertion.prompt, insertion.cursor));
+        window.requestAnimationFrame(() => {
+          composerEditorRef.current?.focusAt(nextCollapsedCursor);
+        });
+      },
+      getSendContext: () => ({
+        prompt: promptRef.current,
+        images: composerImagesRef.current,
+        terminalContexts: composerTerminalContextsRef.current,
+        selectedPromptEffort,
+        selectedModelOptionsForDispatch,
+        selectedModelSelection,
+        selectedProvider,
+        selectedModel,
+        selectedProviderModels,
+      }),
+    }),
+    [
+      activeThread,
+      composerDraftTarget,
+      composerCursor,
+      composerTerminalContexts,
+      insertComposerDraftTerminalContext,
+      promptRef,
+      composerImagesRef,
+      composerTerminalContextsRef,
+      isComposerModelPickerOpen,
+      readComposerSnapshot,
+      selectedModel,
+      selectedModelOptionsForDispatch,
+      selectedModelSelection,
+      selectedPromptEffort,
+      selectedProvider,
+      selectedProviderModels,
+    ],
+  );
+
+  // Render
+  // ------------------------------------------------------------------
+  return (
+    <form
+      ref={composerFormRef}
+      onSubmit={submitComposer}
+      className="mx-auto w-full min-w-0 max-w-208"
+      data-chat-composer-form="true"
+    >
+      <div
+        className={cn(
+          "group rounded-[22px] p-px transition-colors duration-200",
+          composerProviderState.composerFrameClassName,
+        )}
+        onDragEnter={onComposerDragEnter}
+        onDragOver={onComposerDragOver}
+        onDragLeave={onComposerDragLeave}
+        onDrop={onComposerDrop}
+      >
+        <div
+          ref={composerSurfaceRef}
+          data-chat-composer-mobile-collapsed={isComposerCollapsedMobile ? "true" : "false"}
+          className={cn(
+            "rounded-[20px] border bg-card transition-colors duration-200 has-focus-visible:border-ring/45",
+            isDragOverComposer ? "border-primary/70 bg-accent/30" : "border-border",
+            environmentUnavailable ? "opacity-75" : null,
+            composerProviderState.composerSurfaceClassName,
+          )}
+          onFocusCapture={(event) => {
+            const activeElement = event.target;
+            if (
+              isComposerCollapsedMobile &&
+              activeElement instanceof HTMLElement &&
+              activeElement.closest('[data-chat-composer-collapsed-controls="true"]')
+            ) {
+              return;
+            }
+            if (composerBlurFrameRef.current !== null) {
+              window.cancelAnimationFrame(composerBlurFrameRef.current);
+              composerBlurFrameRef.current = null;
+            }
+            setIsComposerFocused(true);
+          }}
+          onBlurCapture={() => {
+            scheduleComposerCollapseCheck();
+          }}
+        >
+          {!isComposerCollapsedMobile &&
+            (activePendingApproval ? (
+              <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
+                <ComposerPendingApprovalPanel
+                  approval={activePendingApproval}
+                  pendingCount={pendingApprovals.length}
+                />
+              </div>
+            ) : pendingUserInputs.length > 0 ? (
+              <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
+                <ComposerPendingUserInputPanel
+                  pendingUserInputs={pendingUserInputs}
+                  respondingRequestIds={respondingRequestIds}
+                  answers={activePendingDraftAnswers}
+                  questionIndex={activePendingQuestionIndex}
+                  onToggleOption={onSelectActivePendingUserInputOption}
+                  onAdvance={onAdvanceActivePendingUserInput}
+                />
+              </div>
+            ) : showPlanFollowUpPrompt && activeProposedPlan ? (
+              <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
+                <ComposerPlanFollowUpBanner
+                  key={activeProposedPlan.id}
+                  planTitle={proposedPlanTitle(activeProposedPlan.planMarkdown) ?? null}
+                />
+              </div>
+            ) : null)}
+
+          {isComposerCollapsedMobile && activePendingApproval ? (
+            <div
+              className="rounded-t-[19px] border-b border-border/65 bg-muted/20"
+              data-chat-composer-collapsed-controls="true"
+            >
+              <ComposerPendingApprovalPanel
+                approval={activePendingApproval}
+                pendingCount={pendingApprovals.length}
+              />
+              <div className="flex flex-wrap items-center justify-end gap-2 px-3 pb-3 sm:px-4">
+                <ComposerPendingApprovalActions
+                  requestId={activePendingApproval.requestId}
+                  isResponding={respondingRequestIds.includes(activePendingApproval.requestId)}
+                  onRespondToApproval={onRespondToApproval}
+                />
+              </div>
+            </div>
+          ) : isComposerCollapsedMobile && pendingUserInputs.length > 0 ? (
+            <div
+              className="rounded-t-[19px] border-b border-border/65 bg-muted/20"
+              data-chat-composer-collapsed-controls="true"
+            >
+              <ComposerPendingUserInputPanel
+                pendingUserInputs={pendingUserInputs}
+                respondingRequestIds={respondingRequestIds}
+                answers={activePendingDraftAnswers}
+                questionIndex={activePendingQuestionIndex}
+                onToggleOption={onSelectActivePendingUserInputOption}
+                onAdvance={onAdvanceActivePendingUserInput}
+              />
+              <div className="px-3 pb-3 sm:px-4">
+                <div
+                  data-chat-composer-mobile-pending-compact="true"
+                  className={cn(
+                    "flex min-w-0 items-center gap-2 rounded-lg border border-border/55 bg-background/55 p-1.5 pl-3 transition-colors hover:bg-background/80",
+                    !activePendingProgress?.activeQuestion?.multiSelect && "p-0",
+                  )}
+                >
+                  <button
+                    type="button"
+                    className={cn(
+                      "min-w-0 flex-1 truncate bg-transparent py-1.5 text-left text-sm",
+                      activePendingProgress?.customAnswer
+                        ? "text-foreground"
+                        : "text-muted-foreground/60",
+                      !activePendingProgress?.activeQuestion?.multiSelect && "px-3 py-2",
+                    )}
+                    onPointerDown={(event) => event.preventDefault()}
+                    onClick={expandMobileComposer}
+                    aria-label="Write custom answer"
+                  >
+                    {activePendingProgress?.customAnswer || "Write custom answer"}
+                  </button>
+                  {activePendingProgress?.activeQuestion?.multiSelect ? (
+                    <ComposerPrimaryActions
+                      compact
+                      pendingAction={pendingPrimaryAction}
+                      isRunning={false}
+                      showPlanFollowUpPrompt={false}
+                      promptHasText={false}
+                      isSendBusy={isSendBusy}
+                      isConnecting={isConnecting}
+                      isEnvironmentUnavailable={environmentUnavailable !== null}
+                      isPreparingWorktree={false}
+                      hasSendableContent={false}
+                      preserveComposerFocusOnPointerDown
+                      onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
+                      onInterrupt={handleInterruptPrimaryAction}
+                      onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
+                    />
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {showCollapsedMobilePromptRow ? (
+            <div className="flex items-center justify-between gap-2 px-3 py-2">
+              <button
+                type="button"
+                className={cn(
+                  "min-w-0 flex-1 truncate bg-transparent p-0 text-left text-[14px] focus:outline-none",
+                  (activePendingProgress ? activePendingProgress.customAnswer : prompt.trim())
+                    ? "text-foreground"
+                    : "text-muted-foreground/35",
+                )}
+                onPointerDown={(event) => event.preventDefault()}
+                onClick={expandMobileComposer}
+                aria-label="Expand composer"
+              >
+                {activePendingProgress
+                  ? activePendingProgress.customAnswer ||
+                    "Type your own answer, or leave this blank to use the selected option"
+                  : prompt.trim() || "Ask anything..."}
+              </button>
+              <button
+                type="button"
+                className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/90 text-primary-foreground disabled:opacity-30"
+                disabled={collapsedComposerPrimaryActionDisabled}
+                aria-label={collapsedComposerPrimaryActionLabel}
+                onPointerDown={(event) => event.preventDefault()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  submitComposer();
+                }}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path
+                    d="M8 3L8 13M8 3L4 7M8 3L12 7"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          ) : null}
+
+          <div
+            className={cn(
+              "relative px-3 pb-2 sm:px-4",
+              hasComposerHeader ? "pt-2.5 sm:pt-3" : "pt-3.5 sm:pt-4",
+              isComposerCollapsedMobile && "hidden",
+            )}
+          >
+            {composerMenuOpen && !isComposerApprovalState && (
+              <div className="absolute inset-x-0 bottom-full z-20 mb-2 px-1">
+                <ComposerCommandMenu
+                  items={composerMenuItems}
+                  resolvedTheme={resolvedTheme}
+                  isLoading={isComposerMenuLoading}
+                  triggerKind={composerTriggerKind}
+                  groupSlashCommandSections={
+                    composerTrigger?.kind === "slash-command" &&
+                    composerTrigger.query.trim().length === 0
+                  }
+                  emptyStateText={composerMenuEmptyState}
+                  activeItemId={activeComposerMenuItem?.id ?? null}
+                  onHighlightedItemChange={onComposerMenuItemHighlighted}
+                  onSelect={onSelectComposerItem}
+                />
+              </div>
+            )}
+
+            {!isComposerCollapsedMobile &&
+              !isComposerApprovalState &&
+              pendingUserInputs.length === 0 &&
+              composerImages.length > 0 && (
+                <div className="mb-3 flex flex-wrap gap-2">
+                  {composerImages.map((image) => (
+                    <div
+                      key={image.id}
+                      className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
+                    >
+                      {image.previewUrl ? (
+                        <button
+                          type="button"
+                          className="h-full w-full cursor-zoom-in"
+                          aria-label={`Preview ${image.name}`}
+                          onClick={() => {
+                            const preview = buildExpandedImagePreview(composerImages, image.id);
+                            if (!preview) return;
+                            onExpandImage(preview);
+                          }}
+                        >
+                          <img
+                            src={image.previewUrl}
+                            alt={image.name}
+                            className="h-full w-full object-cover"
+                          />
+                        </button>
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center px-1 text-center text-[10px] text-muted-foreground/70">
+                          {image.name}
+                        </div>
+                      )}
+                      {nonPersistedComposerImageIdSet.has(image.id) && (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <span
+                                role="img"
+                                aria-label="Draft attachment may not persist"
+                                className="absolute left-1 top-1 inline-flex items-center justify-center rounded bg-background/85 p-0.5 text-amber-600"
+                              >
+                                <CircleAlertIcon className="size-3" />
+                              </span>
+                            }
+                          />
+                          <TooltipPopup
+                            side="top"
+                            className="max-w-64 whitespace-normal leading-tight"
+                          >
+                            Draft attachment could not be saved locally and may be lost on
+                            navigation.
+                          </TooltipPopup>
+                        </Tooltip>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        className="absolute right-1 top-1 bg-background/80 hover:bg-background/90"
+                        onClick={() => removeComposerImage(image.id)}
+                        aria-label={`Remove ${image.name}`}
+                      >
+                        <XIcon />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+            <div className="relative">
+              <ComposerPromptEditor
+                editorRef={composerEditorRef}
+                value={
+                  isComposerApprovalState
+                    ? ""
+                    : activePendingProgress
+                      ? activePendingProgress.customAnswer
+                      : prompt
+                }
+                cursor={composerCursor}
+                terminalContexts={
+                  !isComposerApprovalState && pendingUserInputs.length === 0
+                    ? composerTerminalContexts
+                    : []
+                }
+                skills={selectedProviderStatus?.skills ?? []}
+                {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
+                onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
+                onChange={onPromptChange}
+                onCommandKeyDown={onComposerCommandKey}
+                onPaste={onComposerPaste}
+                placeholder={
+                  isComposerApprovalState
+                    ? (activePendingApproval?.detail ?? "Resolve this approval request to continue")
+                    : activePendingProgress
+                      ? "Type your own answer, or leave this blank to use the selected option"
+                      : showPlanFollowUpPrompt && activeProposedPlan
+                        ? "Add feedback to refine the plan, or leave this blank to implement it"
+                        : environmentUnavailable
+                          ? `${environmentUnavailable.label} is ${
+                              environmentUnavailable.connectionState === "connecting"
+                                ? "connecting"
+                                : "disconnected"
+                            }`
+                          : phase === "disconnected"
+                            ? "Ask for follow-up changes or attach images"
+                            : "Ask anything, @tag files/folders, $use skills, or / for commands"
+                }
+                disabled={
+                  isConnecting ||
+                  isComposerApprovalState ||
+                  (environmentUnavailable !== null && activePendingProgress === null)
+                }
+              />
+              {showMobilePendingAnswerActions ? (
+                <div
+                  data-chat-composer-mobile-pending-actions="true"
+                  className="absolute bottom-0 right-0 flex justify-end"
+                >
+                  <ComposerPrimaryActions
+                    compact
+                    pendingAction={pendingPrimaryAction}
+                    isRunning={false}
+                    showPlanFollowUpPrompt={false}
+                    promptHasText={false}
+                    isSendBusy={isSendBusy}
+                    isConnecting={isConnecting}
+                    isEnvironmentUnavailable={environmentUnavailable !== null}
+                    isPreparingWorktree={false}
+                    hasSendableContent={false}
+                    preserveComposerFocusOnPointerDown
+                    onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
+                    onInterrupt={handleInterruptPrimaryAction}
+                    onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
+                  />
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Bottom toolbar */}
+          {isComposerCollapsedMobile ? null : activePendingApproval ? (
+            <div className="flex items-center justify-end gap-2 px-2.5 pb-2.5 sm:px-3 sm:pb-3">
+              <ComposerPendingApprovalActions
+                requestId={activePendingApproval.requestId}
+                isResponding={respondingRequestIds.includes(activePendingApproval.requestId)}
+                onRespondToApproval={onRespondToApproval}
+              />
+            </div>
+          ) : (
+            <div
+              data-chat-composer-footer="true"
+              data-chat-composer-footer-compact={isComposerFooterCompact ? "true" : "false"}
+              className={cn(
+                "flex min-w-0 flex-nowrap items-center justify-between gap-2 overflow-visible px-2.5 pb-2.5 sm:px-3 sm:pb-3",
+                isComposerFooterCompact ? "gap-1.5" : "gap-2 sm:gap-0",
+                showMobilePendingAnswerActions && "hidden sm:flex",
+              )}
+            >
+              <div className="-m-1 flex min-w-0 flex-1 items-center gap-1 overflow-x-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <ProviderModelPicker
+                  compact={isComposerFooterCompact}
+                  activeInstanceId={selectedInstanceId}
+                  model={selectedModelForPickerWithCustomFallback}
+                  lockedProvider={lockedProvider}
+                  lockedContinuationGroupKey={lockedContinuationGroupKey}
+                  instanceEntries={providerInstanceEntries}
+                  keybindings={keybindings}
+                  modelOptionsByInstance={modelOptionsByInstance}
+                  terminalOpen={terminalOpen}
+                  open={isComposerModelPickerOpen}
+                  persistenceKey="t3code:composer-provider-model-picker:v1"
+                  {...(composerProviderState.modelPickerIconClassName
+                    ? {
+                        activeProviderIconClassName: composerProviderState.modelPickerIconClassName,
+                      }
+                    : {})}
+                  onOpenChange={(open) => {
+                    setIsComposerModelPickerOpen(open);
+                  }}
+                  onInstanceModelChange={onProviderModelSelect}
+                />
+
+                {isComposerFooterCompact ? (
+                  <CompactComposerControlsMenu
+                    activePlan={showPlanSidebarToggle}
+                    interactionMode={interactionMode}
+                    planSidebarLabel={planSidebarLabel}
+                    planSidebarOpen={planSidebarOpen}
+                    runtimeMode={runtimeMode}
+                    showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
+                    traitsMenuContent={providerTraitsMenuContent}
+                    onToggleInteractionMode={toggleInteractionMode}
+                    onTogglePlanSidebar={togglePlanSidebar}
+                    onRuntimeModeChange={handleRuntimeModeChange}
+                  />
+                ) : (
+                  <>
+                    {providerTraitsPicker ? (
+                      <>
+                        <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+                        {providerTraitsPicker}
+                      </>
+                    ) : null}
+                    <ComposerFooterModeControls
+                      showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
+                      interactionMode={interactionMode}
+                      runtimeMode={runtimeMode}
+                      showPlanToggle={showPlanSidebarToggle}
+                      planSidebarLabel={planSidebarLabel}
+                      planSidebarOpen={planSidebarOpen}
+                      onToggleInteractionMode={toggleInteractionMode}
+                      onRuntimeModeChange={handleRuntimeModeChange}
+                      onTogglePlanSidebar={togglePlanSidebar}
+                    />
+                  </>
+                )}
+              </div>
+
+              {/* Right side: send / stop button */}
+              <div
+                data-chat-composer-actions="right"
+                data-chat-composer-primary-actions-compact={
+                  isComposerPrimaryActionsCompact ? "true" : "false"
+                }
+                className="flex shrink-0 flex-nowrap items-center justify-end gap-2"
+              >
+                <ComposerFooterPrimaryActions
+                  compact={isComposerPrimaryActionsCompact}
+                  activeContextWindow={activeContextWindow}
+                  pendingAction={pendingPrimaryAction}
+                  isRunning={phase === "running"}
+                  showPlanFollowUpPrompt={pendingUserInputs.length === 0 && showPlanFollowUpPrompt}
+                  promptHasText={prompt.trim().length > 0}
+                  isSendBusy={isSendBusy}
+                  isConnecting={isConnecting}
+                  isEnvironmentUnavailable={environmentUnavailable !== null}
+                  isPreparingWorktree={isPreparingWorktree}
+                  hasSendableContent={composerSendState.hasSendableContent}
+                  preserveComposerFocusOnPointerDown={isMobileViewport}
+                  onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
+                  onInterrupt={handleInterruptPrimaryAction}
+                  onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </form>
+  );
+});

--- a/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -1,0 +1,664 @@
+import {
+  type ProviderInstanceId,
+  type ProviderDriverKind,
+  type ResolvedKeybindingsConfig,
+} from "@t3tools/contracts";
+import { resolveSelectableModel } from "@t3tools/shared/model";
+import { memo, useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { SearchIcon } from "lucide-react";
+import { ModelListRow } from "./ModelListRow";
+import { ModelPickerSidebar } from "./ModelPickerSidebar";
+import { isModelPickerNewModel } from "./modelPickerModelHighlights";
+import { buildModelPickerSearchText, scoreModelPickerSearch } from "./modelPickerSearch";
+import { Button } from "../ui/button";
+import { Combobox, ComboboxEmpty, ComboboxInput, ComboboxList } from "../ui/combobox";
+import { ModelEsque, PROVIDER_ICON_BY_PROVIDER } from "./providerIconUtils";
+import {
+  modelPickerJumpCommandForIndex,
+  modelPickerJumpIndexFromCommand,
+  resolveShortcutCommand,
+  shortcutLabelForCommand,
+} from "../../keybindings";
+import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
+import { cn } from "~/lib/utils";
+import { TooltipProvider } from "../ui/tooltip";
+import type { ProviderInstanceEntry } from "../../providerInstances";
+import { providerModelKey, sortProviderModelItems } from "../../modelOrdering";
+
+type ModelPickerItem = {
+  slug: string;
+  name: string;
+  shortName?: string;
+  subProvider?: string;
+  instanceId: ProviderInstanceId;
+  driverKind: ProviderDriverKind;
+  instanceDisplayName: string;
+  instanceAccentColor?: string | undefined;
+  continuationGroupKey?: string | undefined;
+};
+
+const EMPTY_MODEL_JUMP_LABELS = new Map<string, string>();
+
+// Split a `${instanceId}:${slug}` combobox key back into its pieces. Slugs
+// can contain colons (e.g. some vendor model ids), so we only split on the
+// first colon — anything after that is the slug.
+function splitInstanceModelKey(key: string): { instanceId: ProviderInstanceId; slug: string } {
+  const colonIndex = key.indexOf(":");
+  if (colonIndex === -1) {
+    return { instanceId: key as ProviderInstanceId, slug: "" };
+  }
+  return {
+    instanceId: key.slice(0, colonIndex) as ProviderInstanceId,
+    slug: key.slice(colonIndex + 1),
+  };
+}
+
+export const ModelPickerContent = memo(function ModelPickerContent(props: {
+  /** The instance currently selected in the composer (combobox "value"). */
+  activeInstanceId: ProviderInstanceId;
+  model: string;
+  /**
+   * When set, the picker is locked to the given driver kind — typically
+   * because the user is editing a previously-sent message and can't change
+   * which driver served the turn. Multiple instances of the same kind
+   * remain selectable (e.g. locked to `codex` still lets the user switch
+   * between the default Codex and a custom Codex Personal).
+   */
+  lockedProvider: ProviderDriverKind | null;
+  lockedContinuationGroupKey?: string | null;
+  /**
+   * All configured provider instances in display order. Used to render
+   * the sidebar (one button per instance) and to resolve display names
+   * for the locked-mode header.
+   */
+  instanceEntries: ReadonlyArray<ProviderInstanceEntry>;
+  keybindings?: ResolvedKeybindingsConfig;
+  /**
+   * Model options per instance. Keyed by `ProviderInstanceId` so the
+   * default Codex instance and any custom Codex instances each have their
+   * own list (custom instances typically start with the same built-in
+   * model set but are free to diverge via customModels).
+   */
+  modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
+  terminalOpen: boolean;
+  showResetToDefault?: boolean;
+  disableResetToDefault?: boolean;
+  onResetToDefault?: () => void;
+  onRequestClose?: () => void;
+  onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
+}) {
+  const {
+    keybindings: providedKeybindings,
+    modelOptionsByInstance,
+    instanceEntries,
+    onInstanceModelChange,
+  } = props;
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listRegionRef = useRef<HTMLDivElement>(null);
+  const highlightedModelKeyRef = useRef<string | null>(null);
+  const favorites = useSettings((s) => s.favorites ?? []);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | "favorites">(
+    () => {
+      if (props.lockedProvider !== null) {
+        // When locked, prime the sidebar to the currently-active instance
+        // so jumping into the picker keeps the focused instance visible.
+        return props.activeInstanceId;
+      }
+      return favorites.length > 0 ? "favorites" : props.activeInstanceId;
+    },
+  );
+  const keybindings = useMemo<ResolvedKeybindingsConfig>(
+    () => providedKeybindings ?? [],
+    [providedKeybindings],
+  );
+  const { updateSettings } = useUpdateSettings();
+
+  const focusSearchInput = useCallback(() => {
+    searchInputRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  const handleSelectInstance = useCallback(
+    (instanceId: ProviderInstanceId | "favorites") => {
+      setSelectedInstanceId(instanceId);
+      window.requestAnimationFrame(() => {
+        focusSearchInput();
+      });
+    },
+    [focusSearchInput],
+  );
+
+  useLayoutEffect(() => {
+    focusSearchInput();
+    const frame = window.requestAnimationFrame(() => {
+      focusSearchInput();
+    });
+    const timeout = window.setTimeout(() => {
+      focusSearchInput();
+    }, 0);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timeout);
+    };
+  }, [focusSearchInput]);
+
+  // Create a Set for efficient lookup. Favorites are keyed by
+  // `${instanceId}:${slug}`; the storage schema widened from ProviderDriverKind
+  // to ProviderInstanceId so pre-migration favorites keyed by driver slugs
+  // (e.g. `"codex:gpt-5"`) still resolve — the default instance id equals
+  // the driver slug.
+  const favoritesSet = useMemo(() => {
+    return new Set(favorites.map((fav) => providerModelKey(fav.provider, fav.model)));
+  }, [favorites]);
+
+  /**
+   * Lookup table keyed by `instanceId`. Used for display name + driver
+   * kind enrichment and for `ready`/enabled filtering before flattening
+   * models into the search list.
+   */
+  const entryByInstanceId = useMemo(
+    () => new Map(instanceEntries.map((entry) => [entry.instanceId, entry])),
+    [instanceEntries],
+  );
+  const matchesLockedProvider = useCallback(
+    (entry: Pick<ProviderInstanceEntry, "driverKind" | "continuationGroupKey">): boolean => {
+      if (props.lockedProvider === null) return true;
+      if (entry.driverKind !== props.lockedProvider) return false;
+      if (!props.lockedContinuationGroupKey) return true;
+      return entry.continuationGroupKey === props.lockedContinuationGroupKey;
+    },
+    [props.lockedContinuationGroupKey, props.lockedProvider],
+  );
+
+  const readyInstanceSet = useMemo(() => {
+    const ready = new Set<ProviderInstanceId>();
+    for (const entry of instanceEntries) {
+      if (entry.status === "ready") {
+        ready.add(entry.instanceId);
+      }
+    }
+    return ready;
+  }, [instanceEntries]);
+
+  // Flatten models into a searchable array. One pass over the
+  // instance-keyed map; each model carries its instance id + driver kind
+  // so the list row can render the right icon and display name without
+  // another lookup.
+  const flatModels = useMemo(() => {
+    const out: ModelPickerItem[] = [];
+    for (const [instanceId, models] of modelOptionsByInstance) {
+      const entry = entryByInstanceId.get(instanceId);
+      if (!entry) {
+        // Instance disappeared between renders (configuration change). Skip
+        // its models — stale options shouldn't appear in the picker.
+        continue;
+      }
+      if (!readyInstanceSet.has(instanceId)) {
+        continue;
+      }
+      for (const model of models) {
+        out.push({
+          slug: model.slug,
+          name: model.name,
+          ...(model.shortName ? { shortName: model.shortName } : {}),
+          ...(model.subProvider ? { subProvider: model.subProvider } : {}),
+          instanceId,
+          driverKind: entry.driverKind,
+          instanceDisplayName: entry.displayName,
+          ...(entry.accentColor ? { instanceAccentColor: entry.accentColor } : {}),
+          ...(entry.continuationGroupKey
+            ? { continuationGroupKey: entry.continuationGroupKey }
+            : {}),
+        });
+      }
+    }
+    return out;
+  }, [modelOptionsByInstance, entryByInstanceId, readyInstanceSet]);
+
+  const isLocked = props.lockedProvider !== null;
+  const isSearching = searchQuery.trim().length > 0;
+  const lockedInstanceEntries = useMemo(
+    () =>
+      props.lockedProvider ? instanceEntries.filter((entry) => matchesLockedProvider(entry)) : [],
+    [instanceEntries, matchesLockedProvider, props.lockedProvider],
+  );
+  const showLockedInstanceSidebar = isLocked && lockedInstanceEntries.length > 1;
+  const showSidebar = !isSearching && (!isLocked || showLockedInstanceSidebar);
+  const sidebarInstanceEntries = showLockedInstanceSidebar
+    ? lockedInstanceEntries
+    : instanceEntries;
+  const instanceOrder = useMemo(
+    () => instanceEntries.map((entry) => entry.instanceId),
+    [instanceEntries],
+  );
+
+  // Filter models based on search query and selected instance
+  const filteredModels = useMemo(() => {
+    let result = flatModels;
+
+    // Apply tokenized fuzzy search across the combined provider/model search fields.
+    if (searchQuery.trim()) {
+      const rankedMatches = result
+        .map((model) => ({
+          model,
+          score: scoreModelPickerSearch(
+            {
+              name: model.name,
+              ...(model.shortName ? { shortName: model.shortName } : {}),
+              ...(model.subProvider ? { subProvider: model.subProvider } : {}),
+              driverKind: model.driverKind,
+              providerDisplayName: model.instanceDisplayName,
+              isFavorite: favoritesSet.has(providerModelKey(model.instanceId, model.slug)),
+            },
+            searchQuery,
+          ),
+          isFavorite: favoritesSet.has(providerModelKey(model.instanceId, model.slug)),
+          tieBreaker: buildModelPickerSearchText({
+            name: model.name,
+            ...(model.shortName ? { shortName: model.shortName } : {}),
+            ...(model.subProvider ? { subProvider: model.subProvider } : {}),
+            driverKind: model.driverKind,
+            providerDisplayName: model.instanceDisplayName,
+          }),
+        }))
+        .filter(
+          (
+            rankedModel,
+          ): rankedModel is {
+            model: ModelPickerItem;
+            score: number;
+            isFavorite: boolean;
+            tieBreaker: string;
+          } => rankedModel.score !== null,
+        );
+
+      // When searching, we only respect locked provider (by driver kind),
+      // ignoring sidebar selection so account-scoped searches can find a
+      // model before the user chooses a specific instance rail item.
+      if (props.lockedProvider !== null) {
+        return rankedMatches
+          .filter((rankedModel) => matchesLockedProvider(rankedModel.model))
+          .toSorted((a, b) => {
+            const scoreDelta = a.score - b.score;
+            if (scoreDelta !== 0) {
+              return scoreDelta;
+            }
+            if (a.isFavorite !== b.isFavorite) {
+              return a.isFavorite ? -1 : 1;
+            }
+            return a.tieBreaker.localeCompare(b.tieBreaker);
+          })
+          .map((rankedModel) => rankedModel.model);
+      }
+
+      return rankedMatches
+        .toSorted((a, b) => {
+          const scoreDelta = a.score - b.score;
+          if (scoreDelta !== 0) {
+            return scoreDelta;
+          }
+          if (a.isFavorite !== b.isFavorite) {
+            return a.isFavorite ? -1 : 1;
+          }
+          return a.tieBreaker.localeCompare(b.tieBreaker);
+        })
+        .map((rankedModel) => rankedModel.model);
+    }
+
+    if (props.lockedProvider !== null) {
+      result = result.filter((m) => matchesLockedProvider(m));
+      if (showLockedInstanceSidebar) {
+        result = result.filter((m) => m.instanceId === selectedInstanceId);
+      }
+    } else if (selectedInstanceId === "favorites") {
+      result = result.filter((m) => favoritesSet.has(providerModelKey(m.instanceId, m.slug)));
+    } else {
+      result = result.filter((m) => m.instanceId === selectedInstanceId);
+    }
+
+    return sortProviderModelItems(result, {
+      favoriteModelKeys: favoritesSet,
+      groupFavorites: selectedInstanceId !== "favorites",
+      instanceOrder: selectedInstanceId === "favorites" ? instanceOrder : [],
+    });
+  }, [
+    favoritesSet,
+    flatModels,
+    instanceOrder,
+    matchesLockedProvider,
+    props.lockedProvider,
+    searchQuery,
+    showLockedInstanceSidebar,
+    selectedInstanceId,
+  ]);
+
+  const handleModelSelect = useCallback(
+    (modelSlug: string, instanceId: ProviderInstanceId) => {
+      const options = modelOptionsByInstance.get(instanceId);
+      if (!options) {
+        return;
+      }
+      const entry = entryByInstanceId.get(instanceId);
+      if (!entry) {
+        return;
+      }
+      // `resolveSelectableModel` uses the driver kind for normalization
+      // (slug casing etc.). Custom instances share their driver's
+      // normalization rules, so pass the driver kind here.
+      const resolvedModel = resolveSelectableModel(entry.driverKind, modelSlug, options);
+      if (resolvedModel) {
+        onInstanceModelChange(instanceId, resolvedModel);
+      }
+    },
+    [entryByInstanceId, modelOptionsByInstance, onInstanceModelChange],
+  );
+
+  const toggleFavorite = useCallback(
+    (instanceId: ProviderInstanceId, model: string) => {
+      const newFavorites = [...favorites];
+      const index = newFavorites.findIndex((f) => f.provider === instanceId && f.model === model);
+      if (index >= 0) {
+        newFavorites.splice(index, 1);
+      } else {
+        newFavorites.push({ provider: instanceId, model });
+      }
+      updateSettings({ favorites: newFavorites });
+    },
+    [favorites, updateSettings],
+  );
+
+  const LockedProviderIcon =
+    isLocked && props.lockedProvider ? PROVIDER_ICON_BY_PROVIDER[props.lockedProvider] : null;
+  // Header label for locked mode. Use the active instance's displayName
+  // when the lock narrows to exactly one instance (so "Codex Personal"
+  // shows instead of the generic driver label); fall back to the first
+  // matching entry otherwise.
+  const lockedHeaderLabel = useMemo(() => {
+    if (!isLocked || !props.lockedProvider) return null;
+    const matches = instanceEntries.filter((entry) => matchesLockedProvider(entry));
+    if (matches.length === 0) return null;
+    const active = matches.find((entry) => entry.instanceId === props.activeInstanceId);
+    return (active ?? matches[0])?.displayName ?? null;
+  }, [
+    isLocked,
+    matchesLockedProvider,
+    props.lockedProvider,
+    props.activeInstanceId,
+    instanceEntries,
+  ]);
+  const modelJumpCommandByKey = useMemo(() => {
+    const mapping = new Map<
+      string,
+      NonNullable<ReturnType<typeof modelPickerJumpCommandForIndex>>
+    >();
+    for (const [visibleModelIndex, model] of filteredModels.entries()) {
+      const jumpCommand = modelPickerJumpCommandForIndex(visibleModelIndex);
+      if (!jumpCommand) {
+        return mapping;
+      }
+      mapping.set(`${model.instanceId}:${model.slug}`, jumpCommand);
+    }
+    return mapping;
+  }, [filteredModels]);
+  const modelJumpModelKeys = useMemo(
+    () => [...modelJumpCommandByKey.keys()],
+    [modelJumpCommandByKey],
+  );
+  const allModelKeys = useMemo(
+    (): string[] => flatModels.map((model) => `${model.instanceId}:${model.slug}`),
+    [flatModels],
+  );
+  const filteredModelKeys = useMemo(
+    (): string[] => filteredModels.map((model) => `${model.instanceId}:${model.slug}`),
+    [filteredModels],
+  );
+  const filteredModelByKey = useMemo(
+    (): ReadonlyMap<string, ModelPickerItem> =>
+      new Map(filteredModels.map((model) => [`${model.instanceId}:${model.slug}`, model] as const)),
+    [filteredModels],
+  );
+  const modelJumpShortcutContext = useMemo(
+    () =>
+      ({
+        terminalFocus: false,
+        terminalOpen: props.terminalOpen,
+        modelPickerOpen: true,
+      }) as const,
+    [props.terminalOpen],
+  );
+  const modelJumpLabelByKey = useMemo((): ReadonlyMap<string, string> => {
+    if (modelJumpCommandByKey.size === 0) {
+      return EMPTY_MODEL_JUMP_LABELS;
+    }
+    const shortcutLabelOptions = {
+      platform: navigator.platform,
+      context: modelJumpShortcutContext,
+    };
+    const mapping = new Map<string, string>();
+    for (const [modelKey, command] of modelJumpCommandByKey) {
+      const label = shortcutLabelForCommand(keybindings, command, shortcutLabelOptions);
+      if (label) {
+        mapping.set(modelKey, label);
+      }
+    }
+    return mapping.size > 0 ? mapping : EMPTY_MODEL_JUMP_LABELS;
+  }, [keybindings, modelJumpCommandByKey, modelJumpShortcutContext]);
+
+  useEffect(() => {
+    const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) {
+        return;
+      }
+
+      const command = resolveShortcutCommand(event, keybindings, {
+        platform: navigator.platform,
+        context: modelJumpShortcutContext,
+      });
+      const jumpIndex = modelPickerJumpIndexFromCommand(command ?? "");
+      if (jumpIndex === null) {
+        return;
+      }
+
+      const targetModelKey = modelJumpModelKeys[jumpIndex];
+      if (!targetModelKey) {
+        return;
+      }
+      const { instanceId, slug } = splitInstanceModelKey(targetModelKey);
+      event.preventDefault();
+      event.stopPropagation();
+      handleModelSelect(slug, instanceId);
+    };
+
+    window.addEventListener("keydown", onWindowKeyDown, true);
+
+    return () => {
+      window.removeEventListener("keydown", onWindowKeyDown, true);
+    };
+  }, [handleModelSelect, keybindings, modelJumpModelKeys, modelJumpShortcutContext]);
+
+  useLayoutEffect(() => {
+    const listRegion = listRegionRef.current;
+    if (!listRegion) {
+      return;
+    }
+
+    let cancelled = false;
+    let frame = 0;
+    let nestedFrame = 0;
+    let timeout = 0;
+
+    const measureScrollArea = () => {
+      if (cancelled) {
+        return;
+      }
+      const viewport = listRegion.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+      if (!viewport || viewport.scrollHeight <= viewport.clientHeight) {
+        return;
+      }
+      const originalScrollTop = viewport.scrollTop;
+      const maxScrollTop = viewport.scrollHeight - viewport.clientHeight;
+      if (maxScrollTop <= 0) {
+        return;
+      }
+      viewport.scrollTop = Math.min(originalScrollTop + 1, maxScrollTop);
+      viewport.scrollTop = originalScrollTop;
+    };
+
+    queueMicrotask(measureScrollArea);
+    frame = window.requestAnimationFrame(() => {
+      measureScrollArea();
+      nestedFrame = window.requestAnimationFrame(measureScrollArea);
+    });
+    timeout = window.setTimeout(measureScrollArea, 0);
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frame);
+      window.cancelAnimationFrame(nestedFrame);
+      window.clearTimeout(timeout);
+    };
+  }, [filteredModelKeys]);
+
+  return (
+    <TooltipProvider delay={0}>
+      <div
+        className={cn(
+          "relative flex h-screen max-h-96 w-screen max-w-100 overflow-hidden rounded-lg border bg-popover not-dark:bg-clip-padding text-popover-foreground shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+          isLocked && !showLockedInstanceSidebar ? "flex-col" : "flex-row",
+        )}
+      >
+        {/* Locked provider header (only shown in locked mode) */}
+        {isLocked && !showLockedInstanceSidebar && LockedProviderIcon && lockedHeaderLabel && (
+          <div className="flex items-center gap-2 px-4 py-3 border-b">
+            <LockedProviderIcon className="size-5 shrink-0" />
+            <span className="font-medium text-sm">{lockedHeaderLabel}</span>
+          </div>
+        )}
+
+        {/* Sidebar (only in unlocked mode) */}
+        {showSidebar && (
+          <ModelPickerSidebar
+            selectedInstanceId={selectedInstanceId}
+            onSelectInstance={handleSelectInstance}
+            instanceEntries={sidebarInstanceEntries}
+            showFavorites={!isLocked}
+            showComingSoon={!isLocked}
+          />
+        )}
+
+        {/* Main content area */}
+        <Combobox
+          inline
+          items={allModelKeys}
+          filteredItems={filteredModelKeys}
+          filter={null}
+          autoHighlight
+          open
+          value={`${props.activeInstanceId}:${props.model}`}
+          onItemHighlighted={(modelKey) => {
+            highlightedModelKeyRef.current = typeof modelKey === "string" ? modelKey : null;
+          }}
+          onValueChange={(modelKey) => {
+            if (typeof modelKey !== "string") {
+              return;
+            }
+            const { instanceId, slug } = splitInstanceModelKey(modelKey);
+            handleModelSelect(slug, instanceId);
+          }}
+        >
+          <div
+            className={cn(
+              "flex min-h-0 flex-1 flex-col overflow-hidden",
+              isLocked && !showLockedInstanceSidebar ? "min-w-0" : showSidebar && "border-l",
+            )}
+          >
+            {/* Search bar */}
+            <div className="flex items-center gap-2 border-b px-3 py-2">
+              <ComboboxInput
+                ref={searchInputRef}
+                className="flex-1 [&_input]:font-sans rounded-md"
+                inputClassName="border-0 shadow-none ring-0 focus-visible:ring-0"
+                placeholder="Search models..."
+                showTrigger={false}
+                startAddon={<SearchIcon className="size-4 shrink-0 text-muted-foreground/50" />}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    props.onRequestClose?.();
+                    return;
+                  }
+                  if (e.key === "Enter" && highlightedModelKeyRef.current) {
+                    (
+                      e as typeof e & { preventBaseUIHandler?: () => void }
+                    ).preventBaseUIHandler?.();
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const { instanceId, slug } = splitInstanceModelKey(
+                      highlightedModelKeyRef.current,
+                    );
+                    handleModelSelect(slug, instanceId);
+                    return;
+                  }
+                  e.stopPropagation();
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
+                size="sm"
+              />
+              {props.showResetToDefault ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="shrink-0 text-xs"
+                  disabled={props.disableResetToDefault}
+                  onClick={() => props.onResetToDefault?.()}
+                >
+                  Reset to default
+                </Button>
+              ) : null}
+            </div>
+
+            {/* Model list */}
+            <div
+              ref={listRegionRef}
+              className="relative min-h-0 flex-1 before:pointer-events-none before:absolute before:inset-0 before:bg-muted/40"
+            >
+              <ComboboxList className="model-picker-list size-full divide-y px-2 py-1">
+                {filteredModelKeys.map((modelKey, index) => {
+                  const model = filteredModelByKey.get(modelKey);
+                  if (!model) {
+                    return null;
+                  }
+                  return (
+                    <ModelListRow
+                      key={modelKey}
+                      index={index}
+                      model={model}
+                      instanceId={model.instanceId}
+                      driverKind={model.driverKind}
+                      providerDisplayName={model.instanceDisplayName}
+                      providerAccentColor={model.instanceAccentColor}
+                      isFavorite={favoritesSet.has(modelKey)}
+                      showProvider={!isLocked || showLockedInstanceSidebar}
+                      preferShortName={!isLocked}
+                      useTriggerLabel={isLocked && !showLockedInstanceSidebar}
+                      showNewBadge={isModelPickerNewModel(model.driverKind, model.slug)}
+                      jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
+                      onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}
+                    />
+                  );
+                })}
+              </ComboboxList>
+            </div>
+            <ComboboxEmpty className="not-empty:py-6 empty:h-0 text-xs font-normal leading-snug">
+              No models found
+            </ComboboxEmpty>
+          </div>
+        </Combobox>
+      </div>
+    </TooltipProvider>
+  );
+});

--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -1,0 +1,1378 @@
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+import { EnvironmentId } from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { page, userEvent } from "vitest/browser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { useState } from "react";
+
+import { ProviderModelPicker } from "./ProviderModelPicker";
+import { getCustomModelOptionsByInstance } from "../../modelSelection";
+import {
+  deriveProviderInstanceEntries,
+  sortProviderInstanceEntries,
+} from "../../providerInstances";
+import type { ModelEsque } from "./providerIconUtils";
+import {
+  DEFAULT_CLIENT_SETTINGS,
+  DEFAULT_UNIFIED_SETTINGS,
+  type UnifiedSettings,
+} from "@t3tools/contracts/settings";
+import { __resetLocalApiForTests } from "../../localApi";
+
+// Mock the environments/runtime module to provide a mock primary environment connection
+vi.mock("../../environments/runtime", () => {
+  const primaryConnection = {
+    kind: "primary" as const,
+    knownEnvironment: {
+      id: "environment-local",
+      label: "Local environment",
+      source: "manual" as const,
+      environmentId: EnvironmentId.make("environment-local"),
+      target: {
+        httpBaseUrl: "http://localhost:3000",
+        wsBaseUrl: "ws://localhost:3000",
+      },
+    },
+    environmentId: EnvironmentId.make("environment-local"),
+    client: {
+      server: {
+        getConfig: vi.fn(),
+        updateSettings: vi.fn(),
+      },
+    },
+    ensureBootstrapped: async () => undefined,
+    reconnect: async () => undefined,
+    dispose: async () => undefined,
+  };
+
+  return {
+    getEnvironmentHttpBaseUrl: () => "http://localhost:3000",
+    getSavedEnvironmentRecord: () => null,
+    getSavedEnvironmentRuntimeState: () => null,
+    hasSavedEnvironmentRegistryHydrated: () => true,
+    listSavedEnvironmentRecords: () => [],
+    resetSavedEnvironmentRegistryStoreForTests: vi.fn(),
+    resetSavedEnvironmentRuntimeStoreForTests: vi.fn(),
+    resolveEnvironmentHttpUrl: (_environmentId: unknown, path: string) =>
+      new URL(path, "http://localhost:3000").toString(),
+    waitForSavedEnvironmentRegistryHydration: async () => undefined,
+    addSavedEnvironment: vi.fn(),
+    disconnectSavedEnvironment: vi.fn(),
+    ensureEnvironmentConnectionBootstrapped: async () => undefined,
+    getPrimaryEnvironmentConnection: () => primaryConnection,
+    readEnvironmentConnection: () => primaryConnection,
+    reconnectSavedEnvironment: vi.fn(),
+    removeSavedEnvironment: vi.fn(),
+    requireEnvironmentConnection: () => primaryConnection,
+    resetEnvironmentServiceForTests: vi.fn(),
+    startEnvironmentConnectionService: vi.fn(),
+    subscribeEnvironmentConnections: () => () => {},
+    useSavedEnvironmentRegistryStore: (
+      selector: (state: { byId: Record<string, never> }) => unknown,
+    ) => selector({ byId: {} }),
+    useSavedEnvironmentRuntimeStore: (
+      selector: (state: { byId: Record<string, never> }) => unknown,
+    ) => selector({ byId: {} }),
+  };
+});
+
+function selectDescriptor(
+  id: string,
+  label: string,
+  options: ReadonlyArray<{ id: string; label: string; isDefault?: boolean }>,
+) {
+  return {
+    id,
+    label,
+    type: "select" as const,
+    options: [...options],
+    ...(options.find((option) => option.isDefault)?.id
+      ? { currentValue: options.find((option) => option.isDefault)?.id }
+      : {}),
+  };
+}
+
+function booleanDescriptor(id: string, label: string) {
+  return {
+    id,
+    label,
+    type: "boolean" as const,
+  };
+}
+
+const TEST_PROVIDERS: ReadonlyArray<ServerProvider> = [
+  {
+    driver: ProviderDriverKind.make("codex"),
+    instanceId: ProviderInstanceId.make("codex"),
+    displayName: "Codex",
+    enabled: true,
+    installed: true,
+    version: "0.116.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: new Date().toISOString(),
+    slashCommands: [],
+    skills: [],
+    models: [
+      {
+        slug: "gpt-5-codex",
+        name: "GPT-5 Codex",
+        isCustom: false,
+        capabilities: createModelCapabilities({
+          optionDescriptors: [
+            selectDescriptor("reasoningEffort", "Reasoning", [
+              { id: "low", label: "low" },
+              { id: "medium", label: "medium", isDefault: true },
+              { id: "high", label: "high" },
+            ]),
+            booleanDescriptor("fastMode", "Fast Mode"),
+          ],
+        }),
+      },
+      {
+        slug: "gpt-5.3-codex",
+        name: "GPT-5.3 Codex",
+        isCustom: false,
+        capabilities: createModelCapabilities({
+          optionDescriptors: [
+            selectDescriptor("reasoningEffort", "Reasoning", [
+              { id: "low", label: "low" },
+              { id: "medium", label: "medium", isDefault: true },
+              { id: "high", label: "high" },
+            ]),
+            booleanDescriptor("fastMode", "Fast Mode"),
+          ],
+        }),
+      },
+    ],
+  },
+  {
+    driver: ProviderDriverKind.make("claudeAgent"),
+    instanceId: ProviderInstanceId.make("claudeAgent"),
+    displayName: "Claude",
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: new Date().toISOString(),
+    slashCommands: [],
+    skills: [],
+    models: [
+      {
+        slug: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        isCustom: false,
+        capabilities: createModelCapabilities({
+          optionDescriptors: [
+            selectDescriptor("effort", "Reasoning", [
+              { id: "low", label: "low" },
+              { id: "medium", label: "medium", isDefault: true },
+              { id: "high", label: "high" },
+              { id: "max", label: "max" },
+            ]),
+            booleanDescriptor("thinking", "Thinking"),
+          ],
+        }),
+      },
+      {
+        slug: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        isCustom: false,
+        capabilities: createModelCapabilities({
+          optionDescriptors: [
+            selectDescriptor("effort", "Reasoning", [
+              { id: "low", label: "low" },
+              { id: "medium", label: "medium", isDefault: true },
+              { id: "high", label: "high" },
+              { id: "max", label: "max" },
+            ]),
+            booleanDescriptor("thinking", "Thinking"),
+          ],
+        }),
+      },
+      {
+        slug: "claude-haiku-4-5",
+        name: "Claude Haiku 4.5",
+        isCustom: false,
+        capabilities: createModelCapabilities({
+          optionDescriptors: [
+            selectDescriptor("effort", "Reasoning", [
+              { id: "low", label: "low" },
+              { id: "medium", label: "medium", isDefault: true },
+              { id: "high", label: "high" },
+            ]),
+            booleanDescriptor("thinking", "Thinking"),
+          ],
+        }),
+      },
+    ],
+  },
+];
+
+const CODEX_INSTANCE_ID = ProviderInstanceId.make("codex");
+const CLAUDE_INSTANCE_ID = ProviderInstanceId.make("claudeAgent");
+const OPENCODE_INSTANCE_ID = ProviderInstanceId.make("opencode");
+const TEST_PROVIDER_PICKER_PERSISTENCE_KEY = "t3code:test-provider-model-picker:v1";
+
+function buildCodexProvider(models: ServerProvider["models"]): ServerProvider {
+  return {
+    driver: ProviderDriverKind.make("codex"),
+    instanceId: ProviderInstanceId.make("codex"),
+    displayName: "Codex",
+    enabled: true,
+    installed: true,
+    version: "0.116.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: new Date().toISOString(),
+    models,
+    slashCommands: [],
+    skills: [],
+  };
+}
+
+function buildOpenCodeProvider(models: ServerProvider["models"]): ServerProvider {
+  return {
+    driver: ProviderDriverKind.make("opencode"),
+    instanceId: ProviderInstanceId.make("opencode"),
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: new Date().toISOString(),
+    models,
+    slashCommands: [],
+    skills: [],
+  };
+}
+
+async function mountPicker(props: {
+  activeInstanceId?: ProviderInstanceId;
+  model: string;
+  lockedProvider: ProviderDriverKind | null;
+  lockedContinuationGroupKey?: string | null;
+  providers?: ReadonlyArray<ServerProvider>;
+  settings?: UnifiedSettings;
+  persistenceKey?: string | null;
+  triggerVariant?: "ghost" | "outline";
+}) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const onInstanceModelChange = vi.fn();
+  const providers = props.providers ?? TEST_PROVIDERS;
+  const instanceEntries = sortProviderInstanceEntries(deriveProviderInstanceEntries(providers));
+  const activeInstanceId = props.activeInstanceId ?? CODEX_INSTANCE_ID;
+  const modelOptionsByInstance = getCustomModelOptionsByInstance(
+    props.settings ?? DEFAULT_UNIFIED_SETTINGS,
+    providers,
+    activeInstanceId,
+    props.model,
+  );
+  const screen = await render(
+    <ProviderModelPicker
+      activeInstanceId={activeInstanceId}
+      model={props.model}
+      lockedProvider={props.lockedProvider}
+      lockedContinuationGroupKey={props.lockedContinuationGroupKey ?? null}
+      instanceEntries={instanceEntries}
+      modelOptionsByInstance={modelOptionsByInstance}
+      {...(props.persistenceKey !== undefined ? { persistenceKey: props.persistenceKey } : {})}
+      triggerVariant={props.triggerVariant}
+      onInstanceModelChange={onInstanceModelChange}
+    />,
+    { container: host },
+  );
+
+  return {
+    onInstanceModelChange,
+    // Back-compat alias used by callers that still assert on the old callback
+    // name. Delegates to the instance-aware mock so existing expectations work.
+    get onProviderModelChange() {
+      return onInstanceModelChange;
+    },
+    cleanup: async () => {
+      await screen.unmount();
+      host.remove();
+    },
+  };
+}
+
+async function mountControlledPicker(props: {
+  activeInstanceId?: ProviderInstanceId;
+  model: string;
+  lockedProvider: ProviderDriverKind | null;
+  providers?: ReadonlyArray<ServerProvider>;
+  persistenceKey: string;
+}) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const providers = props.providers ?? TEST_PROVIDERS;
+  const instanceEntries = sortProviderInstanceEntries(deriveProviderInstanceEntries(providers));
+
+  function ControlledPicker() {
+    const [selection, setSelection] = useState({
+      instanceId: props.activeInstanceId ?? CODEX_INSTANCE_ID,
+      model: props.model,
+    });
+    const modelOptionsByInstance = getCustomModelOptionsByInstance(
+      DEFAULT_UNIFIED_SETTINGS,
+      providers,
+      selection.instanceId,
+      selection.model,
+    );
+
+    return (
+      <>
+        <div data-selected-model={`${selection.instanceId}:${selection.model}`} />
+        <ProviderModelPicker
+          activeInstanceId={selection.instanceId}
+          model={selection.model}
+          lockedProvider={props.lockedProvider}
+          instanceEntries={instanceEntries}
+          modelOptionsByInstance={modelOptionsByInstance}
+          persistenceKey={props.persistenceKey}
+          onInstanceModelChange={(instanceId, model) => {
+            setSelection({ instanceId, model });
+          }}
+        />
+      </>
+    );
+  }
+
+  const screen = await render(<ControlledPicker />, { container: host });
+
+  return {
+    cleanup: async () => {
+      await screen.unmount();
+      host.remove();
+    },
+    getSelection: () =>
+      document.querySelector("[data-selected-model]")?.getAttribute("data-selected-model"),
+  };
+}
+
+function getModelPickerListElement() {
+  const modelPickerList = document.querySelector<HTMLElement>(".model-picker-list");
+  expect(modelPickerList).not.toBeNull();
+  return modelPickerList!;
+}
+
+function getModelPickerListText() {
+  return getModelPickerListElement().textContent ?? "";
+}
+
+function getVisibleModelNames() {
+  return Array.from(getModelPickerListElement().querySelectorAll<HTMLDivElement>("div.font-medium"))
+    .map((element) => element.textContent?.replace(/New$/u, "").trim() ?? "")
+    .filter((text) => text.length > 0);
+}
+
+function getSidebarProviderOrder() {
+  return Array.from(document.querySelectorAll<HTMLElement>("[data-model-picker-provider]")).map(
+    (element) => element.dataset.modelPickerProvider ?? "",
+  );
+}
+
+describe("ProviderModelPicker", () => {
+  beforeEach(async () => {
+    // Reset test environment before each test
+    await __resetLocalApiForTests();
+  });
+
+  afterEach(async () => {
+    document.body.innerHTML = "";
+    await __resetLocalApiForTests();
+    localStorage.removeItem(TEST_PROVIDER_PICKER_PERSISTENCE_KEY);
+  });
+
+  it("shows provider sidebar in unlocked mode", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).not.toContain("Codex");
+        expect(text).toContain("Claude");
+        expect(text).toContain("Claude Opus 4.6");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows favorites first in the provider sidebar", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(getSidebarProviderOrder().slice(0, 3)).toEqual([
+          "favorites",
+          "codex",
+          "claudeAgent",
+        ]);
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("filters models by selected provider in sidebar", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      // Start with Claude models visible
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).not.toContain("GPT-5 Codex");
+        expect(text).toContain("Claude Opus 4.6");
+      });
+
+      // Click on Codex provider in sidebar
+      await vi.waitFor(() => {
+        expect(document.querySelector('[data-model-picker-provider="codex"]')).not.toBeNull();
+      });
+      await page.getByRole("button", { name: "Codex", exact: true }).click();
+
+      // Now should only show Codex models
+      await vi.waitFor(() => {
+        const listText = getModelPickerListText();
+        expect(listText).toContain("GPT-5 Codex");
+        expect(listText).not.toContain("Claude Opus 4.6");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("uses client model visibility and ordering preferences", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+      settings: {
+        ...DEFAULT_UNIFIED_SETTINGS,
+        providerModelPreferences: {
+          [CLAUDE_INSTANCE_ID]: {
+            hiddenModels: ["claude-opus-4-6"],
+            modelOrder: ["claude-haiku-4-5", "claude-sonnet-4-6"],
+          },
+        },
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(getVisibleModelNames()).toEqual(["Claude Haiku 4.5", "Claude Sonnet 4.6"]);
+        expect(getModelPickerListText()).not.toContain("Claude Opus 4.6");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("focuses the search input after selecting a sidebar provider", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(document.querySelector('[data-model-picker-provider="codex"]')).not.toBeNull();
+      });
+      await page.getByRole("button", { name: "Codex", exact: true }).click();
+
+      await vi.waitFor(() => {
+        const searchInput = document.querySelector<HTMLInputElement>(
+          'input[placeholder="Search models..."]',
+        );
+        expect(searchInput).not.toBeNull();
+        expect(document.activeElement).toBe(searchInput);
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows locked provider header and only its models in locked mode", async () => {
+    localStorage.setItem(
+      "t3code:client-settings:v1",
+      JSON.stringify({
+        ...DEFAULT_CLIENT_SETTINGS,
+        favorites: [
+          { provider: "codex", model: "gpt-5-codex" },
+          { provider: "claudeAgent", model: "claude-sonnet-4-6" },
+        ],
+      }),
+    );
+
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: ProviderDriverKind.make("claudeAgent"),
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        // Should show locked provider label
+        expect(text).toContain("Claude");
+        expect(getVisibleModelNames()).toEqual([
+          "Claude Sonnet 4.6",
+          "Claude Opus 4.6",
+          "Claude Haiku 4.5",
+        ]);
+      });
+    } finally {
+      localStorage.removeItem("t3code:client-settings:v1");
+      await mounted.cleanup();
+    }
+  });
+
+  it("keeps an instance sidebar in locked mode when that provider has multiple instances", async () => {
+    const defaultCodexModels: ServerProvider["models"] = [
+      {
+        slug: "gpt-work",
+        name: "GPT Work",
+        isCustom: false,
+        capabilities: createModelCapabilities({ optionDescriptors: [] }),
+      },
+    ];
+    const personalCodexModels: ServerProvider["models"] = [
+      {
+        slug: "gpt-personal",
+        name: "GPT Personal",
+        isCustom: false,
+        capabilities: createModelCapabilities({ optionDescriptors: [] }),
+      },
+    ];
+    const isolatedCodexModels: ServerProvider["models"] = [
+      {
+        slug: "gpt-isolated",
+        name: "GPT Isolated",
+        isCustom: false,
+        capabilities: createModelCapabilities({ optionDescriptors: [] }),
+      },
+    ];
+    const providers: ReadonlyArray<ServerProvider> = [
+      {
+        ...buildCodexProvider(defaultCodexModels),
+        instanceId: "codex" as ProviderInstanceId,
+        displayName: "Codex Work",
+        accentColor: "#2563eb",
+        continuation: { groupKey: "codex:home:/Users/julius/.codex" },
+      },
+      {
+        ...buildCodexProvider(personalCodexModels),
+        instanceId: "codex_personal" as ProviderInstanceId,
+        displayName: "Codex Personal",
+        accentColor: "#dc2626",
+        continuation: { groupKey: "codex:home:/Users/julius/.codex" },
+      },
+      {
+        ...buildCodexProvider(isolatedCodexModels),
+        instanceId: "codex_isolated" as ProviderInstanceId,
+        displayName: "Codex Isolated",
+        accentColor: "#16a34a",
+        continuation: { groupKey: "codex:home:/Users/julius/.codex_isolated" },
+      },
+      TEST_PROVIDERS[1]!,
+    ];
+    const mounted = await mountPicker({
+      activeInstanceId: "codex" as ProviderInstanceId,
+      model: "gpt-work",
+      lockedProvider: ProviderDriverKind.make("codex"),
+      lockedContinuationGroupKey: "codex:home:/Users/julius/.codex",
+      providers,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(getSidebarProviderOrder()).toEqual(["codex", "codex_personal"]);
+        expect(getModelPickerListText()).not.toContain("Codex Isolated");
+        expect(
+          document.querySelector<HTMLElement>('[data-model-picker-provider="codex_personal"]')
+            ?.dataset.providerAccentColor,
+        ).toBe("#dc2626");
+        expect(getModelPickerListText()).toContain("Codex Work");
+        expect(getVisibleModelNames()).toEqual(["GPT Work"]);
+      });
+
+      await page.getByRole("button", { name: "Codex Personal" }).click();
+
+      await vi.waitFor(() => {
+        expect(getModelPickerListText()).toContain("Codex Personal");
+        expect(getVisibleModelNames()).toEqual(["GPT Personal"]);
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("falls back to the active provider's first model when props.model belongs to another provider (#1982)", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const onInstanceModelChange = vi.fn();
+    const modelOptionsByInstance = new Map<ProviderInstanceId, ReadonlyArray<ModelEsque>>([
+      [
+        "claudeAgent" as ProviderInstanceId,
+        [
+          { slug: "claude-opus-4-6", name: "Claude Opus 4.6" },
+          { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+        ],
+      ],
+      ["codex" as ProviderInstanceId, [{ slug: "gpt-5-codex", name: "GPT-5 Codex" }]],
+      ["cursor" as ProviderInstanceId, []],
+      ["opencode" as ProviderInstanceId, []],
+    ]);
+    const instanceEntries = sortProviderInstanceEntries(
+      deriveProviderInstanceEntries(TEST_PROVIDERS),
+    );
+    const screen = await render(
+      <ProviderModelPicker
+        activeInstanceId={"claudeAgent" as ProviderInstanceId}
+        model="gpt-5-codex"
+        lockedProvider={null}
+        instanceEntries={instanceEntries}
+        modelOptionsByInstance={modelOptionsByInstance}
+        onInstanceModelChange={onInstanceModelChange}
+      />,
+      { container: host },
+    );
+
+    try {
+      const trigger = document.querySelector<HTMLElement>(
+        '[data-chat-provider-model-picker="true"]',
+      );
+      expect(trigger).not.toBeNull();
+      const label = trigger?.textContent ?? "";
+      expect(label).not.toContain("gpt-5-codex");
+      expect(label).toContain("Claude Opus 4.6");
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
+
+  it("uses the trigger label for locked opencode rows", async () => {
+    const providers: ReadonlyArray<ServerProvider> = [
+      buildOpenCodeProvider([
+        {
+          slug: "github-copilot/claude-opus-4.5",
+          name: "Claude Opus 4.5",
+          subProvider: "GitHub Copilot",
+          shortName: "Opus 4.5",
+          isCustom: false,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("reasoningEffort", "Reasoning", [
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium", isDefault: true },
+                { id: "high", label: "high" },
+              ]),
+            ],
+          }),
+        },
+      ]),
+    ];
+    const mounted = await mountPicker({
+      activeInstanceId: OPENCODE_INSTANCE_ID,
+      model: "github-copilot/claude-opus-4.5",
+      lockedProvider: ProviderDriverKind.make("opencode"),
+      providers,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        const trigger = document.querySelector<HTMLElement>(
+          '[data-chat-provider-model-picker="true"]',
+        );
+        expect(trigger?.textContent).toContain("GitHub Copilot");
+        expect(trigger?.textContent).toContain("Opus 4.5");
+      });
+
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(getVisibleModelNames()).toEqual(["GitHub Copilot · Opus 4.5"]);
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("searches models by name in flat list", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Claude Opus 4.6");
+        expect(text).not.toContain("GPT-5 Codex");
+      });
+
+      // Find and type in search box
+      const searchInput = page.getByPlaceholder("Search models...");
+      await searchInput.fill("claude");
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Claude Opus 4.6");
+        expect(text).not.toContain("GPT-5 Codex");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("supports arrow-key navigation in the model picker", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: ProviderDriverKind.make("claudeAgent"),
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      const searchInput = page.getByPlaceholder("Search models...");
+      await userEvent.click(searchInput);
+      await userEvent.keyboard("{ArrowDown}");
+      await vi.waitFor(() => {
+        const highlightedItem = document.querySelector<HTMLElement>(
+          '[data-slot="combobox-item"][data-highlighted]',
+        );
+        expect(highlightedItem).not.toBeNull();
+        expect(highlightedItem?.textContent).toContain("Claude Opus 4.6");
+      });
+      await userEvent.keyboard("{ArrowDown}");
+      await vi.waitFor(() => {
+        const highlightedItem = document.querySelector<HTMLElement>(
+          '[data-slot="combobox-item"][data-highlighted]',
+        );
+        expect(highlightedItem).not.toBeNull();
+        expect(highlightedItem?.textContent).toContain("Claude Sonnet 4.6");
+      });
+      await userEvent.keyboard("{Enter}");
+
+      expect(mounted.onProviderModelChange).toHaveBeenCalledWith(
+        "claudeAgent",
+        "claude-sonnet-4-6",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("hides the provider sidebar while searching", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(getSidebarProviderOrder().length).toBeGreaterThan(0);
+      });
+
+      await page.getByPlaceholder("Search models...").fill("cla");
+
+      await vi.waitFor(() => {
+        expect(getSidebarProviderOrder()).toEqual([]);
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("closes the picker when escape is pressed in search", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      const searchInput = page.getByPlaceholder("Search models...");
+      await searchInput.click();
+      const searchInputElement = document.querySelector<HTMLInputElement>(
+        'input[placeholder="Search models..."]',
+      );
+      expect(searchInputElement).not.toBeNull();
+      searchInputElement!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+
+      await vi.waitFor(() => {
+        expect(document.querySelector(".model-picker-list")).toBeNull();
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("searches models by provider name", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Claude Opus 4.6");
+        expect(text).not.toContain("GPT-5 Codex");
+      });
+
+      // Search by provider name
+      const searchInput = page.getByPlaceholder("Search models...");
+      await searchInput.fill("codex");
+
+      await vi.waitFor(() => {
+        const listText = getModelPickerListText();
+        expect(listText).toContain("GPT-5 Codex");
+        expect(listText).not.toContain("Claude Opus 4.6");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("matches fuzzy multi-token queries across provider and model text", async () => {
+    const providers: ReadonlyArray<ServerProvider> = [
+      buildCodexProvider([
+        {
+          slug: "gpt-5-codex",
+          name: "GPT-5 Codex",
+          isCustom: false,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("reasoningEffort", "Reasoning", [
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium", isDefault: true },
+                { id: "high", label: "high" },
+              ]),
+              booleanDescriptor("fastMode", "Fast Mode"),
+            ],
+          }),
+        },
+      ]),
+      buildOpenCodeProvider([
+        {
+          slug: "github-copilot/claude-opus-4.7",
+          name: "Claude Opus 4.7",
+          subProvider: "GitHub Copilot",
+          isCustom: false,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("reasoningEffort", "Reasoning", [
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium", isDefault: true },
+                { id: "high", label: "high" },
+              ]),
+            ],
+          }),
+        },
+      ]),
+    ];
+    const mounted = await mountPicker({
+      activeInstanceId: OPENCODE_INSTANCE_ID,
+      model: "github-copilot/claude-opus-4.7",
+      lockedProvider: null,
+      providers,
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await page.getByPlaceholder("Search models...").fill("coplt op");
+
+      await vi.waitFor(() => {
+        const listText = getModelPickerListText();
+        expect(listText).toContain("Claude Opus 4.7");
+        expect(listText).not.toContain("GPT-5 Codex");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("renders each search result with its own provider branding", async () => {
+    const providers: ReadonlyArray<ServerProvider> = [
+      buildOpenCodeProvider([
+        {
+          slug: "github-copilot/claude-opus-4.7",
+          name: "Claude Opus 4.7",
+          subProvider: "GitHub Copilot",
+          isCustom: false,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("reasoningEffort", "Reasoning", [
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium", isDefault: true },
+                { id: "high", label: "high" },
+              ]),
+            ],
+          }),
+        },
+      ]),
+      {
+        ...TEST_PROVIDERS[1]!,
+        models: [
+          {
+            slug: "claude-opus-4-6",
+            name: "Claude Opus 4.6",
+            isCustom: false,
+            capabilities: createModelCapabilities({
+              optionDescriptors: [
+                selectDescriptor("effort", "Reasoning", [
+                  { id: "low", label: "low" },
+                  { id: "medium", label: "medium", isDefault: true },
+                  { id: "high", label: "high" },
+                  { id: "max", label: "max" },
+                ]),
+                booleanDescriptor("thinking", "Thinking"),
+              ],
+            }),
+          },
+        ],
+      },
+    ];
+    const mounted = await mountPicker({
+      activeInstanceId: OPENCODE_INSTANCE_ID,
+      model: "github-copilot/claude-opus-4.7",
+      lockedProvider: null,
+      providers,
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await page.getByPlaceholder("Search models...").fill("opus");
+
+      await vi.waitFor(() => {
+        const listText = getModelPickerListText();
+        expect(listText).toContain("OpenCode · GitHub Copilot");
+        expect(listText).toContain("Claude");
+        expect(listText).not.toContain("OpenCodeClaude Opus 4.6");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("toggles favorite stars when clicked", async () => {
+    localStorage.removeItem("t3code:client-settings:v1");
+
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Claude Opus 4.6");
+      });
+
+      const getFirstStarButton = () => {
+        const starButton = document.querySelector<HTMLButtonElement>(
+          'button[aria-label*="favorites"]',
+        );
+        expect(starButton).not.toBeNull();
+        return starButton!;
+      };
+
+      const firstStar = getFirstStarButton();
+      const initialAriaLabel = firstStar.getAttribute("aria-label");
+      expect(
+        initialAriaLabel === "Add to favorites" || initialAriaLabel === "Remove from favorites",
+      ).toBe(true);
+
+      await page.getByRole("button", { name: initialAriaLabel! }).first().click();
+
+      const expectedAriaLabel =
+        initialAriaLabel === "Add to favorites" ? "Remove from favorites" : "Add to favorites";
+
+      await vi.waitFor(() => {
+        expect(getFirstStarButton().getAttribute("aria-label")).toBe(expectedAriaLabel);
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem("t3code:client-settings:v1");
+    }
+  });
+
+  it("does not duplicate favorited models across favorites and all models sections", async () => {
+    localStorage.removeItem("t3code:client-settings:v1");
+
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Claude Opus 4.6");
+      });
+
+      const favoriteButton = page.getByRole("button", {
+        name: "Add to favorites",
+      });
+      await favoriteButton.first().click();
+
+      await vi.waitFor(async () => {
+        const favoritedModelRows = Array.from(
+          getModelPickerListElement().querySelectorAll<HTMLDivElement>("div.font-medium"),
+        ).filter((element) => element.textContent?.trim() === "Claude Opus 4.6");
+        expect(favoritedModelRows.length).toBe(1);
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem("t3code:client-settings:v1");
+    }
+  });
+
+  it("shows favorited models first within the selected provider list", async () => {
+    localStorage.setItem(
+      "t3code:client-settings:v1",
+      JSON.stringify({
+        ...DEFAULT_CLIENT_SETTINGS,
+        favorites: [{ provider: "codex", model: "gpt-5.3-codex" }],
+      }),
+    );
+
+    const mounted = await mountPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await page.getByRole("button", { name: "Codex", exact: true }).click();
+
+      await vi.waitFor(() => {
+        expect(getVisibleModelNames().slice(0, 2)).toEqual(["GPT-5.3 Codex", "GPT-5 Codex"]);
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem("t3code:client-settings:v1");
+    }
+  });
+
+  it("dispatches callback with correct provider and model when selected", async () => {
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: ProviderDriverKind.make("claudeAgent"),
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Claude Sonnet 4.6");
+      });
+
+      // Click on a model
+      const modelRow = page.getByText("Claude Sonnet 4.6").first();
+      await modelRow.click();
+
+      // Verify callback was called with correct values
+      expect(mounted.onProviderModelChange).toHaveBeenCalledWith(
+        "claudeAgent",
+        "claude-sonnet-4-6",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("only shows codex spark when the server reports it", async () => {
+    const providersWithoutSpark: ReadonlyArray<ServerProvider> = [
+      buildCodexProvider([
+        {
+          slug: "gpt-5.3-codex",
+          name: "GPT-5.3 Codex",
+          isCustom: false,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("reasoningEffort", "Reasoning", [
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium", isDefault: true },
+                { id: "high", label: "high" },
+              ]),
+              booleanDescriptor("fastMode", "Fast Mode"),
+            ],
+          }),
+        },
+      ]),
+      TEST_PROVIDERS[1]!,
+    ];
+    const providersWithSpark: ReadonlyArray<ServerProvider> = [
+      buildCodexProvider([
+        {
+          slug: "gpt-5.3-codex",
+          name: "GPT-5.3 Codex",
+          isCustom: false,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("reasoningEffort", "Reasoning", [
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium", isDefault: true },
+                { id: "high", label: "high" },
+              ]),
+              booleanDescriptor("fastMode", "Fast Mode"),
+            ],
+          }),
+        },
+        {
+          slug: "gpt-5.3-codex-spark",
+          name: "GPT-5.3 Codex Spark",
+          isCustom: false,
+          capabilities: createModelCapabilities({
+            optionDescriptors: [
+              selectDescriptor("reasoningEffort", "Reasoning", [
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium", isDefault: true },
+                { id: "high", label: "high" },
+              ]),
+              booleanDescriptor("fastMode", "Fast Mode"),
+            ],
+          }),
+        },
+      ]),
+      TEST_PROVIDERS[1]!,
+    ];
+
+    const hidden = await mountPicker({
+      model: "gpt-5.3-codex",
+      lockedProvider: null,
+      providers: providersWithoutSpark,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("GPT-5.3 Codex");
+        expect(text).not.toContain("GPT-5.3 Codex Spark");
+      });
+    } finally {
+      await hidden.cleanup();
+    }
+
+    const visible = await mountPicker({
+      model: "gpt-5.3-codex",
+      lockedProvider: null,
+      providers: providersWithSpark,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(document.body.textContent ?? "").toContain("GPT-5.3 Codex Spark");
+      });
+    } finally {
+      await visible.cleanup();
+    }
+  });
+
+  it("shows disabled providers grayed out in sidebar", async () => {
+    const disabledProviders = TEST_PROVIDERS.slice();
+    const claudeIndex = disabledProviders.findIndex(
+      (provider) => provider.instanceId === ProviderInstanceId.make("claudeAgent"),
+    );
+    if (claudeIndex >= 0) {
+      const claudeProvider = disabledProviders[claudeIndex]!;
+      disabledProviders[claudeIndex] = {
+        ...claudeProvider,
+        enabled: false,
+        status: "disabled",
+      };
+    }
+
+    const mounted = await mountPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+      providers: disabledProviders,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("GPT-5 Codex");
+        // Disabled provider should not have its models shown
+        expect(text).not.toContain("Claude Opus 4.6");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("accepts outline trigger styling", async () => {
+    const mounted = await mountPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+      triggerVariant: "outline",
+    });
+
+    try {
+      const button = document.querySelector("button");
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error("Expected picker trigger button to be rendered.");
+      }
+      expect(button.className).toContain("border-input");
+      expect(button.className).toContain("bg-popover");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("restores a persisted selection and resets back to the default selection", async () => {
+    localStorage.setItem(
+      TEST_PROVIDER_PICKER_PERSISTENCE_KEY,
+      JSON.stringify({
+        instanceId: "claudeAgent",
+        model: "claude-sonnet-4-6",
+      }),
+    );
+
+    const mounted = await mountControlledPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+      persistenceKey: TEST_PROVIDER_PICKER_PERSISTENCE_KEY,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(mounted.getSelection()).toBe("claudeAgent:claude-sonnet-4-6");
+      });
+
+      await page.getByRole("button").click();
+      await page.getByRole("button", { name: "Reset to default" }).click();
+
+      await vi.waitFor(() => {
+        expect(mounted.getSelection()).toBe("codex:gpt-5-codex");
+        expect(localStorage.getItem(TEST_PROVIDER_PICKER_PERSISTENCE_KEY)).toBeNull();
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("falls back invalid persisted values to the first available provider model", async () => {
+    localStorage.setItem(
+      TEST_PROVIDER_PICKER_PERSISTENCE_KEY,
+      JSON.stringify({
+        instanceId: "missing-provider",
+        model: "missing-model",
+      }),
+    );
+
+    const mounted = await mountControlledPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+      persistenceKey: TEST_PROVIDER_PICKER_PERSISTENCE_KEY,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(mounted.getSelection()).toBe("codex:gpt-5-codex");
+        expect(localStorage.getItem(TEST_PROVIDER_PICKER_PERSISTENCE_KEY)).toBe(
+          JSON.stringify({
+            instanceId: "codex",
+            model: "gpt-5-codex",
+          }),
+        );
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("syncs persisted selection updates from storage events", async () => {
+    const mounted = await mountControlledPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+      persistenceKey: TEST_PROVIDER_PICKER_PERSISTENCE_KEY,
+    });
+
+    try {
+      localStorage.setItem(
+        TEST_PROVIDER_PICKER_PERSISTENCE_KEY,
+        JSON.stringify({
+          instanceId: "claudeAgent",
+          model: "claude-sonnet-4-6",
+        }),
+      );
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: TEST_PROVIDER_PICKER_PERSISTENCE_KEY,
+          newValue: localStorage.getItem(TEST_PROVIDER_PICKER_PERSISTENCE_KEY),
+          storageArea: localStorage,
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(mounted.getSelection()).toBe("claudeAgent:claude-sonnet-4-6");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+});

--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -1,0 +1,353 @@
+import {
+  ProviderInstanceId,
+  type ProviderDriverKind,
+  type ResolvedKeybindingsConfig,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
+import type { VariantProps } from "class-variance-authority";
+import { ChevronDownIcon } from "lucide-react";
+import { Button, buttonVariants } from "../ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { cn } from "~/lib/utils";
+import { ModelPickerContent } from "./ModelPickerContent";
+import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
+import {
+  ModelEsque,
+  getTriggerDisplayModelLabel,
+  getTriggerDisplayModelName,
+} from "./providerIconUtils";
+import { setModelPickerOpen } from "../../modelPickerOpenState";
+import type { ProviderInstanceEntry } from "../../providerInstances";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
+
+const ProviderModelPickerPreferenceSchema = Schema.Struct({
+  instanceId: ProviderInstanceId,
+  model: Schema.String,
+});
+
+type ProviderModelPickerPreference = typeof ProviderModelPickerPreferenceSchema.Type;
+
+function resolveSelectableEntries(
+  instanceEntries: ReadonlyArray<ProviderInstanceEntry>,
+  modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>,
+) {
+  const withReadyModels = instanceEntries.filter((entry) => {
+    const models = modelOptionsByInstance.get(entry.instanceId) ?? [];
+    return entry.status === "ready" && models.length > 0;
+  });
+  if (withReadyModels.length > 0) {
+    return withReadyModels;
+  }
+  return instanceEntries.filter((entry) => {
+    const models = modelOptionsByInstance.get(entry.instanceId) ?? [];
+    return models.length > 0;
+  });
+}
+
+function resolveProviderModelPickerPreference(
+  instanceEntries: ReadonlyArray<ProviderInstanceEntry>,
+  modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>,
+  preference: ProviderModelPickerPreference | null,
+): ProviderModelPickerPreference | null {
+  const selectableEntries = resolveSelectableEntries(instanceEntries, modelOptionsByInstance);
+  if (selectableEntries.length === 0) {
+    return null;
+  }
+
+  const preferredEntry =
+    (preference
+      ? selectableEntries.find((entry) => entry.instanceId === preference.instanceId)
+      : null) ?? selectableEntries[0]!;
+  const preferredModels = modelOptionsByInstance.get(preferredEntry.instanceId) ?? [];
+  if (preferredModels.length === 0) {
+    return null;
+  }
+
+  const preferredModel =
+    (preference
+      ? preferredModels.find((option) => option.slug === preference.model)?.slug
+      : null) ?? preferredModels[0]!.slug;
+
+  return {
+    instanceId: preferredEntry.instanceId,
+    model: preferredModel,
+  };
+}
+
+export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
+  /**
+   * The instance currently selected in the composer. Drives the trigger
+   * icon, label and the default-highlighted combobox row.
+   */
+  activeInstanceId: ProviderInstanceId;
+  model: string;
+  lockedProvider: ProviderDriverKind | null;
+  lockedContinuationGroupKey?: string | null;
+  /** Instance entries rendered in the sidebar + used to resolve display name. */
+  instanceEntries: ReadonlyArray<ProviderInstanceEntry>;
+  keybindings?: ResolvedKeybindingsConfig;
+  modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
+  activeProviderIconClassName?: string;
+  compact?: boolean;
+  disabled?: boolean;
+  terminalOpen?: boolean;
+  open?: boolean;
+  triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
+  triggerClassName?: string;
+  persistenceKey?: string | null;
+  onOpenChange?: (open: boolean) => void;
+  onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
+}) {
+  const [uncontrolledIsMenuOpen, setUncontrolledIsMenuOpen] = useState(false);
+  const isMenuOpen = props.open ?? uncontrolledIsMenuOpen;
+  const [persistedPreference, setPersistedPreference] = useLocalStorage(
+    props.persistenceKey ?? "__provider-model-picker:disabled__",
+    null,
+    Schema.NullOr(ProviderModelPickerPreferenceSchema),
+  );
+  const previousPersistedPreferenceRef = useRef<ProviderModelPickerPreference | null | undefined>(
+    undefined,
+  );
+
+  // Resolve the active instance entry by exact routing key. The composer
+  // resolves fallbacks before rendering this component; if the selected
+  // instance disappears, do not infer a replacement from its driver kind.
+  const activeEntry = useMemo(() => {
+    return (
+      props.instanceEntries.find((entry) => entry.instanceId === props.activeInstanceId) ?? null
+    );
+  }, [props.activeInstanceId, props.instanceEntries]);
+
+  const activeInstanceId = props.activeInstanceId;
+  const selectedInstanceOptions = props.modelOptionsByInstance.get(activeInstanceId) ?? [];
+  // If the current slug belongs to a different instance (for example after
+  // a provider switch or disable), prefer the active instance's first
+  // option so the trigger icon and label stay in sync instead of showing
+  // a stale foreign slug.
+  const selectedModel =
+    selectedInstanceOptions.find((option) => option.slug === props.model) ??
+    selectedInstanceOptions[0];
+  const triggerTitle = selectedModel ? getTriggerDisplayModelName(selectedModel) : props.model;
+  const triggerSubtitle = selectedModel?.subProvider;
+  const triggerLabel = selectedModel ? getTriggerDisplayModelLabel(selectedModel) : props.model;
+  const duplicateDriverCount = props.instanceEntries.filter(
+    (entry) => activeEntry !== null && entry.driverKind === activeEntry.driverKind,
+  ).length;
+  const showInstanceBadge = Boolean(activeEntry?.accentColor) || duplicateDriverCount > 1;
+  const defaultPreference = useMemo(
+    () =>
+      resolveProviderModelPickerPreference(
+        props.instanceEntries,
+        props.modelOptionsByInstance,
+        null,
+      ),
+    [props.instanceEntries, props.modelOptionsByInstance],
+  );
+  const resolvedPersistedPreference = useMemo(
+    () =>
+      props.persistenceKey
+        ? resolveProviderModelPickerPreference(
+            props.instanceEntries,
+            props.modelOptionsByInstance,
+            persistedPreference,
+          )
+        : null,
+    [
+      persistedPreference,
+      props.instanceEntries,
+      props.modelOptionsByInstance,
+      props.persistenceKey,
+    ],
+  );
+
+  const setIsMenuOpen = (open: boolean) => {
+    props.onOpenChange?.(open);
+    if (props.open === undefined) {
+      setUncontrolledIsMenuOpen(open);
+    }
+  };
+
+  useEffect(() => {
+    setModelPickerOpen(isMenuOpen);
+    return () => {
+      setModelPickerOpen(false);
+    };
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (!props.persistenceKey) {
+      return;
+    }
+
+    const previousPersistedPreference = previousPersistedPreferenceRef.current;
+    previousPersistedPreferenceRef.current = persistedPreference;
+
+    if (persistedPreference === null) {
+      if (
+        previousPersistedPreference !== undefined &&
+        previousPersistedPreference !== null &&
+        defaultPreference &&
+        (props.activeInstanceId !== defaultPreference.instanceId ||
+          props.model !== defaultPreference.model)
+      ) {
+        props.onInstanceModelChange(defaultPreference.instanceId, defaultPreference.model);
+      }
+      return;
+    }
+
+    if (resolvedPersistedPreference === null) {
+      return;
+    }
+
+    if (
+      persistedPreference.instanceId !== resolvedPersistedPreference.instanceId ||
+      persistedPreference.model !== resolvedPersistedPreference.model
+    ) {
+      setPersistedPreference(resolvedPersistedPreference);
+    }
+
+    if (
+      props.activeInstanceId !== resolvedPersistedPreference.instanceId ||
+      props.model !== resolvedPersistedPreference.model
+    ) {
+      props.onInstanceModelChange(
+        resolvedPersistedPreference.instanceId as ProviderInstanceId,
+        resolvedPersistedPreference.model,
+      );
+    }
+  }, [
+    defaultPreference,
+    persistedPreference,
+    props.activeInstanceId,
+    props.model,
+    props.onInstanceModelChange,
+    props.persistenceKey,
+    resolvedPersistedPreference,
+    setPersistedPreference,
+  ]);
+
+  const handleInstanceModelChange = (instanceId: ProviderInstanceId, model: string) => {
+    if (props.disabled) return;
+    if (props.persistenceKey) {
+      setPersistedPreference({ instanceId, model });
+    }
+    props.onInstanceModelChange(instanceId, model);
+    setIsMenuOpen(false);
+  };
+
+  const handleResetToDefault = () => {
+    if (props.disabled || !props.persistenceKey) {
+      return;
+    }
+    setPersistedPreference(null);
+    if (
+      defaultPreference &&
+      (props.activeInstanceId !== defaultPreference.instanceId ||
+        props.model !== defaultPreference.model)
+    ) {
+      props.onInstanceModelChange(
+        defaultPreference.instanceId as ProviderInstanceId,
+        defaultPreference.model,
+      );
+    }
+    setIsMenuOpen(false);
+  };
+
+  return (
+    <Popover
+      open={isMenuOpen}
+      onOpenChange={(open) => {
+        if (props.disabled) {
+          setIsMenuOpen(false);
+          return;
+        }
+        setIsMenuOpen(open);
+      }}
+    >
+      <PopoverTrigger
+        render={
+          <Button
+            size="sm"
+            variant={props.triggerVariant ?? "ghost"}
+            data-chat-provider-model-picker="true"
+            className={cn(
+              "min-w-0 justify-start overflow-hidden whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 [&_svg]:mx-0",
+              props.compact ? "max-w-42 shrink-0" : "max-w-48 shrink sm:max-w-56 sm:px-3",
+              props.triggerClassName,
+            )}
+            disabled={props.disabled}
+          />
+        }
+      >
+        <span
+          className={cn(
+            "flex min-w-0 w-full box-border items-center gap-2 overflow-hidden",
+            props.compact ? "max-w-36 sm:pl-1" : undefined,
+          )}
+        >
+          {activeEntry ? (
+            <ProviderInstanceIcon
+              driverKind={activeEntry.driverKind}
+              displayName={activeEntry.displayName}
+              accentColor={activeEntry.accentColor}
+              showBadge={showInstanceBadge}
+              className={showInstanceBadge ? "size-5" : "size-4"}
+              iconClassName={cn("size-4", props.activeProviderIconClassName)}
+              badgeClassName="right-[-0.125rem] bottom-[-0.125rem] h-3 min-w-3 text-[7px]"
+            />
+          ) : null}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span
+                  className={cn(
+                    "min-w-0 flex-1 overflow-hidden",
+                    triggerSubtitle
+                      ? "grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-1"
+                      : "truncate",
+                  )}
+                />
+              }
+            >
+              {triggerSubtitle ? (
+                <>
+                  <span className="min-w-0 truncate">{triggerSubtitle}</span>
+                  <span aria-hidden="true" className="shrink-0 opacity-60">
+                    ·
+                  </span>
+                  <span className="min-w-0 truncate">{triggerTitle}</span>
+                </>
+              ) : (
+                triggerTitle
+              )}
+            </TooltipTrigger>
+            <TooltipPopup side="top">{triggerLabel}</TooltipPopup>
+          </Tooltip>
+          <ChevronDownIcon aria-hidden="true" className="size-3 shrink-0 opacity-60" />
+        </span>
+      </PopoverTrigger>
+      <PopoverPopup
+        align="start"
+        className="border-0 bg-transparent p-0 shadow-none before:hidden [--viewport-inline-padding:0] *:data-[slot=popover-viewport]:p-0"
+      >
+        <ModelPickerContent
+          activeInstanceId={activeInstanceId}
+          model={props.model}
+          lockedProvider={props.lockedProvider}
+          lockedContinuationGroupKey={props.lockedContinuationGroupKey ?? null}
+          instanceEntries={props.instanceEntries}
+          {...(props.keybindings ? { keybindings: props.keybindings } : {})}
+          modelOptionsByInstance={props.modelOptionsByInstance}
+          terminalOpen={props.terminalOpen ?? false}
+          showResetToDefault={Boolean(props.persistenceKey)}
+          disableResetToDefault={persistedPreference === null}
+          onResetToDefault={handleResetToDefault}
+          onRequestClose={() => setIsMenuOpen(false)}
+          onInstanceModelChange={handleInstanceModelChange}
+        />
+      </PopoverPopup>
+    </Popover>
+  );
+});

--- a/t3code/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/t3code/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,0 +1,1512 @@
+import { ArchiveIcon, ArchiveX, LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  defaultInstanceIdForDriver,
+  type DesktopUpdateChannel,
+  PROVIDER_DISPLAY_NAMES,
+  ProviderDriverKind,
+  type ProviderInstanceConfig,
+  type ProviderInstanceId,
+  type ScopedThreadRef,
+} from "@t3tools/contracts";
+import { scopeThreadRef } from "@t3tools/client-runtime";
+import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { createModelSelection } from "@t3tools/shared/model";
+import * as Duration from "effect/Duration";
+import * as Equal from "effect/Equal";
+import { APP_VERSION, HOSTED_APP_CHANNEL, HOSTED_APP_CHANNEL_LABEL } from "../../branding";
+import {
+  canCheckForUpdate,
+  getDesktopUpdateButtonTooltip,
+  getDesktopUpdateInstallConfirmationMessage,
+  isDesktopUpdateButtonDisabled,
+  resolveDesktopUpdateButtonAction,
+} from "../../components/desktopUpdate.logic";
+import { ProviderModelPicker } from "../chat/ProviderModelPicker";
+import { TraitsPicker } from "../chat/TraitsPicker";
+import { isElectron } from "../../env";
+import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
+import { useTheme } from "../../hooks/useTheme";
+import { useSettings, useUpdateSettings } from "../../hooks/useSettings";
+import { useThreadActions } from "../../hooks/useThreadActions";
+import {
+  setDesktopUpdateStateQueryData,
+  useDesktopUpdateState,
+} from "../../lib/desktopUpdateReactQuery";
+import {
+  getCustomModelOptionsByInstance,
+  resolveAppModelSelectionState,
+} from "../../modelSelection";
+import {
+  deriveProviderInstanceEntries,
+  sortProviderInstanceEntries,
+} from "../../providerInstances";
+import { ensureLocalApi, readLocalApi } from "../../localApi";
+import { useShallow } from "zustand/react/shallow";
+import { selectProjectsAcrossEnvironments, useStore } from "../../store";
+import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
+import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampFormat";
+import { Button } from "../ui/button";
+import { DraftInput } from "../ui/draft-input";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { Switch } from "../ui/switch";
+import { stackedThreadToast, toastManager } from "../ui/toast";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
+import {
+  canOneClickUpdateProviderCandidate,
+  collectProviderUpdateCandidates,
+  hasOneClickUpdateProviderCandidate,
+  isProviderUpdateActive,
+  type ProviderUpdateCandidate,
+} from "../ProviderUpdateLaunchNotification.logic";
+import { ProviderInstanceCard } from "./ProviderInstanceCard";
+import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
+import {
+  buildProviderInstanceUpdatePatch,
+  formatDiagnosticsDescription,
+} from "./SettingsPanels.logic";
+import {
+  SettingResetButton,
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+  useRelativeTimeTick,
+} from "./settingsLayout";
+import { ProjectFavicon } from "../ProjectFavicon";
+import { useServerObservability, useServerProviders } from "../../rpc/serverState";
+
+const THEME_OPTIONS = [
+  {
+    value: "system",
+    label: "System",
+  },
+  {
+    value: "light",
+    label: "Light",
+  },
+  {
+    value: "dark",
+    label: "Dark",
+  },
+] as const;
+
+const TIMESTAMP_FORMAT_LABELS = {
+  locale: "System default",
+  "12-hour": "12-hour",
+  "24-hour": "24-hour",
+} as const;
+
+const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
+
+function withoutProviderInstanceKey<V>(
+  record: Readonly<Record<ProviderInstanceId, V>> | undefined,
+  key: ProviderInstanceId,
+): Record<ProviderInstanceId, V> {
+  const next = { ...record } as Record<ProviderInstanceId, V>;
+  delete next[key];
+  return next;
+}
+
+function withoutProviderInstanceFavorites(
+  favorites: ReadonlyArray<{ readonly provider: ProviderInstanceId; readonly model: string }>,
+  instanceId: ProviderInstanceId,
+) {
+  return favorites.filter((favorite) => favorite.provider !== instanceId);
+}
+
+const PROVIDER_SETTINGS = DRIVER_OPTIONS.map((definition) => ({
+  provider: definition.value,
+}));
+
+function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }) {
+  useRelativeTimeTick();
+  const lastCheckedRelative = lastCheckedAt ? formatRelativeTime(lastCheckedAt) : null;
+
+  if (!lastCheckedRelative) {
+    return null;
+  }
+
+  return (
+    <span className="text-[11px] text-muted-foreground/60">
+      {lastCheckedRelative.suffix ? (
+        <>
+          Checked <span className="font-mono tabular-nums">{lastCheckedRelative.value}</span>{" "}
+          {lastCheckedRelative.suffix}
+        </>
+      ) : (
+        <>Checked {lastCheckedRelative.value}</>
+      )}
+    </span>
+  );
+}
+
+function AboutVersionTitle() {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span>Version</span>
+      <code className="text-[11px] font-medium text-muted-foreground">{APP_VERSION}</code>
+    </span>
+  );
+}
+
+function AboutVersionSection() {
+  const queryClient = useQueryClient();
+  const updateStateQuery = useDesktopUpdateState();
+  const [isChangingUpdateChannel, setIsChangingUpdateChannel] = useState(false);
+
+  const updateState = updateStateQuery.data ?? null;
+  const hasDesktopBridge = typeof window !== "undefined" && Boolean(window.desktopBridge);
+  const selectedUpdateChannel = updateState?.channel ?? "latest";
+  const selectedHostedAppChannel = hasDesktopBridge ? null : HOSTED_APP_CHANNEL;
+
+  const handleUpdateChannelChange = useCallback(
+    (channel: DesktopUpdateChannel) => {
+      const bridge = window.desktopBridge;
+      if (
+        !bridge ||
+        typeof bridge.setUpdateChannel !== "function" ||
+        channel === selectedUpdateChannel
+      ) {
+        return;
+      }
+
+      setIsChangingUpdateChannel(true);
+      void bridge
+        .setUpdateChannel(channel)
+        .then((state) => {
+          setDesktopUpdateStateQueryData(queryClient, state);
+        })
+        .catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not change update track",
+              description: error instanceof Error ? error.message : "Update track change failed.",
+            }),
+          );
+        })
+        .finally(() => {
+          setIsChangingUpdateChannel(false);
+        });
+    },
+    [queryClient, selectedUpdateChannel],
+  );
+
+  const handleButtonClick = useCallback(() => {
+    const bridge = window.desktopBridge;
+    if (!bridge) return;
+
+    const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
+
+    if (action === "download") {
+      void bridge
+        .downloadUpdate()
+        .then((result) => {
+          setDesktopUpdateStateQueryData(queryClient, result.state);
+        })
+        .catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not download update",
+              description: error instanceof Error ? error.message : "Download failed.",
+            }),
+          );
+        });
+      return;
+    }
+
+    if (action === "install") {
+      const confirmed = window.confirm(
+        getDesktopUpdateInstallConfirmationMessage(
+          updateState ?? { availableVersion: null, downloadedVersion: null },
+        ),
+      );
+      if (!confirmed) return;
+      void bridge
+        .installUpdate()
+        .then((result) => {
+          setDesktopUpdateStateQueryData(queryClient, result.state);
+        })
+        .catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not install update",
+              description: error instanceof Error ? error.message : "Install failed.",
+            }),
+          );
+        });
+      return;
+    }
+
+    if (typeof bridge.checkForUpdate !== "function") return;
+    void bridge
+      .checkForUpdate()
+      .then((result) => {
+        setDesktopUpdateStateQueryData(queryClient, result.state);
+        if (!result.checked) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not check for updates",
+              description:
+                result.state.message ?? "Automatic updates are not available in this build.",
+            }),
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not check for updates",
+            description: error instanceof Error ? error.message : "Update check failed.",
+          }),
+        );
+      });
+  }, [queryClient, updateState]);
+
+  const action = updateState ? resolveDesktopUpdateButtonAction(updateState) : "none";
+  const buttonTooltip = updateState ? getDesktopUpdateButtonTooltip(updateState) : null;
+  const buttonDisabled =
+    action === "none"
+      ? !canCheckForUpdate(updateState)
+      : isDesktopUpdateButtonDisabled(updateState);
+
+  const actionLabel: Record<string, string> = { download: "Download", install: "Install" };
+  const statusLabel: Record<string, string> = {
+    checking: "Checking…",
+    downloading: "Downloading…",
+    "up-to-date": "Up to Date",
+  };
+  const buttonLabel =
+    actionLabel[action] ?? statusLabel[updateState?.status ?? ""] ?? "Check for Updates";
+  const description =
+    action === "download" || action === "install"
+      ? "Update available."
+      : "Current version of the application.";
+
+  return (
+    <>
+      <SettingsRow
+        title={<AboutVersionTitle />}
+        description={description}
+        control={
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  size="xs"
+                  variant={action === "install" ? "default" : "outline"}
+                  disabled={buttonDisabled}
+                  onClick={handleButtonClick}
+                >
+                  {buttonLabel}
+                </Button>
+              }
+            />
+            {buttonTooltip ? <TooltipPopup>{buttonTooltip}</TooltipPopup> : null}
+          </Tooltip>
+        }
+      />
+      {hasDesktopBridge ? (
+        <SettingsRow
+          title="Update track"
+          description="Stable follows full releases. Nightly follows the nightly desktop channel and can switch back to stable immediately."
+          control={
+            <Select
+              value={selectedUpdateChannel}
+              onValueChange={(value) => {
+                handleUpdateChannelChange(value as DesktopUpdateChannel);
+              }}
+            >
+              <SelectTrigger
+                className="w-full sm:w-40"
+                aria-label="Update track"
+                disabled={isChangingUpdateChannel}
+              >
+                <SelectValue>
+                  {selectedUpdateChannel === "nightly" ? "Nightly" : "Stable"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="latest">
+                  Stable
+                </SelectItem>
+                <SelectItem hideIndicator value="nightly">
+                  Nightly
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+      ) : selectedHostedAppChannel ? (
+        <SettingsRow
+          title="Update track"
+          description="Switches the hosted app release channel."
+          control={
+            <Select
+              value={selectedHostedAppChannel}
+              onValueChange={(value) => {
+                if (value === selectedHostedAppChannel) return;
+                window.location.assign(
+                  buildHostedChannelSelectionUrl({ channel: value as HostedAppChannel }),
+                );
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Update track">
+                <SelectValue>{HOSTED_APP_CHANNEL_LABEL}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="latest">
+                  Latest
+                </SelectItem>
+                <SelectItem hideIndicator value="nightly">
+                  Nightly
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function useSettingsRestore(onRestored?: () => void) {
+  const { theme, setTheme } = useTheme();
+  const settings = useSettings();
+  const { updateSettings } = useUpdateSettings();
+
+  const isGitWritingModelDirty = !Equal.equals(
+    settings.textGenerationModelSelection ?? null,
+    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
+  );
+
+  const changedSettingLabels = useMemo(
+    () => [
+      ...(theme !== "system" ? ["Theme"] : []),
+      ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
+        ? ["Time format"]
+        : []),
+      ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
+        ? ["Visible threads"]
+        : []),
+      ...(settings.diffWordWrap !== DEFAULT_UNIFIED_SETTINGS.diffWordWrap
+        ? ["Diff line wrapping"]
+        : []),
+      ...(settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
+        ? ["Diff whitespace changes"]
+        : []),
+      ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
+        ? ["Auto-open task panel"]
+        : []),
+      ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
+        ? ["Assistant output"]
+        : []),
+      ...(Duration.toMillis(settings.automaticGitFetchInterval) !==
+      Duration.toMillis(DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval)
+        ? ["Automatic Git fetch interval"]
+        : []),
+      ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
+        ? ["New thread mode"]
+        : []),
+      ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
+        ? ["Add project base directory"]
+        : []),
+      ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
+        ? ["Archive confirmation"]
+        : []),
+      ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
+        ? ["Delete confirmation"]
+        : []),
+      ...(isGitWritingModelDirty ? ["Git writing model"] : []),
+    ],
+    [
+      isGitWritingModelDirty,
+      settings.autoOpenPlanSidebar,
+      settings.confirmThreadArchive,
+      settings.confirmThreadDelete,
+      settings.addProjectBaseDirectory,
+      settings.defaultThreadEnvMode,
+      settings.diffIgnoreWhitespace,
+      settings.diffWordWrap,
+      settings.automaticGitFetchInterval,
+      settings.enableAssistantStreaming,
+      settings.sidebarThreadPreviewCount,
+      settings.timestampFormat,
+      theme,
+    ],
+  );
+
+  const restoreDefaults = useCallback(async () => {
+    if (changedSettingLabels.length === 0) return;
+    const api = readLocalApi();
+    const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
+      ["Restore default settings?", `This will reset: ${changedSettingLabels.join(", ")}.`].join(
+        "\n",
+      ),
+    );
+    if (!confirmed) return;
+
+    setTheme("system");
+    updateSettings({
+      timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+      diffWordWrap: DEFAULT_UNIFIED_SETTINGS.diffWordWrap,
+      diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+      sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+      autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
+      enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
+      automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+      defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+      addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+      confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+      confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+    });
+    onRestored?.();
+  }, [changedSettingLabels, onRestored, setTheme, updateSettings]);
+
+  return {
+    changedSettingLabels,
+    restoreDefaults,
+  };
+}
+
+export function GeneralSettingsPanel() {
+  const { theme, setTheme } = useTheme();
+  const settings = useSettings();
+  const { updateSettings } = useUpdateSettings();
+  const observability = useServerObservability();
+  const serverProviders = useServerProviders();
+  const diagnosticsDescription = formatDiagnosticsDescription({
+    localTracingEnabled: observability?.localTracingEnabled ?? false,
+    otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
+    otlpTracesUrl: observability?.otlpTracesUrl,
+    otlpMetricsEnabled: observability?.otlpMetricsEnabled ?? false,
+    otlpMetricsUrl: observability?.otlpMetricsUrl,
+  });
+
+  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
+  const textGenInstanceId = textGenerationModelSelection.instanceId;
+  const textGenModel = textGenerationModelSelection.model;
+  const textGenModelOptions = textGenerationModelSelection.options;
+  const gitModelInstanceEntries = sortProviderInstanceEntries(
+    deriveProviderInstanceEntries(serverProviders),
+  );
+  const textGenInstanceEntry = gitModelInstanceEntries.find(
+    (entry) => entry.instanceId === textGenInstanceId,
+  );
+  const textGenProvider: ProviderDriverKind =
+    textGenInstanceEntry?.driverKind ?? DEFAULT_DRIVER_KIND;
+  const gitModelOptionsByInstance = getCustomModelOptionsByInstance(
+    settings,
+    serverProviders,
+    textGenInstanceId,
+    textGenModel,
+  );
+  const isGitWritingModelDirty = !Equal.equals(
+    settings.textGenerationModelSelection ?? null,
+    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
+  );
+
+  return (
+    <SettingsPageContainer>
+      <SettingsSection title="General">
+        <SettingsRow
+          title="Theme"
+          description="Choose how T3 Code looks across the app."
+          resetAction={
+            theme !== "system" ? (
+              <SettingResetButton label="theme" onClick={() => setTheme("system")} />
+            ) : null
+          }
+          control={
+            <Select
+              value={theme}
+              onValueChange={(value) => {
+                if (value === "system" || value === "light" || value === "dark") {
+                  setTheme(value);
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Theme preference">
+                <SelectValue>
+                  {THEME_OPTIONS.find((option) => option.value === theme)?.label ?? "System"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                {THEME_OPTIONS.map((option) => (
+                  <SelectItem hideIndicator key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Time format"
+          description="System default follows your browser or OS clock preference."
+          resetAction={
+            settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat ? (
+              <SettingResetButton
+                label="time format"
+                onClick={() =>
+                  updateSettings({
+                    timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.timestampFormat}
+              onValueChange={(value) => {
+                if (value === "locale" || value === "12-hour" || value === "24-hour") {
+                  updateSettings({ timestampFormat: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Timestamp format">
+                <SelectValue>{TIMESTAMP_FORMAT_LABELS[settings.timestampFormat]}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="locale">
+                  {TIMESTAMP_FORMAT_LABELS.locale}
+                </SelectItem>
+                <SelectItem hideIndicator value="12-hour">
+                  {TIMESTAMP_FORMAT_LABELS["12-hour"]}
+                </SelectItem>
+                <SelectItem hideIndicator value="24-hour">
+                  {TIMESTAMP_FORMAT_LABELS["24-hour"]}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Diff line wrapping"
+          description="Set the default wrap state when the diff panel opens."
+          resetAction={
+            settings.diffWordWrap !== DEFAULT_UNIFIED_SETTINGS.diffWordWrap ? (
+              <SettingResetButton
+                label="diff line wrapping"
+                onClick={() =>
+                  updateSettings({
+                    diffWordWrap: DEFAULT_UNIFIED_SETTINGS.diffWordWrap,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.diffWordWrap}
+              onCheckedChange={(checked) => updateSettings({ diffWordWrap: Boolean(checked) })}
+              aria-label="Wrap diff lines by default"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Hide whitespace changes"
+          description="Set whether the diff panel ignores whitespace-only edits by default."
+          resetAction={
+            settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace ? (
+              <SettingResetButton
+                label="diff whitespace changes"
+                onClick={() =>
+                  updateSettings({
+                    diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.diffIgnoreWhitespace}
+              onCheckedChange={(checked) =>
+                updateSettings({ diffIgnoreWhitespace: Boolean(checked) })
+              }
+              aria-label="Hide whitespace changes by default"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Assistant output"
+          description="Show token-by-token output while a response is in progress."
+          resetAction={
+            settings.enableAssistantStreaming !==
+            DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming ? (
+              <SettingResetButton
+                label="assistant output"
+                onClick={() =>
+                  updateSettings({
+                    enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.enableAssistantStreaming}
+              onCheckedChange={(checked) =>
+                updateSettings({ enableAssistantStreaming: Boolean(checked) })
+              }
+              aria-label="Stream assistant messages"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Auto-open task panel"
+          description="Open the right-side plan and task panel automatically when steps appear."
+          resetAction={
+            settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar ? (
+              <SettingResetButton
+                label="auto-open task panel"
+                onClick={() =>
+                  updateSettings({
+                    autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.autoOpenPlanSidebar}
+              onCheckedChange={(checked) =>
+                updateSettings({ autoOpenPlanSidebar: Boolean(checked) })
+              }
+              aria-label="Open the task panel automatically"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="New threads"
+          description="Pick the default workspace mode for newly created draft threads."
+          resetAction={
+            settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ? (
+              <SettingResetButton
+                label="new threads"
+                onClick={() =>
+                  updateSettings({
+                    defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.defaultThreadEnvMode}
+              onValueChange={(value) => {
+                if (value === "local" || value === "worktree") {
+                  updateSettings({ defaultThreadEnvMode: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-44" aria-label="Default thread mode">
+                <SelectValue>
+                  {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="local">
+                  Local
+                </SelectItem>
+                <SelectItem hideIndicator value="worktree">
+                  New worktree
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Add project starts in"
+          description='Leave empty to use "~/" when the Add Project browser opens.'
+          resetAction={
+            settings.addProjectBaseDirectory !==
+            DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory ? (
+              <SettingResetButton
+                label="add project base directory"
+                onClick={() =>
+                  updateSettings({
+                    addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              className="w-full sm:w-72"
+              value={settings.addProjectBaseDirectory}
+              onCommit={(next) => updateSettings({ addProjectBaseDirectory: next })}
+              placeholder="~/"
+              spellCheck={false}
+              aria-label="Add project base directory"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Archive confirmation"
+          description="Require a second click on the inline archive action before a thread is archived."
+          resetAction={
+            settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive ? (
+              <SettingResetButton
+                label="archive confirmation"
+                onClick={() =>
+                  updateSettings({
+                    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.confirmThreadArchive}
+              onCheckedChange={(checked) =>
+                updateSettings({ confirmThreadArchive: Boolean(checked) })
+              }
+              aria-label="Confirm thread archiving"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Delete confirmation"
+          description="Ask before deleting a thread and its chat history."
+          resetAction={
+            settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete ? (
+              <SettingResetButton
+                label="delete confirmation"
+                onClick={() =>
+                  updateSettings({
+                    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.confirmThreadDelete}
+              onCheckedChange={(checked) =>
+                updateSettings({ confirmThreadDelete: Boolean(checked) })
+              }
+              aria-label="Confirm thread deletion"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Text generation model"
+          description="Configure the model used for generated commit messages, PR titles, and similar Git text."
+          resetAction={
+            isGitWritingModelDirty ? (
+              <SettingResetButton
+                label="text generation model"
+                onClick={() =>
+                  updateSettings({
+                    textGenerationModelSelection:
+                      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <div className="flex flex-wrap items-center justify-end gap-1.5">
+              <ProviderModelPicker
+                activeInstanceId={textGenInstanceId}
+                model={textGenModel}
+                lockedProvider={null}
+                instanceEntries={gitModelInstanceEntries}
+                modelOptionsByInstance={gitModelOptionsByInstance}
+                persistenceKey="t3code:text-generation-provider-model-picker:v1"
+                triggerVariant="outline"
+                triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
+                onInstanceModelChange={(instanceId, model) => {
+                  updateSettings({
+                    textGenerationModelSelection: resolveAppModelSelectionState(
+                      {
+                        ...settings,
+                        textGenerationModelSelection: createModelSelection(instanceId, model),
+                      },
+                      serverProviders,
+                    ),
+                  });
+                }}
+              />
+              <TraitsPicker
+                provider={textGenProvider}
+                models={
+                  // Use the exact instance's models (rather than the
+                  // first-kind-match) so a custom text-gen instance like
+                  // `codex_personal` gets its own model list, not the
+                  // default Codex one.
+                  textGenInstanceEntry?.models ?? []
+                }
+                model={textGenModel}
+                prompt=""
+                onPromptChange={() => {}}
+                modelOptions={textGenModelOptions}
+                allowPromptInjectedEffort={false}
+                triggerVariant="outline"
+                triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
+                onModelOptionsChange={(nextOptions) => {
+                  updateSettings({
+                    textGenerationModelSelection: resolveAppModelSelectionState(
+                      {
+                        ...settings,
+                        textGenerationModelSelection: createModelSelection(
+                          textGenInstanceId,
+                          textGenModel,
+                          nextOptions,
+                        ),
+                      },
+                      serverProviders,
+                    ),
+                  });
+                }}
+              />
+            </div>
+          }
+        />
+      </SettingsSection>
+
+      <SettingsSection title="About">
+        {isElectron || HOSTED_APP_CHANNEL ? (
+          <AboutVersionSection />
+        ) : (
+          <SettingsRow
+            title={<AboutVersionTitle />}
+            description="Current version of the application."
+          />
+        )}
+        <SettingsRow
+          title="Diagnostics"
+          description={diagnosticsDescription}
+          control={
+            <Button render={<Link to="/settings/diagnostics" />} size="xs" variant="outline">
+              View diagnostics
+            </Button>
+          }
+        />
+      </SettingsSection>
+    </SettingsPageContainer>
+  );
+}
+
+export function ProviderSettingsPanel() {
+  const settings = useSettings();
+  const { updateSettings } = useUpdateSettings();
+  const serverProviders = useServerProviders();
+  const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
+  const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
+  const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
+    ReadonlySet<ProviderDriverKind>
+  >(() => new Set());
+  const [openInstanceDetails, setOpenInstanceDetails] = useState<Record<string, boolean>>({});
+  const refreshingRef = useRef(false);
+
+  const providerUpdateCandidates = useMemo(
+    () => collectProviderUpdateCandidates(serverProviders),
+    [serverProviders],
+  );
+  const providerUpdateCandidateByInstanceId = useMemo(
+    () => new Map(providerUpdateCandidates.map((candidate) => [candidate.instanceId, candidate])),
+    [providerUpdateCandidates],
+  );
+  const visibleProviderSettings = PROVIDER_SETTINGS.filter(
+    (providerSettings) =>
+      providerSettings.provider !== "cursor" ||
+      serverProviders.some(
+        (provider) =>
+          provider.instanceId === defaultInstanceIdForDriver(ProviderDriverKind.make("cursor")),
+      ),
+  );
+  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
+  const textGenInstanceId = textGenerationModelSelection.instanceId;
+  const lastCheckedAt =
+    serverProviders.length > 0
+      ? serverProviders.reduce(
+          (latest, provider) => (provider.checkedAt > latest ? provider.checkedAt : latest),
+          serverProviders[0]!.checkedAt,
+        )
+      : null;
+
+  const refreshProviders = useCallback(() => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setIsRefreshingProviders(true);
+    void ensureLocalApi()
+      .server.refreshProviders()
+      .catch((error: unknown) => {
+        console.warn("Failed to refresh providers", error);
+      })
+      .finally(() => {
+        refreshingRef.current = false;
+        setIsRefreshingProviders(false);
+      });
+  }, []);
+
+  const runProviderUpdate = useCallback(async (candidate: ProviderUpdateCandidate) => {
+    let started = false;
+    setUpdatingProviderDrivers((previous) => {
+      if (previous.has(candidate.driver)) {
+        return previous;
+      }
+      started = true;
+      const next = new Set(previous);
+      next.add(candidate.driver);
+      return next;
+    });
+    if (!started) {
+      return;
+    }
+
+    try {
+      await ensureLocalApi().server.updateProvider({
+        provider: candidate.driver,
+        instanceId: candidate.instanceId,
+      });
+    } catch (error) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: `Could not update ${PROVIDER_DISPLAY_NAMES[candidate.driver] ?? candidate.driver}`,
+          description:
+            error instanceof Error
+              ? error.message
+              : "The provider update command could not be started.",
+        }),
+      );
+    } finally {
+      setUpdatingProviderDrivers((previous) => {
+        if (!previous.has(candidate.driver)) {
+          return previous;
+        }
+        const next = new Set(previous);
+        next.delete(candidate.driver);
+        return next;
+      });
+    }
+  }, []);
+
+  interface InstanceRow {
+    readonly instanceId: ProviderInstanceId;
+    readonly instance: ProviderInstanceConfig;
+    readonly driver: ProviderDriverKind;
+    readonly isDefault: boolean;
+    readonly isDirty?: boolean;
+  }
+
+  const instancesByDriver = new Map<
+    ProviderDriverKind,
+    Array<[ProviderInstanceId, ProviderInstanceConfig]>
+  >();
+  for (const [rawId, instance] of Object.entries(settings.providerInstances ?? {})) {
+    const driver = instance.driver;
+    const list = instancesByDriver.get(driver) ?? [];
+    list.push([rawId as ProviderInstanceId, instance]);
+    instancesByDriver.set(driver, list);
+  }
+
+  const defaultSlotIdsBySource = new Set<string>(
+    visibleProviderSettings.map((providerSettings) =>
+      String(defaultInstanceIdForDriver(providerSettings.provider)),
+    ),
+  );
+
+  const rows: InstanceRow[] = [];
+  const visibleDriverKinds = new Set<ProviderDriverKind>(
+    visibleProviderSettings.map((providerSettings) => providerSettings.provider),
+  );
+
+  for (const providerSettings of visibleProviderSettings) {
+    type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
+    const legacyProviders = settings.providers as Record<string, LegacyProviderSettings>;
+    const defaultLegacyProviders = DEFAULT_UNIFIED_SETTINGS.providers as Record<
+      string,
+      LegacyProviderSettings
+    >;
+    const driver = providerSettings.provider;
+    const defaultInstanceId = defaultInstanceIdForDriver(driver);
+    const explicitInstance = settings.providerInstances?.[defaultInstanceId];
+    const legacyConfig = legacyProviders[providerSettings.provider]!;
+    const defaultLegacyConfig = defaultLegacyProviders[providerSettings.provider]!;
+    const effectiveInstance: ProviderInstanceConfig =
+      explicitInstance ??
+      ({
+        driver,
+        enabled: legacyConfig.enabled,
+        config: legacyConfig,
+      } satisfies ProviderInstanceConfig);
+    const isDirty =
+      explicitInstance !== undefined || !Equal.equals(legacyConfig, defaultLegacyConfig);
+    rows.push({
+      instanceId: defaultInstanceId,
+      instance: effectiveInstance,
+      driver,
+      isDefault: true,
+      isDirty,
+    });
+    for (const [id, instance] of instancesByDriver.get(providerSettings.provider) ?? []) {
+      if (id === defaultInstanceId) continue;
+      rows.push({ instanceId: id, instance, driver: instance.driver, isDefault: false });
+    }
+  }
+  for (const [driver, list] of instancesByDriver) {
+    if (visibleDriverKinds.has(driver)) continue;
+    for (const [id, instance] of list) {
+      rows.push({
+        instanceId: id,
+        instance,
+        driver: instance.driver,
+        isDefault: defaultSlotIdsBySource.has(String(id)),
+      });
+    }
+  }
+
+  const updateProviderInstance = (
+    row: InstanceRow,
+    next: ProviderInstanceConfig,
+    options?: {
+      readonly textGenerationModelSelection?: Parameters<
+        typeof buildProviderInstanceUpdatePatch
+      >[0]["textGenerationModelSelection"];
+    },
+  ) => {
+    updateSettings(
+      buildProviderInstanceUpdatePatch({
+        settings,
+        instanceId: row.instanceId,
+        instance: next,
+        driver: row.driver,
+        isDefault: row.isDefault,
+        textGenerationModelSelection: options?.textGenerationModelSelection,
+      }),
+    );
+  };
+
+  const deleteProviderInstance = (id: ProviderInstanceId) => {
+    updateSettings({
+      providerInstances: withoutProviderInstanceKey(settings.providerInstances, id),
+      providerModelPreferences: withoutProviderInstanceKey(settings.providerModelPreferences, id),
+      favorites: withoutProviderInstanceFavorites(settings.favorites ?? [], id),
+    });
+  };
+
+  const updateProviderModelPreferences = (
+    instanceId: ProviderInstanceId,
+    next: {
+      readonly hiddenModels: ReadonlyArray<string>;
+      readonly modelOrder: ReadonlyArray<string>;
+    },
+  ) => {
+    const hiddenModels = [...new Set(next.hiddenModels.filter((slug) => slug.trim().length > 0))];
+    const modelOrder = [...new Set(next.modelOrder.filter((slug) => slug.trim().length > 0))];
+    const rest = withoutProviderInstanceKey(settings.providerModelPreferences, instanceId);
+    updateSettings({
+      providerModelPreferences:
+        hiddenModels.length === 0 && modelOrder.length === 0
+          ? rest
+          : {
+              ...rest,
+              [instanceId]: {
+                hiddenModels,
+                modelOrder,
+              },
+            },
+    });
+  };
+
+  const updateProviderFavoriteModels = (
+    instanceId: ProviderInstanceId,
+    nextFavoriteModels: ReadonlyArray<string>,
+  ) => {
+    const favoriteModels = [
+      ...new Set(nextFavoriteModels.map((slug) => slug.trim()).filter((slug) => slug.length > 0)),
+    ];
+    updateSettings({
+      favorites: [
+        ...withoutProviderInstanceFavorites(settings.favorites ?? [], instanceId),
+        ...favoriteModels.map((model) => ({ provider: instanceId, model })),
+      ],
+    });
+  };
+
+  const resetDefaultInstance = (driverKind: ProviderDriverKind) => {
+    type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
+    const defaultLegacyProviders = DEFAULT_UNIFIED_SETTINGS.providers as Record<
+      string,
+      LegacyProviderSettings | undefined
+    >;
+    const defaultInstanceId = defaultInstanceIdForDriver(driverKind);
+    const defaultLegacyProvider = defaultLegacyProviders[driverKind];
+    if (defaultLegacyProvider === undefined) return;
+    updateSettings({
+      providers: {
+        ...settings.providers,
+        [driverKind]: defaultLegacyProvider,
+      } as typeof settings.providers,
+      providerInstances: withoutProviderInstanceKey(settings.providerInstances, defaultInstanceId),
+      providerModelPreferences: withoutProviderInstanceKey(
+        settings.providerModelPreferences,
+        defaultInstanceId,
+      ),
+      favorites: withoutProviderInstanceFavorites(settings.favorites ?? [], defaultInstanceId),
+    });
+  };
+
+  return (
+    <SettingsPageContainer>
+      <SettingsSection
+        title="Providers"
+        headerAction={
+          <div className="flex items-center gap-1.5">
+            <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    onClick={() => setIsAddInstanceDialogOpen(true)}
+                    aria-label="Add provider instance"
+                  >
+                    <PlusIcon className="size-3" />
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Add provider instance</TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    disabled={isRefreshingProviders}
+                    onClick={() => void refreshProviders()}
+                    aria-label="Refresh provider status"
+                  >
+                    {isRefreshingProviders ? (
+                      <LoaderIcon className="size-3 animate-spin" />
+                    ) : (
+                      <RefreshCwIcon className="size-3" />
+                    )}
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Refresh provider status</TooltipPopup>
+            </Tooltip>
+          </div>
+        }
+      >
+        {rows.map((row) => {
+          const driverOption = getDriverOption(row.driver);
+          const liveProvider = serverProviders.find(
+            (candidate) => candidate.instanceId === row.instanceId,
+          );
+          const updateCandidate = liveProvider
+            ? providerUpdateCandidateByInstanceId.get(liveProvider.instanceId)
+            : undefined;
+          const isDriverUpdateRunning =
+            updateCandidate !== undefined &&
+            (updatingProviderDrivers.has(updateCandidate.driver) ||
+              serverProviders.some(
+                (provider) =>
+                  provider.driver === updateCandidate.driver && isProviderUpdateActive(provider),
+              ));
+          const showInlineUpdateButton =
+            updateCandidate !== undefined &&
+            hasOneClickUpdateProviderCandidate(updateCandidate, serverProviders);
+          const canRunInlineUpdate =
+            updateCandidate !== undefined &&
+            canOneClickUpdateProviderCandidate(updateCandidate, serverProviders) &&
+            !updatingProviderDrivers.has(updateCandidate.driver);
+          const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {
+            hiddenModels: [],
+            modelOrder: [],
+          };
+          const favoriteModels = (settings.favorites ?? [])
+            .filter((favorite) => favorite.provider === row.instanceId)
+            .map((favorite) => favorite.model);
+          const resetLabel = driverOption?.label ?? String(row.driver);
+          const headerAction =
+            row.isDefault && row.isDirty ? (
+              <SettingResetButton
+                label={`${resetLabel} provider settings`}
+                onClick={() => resetDefaultInstance(row.driver)}
+              />
+            ) : null;
+          return (
+            <ProviderInstanceCard
+              key={row.instanceId}
+              instanceId={row.instanceId}
+              instance={row.instance}
+              driverOption={driverOption}
+              liveProvider={liveProvider}
+              isExpanded={openInstanceDetails[row.instanceId] ?? false}
+              onExpandedChange={(open) =>
+                setOpenInstanceDetails((existing) => ({
+                  ...existing,
+                  [row.instanceId]: open,
+                }))
+              }
+              onUpdate={(next) => {
+                const wasEnabled = row.instance.enabled ?? true;
+                const isDisabling = next.enabled === false && wasEnabled;
+                const shouldClearTextGen = isDisabling && textGenInstanceId === row.instanceId;
+                if (shouldClearTextGen) {
+                  updateProviderInstance(row, next, {
+                    textGenerationModelSelection:
+                      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+                  });
+                } else {
+                  updateProviderInstance(row, next);
+                }
+              }}
+              onDelete={row.isDefault ? undefined : () => deleteProviderInstance(row.instanceId)}
+              headerAction={headerAction}
+              hiddenModels={modelPreferences.hiddenModels}
+              favoriteModels={favoriteModels}
+              modelOrder={modelPreferences.modelOrder}
+              onHiddenModelsChange={(hiddenModels) =>
+                updateProviderModelPreferences(row.instanceId, {
+                  ...modelPreferences,
+                  hiddenModels,
+                })
+              }
+              onFavoriteModelsChange={(favoriteModels) =>
+                updateProviderFavoriteModels(row.instanceId, favoriteModels)
+              }
+              onModelOrderChange={(modelOrder) =>
+                updateProviderModelPreferences(row.instanceId, {
+                  ...modelPreferences,
+                  modelOrder,
+                })
+              }
+              onRunUpdate={
+                showInlineUpdateButton && updateCandidate
+                  ? () => {
+                      if (!canRunInlineUpdate) {
+                        return;
+                      }
+                      void runProviderUpdate(updateCandidate);
+                    }
+                  : undefined
+              }
+              isUpdating={showInlineUpdateButton ? isDriverUpdateRunning : undefined}
+            />
+          );
+        })}
+      </SettingsSection>
+
+      <AddProviderInstanceDialog
+        open={isAddInstanceDialogOpen}
+        onOpenChange={setIsAddInstanceDialogOpen}
+      />
+    </SettingsPageContainer>
+  );
+}
+
+export function ArchivedThreadsPanel() {
+  const projects = useStore(useShallow(selectProjectsAcrossEnvironments));
+  const { unarchiveThread, confirmAndDeleteThread } = useThreadActions();
+  const environmentIds = useMemo(
+    () => [...new Set(projects.map((project) => project.environmentId))],
+    [projects],
+  );
+  const {
+    snapshots: archivedSnapshots,
+    error: archiveError,
+    isLoading: isLoadingArchive,
+    refresh: refreshArchivedThreads,
+  } = useArchivedThreadSnapshots(environmentIds);
+
+  const archivedGroups = useMemo(() => {
+    const projectsByEnvironmentAndId = new Map(
+      archivedSnapshots.flatMap(({ environmentId, snapshot }) =>
+        snapshot.projects.map(
+          (project) =>
+            [
+              `${environmentId}:${project.id}`,
+              {
+                id: project.id,
+                environmentId,
+                name: project.title,
+                cwd: project.workspaceRoot,
+              },
+            ] as const,
+        ),
+      ),
+    );
+    const threads = archivedSnapshots.flatMap(({ environmentId, snapshot }) =>
+      snapshot.threads.map((thread) => ({
+        ...thread,
+        environmentId,
+      })),
+    );
+
+    return [...projectsByEnvironmentAndId.values()]
+      .map((project) => ({
+        project,
+        threads: threads
+          .filter(
+            (thread) =>
+              thread.projectId === project.id && thread.environmentId === project.environmentId,
+          )
+          .toSorted((left, right) => {
+            const leftKey = left.archivedAt ?? left.createdAt;
+            const rightKey = right.archivedAt ?? right.createdAt;
+            return rightKey.localeCompare(leftKey) || right.id.localeCompare(left.id);
+          }),
+      }))
+      .filter((group) => group.threads.length > 0);
+  }, [archivedSnapshots]);
+
+  const handleArchivedThreadContextMenu = useCallback(
+    async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
+      const api = readLocalApi();
+      if (!api) return;
+      const clicked = await api.contextMenu.show(
+        [
+          { id: "unarchive", label: "Unarchive" },
+          { id: "delete", label: "Delete", destructive: true },
+        ],
+        position,
+      );
+
+      if (clicked === "unarchive") {
+        try {
+          await unarchiveThread(threadRef);
+          refreshArchivedThreads();
+        } catch (error) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to unarchive thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+        return;
+      }
+
+      if (clicked === "delete") {
+        await confirmAndDeleteThread(threadRef);
+        refreshArchivedThreads();
+      }
+    },
+    [confirmAndDeleteThread, refreshArchivedThreads, unarchiveThread],
+  );
+
+  return (
+    <SettingsPageContainer>
+      {archivedGroups.length === 0 ? (
+        <SettingsSection title="Archived threads">
+          <SettingsRow
+            title={
+              <span className="inline-flex items-center gap-2">
+                {isLoadingArchive ? (
+                  <LoaderIcon className="size-3.5 animate-spin text-muted-foreground" />
+                ) : (
+                  <ArchiveIcon className="size-3.5 text-muted-foreground" />
+                )}
+                {isLoadingArchive
+                  ? "Loading archived threads"
+                  : archiveError
+                    ? "Could not load archived threads"
+                    : "No archived threads"}
+              </span>
+            }
+            description={
+              isLoadingArchive
+                ? "Checking connected environments."
+                : (archiveError ?? "Archived threads will appear here.")
+            }
+          />
+        </SettingsSection>
+      ) : (
+        archivedGroups.map(({ project, threads: projectThreads }) => (
+          <SettingsSection
+            key={project.id}
+            title={project.name}
+            icon={<ProjectFavicon environmentId={project.environmentId} cwd={project.cwd} />}
+          >
+            {projectThreads.map((thread) => (
+              <SettingsRow
+                key={thread.id}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  void handleArchivedThreadContextMenu(
+                    scopeThreadRef(thread.environmentId, thread.id),
+                    {
+                      x: event.clientX,
+                      y: event.clientY,
+                    },
+                  );
+                }}
+                title={thread.title}
+                description={
+                  <>
+                    Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
+                    {" \u00b7 Created "}
+                    {formatRelativeTimeLabel(thread.createdAt)}
+                  </>
+                }
+                control={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 shrink-0 cursor-pointer gap-1.5 px-2.5"
+                    onClick={() =>
+                      void unarchiveThread(scopeThreadRef(thread.environmentId, thread.id))
+                        .then(() => refreshArchivedThreads())
+                        .catch((error) => {
+                          toastManager.add(
+                            stackedThreadToast({
+                              type: "error",
+                              title: "Failed to unarchive thread",
+                              description:
+                                error instanceof Error ? error.message : "An error occurred.",
+                            }),
+                          );
+                        })
+                    }
+                  >
+                    <ArchiveX className="size-3.5" />
+                    <span>Unarchive</span>
+                  </Button>
+                }
+              />
+            ))}
+          </SettingsSection>
+        ))
+      )}
+    </SettingsPageContainer>
+  );
+}


### PR DESCRIPTION
/claim #834

## Summary
- persist provider/model selection in localStorage with namespaced keys
- restore the stored choice on mount and fall back to the first available provider/model when the stored value is stale
- add a Reset to default action in the picker
- sync selection changes across tabs via storage events

## Verification
- `bun run --filter @t3tools/web typecheck`
- `bun run --filter @t3tools/web test:browser -- src/components/chat/ProviderModelPicker.browser.tsx`
