### PR TITLE
Fix phantom reward accrual after period expiry in YieldVault

### DIFF
--- a/solidity/contracts/YieldVaultV2.sol
+++ b/solidity/contracts/YieldVaultV2.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title YieldVaultV2
+ * @dev Fixed: Phantom reward accrual capped at periodFinish.
+ */
+contract YieldVaultV2 {
+    uint256 public rewardRate;
+    uint256 public periodFinish;
+    uint256 public lastUpdateTime;
+    uint256 public rewardPerTokenStored;
+    uint256 public totalSupply;
+    
+    mapping(address => uint256) public stakedBalance;
+    mapping(address => uint256) public userRewardPerTokenPaid;
+    mapping(address => uint256) public rewards;
+    
+    function _cappedTimestamp() internal view returns (uint256) {
+        return block.timestamp < periodFinish ? block.timestamp : periodFinish;
+    }
+    
+    function rewardPerToken() public view returns (uint256) {
+        if (totalSupply == 0) return rewardPerTokenStored;
+        return rewardPerTokenStored + ((_cappedTimestamp() - lastUpdateTime) * rewardRate * 1e18 / totalSupply);
+    }
+    
+    function earned(address account) public view returns (uint256) {
+        return (stakedBalance[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / 1e18) + rewards[account];
+    }
+    
+    function updateReward(address account) internal {
+        rewardPerTokenStored = rewardPerToken();
+        lastUpdateTime = _cappedTimestamp();
+        if (account != address(0)) {
+            rewards[account] = earned(account);
+            userRewardPerTokenPaid[account] = rewardPerTokenStored;
+        }
+    }
+}


### PR DESCRIPTION
## Fix for #917

Same issue as #914 but different contract. Cap timestamp at periodFinish.

Wallet: zp6