### PR TITLE
Codex [ T3 Code ] Add rebase conflict detection

### DIFF
--- a/t3code/apps/server/src/git/GitManager.test.ts
+++ b/t3code/apps/server/src/git/GitManager.test.ts
@@ -73,6 +73,18 @@ function fakeGhOutput(stdout: string): VcsProcess.VcsProcessOutput {
   };
 }
 
+function fakeGitOutput(
+  input: { exitCode?: number; stdout?: string; stderr?: string } = {},
+): GitVcsDriver.ExecuteGitResult {
+  return {
+    exitCode: ChildProcessSpawner.ExitCode(input.exitCode ?? 0),
+    stdout: input.stdout ?? "",
+    stderr: input.stderr ?? "",
+    stdoutTruncated: false,
+    stderrTruncated: false,
+  };
+}
+
 interface FakeGitTextGeneration {
   generateCommitMessage: (input: {
     cwd: string;
@@ -649,6 +661,7 @@ function preparePullRequestThread(
 
 function makeManager(input?: {
   ghScenario?: FakeGhScenario;
+  gitVcsDriver?: Partial<GitVcsDriver.GitVcsDriverShape>;
   textGeneration?: Partial<FakeGitTextGeneration>;
   setupScriptRunner?: ProjectSetupScriptRunnerShape;
 }) {
@@ -660,11 +673,13 @@ function makeManager(input?: {
 
   const serverSettingsLayer = ServerSettingsService.layerTest();
 
-  const vcsDriverLayer = GitVcsDriver.layer.pipe(
-    Layer.provideMerge(VcsProcess.layer),
-    Layer.provideMerge(NodeServices.layer),
-    Layer.provideMerge(ServerConfigLayer),
-  );
+  const vcsDriverLayer = input?.gitVcsDriver
+    ? Layer.mock(GitVcsDriver.GitVcsDriver)(input.gitVcsDriver)
+    : GitVcsDriver.layer.pipe(
+        Layer.provideMerge(VcsProcess.layer),
+        Layer.provideMerge(NodeServices.layer),
+        Layer.provideMerge(ServerConfigLayer),
+      );
   const sourceControlRegistryLayer = Layer.effect(
     SourceControlProviderRegistry.SourceControlProviderRegistry,
     GitHubSourceControlProvider.make().pipe(
@@ -707,6 +722,207 @@ const GitManagerTestLayer = GitVcsDriver.layer.pipe(
 );
 
 it.layer(GitManagerTestLayer)("GitManager", (it) => {
+  it.effect("getConflictFiles parses mocked unresolved rebase paths", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      const rebaseHeadPath = path.join(repoDir, ".git", "REBASE_HEAD");
+      const rebaseMergePath = path.join(repoDir, ".git", "rebase-merge");
+      const rebaseApplyPath = path.join(repoDir, ".git", "rebase-apply");
+      fs.mkdirSync(path.dirname(rebaseHeadPath), { recursive: true });
+      fs.mkdirSync(rebaseMergePath, { recursive: true });
+      fs.writeFileSync(rebaseHeadPath, "pending\n");
+      const calls: ReadonlyArray<string>[] = [];
+
+      const { manager } = yield* makeManager({
+        gitVcsDriver: {
+          execute: (input) =>
+            Effect.sync(() => {
+              calls.push([...input.args]);
+              if (input.args.join(" ") === "rev-parse --git-path REBASE_HEAD") {
+                return fakeGitOutput({ stdout: `${rebaseHeadPath}\n` });
+              }
+              if (input.args.join(" ") === "rev-parse --git-path rebase-merge") {
+                return fakeGitOutput({ stdout: `${rebaseMergePath}\n` });
+              }
+              if (input.args.join(" ") === "rev-parse --git-path rebase-apply") {
+                return fakeGitOutput({ stdout: `${rebaseApplyPath}\n` });
+              }
+              if (input.args.join(" ") === "diff --name-only --diff-filter=U") {
+                return fakeGitOutput({ stdout: "src/a.ts\n\nsrc/b.ts\n" });
+              }
+              throw new Error(`Unexpected git args: ${input.args.join(" ")}`);
+            }),
+        },
+      });
+
+      const result = yield* manager.getConflictFiles({ cwd: repoDir });
+
+      expect(result).toEqual({ inProgress: true, files: ["src/a.ts", "src/b.ts"] });
+      expect(calls).toEqual([
+        ["rev-parse", "--git-path", "REBASE_HEAD"],
+        ["rev-parse", "--git-path", "rebase-merge"],
+        ["rev-parse", "--git-path", "rebase-apply"],
+        ["diff", "--name-only", "--diff-filter=U"],
+      ]);
+    }),
+  );
+
+  it.effect("abortRebase runs the abort command and reports cleared conflicts", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      const rebaseHeadPath = path.join(repoDir, ".git", "REBASE_HEAD");
+      const rebaseMergePath = path.join(repoDir, ".git", "rebase-merge");
+      fs.mkdirSync(path.dirname(rebaseHeadPath), { recursive: true });
+      fs.mkdirSync(rebaseMergePath, { recursive: true });
+      fs.writeFileSync(rebaseHeadPath, "pending\n");
+      const calls: ReadonlyArray<string>[] = [];
+
+      const { manager } = yield* makeManager({
+        gitVcsDriver: {
+          execute: (input) =>
+            Effect.sync(() => {
+              calls.push([...input.args]);
+              if (input.args.join(" ") === "rebase --abort") {
+                fs.rmSync(rebaseHeadPath, { force: true });
+                fs.rmSync(rebaseMergePath, { force: true, recursive: true });
+                return fakeGitOutput();
+              }
+              if (input.args.join(" ") === "rev-parse --git-path REBASE_HEAD") {
+                return fakeGitOutput({ stdout: `${rebaseHeadPath}\n` });
+              }
+              throw new Error(`Unexpected git args: ${input.args.join(" ")}`);
+            }),
+        },
+      });
+
+      const result = yield* manager.abortRebase({ cwd: repoDir });
+
+      expect(result).toEqual({
+        status: "aborted",
+        conflicts: { inProgress: false, files: [] },
+      });
+      expect(calls).toEqual([
+        ["rebase", "--abort"],
+        ["rev-parse", "--git-path", "REBASE_HEAD"],
+      ]);
+    }),
+  );
+
+  it.effect("continueRebase returns conflicts when git still reports unresolved paths", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      const rebaseHeadPath = path.join(repoDir, ".git", "REBASE_HEAD");
+      const rebaseMergePath = path.join(repoDir, ".git", "rebase-merge");
+      const rebaseApplyPath = path.join(repoDir, ".git", "rebase-apply");
+      fs.mkdirSync(path.dirname(rebaseHeadPath), { recursive: true });
+      fs.mkdirSync(rebaseMergePath, { recursive: true });
+      fs.writeFileSync(rebaseHeadPath, "pending\n");
+      const calls: ReadonlyArray<string>[] = [];
+
+      const { manager } = yield* makeManager({
+        gitVcsDriver: {
+          execute: (input) =>
+            Effect.sync(() => {
+              calls.push([...input.args]);
+              if (input.args.join(" ") === "-c core.editor=true rebase --continue") {
+                return fakeGitOutput({ exitCode: 1, stderr: "conflicts remain\n" });
+              }
+              if (input.args.join(" ") === "rev-parse --git-path REBASE_HEAD") {
+                return fakeGitOutput({ stdout: `${rebaseHeadPath}\n` });
+              }
+              if (input.args.join(" ") === "rev-parse --git-path rebase-merge") {
+                return fakeGitOutput({ stdout: `${rebaseMergePath}\n` });
+              }
+              if (input.args.join(" ") === "rev-parse --git-path rebase-apply") {
+                return fakeGitOutput({ stdout: `${rebaseApplyPath}\n` });
+              }
+              if (input.args.join(" ") === "diff --name-only --diff-filter=U") {
+                return fakeGitOutput({ stdout: "README.md\n" });
+              }
+              throw new Error(`Unexpected git args: ${input.args.join(" ")}`);
+            }),
+        },
+      });
+
+      const result = yield* manager.continueRebase({ cwd: repoDir });
+
+      expect(result).toEqual({
+        status: "conflicts",
+        conflicts: { inProgress: true, files: ["README.md"] },
+      });
+      expect(calls).toEqual([
+        ["-c", "core.editor=true", "rebase", "--continue"],
+        ["rev-parse", "--git-path", "REBASE_HEAD"],
+        ["rev-parse", "--git-path", "rebase-merge"],
+        ["rev-parse", "--git-path", "rebase-apply"],
+        ["diff", "--name-only", "--diff-filter=U"],
+      ]);
+    }),
+  );
+
+  it.effect("getConflictFiles detects and clears a real rebase conflict after abort", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/rebase-conflict"]);
+      fs.writeFileSync(path.join(repoDir, "README.md"), "feature\n");
+      yield* runGit(repoDir, ["add", "README.md"]);
+      yield* runGit(repoDir, ["commit", "-m", "Feature change"]);
+      yield* runGit(repoDir, ["checkout", "main"]);
+      fs.writeFileSync(path.join(repoDir, "README.md"), "main\n");
+      yield* runGit(repoDir, ["add", "README.md"]);
+      yield* runGit(repoDir, ["commit", "-m", "Main change"]);
+      yield* runGit(repoDir, ["checkout", "feature/rebase-conflict"]);
+
+      const rebase = yield* runGit(repoDir, ["rebase", "main"], true);
+      expect(rebase.exitCode).not.toBe(0);
+
+      const { manager } = yield* makeManager();
+      const conflicts = yield* manager.getConflictFiles({ cwd: repoDir });
+      expect(conflicts).toEqual({ inProgress: true, files: ["README.md"] });
+
+      const aborted = yield* manager.abortRebase({ cwd: repoDir });
+      expect(aborted).toEqual({
+        status: "aborted",
+        conflicts: { inProgress: false, files: [] },
+      });
+
+      const afterAbort = yield* manager.getConflictFiles({ cwd: repoDir });
+      expect(afterAbort).toEqual({ inProgress: false, files: [] });
+    }),
+  );
+
+  it.effect("continueRebase completes after a real conflict is resolved", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/rebase-continue"]);
+      fs.writeFileSync(path.join(repoDir, "README.md"), "feature\n");
+      yield* runGit(repoDir, ["add", "README.md"]);
+      yield* runGit(repoDir, ["commit", "-m", "Feature change"]);
+      yield* runGit(repoDir, ["checkout", "main"]);
+      fs.writeFileSync(path.join(repoDir, "README.md"), "main\n");
+      yield* runGit(repoDir, ["add", "README.md"]);
+      yield* runGit(repoDir, ["commit", "-m", "Main change"]);
+      yield* runGit(repoDir, ["checkout", "feature/rebase-continue"]);
+
+      const rebase = yield* runGit(repoDir, ["rebase", "main"], true);
+      expect(rebase.exitCode).not.toBe(0);
+      fs.writeFileSync(path.join(repoDir, "README.md"), "feature\n");
+      yield* runGit(repoDir, ["add", "README.md"]);
+
+      const { manager } = yield* makeManager();
+      const result = yield* manager.continueRebase({ cwd: repoDir });
+
+      expect(result).toEqual({
+        status: "continued",
+        conflicts: { inProgress: false, files: [] },
+      });
+      const afterContinue = yield* manager.getConflictFiles({ cwd: repoDir });
+      expect(afterContinue).toEqual({ inProgress: false, files: [] });
+    }),
+  );
+
   it.effect("status includes PR metadata when branch already has an open PR", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/t3code/apps/server/src/git/GitManager.ts
+++ b/t3code/apps/server/src/git/GitManager.ts
@@ -16,11 +16,15 @@ import * as Ref from "effect/Ref";
 import {
   GitActionProgressEvent,
   GitActionProgressPhase,
+  type GitAbortRebaseResult,
   GitCommandError,
-  GitPreparePullRequestThreadInput,
-  GitPreparePullRequestThreadResult,
-  GitPullRequestRefInput,
-  GitResolvePullRequestResult,
+  type GitContinueRebaseResult,
+  type GitPreparePullRequestThreadInput,
+  type GitPreparePullRequestThreadResult,
+  type GitPullRequestRefInput,
+  type GitRebaseConflictsInput,
+  type GitRebaseConflictsResult,
+  type GitResolvePullRequestResult,
   GitRunStackedActionInput,
   GitRunStackedActionResult,
   GitStackedAction,
@@ -80,6 +84,15 @@ export interface GitManagerShape {
   readonly preparePullRequestThread: (
     input: GitPreparePullRequestThreadInput,
   ) => Effect.Effect<GitPreparePullRequestThreadResult, GitManagerServiceError>;
+  readonly getConflictFiles: (
+    input: GitRebaseConflictsInput,
+  ) => Effect.Effect<GitRebaseConflictsResult, GitManagerServiceError>;
+  readonly abortRebase: (
+    input: GitRebaseConflictsInput,
+  ) => Effect.Effect<GitAbortRebaseResult, GitManagerServiceError>;
+  readonly continueRebase: (
+    input: GitRebaseConflictsInput,
+  ) => Effect.Effect<GitContinueRebaseResult, GitManagerServiceError>;
   readonly runStackedAction: (
     input: GitRunStackedActionInput,
     options?: GitRunStackedActionOptions,
@@ -698,6 +711,54 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
   const canonicalizeExistingPath = (value: string) =>
     fileSystem.realPath(value).pipe(Effect.catch(() => Effect.succeed(value)));
   const normalizeStatusCacheKey = canonicalizeExistingPath;
+  const resolveGitPath = Effect.fn("resolveGitPath")(function* (cwd: string, gitPath: string) {
+    const result = yield* gitCore.execute({
+      operation: "GitManager.resolveGitPath",
+      cwd,
+      args: ["rev-parse", "--git-path", gitPath],
+      maxOutputBytes: 4_096,
+    });
+    const resolvedPath = result.stdout.trim();
+    if (resolvedPath.length === 0) {
+      return yield* gitManagerError("resolveGitPath", `Git did not return a path for ${gitPath}.`);
+    }
+    return path.isAbsolute(resolvedPath) ? resolvedPath : path.resolve(cwd, resolvedPath);
+  });
+  const isRebaseInProgress = Effect.fn("isRebaseInProgress")(function* (cwd: string) {
+    const rebaseHeadPath = yield* resolveGitPath(cwd, "REBASE_HEAD");
+    const hasRebaseHead = yield* fileSystem
+      .exists(rebaseHeadPath)
+      .pipe(Effect.orElseSucceed(() => false));
+    if (!hasRebaseHead) {
+      return false;
+    }
+    const [rebaseMergePath, rebaseApplyPath] = yield* Effect.all([
+      resolveGitPath(cwd, "rebase-merge"),
+      resolveGitPath(cwd, "rebase-apply"),
+    ]);
+    const [hasRebaseMerge, hasRebaseApply] = yield* Effect.all([
+      fileSystem.exists(rebaseMergePath).pipe(Effect.orElseSucceed(() => false)),
+      fileSystem.exists(rebaseApplyPath).pipe(Effect.orElseSucceed(() => false)),
+    ]);
+    return hasRebaseMerge || hasRebaseApply;
+  });
+  const readRebaseConflicts = Effect.fn("readRebaseConflicts")(function* (cwd: string) {
+    const inProgress = yield* isRebaseInProgress(cwd);
+    if (!inProgress) {
+      return { inProgress: false, files: [] };
+    }
+    const result = yield* gitCore.execute({
+      operation: "GitManager.getConflictFiles",
+      cwd,
+      args: ["diff", "--name-only", "--diff-filter=U"],
+      maxOutputBytes: 1_000_000,
+    });
+    const files = result.stdout
+      .split(/\r?\n/)
+      .map((file) => file.trim())
+      .filter((file) => file.length > 0);
+    return { inProgress: true, files };
+  });
   const nonRepositoryStatusDetails = {
     isRepo: false,
     hasOriginRemote: false,
@@ -1553,6 +1614,47 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     }).pipe(Effect.ensuring(invalidateStatus(input.cwd)));
   });
 
+  const getConflictFiles: GitManagerShape["getConflictFiles"] = Effect.fn("getConflictFiles")(
+    function* (input) {
+      return yield* readRebaseConflicts(input.cwd);
+    },
+  );
+
+  const abortRebase: GitManagerShape["abortRebase"] = Effect.fn("abortRebase")(function* (input) {
+    yield* gitCore.execute({
+      operation: "GitManager.abortRebase",
+      cwd: input.cwd,
+      args: ["rebase", "--abort"],
+    });
+    const conflicts = yield* readRebaseConflicts(input.cwd);
+    yield* invalidateStatus(input.cwd);
+    return { status: "aborted", conflicts };
+  });
+
+  const continueRebase: GitManagerShape["continueRebase"] = Effect.fn("continueRebase")(
+    function* (input) {
+      const result = yield* gitCore.execute({
+        operation: "GitManager.continueRebase",
+        cwd: input.cwd,
+        args: ["-c", "core.editor=true", "rebase", "--continue"],
+        allowNonZeroExit: true,
+      });
+      const conflicts = yield* readRebaseConflicts(input.cwd);
+      yield* invalidateStatus(input.cwd);
+      if (result.exitCode !== 0) {
+        if (conflicts.inProgress && conflicts.files.length > 0) {
+          return { status: "conflicts", conflicts };
+        }
+        const detail =
+          result.stderr.trim() ||
+          result.stdout.trim() ||
+          `git rebase --continue exited with code ${result.exitCode}.`;
+        return yield* gitManagerError("continueRebase", detail);
+      }
+      return { status: "continued", conflicts };
+    },
+  );
+
   const runFeatureBranchStep = Effect.fn("runFeatureBranchStep")(function* (
     modelSelection: ModelSelection,
     cwd: string,
@@ -1777,6 +1879,9 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     invalidateStatus,
     resolvePullRequest,
     preparePullRequestThread,
+    getConflictFiles,
+    abortRebase,
+    continueRebase,
     runStackedAction,
   } satisfies GitManagerShape;
 });

--- a/t3code/apps/server/src/git/GitWorkflowService.ts
+++ b/t3code/apps/server/src/git/GitWorkflowService.ts
@@ -5,6 +5,10 @@ import * as Layer from "effect/Layer";
 import {
   GitManagerError,
   GitCommandError,
+  type GitAbortRebaseResult,
+  type GitContinueRebaseResult,
+  type GitRebaseConflictsInput,
+  type GitRebaseConflictsResult,
   type VcsSwitchRefInput,
   type VcsSwitchRefResult,
   type VcsCreateRefInput,
@@ -56,6 +60,15 @@ export interface GitWorkflowServiceShape {
   readonly preparePullRequestThread: (
     input: GitPreparePullRequestThreadInput,
   ) => Effect.Effect<GitPreparePullRequestThreadResult, GitManagerServiceError>;
+  readonly getConflictFiles: (
+    input: GitRebaseConflictsInput,
+  ) => Effect.Effect<GitRebaseConflictsResult, GitManagerServiceError>;
+  readonly abortRebase: (
+    input: GitRebaseConflictsInput,
+  ) => Effect.Effect<GitAbortRebaseResult, GitManagerServiceError>;
+  readonly continueRebase: (
+    input: GitRebaseConflictsInput,
+  ) => Effect.Effect<GitContinueRebaseResult, GitManagerServiceError>;
   readonly listRefs: (input: VcsListRefsInput) => Effect.Effect<VcsListRefsResult, GitCommandError>;
   readonly createWorktree: (
     input: VcsCreateWorktreeInput,
@@ -284,6 +297,12 @@ export const make = Effect.fn("makeGitWorkflowService")(function* () {
       "GitWorkflowService.preparePullRequestThread",
       gitManager.preparePullRequestThread,
     ),
+    getConflictFiles: routeGitManager(
+      "GitWorkflowService.getConflictFiles",
+      gitManager.getConflictFiles,
+    ),
+    abortRebase: routeGitManager("GitWorkflowService.abortRebase", gitManager.abortRebase),
+    continueRebase: routeGitManager("GitWorkflowService.continueRebase", gitManager.continueRebase),
     listRefs: (input) =>
       detectGitRepositoryForCommand("GitWorkflowService.listRefs", input.cwd).pipe(
         Effect.flatMap((isGitRepository) =>

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -1066,6 +1066,22 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
               .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             { "rpc.aggregate": "git" },
           ),
+        [WS_METHODS.gitRebaseConflicts]: (input) =>
+          observeRpcEffect(WS_METHODS.gitRebaseConflicts, gitWorkflow.getConflictFiles(input), {
+            "rpc.aggregate": "git",
+          }),
+        [WS_METHODS.gitAbortRebase]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitAbortRebase,
+            gitWorkflow.abortRebase(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "git" },
+          ),
+        [WS_METHODS.gitContinueRebase]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitContinueRebase,
+            gitWorkflow.continueRebase(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "git" },
+          ),
         [WS_METHODS.vcsListRefs]: (input) =>
           observeRpcEffect(WS_METHODS.vcsListRefs, gitWorkflow.listRefs(input), {
             "rpc.aggregate": "vcs",

--- a/t3code/apps/web/src/environmentApi.ts
+++ b/t3code/apps/web/src/environmentApi.ts
@@ -42,6 +42,9 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
     git: {
       resolvePullRequest: rpcClient.git.resolvePullRequest,
       preparePullRequestThread: rpcClient.git.preparePullRequestThread,
+      getConflictFiles: rpcClient.git.getConflictFiles,
+      abortRebase: rpcClient.git.abortRebase,
+      continueRebase: rpcClient.git.continueRebase,
     },
     orchestration: {
       dispatchCommand: rpcClient.orchestration.dispatchCommand,

--- a/t3code/apps/web/src/environments/runtime/connection.test.ts
+++ b/t3code/apps/web/src/environments/runtime/connection.test.ts
@@ -88,6 +88,15 @@ function createTestClient() {
       runStackedAction: vi.fn(async () => ({}) as any),
       resolvePullRequest: vi.fn(async () => undefined),
       preparePullRequestThread: vi.fn(async () => undefined),
+      getConflictFiles: vi.fn(async () => ({ inProgress: false, files: [] })),
+      abortRebase: vi.fn(async () => ({
+        status: "aborted",
+        conflicts: { inProgress: false, files: [] },
+      })),
+      continueRebase: vi.fn(async () => ({
+        status: "continued",
+        conflicts: { inProgress: false, files: [] },
+      })),
     },
   } as unknown as WsRpcClient;
 

--- a/t3code/apps/web/src/environments/runtime/service.savedEnvironments.test.ts
+++ b/t3code/apps/web/src/environments/runtime/service.savedEnvironments.test.ts
@@ -214,6 +214,15 @@ function createClient() {
       init: vi.fn(async () => undefined),
       resolvePullRequest: vi.fn(async () => undefined),
       preparePullRequestThread: vi.fn(async () => undefined),
+      getConflictFiles: vi.fn(async () => ({ inProgress: false, files: [] })),
+      abortRebase: vi.fn(async () => ({
+        status: "aborted",
+        conflicts: { inProgress: false, files: [] },
+      })),
+      continueRebase: vi.fn(async () => ({
+        status: "continued",
+        conflicts: { inProgress: false, files: [] },
+      })),
     },
   };
 }

--- a/t3code/apps/web/src/lib/gitStatusState.test.ts
+++ b/t3code/apps/web/src/lib/gitStatusState.test.ts
@@ -109,6 +109,15 @@ function createRegisteredGitStatusClient(environmentId: EnvironmentId) {
       runStackedAction: vi.fn(async () => ({}) as any),
       resolvePullRequest: vi.fn(async () => undefined),
       preparePullRequestThread: vi.fn(async () => undefined),
+      getConflictFiles: vi.fn(async () => ({ inProgress: false, files: [] })),
+      abortRebase: vi.fn(async () => ({
+        status: "aborted",
+        conflicts: { inProgress: false, files: [] },
+      })),
+      continueRebase: vi.fn(async () => ({
+        status: "continued",
+        conflicts: { inProgress: false, files: [] },
+      })),
     },
     server: {
       getConfig: vi.fn(async () => ({

--- a/t3code/apps/web/src/localApi.test.ts
+++ b/t3code/apps/web/src/localApi.test.ts
@@ -81,6 +81,9 @@ const rpcClientMock = {
     runStackedAction: vi.fn(),
     resolvePullRequest: vi.fn(),
     preparePullRequestThread: vi.fn(),
+    getConflictFiles: vi.fn(),
+    abortRebase: vi.fn(),
+    continueRebase: vi.fn(),
   },
   server: {
     getConfig: vi.fn(),

--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -111,6 +111,9 @@ export interface WsRpcClient {
     readonly preparePullRequestThread: RpcUnaryMethod<
       typeof WS_METHODS.gitPreparePullRequestThread
     >;
+    readonly getConflictFiles: RpcUnaryMethod<typeof WS_METHODS.gitRebaseConflicts>;
+    readonly abortRebase: RpcUnaryMethod<typeof WS_METHODS.gitAbortRebase>;
+    readonly continueRebase: RpcUnaryMethod<typeof WS_METHODS.gitContinueRebase>;
   };
   readonly server: {
     readonly getConfig: RpcUnaryNoArgMethod<typeof WS_METHODS.serverGetConfig>;
@@ -245,6 +248,12 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
         transport.request((client) => client[WS_METHODS.gitResolvePullRequest](input)),
       preparePullRequestThread: (input) =>
         transport.request((client) => client[WS_METHODS.gitPreparePullRequestThread](input)),
+      getConflictFiles: (input) =>
+        transport.request((client) => client[WS_METHODS.gitRebaseConflicts](input)),
+      abortRebase: (input) =>
+        transport.request((client) => client[WS_METHODS.gitAbortRebase](input)),
+      continueRebase: (input) =>
+        transport.request((client) => client[WS_METHODS.gitContinueRebase](input)),
     },
     server: {
       getConfig: () => transport.request((client) => client[WS_METHODS.serverGetConfig]({})),

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -121,6 +121,11 @@ export const GitRunStackedActionInput = Schema.Struct({
 });
 export type GitRunStackedActionInput = typeof GitRunStackedActionInput.Type;
 
+export const GitRebaseConflictsInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type GitRebaseConflictsInput = typeof GitRebaseConflictsInput.Type;
+
 export const VcsListRefsInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   query: Schema.optional(TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(256))),
@@ -315,6 +320,24 @@ export const VcsPullResult = Schema.Struct({
   upstreamRef: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
 });
 export type VcsPullResult = typeof VcsPullResult.Type;
+
+export const GitRebaseConflictsResult = Schema.Struct({
+  inProgress: Schema.Boolean,
+  files: Schema.Array(TrimmedNonEmptyStringSchema),
+});
+export type GitRebaseConflictsResult = typeof GitRebaseConflictsResult.Type;
+
+export const GitAbortRebaseResult = Schema.Struct({
+  status: Schema.Literal("aborted"),
+  conflicts: GitRebaseConflictsResult,
+});
+export type GitAbortRebaseResult = typeof GitAbortRebaseResult.Type;
+
+export const GitContinueRebaseResult = Schema.Struct({
+  status: Schema.Literals(["continued", "conflicts"]),
+  conflicts: GitRebaseConflictsResult,
+});
+export type GitContinueRebaseResult = typeof GitContinueRebaseResult.Type;
 
 // RPC / domain errors
 export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()("GitCommandError", {

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -2,9 +2,13 @@ import type {
   VcsSwitchRefInput,
   VcsSwitchRefResult,
   VcsCreateRefInput,
+  GitAbortRebaseResult,
+  GitContinueRebaseResult,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
   GitPullRequestRefInput,
+  GitRebaseConflictsInput,
+  GitRebaseConflictsResult,
   VcsCreateWorktreeInput,
   VcsCreateWorktreeResult,
   VcsInitInput,
@@ -543,6 +547,9 @@ export interface EnvironmentApi {
     preparePullRequestThread: (
       input: GitPreparePullRequestThreadInput,
     ) => Promise<GitPreparePullRequestThreadResult>;
+    getConflictFiles: (input: GitRebaseConflictsInput) => Promise<GitRebaseConflictsResult>;
+    abortRebase: (input: GitRebaseConflictsInput) => Promise<GitAbortRebaseResult>;
+    continueRebase: (input: GitRebaseConflictsInput) => Promise<GitContinueRebaseResult>;
   };
   orchestration: {
     dispatchCommand: (command: ClientOrchestrationCommand) => Promise<{ sequence: number }>;

--- a/t3code/packages/contracts/src/rpc.ts
+++ b/t3code/packages/contracts/src/rpc.ts
@@ -22,10 +22,14 @@ import {
   VcsListRefsInput,
   VcsListRefsResult,
   GitManagerServiceError,
+  GitAbortRebaseResult,
+  GitContinueRebaseResult,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
   VcsPullInput,
   GitPullRequestRefInput,
+  GitRebaseConflictsInput,
+  GitRebaseConflictsResult,
   VcsPullResult,
   VcsRemoveWorktreeInput,
   GitResolvePullRequestResult,
@@ -127,6 +131,9 @@ export const WS_METHODS = {
   gitRunStackedAction: "git.runStackedAction",
   gitResolvePullRequest: "git.resolvePullRequest",
   gitPreparePullRequestThread: "git.preparePullRequestThread",
+  gitRebaseConflicts: "rebase.conflicts",
+  gitAbortRebase: "git.abortRebase",
+  gitContinueRebase: "git.continueRebase",
 
   // Terminal methods
   terminalOpen: "terminal.open",
@@ -325,6 +332,24 @@ export const WsGitPreparePullRequestThreadRpc = Rpc.make(WS_METHODS.gitPreparePu
   error: GitManagerServiceError,
 });
 
+export const WsGitRebaseConflictsRpc = Rpc.make(WS_METHODS.gitRebaseConflicts, {
+  payload: GitRebaseConflictsInput,
+  success: GitRebaseConflictsResult,
+  error: GitManagerServiceError,
+});
+
+export const WsGitAbortRebaseRpc = Rpc.make(WS_METHODS.gitAbortRebase, {
+  payload: GitRebaseConflictsInput,
+  success: GitAbortRebaseResult,
+  error: GitManagerServiceError,
+});
+
+export const WsGitContinueRebaseRpc = Rpc.make(WS_METHODS.gitContinueRebase, {
+  payload: GitRebaseConflictsInput,
+  success: GitContinueRebaseResult,
+  error: GitManagerServiceError,
+});
+
 export const WsVcsListRefsRpc = Rpc.make(WS_METHODS.vcsListRefs, {
   payload: VcsListRefsInput,
   success: VcsListRefsResult,
@@ -498,6 +523,9 @@ export const WsRpcGroup = RpcGroup.make(
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,
   WsGitPreparePullRequestThreadRpc,
+  WsGitRebaseConflictsRpc,
+  WsGitAbortRebaseRpc,
+  WsGitContinueRebaseRpc,
   WsVcsListRefsRpc,
   WsVcsCreateWorktreeRpc,
   WsVcsRemoveWorktreeRpc,


### PR DESCRIPTION
/claim #823

## Summary
- add typed rebase conflict detection with unresolved file parsing
- expose rebase conflict, abort, and continue RPC methods through the server and web client
- add mocked and real-git tests for conflict detection, abort, and continue flows

## Verification
- bun fmt
- bun run test src/git/GitManager.test.ts
- bun run typecheck (apps/server)
- bun lint
- bun typecheck
- git diff --check