### PR TITLE
[leoliu201204-cmyk] [ T3 Code ] Fix turbo.json missing dependency graph for incremental builds

### DIFF
--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -28,26 +28,66 @@
     "VITE_HOSTED_APP_URL",
     "VITE_HOSTED_APP_CHANNEL"
   ],
-  "globalPassThroughEnv": ["PATHEXT"],
+  "globalPassThroughEnv": [
+    "PATHEXT"
+  ],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", "dist-electron/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        "dist-electron/**"
+      ]
     },
     "dev": {
-      "dependsOn": ["@t3tools/contracts#build"],
+      "dependsOn": [
+        "@t3tools/contracts#build"
+      ],
       "cache": false,
       "persistent": true
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"],
+      "dependsOn": [
+        "^typecheck"
+      ],
       "outputs": [],
       "cache": false
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "cache": false,
       "outputs": []
+    },
+    "apps/web#build": {
+      "dependsOn": [
+        "packages/contracts#build",
+        "packages/client-runtime#build"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
+    "apps/server#build": {
+      "dependsOn": [
+        "packages/contracts#build"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
+    "apps/desktop#build": {
+      "dependsOn": [
+        "packages/contracts#build",
+        "packages/effect-acp#build"
+      ],
+      "outputs": [
+        "dist/**",
+        "dist-electron/**"
+      ]
     }
   }
-}
+}\n


### PR DESCRIPTION
## Summary\n\nAdded package-specific dependency relationships to `turbo.json`:\n- `apps/web#build` depends on `packages/contracts#build`, `packages/client-runtime#build`\n- `apps/server#build` depends on `packages/contracts#build`\n- `apps/desktop#build` depends on `packages/contracts#build`, `packages/effect-acp#build`\n\nThis ensures Turbo only rebuilds affected packages, avoiding unnecessary rebuilds.\n\nCloses #828\n\n**Bounty: $15**