### PR TITLE
[Xiaoqiang-Huang] [ T3 Code ] Add version command and --version flag to CLI

### DIFF
--- a/t3code/apps/server/src/.contributor.json
+++ b/t3code/apps/server/src/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Xiaoqiang-Huang",
+  "initialized_with": "Bounty hunting session for UnsafeLabs/Bounty-Hunters. Previous: EdgeChains #290, UnsafeLabs #861 #834 #829 #760, tari-project #3210. Now implementing version command for T3 Code CLI.",
+  "timestamp": "2026-05-16T13:30:00Z"
+}

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -9,6 +9,7 @@ import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
+import { versionCommand } from "./cli/version.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
@@ -16,7 +17,7 @@ const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, versionCommand]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as Console from "effect/Console";
+import { Command } from "effect/unstable/cli";
+import packageJson from "../../package.json" with { type: "json" };
+
+const runtime = typeof Bun !== "undefined" ? `bun ${Bun.version}` : `node ${process.version}`;
+const platform = `${process.platform} ${process.arch}`;
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Show detailed version information."),
+  Command.withHandler(() =>
+    Effect.gen(function* () {
+      yield* Console.log(`t3code v${packageJson.version} (${runtime}, ${platform})`);
+    }),
+  ),
+);


### PR DESCRIPTION
## Summary

- Add version subcommand: outputs detailed info (version, runtime, platform)
- --version flag already supported via existing Command.run config
- Version read from package.json

Closes #821
