### PR TITLE
OpenAI Codex [ FastAPI ] Add BackgroundTasks error handling and retries

### DIFF
--- a/fastapi/.contributor.json
+++ b/fastapi/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "You are apointed as a AI bounty expert, you need to fin comb the internet to find the largest bounties, you then need to rank them in a order from eurning the most money to the least. you need to then focus on the highest paying jobs, you then task this job to one of your AI expert clone sub agent, you review their work so that we can have a high turnaround to get the most bounties in per month, you can continue running one after the other bounty to make to most out of the month, You can design a platform for yourself to use, it doesnt need to be visual or anything, you can decide what will make this project the most efficient. you can create as many sub agents as you need and design a system that will suit your suggestions. you have autonomy to dicide and execute. you can use any tool nessisary. ",
+  "timestamp": "2026-05-15T16:04:40Z"
+}

--- a/fastapi/fastapi/background.py
+++ b/fastapi/fastapi/background.py
@@ -1,11 +1,159 @@
+import inspect
 from collections.abc import Callable
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from annotated_doc import Doc
+from starlette.background import BackgroundTask as StarletteBackgroundTask
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
-from typing_extensions import ParamSpec
 
-P = ParamSpec("P")
+from .logger import logger
+
+TaskResult = dict[str, Any]
+ErrorCallback = Callable[[Exception, dict[str, Any]], Any]
+_Unset = object()
+
+
+class BackgroundTask:
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        _background_on_error: ErrorCallback | None = None,
+        _background_max_retries: int = 0,
+        _background_handle_errors: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        if _background_max_retries < 0:
+            raise ValueError("max_retries must be greater than or equal to 0")
+
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+        self.on_error = _background_on_error
+        self.max_retries = _background_max_retries
+        self.handle_errors = _background_handle_errors
+        self.task_name = getattr(func, "__name__", func.__class__.__name__)
+        self._task = StarletteBackgroundTask(func, *args, **kwargs)
+        self.last_result: TaskResult | None = None
+
+    async def __call__(self) -> TaskResult:
+        retry_count = 0
+
+        while True:
+            try:
+                await self._task()
+            except Exception as exc:
+                logger.exception(
+                    "Background task %s failed on attempt %s",
+                    self.task_name,
+                    retry_count + 1,
+                )
+                task_info = self._task_info(retry_count=retry_count)
+                await self._call_error_callback(exc, task_info)
+
+                if retry_count < self.max_retries:
+                    retry_count += 1
+                    continue
+
+                result = self._task_result(
+                    status="failed",
+                    retry_count=retry_count,
+                    exception=exc,
+                )
+                if not self.handle_errors:
+                    raise
+                return result
+
+            return self._task_result(status="success", retry_count=retry_count)
+
+    def _task_info(self, *, retry_count: int) -> dict[str, Any]:
+        return {
+            "task_name": self.task_name,
+            "retry_count": retry_count,
+            "max_retries": self.max_retries,
+            "args": self.args,
+            "kwargs": self.kwargs,
+        }
+
+    async def _call_error_callback(
+        self, exc: Exception, task_info: dict[str, Any]
+    ) -> None:
+        if self.on_error is None:
+            return
+
+        try:
+            result = self.on_error(exc, task_info)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.exception(
+                "Background task error callback failed for %s",
+                self.task_name,
+            )
+
+    def _task_result(
+        self,
+        *,
+        status: str,
+        retry_count: int,
+        exception: Exception | None = None,
+    ) -> TaskResult:
+        result = {
+            "task_name": self.task_name,
+            "status": status,
+            "exception": str(exception) if exception else None,
+            "retry_count": retry_count,
+        }
+        self.last_result = result
+        return result
+
+
+def _task_name(task: Any) -> str:
+    func = getattr(task, "func", None)
+    if func is not None:
+        return str(getattr(func, "__name__", func.__class__.__name__))
+    return str(task.__class__.__name__)
+
+
+def _accepts_keyword(func: Callable[..., Any], keyword: str) -> bool:
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True
+
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == keyword
+            and parameter.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        )
+        for parameter in signature.parameters.values()
+    )
+
+
+def _resolve_control_argument(
+    *,
+    func: Callable[..., Any],
+    kwargs: dict[str, Any],
+    keyword: str,
+    value: Any,
+    alias_value: Any,
+    default: Any,
+) -> Any:
+    if alias_value is not _Unset:
+        if value is not _Unset:
+            kwargs[keyword] = value
+        return alias_value
+    if value is _Unset:
+        return default
+    if _accepts_keyword(func, keyword):
+        kwargs[keyword] = value
+        return default
+    return value
 
 
 class BackgroundTasks(StarletteBackgroundTasks):
@@ -37,10 +185,14 @@ class BackgroundTasks(StarletteBackgroundTasks):
     ```
     """
 
+    def __init__(self, tasks: list[Any] | None = None):
+        super().__init__(tasks=tasks)
+        self.task_results: list[TaskResult] = []
+
     def add_task(
         self,
         func: Annotated[
-            Callable[P, Any],
+            Callable[..., Any],
             Doc(
                 """
                 The function to call after the response is sent.
@@ -49,8 +201,29 @@ class BackgroundTasks(StarletteBackgroundTasks):
                 """
             ),
         ],
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Any,
+        on_error: Annotated[
+            ErrorCallback | None | object,
+            Doc(
+                """
+                An optional callback called when a task raises an exception. It
+                receives the exception and a task info dictionary containing the
+                original task function name.
+                """
+            ),
+        ] = _Unset,
+        max_retries: Annotated[
+            int | object,
+            Doc(
+                """
+                The number of times to retry a failed background task before
+                recording it as failed.
+                """
+            ),
+        ] = _Unset,
+        background_on_error: ErrorCallback | None | object = _Unset,
+        background_max_retries: int | object = _Unset,
+        **kwargs: Any,
     ) -> None:
         """
         Add a function to be called in the background after the response is sent.
@@ -58,4 +231,66 @@ class BackgroundTasks(StarletteBackgroundTasks):
         Read more about it in the
         [FastAPI docs for Background Tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/).
         """
-        return super().add_task(func, *args, **kwargs)
+        control_on_error = _resolve_control_argument(
+            func=func,
+            kwargs=kwargs,
+            keyword="on_error",
+            value=on_error,
+            alias_value=background_on_error,
+            default=None,
+        )
+        control_max_retries = _resolve_control_argument(
+            func=func,
+            kwargs=kwargs,
+            keyword="max_retries",
+            value=max_retries,
+            alias_value=background_max_retries,
+            default=0,
+        )
+        should_handle_errors = (
+            control_on_error is not None or int(control_max_retries) > 0
+        )
+        task = BackgroundTask(
+            func,
+            *args,
+            _background_on_error=cast(ErrorCallback | None, control_on_error),
+            _background_max_retries=int(control_max_retries),
+            _background_handle_errors=should_handle_errors,
+            **kwargs,
+        )
+        cast(list[Any], self.tasks).append(task)
+
+    async def __call__(self) -> None:
+        for task in self.tasks:
+            if isinstance(task, BackgroundTask):
+                try:
+                    result = await task()
+                except Exception:
+                    if task.last_result is not None:
+                        self.task_results.append(task.last_result)
+                    raise
+            else:
+                result = await self._run_existing_task(task)
+            self.task_results.append(result)
+
+    async def _run_existing_task(self, task: Any) -> TaskResult:
+        name = _task_name(task)
+        try:
+            await task()
+        except Exception as exc:
+            logger.exception("Background task %s failed on attempt 1", name)
+            result = {
+                "task_name": name,
+                "status": "failed",
+                "exception": str(exc),
+                "retry_count": 0,
+            }
+            self.task_results.append(result)
+            raise
+
+        return {
+            "task_name": name,
+            "status": "success",
+            "exception": None,
+            "retry_count": 0,
+        }

--- a/fastapi/tests/test_background_tasks_retries.py
+++ b/fastapi/tests/test_background_tasks_retries.py
@@ -1,0 +1,206 @@
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+from fastapi import BackgroundTasks, FastAPI
+from fastapi.testclient import TestClient
+
+
+def run_background_tasks(tasks: BackgroundTasks) -> None:
+    asyncio.run(tasks())
+
+
+def test_successful_background_task_records_result():
+    events: list[str] = []
+    tasks = BackgroundTasks()
+
+    def write_event(value: str) -> None:
+        events.append(value)
+
+    tasks.add_task(write_event, "sent")
+    run_background_tasks(tasks)
+
+    assert events == ["sent"]
+    assert tasks.task_results == [
+        {
+            "task_name": "write_event",
+            "status": "success",
+            "exception": None,
+            "retry_count": 0,
+        }
+    ]
+
+
+def test_background_task_exception_is_logged_and_recorded(caplog: pytest.LogCaptureFixture):
+    errors: list[tuple[str, str, int]] = []
+    tasks = BackgroundTasks()
+
+    def failing_task() -> None:
+        raise RuntimeError("boom")
+
+    def on_error(exc: Exception, task_info: dict[str, Any]) -> None:
+        errors.append(
+            (str(exc), task_info["task_name"], task_info["retry_count"])
+        )
+
+    tasks.add_task(failing_task, on_error=on_error)
+
+    with caplog.at_level(logging.ERROR, logger="fastapi"):
+        run_background_tasks(tasks)
+
+    assert "Background task failing_task failed on attempt 1" in caplog.text
+    assert errors == [("boom", "failing_task", 0)]
+    assert tasks.task_results == [
+        {
+            "task_name": "failing_task",
+            "status": "failed",
+            "exception": "boom",
+            "retry_count": 0,
+        }
+    ]
+
+
+def test_default_background_task_failure_is_still_raised_for_compatibility(
+    caplog: pytest.LogCaptureFixture,
+):
+    tasks = BackgroundTasks()
+
+    def failing_task() -> None:
+        raise RuntimeError("unchanged")
+
+    tasks.add_task(failing_task)
+
+    with caplog.at_level(logging.ERROR, logger="fastapi"):
+        with pytest.raises(RuntimeError, match="unchanged"):
+            run_background_tasks(tasks)
+
+    assert "Background task failing_task failed on attempt 1" in caplog.text
+    assert tasks.task_results == [
+        {
+            "task_name": "failing_task",
+            "status": "failed",
+            "exception": "unchanged",
+            "retry_count": 0,
+        }
+    ]
+
+
+def test_background_task_retries_until_success():
+    calls: list[int] = []
+    errors: list[int] = []
+    tasks = BackgroundTasks()
+
+    def flaky_task() -> None:
+        calls.append(1)
+        if len(calls) < 3:
+            raise RuntimeError(f"failure {len(calls)}")
+
+    def on_error(exc: Exception, task_info: dict[str, Any]) -> None:
+        errors.append(task_info["retry_count"])
+
+    tasks.add_task(flaky_task, on_error=on_error, max_retries=2)
+    run_background_tasks(tasks)
+
+    assert len(calls) == 3
+    assert errors == [0, 1]
+    assert tasks.task_results == [
+        {
+            "task_name": "flaky_task",
+            "status": "success",
+            "exception": None,
+            "retry_count": 2,
+        }
+    ]
+
+
+def test_background_task_stops_after_max_retries():
+    calls: list[int] = []
+    tasks = BackgroundTasks()
+
+    def always_fails() -> None:
+        calls.append(1)
+        raise RuntimeError("still failing")
+
+    tasks.add_task(always_fails, max_retries=2)
+    run_background_tasks(tasks)
+
+    assert len(calls) == 3
+    assert tasks.task_results == [
+        {
+            "task_name": "always_fails",
+            "status": "failed",
+            "exception": "still failing",
+            "retry_count": 2,
+        }
+    ]
+
+
+def test_async_error_callback_is_supported():
+    errors: list[tuple[str, str]] = []
+    tasks = BackgroundTasks()
+
+    def failing_task() -> None:
+        raise RuntimeError("async callback")
+
+    async def on_error(exc: Exception, task_info: dict[str, Any]) -> None:
+        errors.append((str(exc), task_info["task_name"]))
+
+    tasks.add_task(failing_task, on_error=on_error)
+    run_background_tasks(tasks)
+
+    assert errors == [("async callback", "failing_task")]
+
+
+def test_negative_max_retries_is_rejected():
+    tasks = BackgroundTasks()
+
+    with pytest.raises(ValueError, match="max_retries"):
+        tasks.add_task(lambda: None, max_retries=-1)
+
+
+def test_existing_task_kwargs_named_like_retry_options_are_preserved():
+    captured: list[Any] = []
+    tasks = BackgroundTasks()
+
+    def task_with_retry_kwargs(max_retries: int, on_error: str) -> None:
+        captured.append((max_retries, on_error))
+
+    tasks.add_task(task_with_retry_kwargs, max_retries=3, on_error="passthrough")
+    run_background_tasks(tasks)
+
+    assert captured == [(3, "passthrough")]
+    assert tasks.task_results[0]["status"] == "success"
+
+
+def test_fastapi_route_continues_when_background_task_failure_is_handled():
+    app = FastAPI()
+    state: dict[str, Any] = {}
+    errors: list[str] = []
+
+    def failing_task() -> None:
+        raise RuntimeError("route failure")
+
+    def on_error(exc: Exception, task_info: dict[str, Any]) -> None:
+        errors.append(f"{task_info['task_name']}: {exc}")
+
+    @app.get("/background-error")
+    def background_error(background_tasks: BackgroundTasks):
+        state["tasks"] = background_tasks
+        background_tasks.add_task(failing_task, on_error=on_error)
+        return {"ok": True}
+
+    client = TestClient(app)
+    response = client.get("/background-error")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert errors == ["failing_task: route failure"]
+    assert state["tasks"].task_results == [
+        {
+            "task_name": "failing_task",
+            "status": "failed",
+            "exception": "route failure",
+            "retry_count": 0,
+        }
+    ]


### PR DESCRIPTION
```text
Task-specific prompt used for this bounty implementation (sanitized to exclude private platform/developer instructions):
Act as an AI coding agent working on UnsafeLabs/Bounty-Hunters issue #760. Extend FastAPI BackgroundTasks with logged task failures, optional error callbacks, per-task retry support through max_retries, task_results inspection, and focused test coverage. Preserve existing background task behavior when no error callback or retry handling is requested, include the required contributor metadata file, verify compatibility with existing FastAPI background task tests, and prepare a PR that claims the bounty.
```

/claim #760

Resubmission note:
- This is a new PR replacing #880, which was auto-closed for not fully satisfying the issue metadata requirements.
- Added the required `fastapi/.contributor.json` file and rebased onto the latest upstream `main` before resubmitting.

Summary:
- Added a FastAPI-owned `BackgroundTask` wrapper that records task results and delegates execution through Starlette's background task implementation.
- Added optional `on_error` callback support with task info including original task name, retry count, args, kwargs, and max retries.
- Added per-task `max_retries` support that retries failures and records final success/failure status.
- Logged background task failures through the FastAPI logger.
- Preserved default Starlette/FastAPI behavior when no callback/retry handling is requested: default failures still raise, and task kwargs named `on_error` or `max_retries` are passed through when the task function expects them.

Demo video:
- https://raw.githubusercontent.com/Bjvsquare/Bounty-Hunters/codex/fastapi-background-retries-demo/bounty-760-demo.mp4

Verification:
- `uv run pytest tests/test_background_tasks_retries.py` -> 9 passed
- `uv run pytest tests/test_background_tasks_retries.py tests/test_dependency_contextmanager.py tests/test_response_dependency.py tests/test_tutorial/test_background_tasks -q` -> 41 passed
- `uv run ruff check fastapi/background.py tests/test_background_tasks_retries.py` -> All checks passed
- `uv run mypy fastapi/background.py` -> Success: no issues found
- `uv run python -m json.tool .contributor.json` -> JSON validated
- `git diff --check origin/main...HEAD` -> no whitespace errors