### PR TITLE
Codex [ T3 Code ] Add request body size limiting

### DIFF
--- a/t3code/apps/server/src/auth/http.ts
+++ b/t3code/apps/server/src/auth/http.ts
@@ -14,6 +14,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import { AuthError, ServerAuth } from "./Services/ServerAuth.ts";
 import { SessionCredentialService } from "./Services/SessionCredentialService.ts";
 import { deriveAuthClientMetadata } from "./utils.ts";
+import { enforceRequestBodySizeLimit } from "../bodyLimit.ts";
 import { browserApiCorsHeaders } from "../httpCors.ts";
 
 export const respondToAuthError = (error: AuthError) =>
@@ -68,6 +69,9 @@ export const authBootstrapRouteLayer = HttpRouter.add(
   "/api/auth/bootstrap",
   Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const serverAuth = yield* ServerAuth;
     const sessions = yield* SessionCredentialService;
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthBootstrapInput).pipe(
@@ -104,6 +108,9 @@ export const authBearerBootstrapRouteLayer = HttpRouter.add(
   "/api/auth/bootstrap/bearer",
   Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const serverAuth = yield* ServerAuth;
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthBootstrapInput).pipe(
       Effect.mapError(
@@ -131,6 +138,9 @@ export const authWebSocketTokenRouteLayer = HttpRouter.add(
   "/api/auth/ws-token",
   Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const serverAuth = yield* ServerAuth;
     const session = yield* serverAuth.authenticateHttpRequest(request);
     const result = yield* serverAuth.issueWebSocketToken(session);
@@ -147,6 +157,9 @@ export const authPairingCredentialRouteLayer = HttpRouter.add(
   Effect.gen(function* () {
     const serverAuth = yield* ServerAuth;
     const request = yield* HttpServerRequest.HttpServerRequest;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const session = yield* serverAuth.authenticateHttpRequest(request);
     if (session.role !== "owner") {
       return yield* new AuthError({
@@ -209,6 +222,9 @@ export const authPairingLinksRevokeRouteLayer = HttpRouter.add(
   "/api/auth/pairing-links/revoke",
   Effect.gen(function* () {
     const { serverAuth } = yield* authenticateOwnerSession;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthRevokePairingLinkInput).pipe(
       Effect.mapError(
         (cause) =>
@@ -239,6 +255,9 @@ export const authClientsRevokeRouteLayer = HttpRouter.add(
   "/api/auth/clients/revoke",
   Effect.gen(function* () {
     const { serverAuth, session } = yield* authenticateOwnerSession;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthRevokeClientSessionInput).pipe(
       Effect.mapError(
         (cause) =>
@@ -259,6 +278,9 @@ export const authClientsRevokeOthersRouteLayer = HttpRouter.add(
   "/api/auth/clients/revoke-others",
   Effect.gen(function* () {
     const { serverAuth, session } = yield* authenticateOwnerSession;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const revokedCount = yield* serverAuth.revokeOtherClientSessions(session.sessionId);
     return HttpServerResponse.jsonUnsafe({ revokedCount }, { status: 200 });
   }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),

--- a/t3code/apps/server/src/bodyLimit.test.ts
+++ b/t3code/apps/server/src/bodyLimit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_REQUEST_BODY_LIMIT_BYTES,
+  FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES,
+  oversizedRequestBodyInfo,
+  parseContentLengthHeader,
+  resolveRequestBodySizeLimit,
+} from "./bodyLimit.ts";
+
+describe("request body size limits", () => {
+  it("uses a 10MB default limit for regular request bodies", () => {
+    expect(resolveRequestBodySizeLimit()).toBe(DEFAULT_REQUEST_BODY_LIMIT_BYTES);
+    expect(
+      oversizedRequestBodyInfo({
+        "content-length": String(DEFAULT_REQUEST_BODY_LIMIT_BYTES),
+      }),
+    ).toBeNull();
+    expect(
+      oversizedRequestBodyInfo({
+        "content-length": String(DEFAULT_REQUEST_BODY_LIMIT_BYTES + 1),
+      }),
+    ).toEqual({
+      limitBytes: DEFAULT_REQUEST_BODY_LIMIT_BYTES,
+      receivedBytes: DEFAULT_REQUEST_BODY_LIMIT_BYTES + 1,
+    });
+  });
+
+  it("supports a 50MB per-route override for file upload routes", () => {
+    expect(resolveRequestBodySizeLimit({ limitBytes: FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES })).toBe(
+      FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES,
+    );
+    expect(
+      oversizedRequestBodyInfo(
+        {
+          "content-length": String(FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES),
+        },
+        { limitBytes: FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES },
+      ),
+    ).toBeNull();
+    expect(
+      oversizedRequestBodyInfo(
+        {
+          "content-length": String(FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES + 1),
+        },
+        { limitBytes: FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES },
+      ),
+    ).toEqual({
+      limitBytes: FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES,
+      receivedBytes: FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES + 1,
+    });
+  });
+
+  it("ignores missing or invalid content length headers", () => {
+    expect(parseContentLengthHeader(undefined)).toBeNull();
+    expect(parseContentLengthHeader("12.5")).toBeNull();
+    expect(parseContentLengthHeader("abc")).toBeNull();
+    expect(parseContentLengthHeader("42")).toBe(42);
+  });
+});

--- a/t3code/apps/server/src/bodyLimit.ts
+++ b/t3code/apps/server/src/bodyLimit.ts
@@ -1,0 +1,66 @@
+import * as Effect from "effect/Effect";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+import { browserApiCorsHeaders } from "./httpCors.ts";
+
+export const DEFAULT_REQUEST_BODY_LIMIT_BYTES = 10 * 1024 * 1024;
+export const FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES = 50 * 1024 * 1024;
+
+export interface RequestBodySizeLimitOptions {
+  readonly limitBytes?: number;
+}
+
+export interface OversizedRequestBodyInfo {
+  readonly limitBytes: number;
+  readonly receivedBytes: number;
+}
+
+export function parseContentLengthHeader(value: string | undefined): number | null {
+  if (typeof value !== "string" || !/^\d+$/.test(value.trim())) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+export function resolveRequestBodySizeLimit(options: RequestBodySizeLimitOptions = {}): number {
+  return options.limitBytes ?? DEFAULT_REQUEST_BODY_LIMIT_BYTES;
+}
+
+export function oversizedRequestBodyInfo(
+  headers: Record<string, string | undefined>,
+  options: RequestBodySizeLimitOptions = {},
+): OversizedRequestBodyInfo | null {
+  const limitBytes = resolveRequestBodySizeLimit(options);
+  const receivedBytes = parseContentLengthHeader(headers["content-length"]);
+  if (receivedBytes === null || receivedBytes <= limitBytes) {
+    return null;
+  }
+
+  return { limitBytes, receivedBytes };
+}
+
+export function payloadTooLargeResponse(info: OversizedRequestBodyInfo) {
+  return HttpServerResponse.jsonUnsafe(
+    {
+      error: "Payload Too Large",
+      limitBytes: info.limitBytes,
+      receivedBytes: info.receivedBytes,
+    },
+    {
+      status: 413,
+      headers: {
+        ...browserApiCorsHeaders,
+        "X-Max-Body-Size": String(info.limitBytes),
+      },
+    },
+  );
+}
+
+export const enforceRequestBodySizeLimit = (options: RequestBodySizeLimitOptions = {}) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const info = oversizedRequestBodyInfo(request.headers, options);
+    return info ? payloadTooLargeResponse(info) : null;
+  });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -22,6 +22,7 @@ import {
   resolveAttachmentRelativePath,
 } from "./attachmentPaths.ts";
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
+import { enforceRequestBodySizeLimit } from "./bodyLimit.ts";
 import { resolveStaticDir, ServerConfig } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
@@ -91,6 +92,9 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
   OTLP_TRACES_PROXY_PATH,
   Effect.gen(function* () {
     yield* requireAuthenticatedRequest;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const request = yield* HttpServerRequest.HttpServerRequest;
     const config = yield* ServerConfig;
     const otlpTracesUrl = config.otlpTracesUrl;

--- a/t3code/apps/server/src/orchestration/http.ts
+++ b/t3code/apps/server/src/orchestration/http.ts
@@ -11,6 +11,7 @@ import { ServerAuth } from "../auth/Services/ServerAuth.ts";
 import { normalizeDispatchCommand } from "./Normalizer.ts";
 import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
+import { enforceRequestBodySizeLimit } from "../bodyLimit.ts";
 
 const respondToOrchestrationHttpError = (
   error: OrchestrationDispatchCommandError | OrchestrationGetSnapshotError,
@@ -68,6 +69,9 @@ export const orchestrationDispatchRouteLayer = HttpRouter.add(
   "/api/orchestration/dispatch",
   Effect.gen(function* () {
     yield* authenticateOwnerSession;
+    const oversizedBodyResponse = yield* enforceRequestBodySizeLimit();
+    if (oversizedBodyResponse) return oversizedBodyResponse;
+
     const orchestrationEngine = yield* OrchestrationEngineService;
     const command = yield* HttpServerRequest.schemaBodyJson(ClientOrchestrationCommand).pipe(
       Effect.mapError(


### PR DESCRIPTION
/claim #841

Summary:
- add shared request body size-limit helpers with a 10MB default and 50MB upload override constant
- return 413 JSON responses before JSON body parsing when Content-Length exceeds the route limit
- include limitBytes, receivedBytes, and X-Max-Body-Size on oversized responses
- apply the default limit to authenticated POST routes that currently parse JSON payloads

Verification:
- npx --yes -p node@24 -p bun@1.3.11 bun fmt
- npx --yes -p node@24 -p bun@1.3.11 bun run test -- bodyLimit http orchestration/http auth/http in apps/server
- npx --yes -p node@24 -p bun@1.3.11 bun run typecheck in apps/server
- git diff --check
- npx --yes -p node@24 -p bun@1.3.11 bun lint
- npx --yes -p node@24 -p bun@1.3.11 bun typecheck

Note: full lint reports existing warnings outside these changes and no errors.
