### PR TITLE
Codex [ T3 Code ] Fix SSH askpass temp file permissions

### DIFF
--- a/t3code/packages/ssh/src/auth.test.ts
+++ b/t3code/packages/ssh/src/auth.test.ts
@@ -4,12 +4,50 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import {
+  ASKPASS_POSIX_SCRIPT,
+  ASKPASS_WINDOWS_SCRIPT,
   buildSshAskpassHelperDescriptor,
   buildSshChildEnvironment,
   isSshAuthFailure,
+  validateSshAskpassScriptPath,
 } from "./auth.ts";
+
+const collectText = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
+  stream.pipe(
+    Stream.decodeText(),
+    Stream.runFold(
+      () => "",
+      (acc, chunk) => acc + chunk,
+    ),
+  );
+
+const runAskpassScript = (
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+): Effect.Effect<
+  { readonly stdout: string; readonly stderr: string; readonly exitCode: number },
+  PlatformError.PlatformError,
+  ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const child = yield* spawner.spawn(ChildProcess.make(scriptPath, [], { env }));
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectText(child.stdout),
+        collectText(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ],
+      { concurrency: "unbounded" },
+    );
+    return { stdout, stderr, exitCode };
+  });
 
 describe("ssh auth", () => {
   it.effect("detects ssh auth failures from common permission denied messages", () =>
@@ -47,7 +85,112 @@ describe("ssh auth", () => {
       assert.equal(env.T3_SSH_AUTH_SECRET, "super-secret");
       assert.equal(env.DISPLAY, "t3code");
       assert.equal(yield* fs.exists(askpassPath), true);
-      assert.include(yield* fs.readFileString(askpassPath), 'printf "%s\\n" "$T3_SSH_AUTH_SECRET"');
+      assert.include(yield* fs.readFileString(askpassPath), "mktemp");
+      assert.equal((yield* fs.stat(askpassPath)).mode & 0o777, 0o700);
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("uses a 0600 temp file and removes it after POSIX askpass exits", () =>
+    Effect.gen(function* () {
+      if (process.platform === "win32") {
+        return;
+      }
+
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-askpass-test-" });
+      const binDirectory = path.join(directory, "bin");
+      const modePath = path.join(directory, "mode.txt");
+      const scriptPath = yield* buildSshChildEnvironment({
+        authSecret: "super-secret",
+        interactiveAuth: true,
+        askpassDirectory: directory,
+        platform: "linux",
+        baseEnv: {},
+      }).pipe(Effect.map((env) => env.SSH_ASKPASS));
+      if (!scriptPath) {
+        assert.fail("Expected SSH_ASKPASS to be set.");
+      }
+
+      yield* fs.makeDirectory(binDirectory);
+      const catWrapperPath = path.join(binDirectory, "cat");
+      yield* fs.writeFileString(
+        catWrapperPath,
+        `#!/bin/sh
+if stat -f '%Lp' "$1" > "$MODE_OUT" 2>/dev/null; then
+  :
+else
+  stat -c '%a' "$1" > "$MODE_OUT"
+fi
+exec /bin/cat "$@"
+`,
+      );
+      yield* fs.chmod(catWrapperPath, 0o700);
+
+      const result = yield* runAskpassScript(scriptPath, {
+        PATH: `${binDirectory}:/bin:/usr/bin`,
+        MODE_OUT: modePath,
+        TMPDIR: directory,
+        T3_SSH_AUTH_SECRET: "super-secret",
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stdout, "super-secret\n");
+      assert.equal(result.stderr, "");
+      assert.equal((yield* fs.readFileString(modePath)).trim(), "600");
+      assert.deepEqual(
+        (yield* fs.readDirectory(directory)).filter((entry) =>
+          entry.startsWith("t3code-ssh-askpass-secret."),
+        ),
+        [],
+      );
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("removes the POSIX askpass temp file on TERM", () =>
+    Effect.gen(function* () {
+      if (process.platform === "win32") {
+        return;
+      }
+
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-askpass-test-" });
+      const binDirectory = path.join(directory, "bin");
+      const tempPathRecord = path.join(directory, "temp-path.txt");
+      const scriptPath = yield* buildSshChildEnvironment({
+        authSecret: "super-secret",
+        interactiveAuth: true,
+        askpassDirectory: directory,
+        platform: "linux",
+        baseEnv: {},
+      }).pipe(Effect.map((env) => env.SSH_ASKPASS));
+      if (!scriptPath) {
+        assert.fail("Expected SSH_ASKPASS to be set.");
+      }
+
+      yield* fs.makeDirectory(binDirectory);
+      const catWrapperPath = path.join(binDirectory, "cat");
+      yield* fs.writeFileString(
+        catWrapperPath,
+        `#!/bin/sh
+printf '%s\\n' "$1" > "$TEMP_PATH_OUT"
+kill -TERM "$PPID"
+sleep 1
+`,
+      );
+      yield* fs.chmod(catWrapperPath, 0o700);
+
+      const result = yield* runAskpassScript(scriptPath, {
+        PATH: `${binDirectory}:/bin:/usr/bin`,
+        TEMP_PATH_OUT: tempPathRecord,
+        TMPDIR: directory,
+        T3_SSH_AUTH_SECRET: "super-secret",
+      });
+
+      assert.equal(result.exitCode, 143);
+      const secretTempPath = (yield* fs.readFileString(tempPathRecord)).trim();
+      assert.equal(yield* fs.exists(secretTempPath), false);
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
 
@@ -63,6 +206,31 @@ describe("ssh auth", () => {
         descriptor.files.map((file) => file.path.split("\\").at(-1)),
         ["ssh-askpass.cmd", "ssh-askpass.ps1"],
       );
+      assert.include(ASKPASS_WINDOWS_SCRIPT, "ConvertTo-SecureString");
+      assert.include(ASKPASS_WINDOWS_SCRIPT, "ZeroFreeBSTR");
     }),
   );
+
+  it.effect("rejects askpass script paths with shell metacharacters", () =>
+    Effect.gen(function* () {
+      assert.equal(
+        yield* validateSshAskpassScriptPath("/tmp/t3code-ssh-askpass/ssh-askpass.sh").pipe(
+          Effect.provide(NodeServices.layer),
+        ),
+        "/tmp/t3code-ssh-askpass/ssh-askpass.sh",
+      );
+
+      const error = yield* buildSshAskpassHelperDescriptor({
+        directory: "/tmp/t3code ssh;askpass",
+        platform: "linux",
+      }).pipe(Effect.provide(NodeServices.layer), Effect.flip);
+      assert.equal(error._tag, "SshAskpassPathError");
+    }),
+  );
+
+  it("installs POSIX cleanup traps for exit and signals", () => {
+    assert.include(ASKPASS_POSIX_SCRIPT, "trap cleanup EXIT");
+    assert.include(ASKPASS_POSIX_SCRIPT, "trap 'cleanup; exit 130' INT");
+    assert.include(ASKPASS_POSIX_SCRIPT, "trap 'cleanup; exit 143' TERM");
+  });
 });

--- a/t3code/packages/ssh/src/auth.ts
+++ b/t3code/packages/ssh/src/auth.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 
-import { SshPasswordPromptError } from "./errors.ts";
+import { SshAskpassPathError, SshPasswordPromptError } from "./errors.ts";
 
 export interface SshPasswordRequest {
   readonly destination: string;
@@ -59,6 +59,7 @@ export interface SshChildEnvironmentOptions {
 }
 
 const SSH_ASKPASS_DIR_NAME = "t3code-ssh-askpass";
+const SSH_ASKPASS_SAFE_SCRIPT_PATH_PATTERN = /^[A-Za-z0-9_./:\\-]+$/u;
 
 function joinSshAskpassPath(
   directory: string,
@@ -74,7 +75,28 @@ export const ASKPASS_POSIX_SCRIPT = `#!/bin/sh
 # from the renderer's in-app prompt. We never expose a native dialog here - if
 # T3_SSH_AUTH_SECRET is missing, that's a caller bug and we fail loudly.
 if [ "\${T3_SSH_AUTH_SECRET+x}" = "x" ]; then
-  printf "%s\\n" "$T3_SSH_AUTH_SECRET"
+  secret_file=
+  cleanup() {
+    if [ -n "\${secret_file:-}" ]; then
+      rm -f -- "$secret_file"
+    fi
+  }
+  trap cleanup EXIT
+  trap 'cleanup; exit 130' INT
+  trap 'cleanup; exit 143' TERM
+
+  old_umask=$(umask)
+  umask 077
+  secret_file=$(mktemp "\${TMPDIR:-/tmp}/t3code-ssh-askpass-secret.XXXXXX") || {
+    status=$?
+    umask "$old_umask"
+    exit "$status"
+  }
+  umask "$old_umask"
+  chmod 600 "$secret_file" || exit 1
+  printf "%s\\n" "$T3_SSH_AUTH_SECRET" > "$secret_file" || exit 1
+  unset T3_SSH_AUTH_SECRET
+  cat "$secret_file"
   exit 0
 fi
 printf 'T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.\\n' >&2
@@ -90,12 +112,35 @@ export const ASKPASS_WINDOWS_SCRIPT = `# Invoked by ssh via SSH_ASKPASS (through
 # a native dialog here - if T3_SSH_AUTH_SECRET is missing, that's a caller bug\r
 # and we fail loudly.\r
 if ($null -ne $env:T3_SSH_AUTH_SECRET) {\r
-  [Console]::Out.WriteLine($env:T3_SSH_AUTH_SECRET)\r
-  exit 0\r
+  $secureSecret = ConvertTo-SecureString -String $env:T3_SSH_AUTH_SECRET -AsPlainText -Force\r
+  $env:T3_SSH_AUTH_SECRET = $null\r
+  $secretPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureSecret)\r
+  try {\r
+    [Console]::Out.WriteLine([Runtime.InteropServices.Marshal]::PtrToStringBSTR($secretPointer))\r
+    exit 0\r
+  }\r
+  finally {\r
+    if ([IntPtr]::Zero -ne $secretPointer) {\r
+      [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($secretPointer)\r
+    }\r
+  }\r
 }\r
 [Console]::Error.WriteLine("T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.")\r
 exit 1\r
 `;
+
+export const validateSshAskpassScriptPath = Effect.fn("ssh/auth.validateSshAskpassScriptPath")(
+  function* (scriptPath: string): Effect.fn.Return<string, SshAskpassPathError> {
+    if (scriptPath.length > 0 && SSH_ASKPASS_SAFE_SCRIPT_PATH_PATTERN.test(scriptPath)) {
+      return scriptPath;
+    }
+
+    return yield* new SshAskpassPathError({
+      path: scriptPath,
+      message: "SSH askpass script path contains spaces or shell metacharacters.",
+    });
+  },
+);
 
 export const getDefaultSshAskpassDirectory = Effect.fn("ssh/auth.getDefaultSshAskpassDirectory")(
   function* () {
@@ -111,18 +156,21 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
 )(function* (input: {
   readonly directory: string;
   readonly platform?: NodeJS.Platform;
-}): Effect.fn.Return<SshAskpassHelperDescriptor, never, Path.Path> {
+}): Effect.fn.Return<SshAskpassHelperDescriptor, SshAskpassPathError, Path.Path> {
   const platform = input.platform ?? process.platform;
   const path = yield* Path.Path;
   const directory = input.directory;
 
   if (platform === "win32") {
+    const launcherPath = joinSshAskpassPath(directory, "ssh-askpass.cmd", platform);
     const powershellPath = joinSshAskpassPath(directory, "ssh-askpass.ps1", platform);
+    yield* validateSshAskpassScriptPath(launcherPath);
+    yield* validateSshAskpassScriptPath(powershellPath);
     return {
-      launcherPath: joinSshAskpassPath(directory, "ssh-askpass.cmd", platform),
+      launcherPath,
       files: [
         {
-          path: joinSshAskpassPath(directory, "ssh-askpass.cmd", platform),
+          path: launcherPath,
           contents: ASKPASS_WINDOWS_LAUNCHER_SCRIPT,
         },
         {
@@ -133,11 +181,13 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
     };
   }
 
+  const launcherPath = path.join(directory, "ssh-askpass.sh");
+  yield* validateSshAskpassScriptPath(launcherPath);
   return {
-    launcherPath: path.join(directory, "ssh-askpass.sh"),
+    launcherPath,
     files: [
       {
-        path: path.join(directory, "ssh-askpass.sh"),
+        path: launcherPath,
         contents: ASKPASS_POSIX_SCRIPT,
         mode: 0o700,
       },
@@ -149,7 +199,11 @@ export const ensureSshAskpassHelpers = Effect.fn("ssh/auth.ensureSshAskpassHelpe
   function* (input: {
     readonly directory: string;
     readonly platform?: NodeJS.Platform;
-  }): Effect.fn.Return<string, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> {
+  }): Effect.fn.Return<
+    string,
+    SshAskpassPathError | PlatformError.PlatformError,
+    FileSystem.FileSystem | Path.Path
+  > {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const descriptor = yield* buildSshAskpassHelperDescriptor(input);
@@ -176,7 +230,7 @@ export const buildSshChildEnvironment = Effect.fn("ssh/auth.buildSshChildEnviron
   input: SshChildEnvironmentOptions = {},
 ): Effect.fn.Return<
   NodeJS.ProcessEnv,
-  PlatformError.PlatformError,
+  SshAskpassPathError | PlatformError.PlatformError,
   FileSystem.FileSystem | Path.Path
 > {
   const baseEnv = { ...(input.baseEnv ?? process.env) };

--- a/t3code/packages/ssh/src/errors.ts
+++ b/t3code/packages/ssh/src/errors.ts
@@ -44,3 +44,8 @@ export class SshPasswordPromptError extends Data.TaggedError("SshPasswordPromptE
   readonly message: string;
   readonly cause?: unknown;
 }> {}
+
+export class SshAskpassPathError extends Data.TaggedError("SshAskpassPathError")<{
+  readonly message: string;
+  readonly path: string;
+}> {}


### PR DESCRIPTION
Summary:
- Harden POSIX ssh-askpass temp file creation with umask/mktemp, 0600 chmod, and EXIT/INT/TERM cleanup traps.
- Validate generated askpass script paths before use.
- Route Windows askpass secret output through SecureString and zero the marshaled buffer.
- Add focused SSH auth tests for permissions, cleanup, path validation, and Windows script generation.

Verification:
- bun fmt
- bun lint
- bun typecheck
- bun run --filter @t3tools/ssh test

/claim #822