### PR TITLE
Codex [ T3 Code ] Add container and CI detection

### DIFF
--- a/t3code/packages/client-runtime/src/knownEnvironment.test.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.test.ts
@@ -1,7 +1,11 @@
 import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { createKnownEnvironment, getKnownEnvironmentHttpBaseUrl } from "./knownEnvironment.ts";
+import {
+  createKnownEnvironment,
+  detectEnvironmentInfo,
+  getKnownEnvironmentHttpBaseUrl,
+} from "./knownEnvironment.ts";
 import {
   parseScopedProjectKey,
   parseScopedThreadKey,
@@ -57,6 +61,114 @@ describe("known environment bootstrap helpers", () => {
         }),
       ),
     ).toBe("https://remote.example.com/api");
+  });
+});
+
+describe("environment info detection", () => {
+  it("detects Docker from /.dockerenv", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        arch: "x64",
+        fileExists: (path) => path === "/.dockerenv",
+        readFile: () => null,
+      }),
+    ).toMatchObject({
+      runtime: "node",
+      platform: "linux",
+      arch: "x64",
+      isContainer: true,
+      isCI: false,
+      ciProvider: null,
+      isWSL: false,
+    });
+  });
+
+  it("detects containers from cgroup markers", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        arch: "x64",
+        fileExists: () => false,
+        readFile: (path) => (path === "/proc/self/cgroup" ? "0::/docker/test" : null),
+      }).isContainer,
+    ).toBe(true);
+  });
+
+  it("detects CI providers and keeps ciProvider null outside CI", () => {
+    const providers = [
+      ["GITHUB_ACTIONS", "github-actions"],
+      ["GITLAB_CI", "gitlab-ci"],
+      ["JENKINS_URL", "jenkins"],
+      ["CIRCLECI", "circleci"],
+      ["TRAVIS", "travis"],
+      ["CI", "ci"],
+    ] as const;
+
+    for (const [envKey, ciProvider] of providers) {
+      expect(
+        detectEnvironmentInfo({
+          env: { [envKey]: "true" },
+          runtime: "node",
+          platform: "linux",
+          arch: "arm64",
+          fileExists: () => false,
+          readFile: () => null,
+        }),
+      ).toMatchObject({
+        isCI: true,
+        ciProvider,
+      });
+    }
+
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        arch: "arm64",
+        fileExists: () => false,
+        readFile: () => null,
+      }),
+    ).toMatchObject({
+      isCI: false,
+      ciProvider: null,
+    });
+  });
+
+  it("detects WSL from proc version without throwing on missing files", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        arch: "x64",
+        fileExists: () => false,
+        readFile: (path) => (path === "/proc/version" ? "Linux version Microsoft" : null),
+      }).isWSL,
+    ).toBe(true);
+
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        arch: "x64",
+        fileExists: () => {
+          throw new Error("unavailable");
+        },
+        readFile: () => {
+          throw new Error("unavailable");
+        },
+      }),
+    ).toMatchObject({
+      isContainer: false,
+      isWSL: false,
+    });
   });
 });
 

--- a/t3code/packages/client-runtime/src/knownEnvironment.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.ts
@@ -1,5 +1,24 @@
 import type { EnvironmentId, ExecutionEnvironmentDescriptor } from "@t3tools/contracts";
 
+export interface EnvironmentInfo {
+  readonly runtime: string;
+  readonly platform: string;
+  readonly arch: string;
+  readonly isContainer: boolean;
+  readonly isCI: boolean;
+  readonly ciProvider: string | null;
+  readonly isWSL: boolean;
+}
+
+export interface EnvironmentDetectionInput {
+  readonly env?: Record<string, string | undefined>;
+  readonly runtime?: string;
+  readonly platform?: string;
+  readonly arch?: string;
+  readonly fileExists?: (path: string) => boolean;
+  readonly readFile?: (path: string) => string | null | undefined;
+}
+
 export interface KnownEnvironmentConnectionTarget {
   readonly httpBaseUrl: string;
   readonly wsBaseUrl: string;
@@ -49,5 +68,145 @@ export function attachEnvironmentDescriptor(
     ...environment,
     environmentId: descriptor.environmentId,
     label: descriptor.label,
+  };
+}
+
+const ciProviders: ReadonlyArray<readonly [string, string]> = [
+  ["GITHUB_ACTIONS", "github-actions"],
+  ["GITLAB_CI", "gitlab-ci"],
+  ["JENKINS_URL", "jenkins"],
+  ["CIRCLECI", "circleci"],
+  ["TRAVIS", "travis"],
+  ["CI", "ci"],
+];
+
+function getProcessLike():
+  | {
+      readonly env?: Record<string, string | undefined>;
+      readonly platform?: string;
+      readonly arch?: string;
+      readonly versions?: Record<string, string | undefined>;
+      readonly getBuiltinModule?: (name: string) => unknown;
+    }
+  | undefined {
+  return typeof process === "undefined" ? undefined : process;
+}
+
+interface EnvironmentFileAccessors {
+  fileExists?: (path: string) => boolean;
+  readFile?: (path: string) => string | null | undefined;
+}
+
+function getNodeFsAccessors(): EnvironmentFileAccessors {
+  const fs = getProcessLike()?.getBuiltinModule?.("node:fs") as
+    | {
+        readonly existsSync?: (path: string) => boolean;
+        readonly readFileSync?: (path: string, encoding: "utf8") => string;
+      }
+    | undefined;
+
+  const accessors: EnvironmentFileAccessors = {};
+  if (fs?.existsSync) {
+    accessors.fileExists = (path) => {
+      try {
+        return fs.existsSync?.(path) ?? false;
+      } catch {
+        return false;
+      }
+    };
+  }
+  if (fs?.readFileSync) {
+    accessors.readFile = (path) => {
+      try {
+        return fs.readFileSync?.(path, "utf8") ?? null;
+      } catch {
+        return null;
+      }
+    };
+  }
+  return accessors;
+}
+
+function detectRuntime(inputRuntime: string | undefined): string {
+  if (inputRuntime) return inputRuntime;
+
+  const versions = getProcessLike()?.versions;
+  if (versions?.bun) return "bun";
+  if (versions?.node) return "node";
+  const globals = globalThis as typeof globalThis & {
+    readonly Deno?: unknown;
+    readonly window?: unknown;
+  };
+  if (globals.Deno) return "deno";
+  if (globals.window) return "browser";
+  return "unknown";
+}
+
+function detectCiProvider(env: Record<string, string | undefined>): string | null {
+  for (const [key, provider] of ciProviders) {
+    if (env[key]) return provider;
+  }
+  return null;
+}
+
+function readAny(
+  readFile: (path: string) => string | null | undefined,
+  paths: readonly string[],
+): string {
+  return paths
+    .map((path) => {
+      try {
+        return readFile(path) ?? "";
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+}
+
+function detectContainer(input: EnvironmentDetectionInput): boolean {
+  const fsAccessors = getNodeFsAccessors();
+  const fileExists = input.fileExists ?? fsAccessors.fileExists;
+  const readFile = input.readFile ?? fsAccessors.readFile;
+
+  try {
+    if (fileExists?.("/.dockerenv")) return true;
+  } catch {
+    // Fall back to cgroup detection if the direct marker cannot be checked.
+  }
+  if (!readFile) return false;
+
+  const cgroup = readAny(readFile, ["/proc/1/cgroup", "/proc/self/cgroup"]).toLowerCase();
+  return ["docker", "kubepods", "containerd", "libpod", "podman"].some((marker) =>
+    cgroup.includes(marker),
+  );
+}
+
+function detectWsl(input: EnvironmentDetectionInput, platform: string): boolean {
+  const readFile = input.readFile ?? getNodeFsAccessors().readFile;
+  if (!readFile || platform !== "linux") return false;
+
+  try {
+    return readFile("/proc/version")?.toLowerCase().includes("microsoft") ?? false;
+  } catch {
+    return false;
+  }
+}
+
+export function detectEnvironmentInfo(input: EnvironmentDetectionInput = {}): EnvironmentInfo {
+  const processLike = getProcessLike();
+  const env = input.env ?? processLike?.env ?? {};
+  const platform = input.platform ?? processLike?.platform ?? "unknown";
+  const arch = input.arch ?? processLike?.arch ?? "unknown";
+  const ciProvider = detectCiProvider(env);
+
+  return {
+    runtime: detectRuntime(input.runtime),
+    platform,
+    arch,
+    isContainer: detectContainer(input),
+    isCI: ciProvider !== null,
+    ciProvider,
+    isWSL: detectWsl(input, platform),
   };
 }


### PR DESCRIPTION
/claim #836

Summary:
- add structured EnvironmentInfo detection for runtime, platform, architecture, container, CI provider, and WSL
- detect Docker/container runtimes through /.dockerenv and cgroup markers
- detect GitHub Actions, GitLab CI, Jenkins, CircleCI, Travis, and generic CI envs
- keep detection safe when process/file APIs are unavailable or throw

Verification:
- npx --yes -p node@24 -p bun@1.3.11 bun fmt
- npx --yes -p node@24 -p bun@1.3.11 bun run test in packages/client-runtime
- npx --yes -p node@24 -p bun@1.3.11 bun run typecheck in packages/client-runtime
- git diff --check
- npx --yes -p node@24 -p bun@1.3.11 bun lint
- npx --yes -p node@24 -p bun@1.3.11 bun typecheck
