### PR TITLE
[leoliu201204-cmyk] [ FastAPI ] Add error handling and retry mechanism to BackgroundTasks

### DIFF
--- a/fastapi/fastapi/background.py
+++ b/fastapi/fastapi/background.py
@@ -1,11 +1,24 @@
 from collections.abc import Callable
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from annotated_doc import Doc
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
 from typing_extensions import ParamSpec
 
 P = ParamSpec("P")
+
+
+class BackgroundTaskError(Exception):
+    """
+    Exception raised when a background task fails.
+
+    Wraps the original exception with metadata about the task function.
+    """
+
+    def __init__(self, func_name: str, original_exception: Exception):
+        self.func_name = func_name
+        self.original_exception = original_exception
+        super().__init__(f"Background task '{func_name}' failed: {original_exception}")
 
 
 class BackgroundTasks(StarletteBackgroundTasks):
@@ -50,6 +63,52 @@ class BackgroundTasks(StarletteBackgroundTasks):
             ),
         ],
         *args: P.args,
+        on_error: Annotated[
+            Optional[Callable[[BackgroundTaskError], Any]],
+            Doc(
+                """
+                Optional callback invoked when the background task fails.
+
+                The callback receives a `BackgroundTaskError` instance containing
+                the original exception and the task function name.
+                """
+            ),
+        ] = None,
+        raise_on_error: Annotated[
+            bool,
+            Doc(
+                """
+                If `True`, re-raises the exception when a background task fails.
+
+                Use with caution — this will cause the background task runner to
+                raise the exception, which may affect the server's behavior.
+                Defaults to `False`.
+                """
+            ),
+        ] = False,
+        max_retries: Annotated[
+            int,
+            Doc(
+                """
+                Maximum number of retry attempts on failure.
+
+                The task will be retried up to this many times before the
+                error is propagated or the `on_error` callback is invoked.
+                Defaults to `0` (no retries).
+                """
+            ),
+        ] = 0,
+        retry_delay: Annotated[
+            float,
+            Doc(
+                """
+                Base delay in seconds between retries.
+
+                Uses exponential backoff: actual delay = `retry_delay * (2 ** attempt)`.
+                Defaults to `1.0` second.
+                """
+            ),
+        ] = 1.0,
         **kwargs: P.kwargs,
     ) -> None:
         """
@@ -58,4 +117,30 @@ class BackgroundTasks(StarletteBackgroundTasks):
         Read more about it in the
         [FastAPI docs for Background Tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/).
         """
-        return super().add_task(func, *args, **kwargs)
+        import time as time_module
+
+        func_name = getattr(func, "__name__", str(func))
+
+        def _run_with_retries(*run_args: Any, **run_kwargs: Any) -> Any:
+            last_exception: Optional[Exception] = None
+            attempts = max_retries + 1  # initial try + retries
+
+            for attempt in range(attempts):
+                try:
+                    return func(*run_args, **run_kwargs)
+                except Exception as e:
+                    last_exception = e
+                    if attempt < max_retries:
+                        delay = retry_delay * (2 ** attempt)
+                        time_module.sleep(delay)
+
+            # All attempts exhausted
+            error = BackgroundTaskError(func_name=func_name, original_exception=last_exception)
+
+            if on_error is not None:
+                on_error(error)
+
+            if raise_on_error:
+                raise error
+
+        return super().add_task(_run_with_retries, *args, **kwargs)


### PR DESCRIPTION
## Summary

Adds error handling and retry mechanism to the `BackgroundTasks` class in `fastapi/fastapi/background.py`.

### Changes

1. **`BackgroundTaskError` exception class** — Wraps the original exception with the task function name, providing clear error context.

2. **`on_error` callback** — Optional callback parameter on `add_task()` that receives a `BackgroundTaskError` instance when a task fails after all retries are exhausted.

3. **`raise_on_error` flag** — Optional boolean parameter; when `True`, re-raises the `BackgroundTaskError` after all retries are exhausted.

4. **Retry support** — `max_retries` (default: 0) and `retry_delay` (default: 1.0 second) parameters. Uses exponential backoff: actual delay = `retry_delay * (2 ** attempt)`.

### Implementation

The `add_task` method wraps the original function in an inner `_run_with_retries` wrapper that:
- Calls the original function
- On failure, retries up to `max_retries` times with exponential backoff
- After exhausting retries, invokes `on_error` callback (if provided)
- If `raise_on_error` is `True`, raises the `BackgroundTaskError`

### Usage Example

```python
from fastapi import BackgroundTasks, FastAPI

app = FastAPI()


def on_task_error(error):
    print(f"Task {error.func_name} failed: {error.original_exception}")


def my_task():
    raise ValueError("something went wrong")


@app.post("/test")
async def test(background_tasks: BackgroundTasks):
    background_tasks.add_task(
        my_task,
        on_error=on_task_error,
        max_retries=3,
        retry_delay=0.5,
    )
    return {"message": "task queued"}
```

Closes #760

Bounty: $500