### PR TITLE
Codex [ FastAPI ] Fix jsonable_encoder bytes handling

### DIFF
--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -126,6 +127,15 @@ def generate_encoders_by_class_tuples(
 encoders_by_class_tuples = generate_encoders_by_class_tuples(ENCODERS_BY_TYPE)
 
 
+def _encode_bytes(value: bytes | memoryview, bytes_encoding: str) -> str:
+    data = bytes(value)
+    if bytes_encoding == "base64":
+        return base64.b64encode(data).decode("ascii")
+    if bytes_encoding == "hex":
+        return data.hex()
+    raise ValueError("bytes_encoding must be either 'base64' or 'hex'")
+
+
 def jsonable_encoder(
     obj: Annotated[
         Any,
@@ -215,6 +225,16 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding to use for bytes-like values.
+
+            Supported values are `base64` and `hex`.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -255,6 +275,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +290,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -278,6 +300,8 @@ def jsonable_encoder(
         return obj
     if isinstance(obj, PydanticUndefinedType):
         return None
+    if isinstance(obj, (bytes, memoryview)):
+        return _encode_bytes(obj, bytes_encoding)
     if isinstance(obj, dict):
         encoded_dict = {}
         allowed_keys = set(obj.keys())
@@ -302,6 +326,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +335,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +353,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +388,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -313,6 +313,31 @@ def test_encode_pydantic_undefined():
     assert jsonable_encoder(data) == {"value": None}
 
 
+def test_encode_bytes_base64_by_default():
+    data = {"value": b"\x00\xfffastapi"}
+
+    assert jsonable_encoder(data) == {"value": "AP9mYXN0YXBp"}
+
+
+def test_encode_memoryview_base64_by_default():
+    data = {"value": memoryview(b"fastapi")}
+
+    assert jsonable_encoder(data) == {"value": "ZmFzdGFwaQ=="}
+
+
+def test_encode_bytes_hex():
+    data = {"value": b"\x00\xfffastapi"}
+
+    assert jsonable_encoder(data, bytes_encoding="hex") == {
+        "value": "00ff66617374617069"
+    }
+
+
+def test_encode_rejects_unknown_bytes_encoding():
+    with pytest.raises(ValueError, match="bytes_encoding"):
+        jsonable_encoder(b"fastapi", bytes_encoding="utf-8")
+
+
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(
     "module_path",


### PR DESCRIPTION
## Summary
- encode bytes as base64 strings by default in `jsonable_encoder`
- encode memoryview values through the same bytes path
- add `bytes_encoding="hex"` for hexadecimal output and reject unknown encodings
- add regression tests for bytes, memoryview, hex output, and invalid encoding

/claim #759

## Verification
- uv run pytest tests/test_jsonable_encoder.py -q
- uv run ruff check fastapi/encoders.py tests/test_jsonable_encoder.py
- uv run python -m compileall -q fastapi/encoders.py tests/test_jsonable_encoder.py
- git diff --check

AI-assisted with Codex; I reviewed the diff and local verification before submitting.