### PR TITLE
Codex [ FastAPI ] Add request-scoped dependency caching

### DIFF
--- a/fastapi/fastapi/dependencies/utils.py
+++ b/fastapi/fastapi/dependencies/utils.py
@@ -130,6 +130,7 @@ def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> De
     return get_dependant(
         path=path,
         call=depends.dependency,
+        use_cache=depends.use_cache,
         scope=depends.scope,
         own_oauth_scopes=own_oauth_scopes,
     )
@@ -680,7 +681,7 @@ async def solve_dependencies(
             solved = await run_in_threadpool(call, **solved_result.values)
         if sub_dependant.name is not None:
             values[sub_dependant.name] = solved
-        if sub_dependant.cache_key not in dependency_cache:
+        if sub_dependant.use_cache and sub_dependant.cache_key not in dependency_cache:
             dependency_cache[sub_dependant.cache_key] = solved
     path_values, path_errors = request_params_to_args(
         dependant.path_params, request.path_params

--- a/fastapi/tests/test_dependency_cache.py
+++ b/fastapi/tests/test_dependency_cache.py
@@ -11,6 +11,11 @@ async def dep_counter():
     return counter_holder["counter"]
 
 
+def sync_dep_counter():
+    counter_holder["counter"] += 1
+    return counter_holder["counter"]
+
+
 async def super_dep(count: int = Depends(dep_counter)):
     return count
 
@@ -18,6 +23,14 @@ async def super_dep(count: int = Depends(dep_counter)):
 @app.get("/counter/")
 async def get_counter(count: int = Depends(dep_counter)):
     return {"counter": count}
+
+
+@app.get("/sync-counter/")
+async def get_sync_counter(
+    first: int = Depends(sync_dep_counter),
+    second: int = Depends(sync_dep_counter),
+):
+    return {"first": first, "second": second}
 
 
 @app.get("/sub-counter/")
@@ -33,6 +46,25 @@ async def get_sub_counter_no_cache(
     count: int = Depends(dep_counter, use_cache=False),
 ):
     return {"counter": count, "subcounter": subcount}
+
+
+@app.get("/sub-counter-no-cache-first/")
+async def get_sub_counter_no_cache_first(
+    count: int = Depends(dep_counter, use_cache=False),
+    subcount: int = Depends(super_dep),
+):
+    return {"counter": count, "subcounter": subcount}
+
+
+@app.get(
+    "/decorator-dependency-no-cache/",
+    dependencies=[
+        Depends(dep_counter, use_cache=False),
+        Depends(dep_counter, use_cache=False),
+    ],
+)
+async def get_decorator_dependency_no_cache():
+    return {"counter": counter_holder["counter"]}
 
 
 @app.get("/scope-counter")
@@ -61,6 +93,16 @@ def test_normal_counter():
     assert response.json() == {"counter": 2}
 
 
+def test_sync_counter():
+    counter_holder["counter"] = 0
+    response = client.get("/sync-counter/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"first": 1, "second": 1}
+    response = client.get("/sync-counter/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"first": 2, "second": 2}
+
+
 def test_sub_counter():
     counter_holder["counter"] = 0
     response = client.get("/sub-counter/")
@@ -79,6 +121,26 @@ def test_sub_counter_no_cache():
     response = client.get("/sub-counter-no-cache/")
     assert response.status_code == 200, response.text
     assert response.json() == {"counter": 4, "subcounter": 3}
+
+
+def test_sub_counter_no_cache_first():
+    counter_holder["counter"] = 0
+    response = client.get("/sub-counter-no-cache-first/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 1, "subcounter": 2}
+    response = client.get("/sub-counter-no-cache-first/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 3, "subcounter": 4}
+
+
+def test_decorator_dependency_no_cache():
+    counter_holder["counter"] = 0
+    response = client.get("/decorator-dependency-no-cache/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 2}
+    response = client.get("/decorator-dependency-no-cache/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 4}
 
 
 def test_security_cache():


### PR DESCRIPTION
/claim #795

Summary:
- Preserve Depends(..., use_cache=False) for parameterless dependencies.
- Only store solved dependency values in the request cache when use_cache=True.
- Add sync, async, request isolation, and no-cache ordering coverage.

Verification:
- uv run pytest tests/test_dependency_cache.py
- uv run pytest tests/test_dependency_cache.py tests/test_dependencies_utils.py tests/test_dependency_overrides.py tests/test_dependency_yield_scope.py tests/test_ws_dependencies.py
- uv run ruff check fastapi/dependencies/utils.py tests/test_dependency_cache.py
- uv run ruff format --check fastapi/dependencies/utils.py tests/test_dependency_cache.py
- git diff --check