### PR TITLE
[OpenAI Codex] [ Laravel ] Implement lightweight RBAC with permissions

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "You are apointed as a AI bounty expert, you need to fin comb the internet to find the largest bounties, you then need to rank them in a order from eurning the most money to the least. you need to then focus on the highest paying jobs, you then task this job to one of your AI expert clone sub agent, you review their work so that we can have a high turnaround to get the most bounties in per month, you can continue running one after the other bounty to make to most out of the month, You can design a platform for yourself to use, it doesnt need to be visual or anything, you can decide what will make this project the most efficient. you can create as many sub agents as you need and design a system that will suit your suggestions. you have autonomy to dicide and execute. you can use any tool nessisary. ",
+  "timestamp": "2026-05-15T16:50:15Z"
+}

--- a/laravel/app/Http/Middleware/CheckRole.php
+++ b/laravel/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * @param Closure(Request): Response $next
+     */
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! method_exists($user, 'hasRole') || ! $user->hasRole($role)) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Permission extends Model
+{
+    /**
+     * @return BelongsToMany<Role, $this>
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_has_permissions');
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Role extends Model
+{
+    /**
+     * @return BelongsToMany<Permission, $this>
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_has_permissions');
+    }
+
+    public function givePermissionTo(Permission|string $permission): static
+    {
+        $permission = $permission instanceof Permission
+            ? $permission
+            : Permission::query()->where('name', $permission)->firstOrFail();
+
+        $this->permissions()->syncWithoutDetaching([$permission->getKey()]);
+
+        return $this;
+    }
+
+    public function revokePermissionTo(Permission|string $permission): static
+    {
+        $permission = $permission instanceof Permission
+            ? $permission
+            : Permission::query()->where('name', $permission)->firstOrFail();
+
+        $this->permissions()->detach($permission->getKey());
+
+        return $this;
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\HasRoles;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Collection;
+
+trait HasRoles
+{
+    /**
+     * @return MorphToMany<Role, $this>
+     */
+    public function roles(): MorphToMany
+    {
+        return $this->morphToMany(Role::class, 'model', 'model_has_roles', 'model_id', 'role_id');
+    }
+
+    /**
+     * @return MorphToMany<Permission, $this>
+     */
+    public function permissions(): MorphToMany
+    {
+        return $this->morphToMany(
+            Permission::class,
+            'model',
+            'model_has_permissions',
+            'model_id',
+            'permission_id',
+        );
+    }
+
+    public function assignRole(Role|string $role): static
+    {
+        $role = $this->resolveRole($role);
+
+        $this->roles()->syncWithoutDetaching([$role->getKey()]);
+        $this->unsetRelation('roles');
+
+        return $this;
+    }
+
+    public function removeRole(Role|string $role): static
+    {
+        $role = $this->resolveRole($role);
+
+        $this->roles()->detach($role->getKey());
+        $this->unsetRelation('roles');
+
+        return $this;
+    }
+
+    public function hasRole(Role|string $role): bool
+    {
+        if ($role instanceof Role) {
+            return $this->roles()->whereKey($role->getKey())->exists();
+        }
+
+        return $this->roles()->where('name', $role)->exists();
+    }
+
+    public function hasPermission(Permission|string $permission): bool
+    {
+        if ($permission instanceof Permission) {
+            $permissionId = $permission->getKey();
+
+            return $this->permissions()->whereKey($permissionId)->exists()
+                || $this->roles()
+                    ->whereHas('permissions', fn ($query) => $query->whereKey($permissionId))
+                    ->exists();
+        }
+
+        return $this->permissions()->where('name', $permission)->exists()
+            || $this->roles()
+                ->whereHas('permissions', fn ($query) => $query->where('name', $permission))
+                ->exists();
+    }
+
+    /**
+     * @return Collection<int, Permission>
+     */
+    public function getAllPermissions(): Collection
+    {
+        $directPermissions = $this->permissions()->get();
+        $roleIds = $this->roles()->pluck('roles.id');
+
+        if ($roleIds->isEmpty()) {
+            return $directPermissions->unique('id')->values();
+        }
+
+        $rolePermissions = Permission::query()
+            ->whereHas('roles', fn ($query) => $query->whereIn('roles.id', $roleIds))
+            ->get();
+
+        return $directPermissions->merge($rolePermissions)->unique('id')->values();
+    }
+
+    protected function resolveRole(Role|string $role): Role
+    {
+        return $role instanceof Role
+            ? $role
+            : Role::query()->where('name', $role)->firstOrFail();
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\CheckRole;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/database/migrations/2026_05_15_165100_create_roles_and_permissions_tables.php
+++ b/laravel/database/migrations/2026_05_15_165100_create_roles_and_permissions_tables.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+
+            $table->primary(['role_id', 'permission_id']);
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+
+            $table->primary(['role_id', 'model_id', 'model_type']);
+            $table->index(['model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+
+            $table->primary(['permission_id', 'model_id', 'model_type'], 'model_has_permissions_primary');
+            $table->index(['model_id', 'model_type'], 'model_has_permissions_model_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/tests/Feature/RoleBasedAccessControlTest.php
+++ b/laravel/tests/Feature/RoleBasedAccessControlTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RoleBasedAccessControlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_be_assigned_and_removed_from_role(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::query()->create(['name' => 'editor']);
+
+        $user->assignRole($role);
+
+        $this->assertTrue($user->hasRole('editor'));
+        $this->assertTrue($user->hasRole($role));
+
+        $user->removeRole('editor');
+
+        $this->assertFalse($user->hasRole('editor'));
+    }
+
+    public function test_user_has_direct_and_role_inherited_permissions(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::query()->create(['name' => 'manager']);
+        $approveInvoices = Permission::query()->create(['name' => 'approve invoices']);
+        $viewReports = Permission::query()->create(['name' => 'view reports']);
+
+        $role->givePermissionTo($approveInvoices);
+        $user->assignRole($role);
+        $user->permissions()->attach($viewReports);
+
+        $this->assertTrue($user->hasPermission('approve invoices'));
+        $this->assertTrue($user->hasPermission($viewReports));
+        $this->assertFalse($user->hasPermission('delete users'));
+
+        $this->assertEqualsCanonicalizing(
+            ['approve invoices', 'view reports'],
+            $user->getAllPermissions()->pluck('name')->all(),
+        );
+    }
+
+    public function test_role_middleware_rejects_users_without_required_role(): void
+    {
+        Route::middleware('role:admin')->get('/rbac-protected', fn () => 'allowed');
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->get('/rbac-protected')->assertForbidden();
+
+        $user->assignRole(Role::query()->create(['name' => 'admin']));
+
+        $this->actingAs($user)->get('/rbac-protected')->assertOk()->assertSee('allowed');
+    }
+}


### PR DESCRIPTION
## Summary
- Adds lightweight Role and Permission models with role/permission and polymorphic user pivot tables.
- Adds the HasRoles trait with assign/remove role helpers, direct and inherited permission checks, and merged permission retrieval.
- Adds CheckRole middleware, registers the ole middleware alias, and applies HasRoles to the User model.
- Adds feature tests for role assignment/removal, direct and role-inherited permissions, and middleware rejection/allowance.
- Includes required Laravel .contributor.json metadata.

## Verification
- git diff --cached --check
- .contributor.json parsed with PowerShell ConvertFrom-Json
- Manual static review of added Laravel files

Not run locally: php artisan test / PHP lint / Composer install because this machine does not have php or composer on PATH.

/claim #788