### PR TITLE
OpenAI Codex [ FastAPI ] Add SSE manager filtering, replay, and disconnect handling

### DIFF
--- a/fastapi/.contributor.json
+++ b/fastapi/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "You are apointed as a AI bounty expert, you need to fin comb the internet to find the largest bounties, you then need to rank them in a order from eurning the most money to the least. you need to then focus on the highest paying jobs, you then task this job to one of your AI expert clone sub agent, you review their work so that we can have a high turnaround to get the most bounties in per month, you can continue running one after the other bounty to make to most out of the month, You can design a platform for yourself to use, it doesnt need to be visual or anything, you can decide what will make this project the most efficient. you can create as many sub agents as you need and design a system that will suit your suggestions. you have autonomy to dicide and execute. you can use any tool nessisary. ",
+  "timestamp": "2026-05-15T16:00:08Z"
+}

--- a/fastapi/fastapi/sse.py
+++ b/fastapi/fastapi/sse.py
@@ -1,4 +1,7 @@
-from typing import Annotated, Any
+import asyncio
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass, field
+from typing import Annotated, Any, cast
 
 from annotated_doc import Doc
 from pydantic import AfterValidator, BaseModel, Field, model_validator
@@ -220,3 +223,182 @@ KEEPALIVE_COMMENT = b": ping\n\n"
 # Seconds between keep-alive pings when a generator is idle.
 # Private but importable so tests can monkeypatch it.
 _PING_INTERVAL: float = 15.0
+
+
+@dataclass(eq=False)
+class _SSEConnection:
+    event_types: set[str] | None
+    queue: asyncio.Queue[ServerSentEvent] = field(default_factory=asyncio.Queue)
+
+
+class SSEManager:
+    """Manage Server-Sent Event connections, history replay, and broadcasts."""
+
+    def __init__(
+        self,
+        *,
+        retry: int | None = None,
+        history_limit: int = 100,
+    ) -> None:
+        if retry is not None and retry < 0:
+            raise ValueError("retry must be greater than or equal to 0")
+        if history_limit < 0:
+            raise ValueError("history_limit must be greater than or equal to 0")
+
+        self.retry = retry
+        self.history_limit = history_limit
+        self._connections: set[_SSEConnection] = set()
+        self._history: list[ServerSentEvent] = []
+        self._next_id = 1
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._connections)
+
+    @property
+    def history(self) -> tuple[ServerSentEvent, ...]:
+        return tuple(self._history)
+
+    async def stream(
+        self,
+        request: Any | None = None,
+        *,
+        event_type: str | Sequence[str] | None = None,
+        last_event_id: str | None = None,
+        retry: int | None = None,
+        disconnect_poll_interval: float = 0.1,
+    ) -> AsyncIterator[ServerSentEvent]:
+        """Yield matching events until the client disconnects."""
+        event_types = self._event_types_from_request(request, event_type)
+        last_id = self._last_event_id_from_request(request, last_event_id)
+        retry_ms = self.retry if retry is None else retry
+        if retry_ms is not None and retry_ms < 0:
+            raise ValueError("retry must be greater than or equal to 0")
+
+        connection = _SSEConnection(event_types=event_types)
+        self._connections.add(connection)
+        try:
+            for event in self.replay(last_event_id=last_id, event_type=event_types):
+                yield self._with_retry(event, retry_ms)
+
+            while True:
+                if request is not None and await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(
+                        connection.queue.get(),
+                        timeout=disconnect_poll_interval,
+                    )
+                except TimeoutError:
+                    continue
+                yield self._with_retry(event, retry_ms)
+        finally:
+            self._connections.discard(connection)
+
+    async def broadcast(
+        self,
+        data: Any = None,
+        *,
+        raw_data: str | None = None,
+        event: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        comment: str | None = None,
+    ) -> ServerSentEvent:
+        sse_event = ServerSentEvent(
+            data=data,
+            raw_data=raw_data,
+            event=event,
+            id=id or self._new_event_id(),
+            retry=retry,
+            comment=comment,
+        )
+        self._remember(sse_event)
+
+        for connection in tuple(self._connections):
+            if self._matches(sse_event, connection.event_types):
+                connection.queue.put_nowait(sse_event)
+
+        return sse_event
+
+    def replay(
+        self,
+        *,
+        last_event_id: str | None,
+        event_type: str | Sequence[str] | set[str] | None = None,
+    ) -> list[ServerSentEvent]:
+        if last_event_id is None:
+            return []
+
+        event_types = self._normalize_event_types(event_type)
+        start_index = 0
+        for index, event in enumerate(self._history):
+            if event.id == last_event_id:
+                start_index = index + 1
+                break
+
+        return [
+            event
+            for event in self._history[start_index:]
+            if self._matches(event, event_types)
+        ]
+
+    def _remember(self, event: ServerSentEvent) -> None:
+        if self.history_limit == 0:
+            return
+        self._history.append(event)
+        if len(self._history) > self.history_limit:
+            self._history = self._history[-self.history_limit :]
+
+    def _new_event_id(self) -> str:
+        event_id = str(self._next_id)
+        self._next_id += 1
+        return event_id
+
+    @staticmethod
+    def _with_retry(
+        event: ServerSentEvent, retry: int | None
+    ) -> ServerSentEvent:
+        if retry is None or event.retry is not None:
+            return event
+        return event.model_copy(update={"retry": retry})
+
+    @classmethod
+    def _event_types_from_request(
+        cls, request: Any | None, event_type: str | Sequence[str] | None
+    ) -> set[str] | None:
+        if event_type is not None:
+            return cls._normalize_event_types(event_type)
+        if request is None:
+            return None
+        return cls._normalize_event_types(request.query_params.get("event_type"))
+
+    @staticmethod
+    def _last_event_id_from_request(
+        request: Any | None, last_event_id: str | None
+    ) -> str | None:
+        if last_event_id is not None or request is None:
+            return last_event_id
+        return cast(
+            str | None,
+            request.headers.get("last-event-id")
+            or request.headers.get("Last-Event-ID"),
+        )
+
+    @staticmethod
+    def _normalize_event_types(
+        event_type: str | Sequence[str] | set[str] | None,
+    ) -> set[str] | None:
+        if event_type is None:
+            return None
+        if isinstance(event_type, str):
+            event_types = {item.strip() for item in event_type.split(",")}
+        else:
+            event_types = {item.strip() for item in event_type}
+        return {item for item in event_types if item} or None
+
+    @staticmethod
+    def _matches(event: ServerSentEvent, event_types: set[str] | None) -> bool:
+        if event_types is None:
+            return True
+        return event.event in event_types

--- a/fastapi/tests/test_sse_manager.py
+++ b/fastapi/tests/test_sse_manager.py
@@ -1,0 +1,199 @@
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import EventSourceResponse
+from fastapi.sse import ServerSentEvent, SSEManager, format_sse_event
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class FakeRequest:
+    def __init__(
+        self,
+        *,
+        query_params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        disconnect_after: int | None = None,
+    ) -> None:
+        self.query_params = query_params or {}
+        self.headers = headers or {}
+        self.disconnect_after = disconnect_after
+        self.disconnect_checks = 0
+
+    async def is_disconnected(self) -> bool:
+        self.disconnect_checks += 1
+        if self.disconnect_after is None:
+            return False
+        return self.disconnect_checks > self.disconnect_after
+
+
+@pytest.mark.anyio
+async def test_sse_manager_broadcasts_to_all_and_filtered_connections():
+    manager = SSEManager()
+    all_stream = manager.stream(disconnect_poll_interval=0.01)
+    deploy_stream = manager.stream(event_type="deploy", disconnect_poll_interval=0.01)
+    all_next = asyncio.create_task(anext(all_stream))
+    deploy_next = asyncio.create_task(anext(deploy_stream))
+
+    await asyncio.sleep(0)
+    assert manager.connection_count == 2
+
+    await manager.broadcast({"message": "audit"}, event="audit")
+    all_event = await all_next
+    assert all_event.event == "audit"
+    assert all_event.data == {"message": "audit"}
+    assert deploy_next.done() is False
+
+    await manager.broadcast({"message": "deploy"}, event="deploy")
+    deploy_event = await deploy_next
+    assert deploy_event.event == "deploy"
+    assert deploy_event.data == {"message": "deploy"}
+
+    await all_stream.aclose()
+    await deploy_stream.aclose()
+    assert manager.connection_count == 0
+
+
+@pytest.mark.anyio
+async def test_sse_manager_reads_query_filter_and_replays_after_last_event_id():
+    manager = SSEManager(retry=2500)
+    first = await manager.broadcast("one", event="audit")
+    second = await manager.broadcast("two", event="deploy")
+    third = await manager.broadcast("three", event="deploy")
+    await manager.broadcast("four", event="audit")
+    request = FakeRequest(
+        query_params={"event_type": "deploy"},
+        headers={"last-event-id": first.id or ""},
+    )
+
+    stream = manager.stream(request, disconnect_poll_interval=0.01)
+    replayed_second = await anext(stream)
+    replayed_third = await anext(stream)
+
+    assert replayed_second.id == second.id
+    assert replayed_second.retry == 2500
+    assert replayed_third.id == third.id
+    assert replayed_third.retry == 2500
+
+    await stream.aclose()
+    assert manager.connection_count == 0
+
+
+@pytest.mark.anyio
+async def test_sse_manager_stops_and_cleans_up_on_disconnect():
+    manager = SSEManager()
+    request = FakeRequest(disconnect_after=0)
+    stream = manager.stream(request, disconnect_poll_interval=0.01)
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+    assert request.disconnect_checks == 1
+    assert manager.connection_count == 0
+
+
+@pytest.mark.anyio
+async def test_sse_manager_handles_concurrent_connections_without_blocking():
+    manager = SSEManager()
+    streams = [manager.stream(disconnect_poll_interval=0.01) for _ in range(3)]
+    pending = [asyncio.create_task(anext(stream)) for stream in streams]
+
+    await asyncio.sleep(0)
+    assert manager.connection_count == 3
+
+    event = await manager.broadcast({"batch": 1}, event="batch")
+    received = await asyncio.gather(*pending)
+
+    assert [item.id for item in received] == [event.id, event.id, event.id]
+    assert [item.event for item in received] == ["batch", "batch", "batch"]
+
+    for stream in streams:
+        await stream.aclose()
+    assert manager.connection_count == 0
+
+
+def test_sse_manager_replay_returns_events_after_matching_id():
+    manager = SSEManager()
+    first = asyncio.run(manager.broadcast("one", event="alpha"))
+    second = asyncio.run(manager.broadcast("two", event="beta"))
+    third = asyncio.run(manager.broadcast("three", event="beta"))
+
+    replayed = manager.replay(last_event_id=first.id, event_type="beta")
+
+    assert [event.id for event in replayed] == [second.id, third.id]
+    assert [event.data for event in replayed] == ["two", "three"]
+
+
+def test_sse_manager_retry_field_serializes_in_sse_stream():
+    event = SSEManager(retry=1000)._with_retry(
+        ServerSentEvent(data="payload", event="update", id="1"),
+        retry=1000,
+    )
+
+    assert event.retry == 1000
+    assert (
+        format_sse_event(
+            data_str='"payload"',
+            event=event.event,
+            id=event.id,
+            retry=event.retry,
+        )
+        == b'event: update\ndata: "payload"\nid: 1\nretry: 1000\n\n'
+    )
+
+
+def test_sse_manager_streams_through_fastapi_route_with_replay_filter_and_retry():
+    manager = SSEManager(retry=1500)
+    first = asyncio.run(manager.broadcast("one", event="audit"))
+    second = asyncio.run(manager.broadcast("two", event="deploy"))
+    third = asyncio.run(manager.broadcast("three", event="deploy"))
+    app = FastAPI()
+
+    @app.get("/events", response_class=EventSourceResponse)
+    async def events(request: Request):
+        async for event in manager.stream(
+            request,
+            last_event_id=first.id,
+            disconnect_poll_interval=0.01,
+        ):
+            yield event
+            if event.id == third.id:
+                break
+
+    client = TestClient(app)
+    response = client.get("/events?event_type=deploy")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+    assert "event: deploy\n" in response.text
+    assert f"id: {second.id}\n" in response.text
+    assert f"id: {third.id}\n" in response.text
+    assert "data: \"one\"\n" not in response.text
+    assert "retry: 1500\n" in response.text
+
+
+def test_sse_manager_validates_retry_and_history_limit():
+    with pytest.raises(ValueError, match="retry"):
+        SSEManager(retry=-1)
+    with pytest.raises(ValueError, match="history_limit"):
+        SSEManager(history_limit=-1)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("alpha,beta", {"alpha", "beta"}),
+        (["alpha", " beta ", ""], {"alpha", "beta"}),
+        ("", None),
+    ],
+)
+def test_sse_manager_normalizes_event_type_filters(
+    value: Any, expected: set[str] | None
+):
+    assert SSEManager._normalize_event_types(value) == expected


### PR DESCRIPTION
```text
Task-specific prompt used for this bounty implementation (sanitized to exclude private platform/developer instructions):
Act as an AI coding agent working on UnsafeLabs/Bounty-Hunters issue #798. Extend FastAPI SSE support with disconnect-aware event streams, query/header event type filtering, Last-Event-ID reconnect replay, configurable retry fields, and an SSEManager that can broadcast to all connections or filtered subsets. Add tests for disconnect cleanup, filtering, replay, retry serialization, concurrent connections, and route-level EventSourceResponse usage. Include the required contributor metadata file and prepare a PR that claims the bounty.
```

/claim #798

Summary:
- Added `SSEManager` in `fastapi.sse` with per-connection queues, connection cleanup, event history, reconnect replay, event-type filtering, and broadcast fanout.
- Added query/header handling for `event_type` and `Last-Event-ID`, plus configurable `retry` values on streamed/replayed events.
- Added tests for disconnect cleanup, filtered broadcasts, replay after last event id, concurrent connections, retry serialization, filter normalization, and a real FastAPI route returning `EventSourceResponse` from `manager.stream(request)`.
- Added the required `fastapi/.contributor.json` file for this bounty.

Demo video:
- https://raw.githubusercontent.com/Bjvsquare/Bounty-Hunters/codex/fastapi-sse-manager-demo/bounty-798-demo.mp4

Verification:
- `uv run pytest tests/test_sse_manager.py` -> 11 passed
- `uv run pytest tests/test_sse.py tests/test_sse_manager.py -q` -> 29 passed
- `uv run ruff check fastapi/sse.py tests/test_sse_manager.py` -> All checks passed
- `uv run mypy fastapi/sse.py` -> Success: no issues found
- `uv run python -m json.tool .contributor.json` -> JSON validated
- `uv run python -c "from fastapi.sse import SSEManager; manager=SSEManager(retry=1000); print(manager.connection_count, manager.retry)"` -> import smoke test passed
- `git diff --check` -> no whitespace errors; Git only reported line-ending normalization warnings on Windows