### PR TITLE
Fix reentrancy vulnerability in StakingVault

### DIFF
--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+contract StakingVault is ReentrancyGuard {
+    mapping(address => uint256) public balances;
+    mapping(address => uint256) public rewardDebt;
+    uint256 public totalStaked;
+    uint256 public rewardRate;
+    uint256 public rewardPerTokenStored;
+    uint256 public lastUpdateTime;
+
+    event Staked(address indexed user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
+    event RewardClaimed(address indexed user, uint256 amount);
+
+    function stake() external payable nonReentrant {
+        require(msg.value > 0, "Cannot stake 0");
+        _updateReward(msg.sender);
+        balances[msg.sender] += msg.value;
+        totalStaked += msg.value;
+        emit Staked(msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 amount) external nonReentrant {
+        require(amount > 0, "Cannot withdraw 0");
+        require(balances[msg.sender] >= amount, "Insufficient balance");
+        _updateReward(msg.sender);
+        // Fix: CEI pattern - state updates BEFORE external call
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Transfer failed");
+        emit Withdrawn(msg.sender, amount);
+    }
+
+    function claimRewards() external nonReentrant {
+        _updateReward(msg.sender);
+        uint256 reward = _earned(msg.sender);
+        // Fix: Update state BEFORE external call
+        rewardDebt[msg.sender] = _rewardPerToken() * balances[msg.sender];
+        require(reward > 0, "No rewards");
+        (bool success, ) = payable(msg.sender).call{value: reward}("");
+        require(success, "Transfer failed");
+        emit RewardClaimed(msg.sender, reward);
+    }
+
+    function _updateReward(address account) internal {
+        rewardPerTokenStored = _rewardPerToken();
+        lastUpdateTime = block.timestamp;
+    }
+
+    function _rewardPerToken() internal view returns (uint256) {
+        if (totalStaked == 0) return rewardPerTokenStored;
+        return rewardPerTokenStored + (rewardRate * (block.timestamp - lastUpdateTime) * 1e18 / totalStaked);
+    }
+
+    function _earned(address account) internal view returns (uint256) {
+        return (_rewardPerToken() * balances[account] / 1e18) - rewardDebt[account];
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
Fixes #911 - Reentrancy in StakingVault.

- CEI pattern (state before external calls)
- ReentrancyGuard from OpenZeppelin
- Both withdraw and claimRewards protected

Wallet: zp6