### PR TITLE
Codex [ FastAPI ] Fix duplicate generated operation IDs

### DIFF
--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -244,12 +244,17 @@ def get_openapi_operation_metadata(
         operation["description"] = route.description
     operation_id = route.operation_id or route.unique_id
     if operation_id in operation_ids:
+        base_operation_id = operation_id
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
         file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        suffix = 2
+        while operation_id in operation_ids:
+            operation_id = f"{base_operation_id}_{suffix}"
+            suffix += 1
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -93,11 +93,12 @@ def generate_operation_id_for_path(
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0].lower()
+    path = re.sub(r"\W+", "_", route.path_format).strip("_").lower()
+    name = re.sub(r"\W+", "_", route.name).strip("_").lower()
+    operation_id = "_".join(part for part in [method, path, name] if part)
+    return re.sub(r"_+", "_", operation_id)
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_generate_unique_id_function.py
+++ b/fastapi/tests/test_generate_unique_id_function.py
@@ -1697,3 +1697,81 @@ def test_warn_duplicate_operation_id():
         ]
         assert len(duplicate_warnings) > 0
         assert "Duplicate Operation ID" in str(duplicate_warnings[0].message)
+
+
+def test_default_generate_unique_id_includes_method_path_and_endpoint_name():
+    app = FastAPI()
+
+    @app.get("/users")
+    def list_users():
+        return []  # pragma: nocover
+
+    @app.post("/api/v1")
+    def create_item():
+        return {}  # pragma: nocover
+
+    openapi = app.openapi()
+
+    assert openapi["paths"]["/users"]["get"]["operationId"] == "get_users_list_users"
+    assert (
+        openapi["paths"]["/api/v1"]["post"]["operationId"] == "post_api_v1_create_item"
+    )
+
+
+def test_default_generate_unique_id_uses_router_prefix_for_duplicate_endpoint_names():
+    app = FastAPI()
+    users_router = APIRouter(prefix="/users")
+    admins_router = APIRouter(prefix="/admins")
+
+    def list_user_records():
+        return []  # pragma: nocover
+
+    def list_admin_records():
+        return []  # pragma: nocover
+
+    list_user_records.__name__ = "list_records"
+    list_admin_records.__name__ = "list_records"
+    users_router.add_api_route("/", list_user_records, methods=["GET"])
+    admins_router.add_api_route("/", list_admin_records, methods=["GET"])
+    app.include_router(users_router)
+    app.include_router(admins_router)
+    openapi = app.openapi()
+
+    operation_ids = {
+        openapi["paths"]["/users/"]["get"]["operationId"],
+        openapi["paths"]["/admins/"]["get"]["operationId"],
+    }
+    assert operation_ids == {
+        "get_users_list_records",
+        "get_admins_list_records",
+    }
+
+
+def test_duplicate_generated_operation_id_gets_numeric_suffix():
+    app = FastAPI()
+
+    def read_item_dash():
+        return {}  # pragma: nocover
+
+    def read_item_underscore():
+        return {}  # pragma: nocover
+
+    read_item_dash.__name__ = "read_item"
+    read_item_underscore.__name__ = "read_item"
+    app.add_api_route("/items/{item-id}", read_item_dash, methods=["GET"])
+    app.add_api_route("/items/{item_id}", read_item_underscore, methods=["GET"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        openapi = app.openapi()
+
+    operation_ids = [
+        openapi["paths"]["/items/{item-id}"]["get"]["operationId"],
+        openapi["paths"]["/items/{item_id}"]["get"]["operationId"],
+    ]
+
+    assert operation_ids == [
+        "get_items_item_id_read_item",
+        "get_items_item_id_read_item_2",
+    ]
+    assert any("Duplicate Operation ID" in str(warning.message) for warning in caught)


### PR DESCRIPTION
/claim #764

## Summary
- update default operation ID generation to include HTTP method, route path, and endpoint name
- sanitize generated IDs to lowercase alphanumeric and underscore characters
- append numeric suffixes when OpenAPI generation still finds a duplicate ID
- add tests for method/path/name IDs, router-prefix uniqueness, and suffix handling

## Verification
- uv run pytest tests/test_generate_unique_id_function.py -q
- uv run ruff check fastapi/utils.py fastapi/openapi/utils.py tests/test_generate_unique_id_function.py
- uv run ruff format --check fastapi/utils.py fastapi/openapi/utils.py tests/test_generate_unique_id_function.py
- python -m compileall -q fastapi/fastapi fastapi/tests/test_generate_unique_id_function.py
- git diff --check