### PR TITLE
xiaoqiang [ Laravel ] Implement file upload with checksum dedup and thumbnail generation

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent": "xiaoqiang", "initial_directives": "Implement Laravel file upload system with checksum dedup and thumbnail generation per issue #790", "date": "2026-05-16T12:00:00Z"}

--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class FileController extends Controller
+{
+    public function upload(Request $request): JsonResponse
+    {
+        $request->validate([
+            'file' => 'required|file|max:102400',
+        ]);
+
+        $uploadedFile = $request->file('file');
+        $contents = file_get_contents($uploadedFile->getRealPath());
+        $checksum = hash('sha256', $contents);
+
+        $existing = File::where('checksum_sha256', $checksum)->first();
+        if ($existing) {
+            return response()->json([
+                'error' => 'A file with this content already exists',
+                'existing_file_id' => $existing->id,
+            ], 409);
+        }
+
+        $datePath = now()->format('Y/m/d');
+        $storedName = Str::random(40) . '.' . $uploadedFile->getClientOriginalExtension();
+        $storedPath = $uploadedFile->storeAs("uploads/{$datePath}", $storedName, 'local');
+
+        $mimeType = $uploadedFile->getMimeType();
+        $thumbnailPath = null;
+
+        if (str_starts_with($mimeType, 'image/')) {
+            $thumbnailPath = $this->generateThumbnail($uploadedFile->getRealPath(), $storedName, $datePath);
+        }
+
+        $file = File::create([
+            'original_name' => $uploadedFile->getClientOriginalName(),
+            'stored_path' => $storedPath,
+            'mime_type' => $mimeType,
+            'size_bytes' => $uploadedFile->getSize(),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => $request->user()?->id,
+            'thumbnail_path' => $thumbnailPath,
+        ]);
+
+        return response()->json($file, 201);
+    }
+
+    public function download(int $id)
+    {
+        $file = File::findOrFail($id);
+
+        if (!Storage::disk('local')->exists($file->stored_path)) {
+            return response()->json(['error' => 'File not found on disk'], 404);
+        }
+
+        return Storage::disk('local')->response(
+            $file->stored_path,
+            $file->original_name,
+            ['Content-Type' => $file->mime_type]
+        );
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $file = File::findOrFail($id);
+
+        if (Storage::disk('local')->exists($file->stored_path)) {
+            Storage::disk('local')->delete($file->stored_path);
+        }
+
+        if ($file->thumbnail_path && Storage::disk('local')->exists($file->thumbnail_path)) {
+            Storage::disk('local')->delete($file->thumbnail_path);
+        }
+
+        $file->delete();
+
+        return response()->json(null, 204);
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $page = $request->integer('page', 1);
+        $perPage = 20;
+
+        $files = File::orderBy('created_at', 'desc')
+            ->paginate($perPage, ['*'], 'page', $page);
+
+        return response()->json($files);
+    }
+
+    private function generateThumbnail(string $sourcePath, string $storedName, string $datePath): ?string
+    {
+        if (!extension_loaded('gd')) {
+            return null;
+        }
+
+        $imageInfo = getimagesize($sourcePath);
+        if ($imageInfo === false) {
+            return null;
+        }
+
+        $sourceImage = match ($imageInfo[2]) {
+            IMAGETYPE_JPEG => imagecreatefromjpeg($sourcePath),
+            IMAGETYPE_PNG => imagecreatefrompng($sourcePath),
+            IMAGETYPE_GIF => imagecreatefromgif($sourcePath),
+            IMAGETYPE_WEBP => imagecreatefromwebp($sourcePath),
+            default => null,
+        };
+
+        if ($sourceImage === false || $sourceImage === null) {
+            return null;
+        }
+
+        $origWidth = imagesx($sourceImage);
+        $origHeight = imagesy($sourceImage);
+        $thumbSize = 200;
+
+        $ratio = min($thumbSize / $origWidth, $thumbSize / $origHeight);
+        $newWidth = (int)($origWidth * $ratio);
+        $newHeight = (int)($origHeight * $ratio);
+
+        $thumb = imagecreatetruecolor($newWidth, $newHeight);
+        imagecopyresampled($thumb, $sourceImage, 0, 0, 0, 0, $newWidth, $newHeight, $origWidth, $origHeight);
+
+        $thumbDir = "thumbnails/{$datePath}";
+        Storage::disk('local')->makeDirectory($thumbDir);
+
+        $thumbPath = "{$thumbDir}/thumb_{$storedName}";
+        $fullThumbPath = Storage::disk('local')->path($thumbPath);
+
+        imagejpeg($thumb, $fullThumbPath, 85);
+        imagedestroy($thumb);
+        imagedestroy($sourceImage);
+
+        return $thumbPath;
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['original_name', 'stored_path', 'mime_type', 'size_bytes', 'checksum_sha256', 'uploaded_by', 'thumbnail_path'])]
+class File extends Model
+{
+    protected $table = 'files';
+
+    protected function casts(): array
+    {
+        return [
+            'size_bytes' => 'integer',
+            'uploaded_by' => 'integer',
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_16_000000_create_files_table.php
+++ b/laravel/database/migrations/2026_05_16_000000_create_files_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size_bytes');
+            $table->string('checksum_sha256');
+            $table->unsignedBigInteger('uploaded_by')->nullable();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+
+            $table->index('checksum_sha256');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Http\Controllers\FileController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('files')->group(function () {
+    Route::post('/upload', [FileController::class, 'upload']);
+    Route::get('/{id}/download', [FileController::class, 'download']);
+    Route::delete('/{id}', [FileController::class, 'destroy']);
+    Route::get('/', [FileController::class, 'index']);
+});

--- a/laravel/tests/Feature/FileUploadTest.php
+++ b/laravel/tests/Feature/FileUploadTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class FileUploadTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+        $this->withoutMiddleware();
+    }
+
+    public function test_upload_creates_file_record(): void
+    {
+        $file = UploadedFile::fake()->create('document.pdf', 1024, 'application/pdf');
+
+        $response = $this->postJson('/api/files/upload', ['file' => $file]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'id', 'original_name', 'stored_path', 'mime_type',
+            'size_bytes', 'checksum_sha256', 'thumbnail_path', 'created_at',
+        ]);
+
+        $this->assertEquals('document.pdf', $response->json('original_name'));
+        $this->assertEquals('application/pdf', $response->json('mime_type'));
+        $this->assertNull($response->json('thumbnail_path'));
+    }
+
+    public function test_sha256_checksum_computed_and_stored(): void
+    {
+        $file = UploadedFile::fake()->create('test.txt', 100, 'text/plain');
+
+        $response = $this->postJson('/api/files/upload', ['file' => $file]);
+
+        $response->assertStatus(201);
+        $this->assertEquals(64, strlen($response->json('checksum_sha256')));
+
+        $dbFile = File::first();
+        $this->assertEquals($response->json('checksum_sha256'), $dbFile->checksum_sha256);
+    }
+
+    public function test_duplicate_file_rejected_with_409(): void
+    {
+        Storage::disk('local')->put('uploads/2026/05/16/existing.txt', 'hello world');
+
+        File::create([
+            'original_name' => 'original.txt',
+            'stored_path' => 'uploads/2026/05/16/existing.txt',
+            'mime_type' => 'text/plain',
+            'size_bytes' => 11,
+            'checksum_sha256' => hash('sha256', 'hello world'),
+        ]);
+
+        $file = UploadedFile::fake()->createWithContent('duplicate.txt', 'hello world');
+
+        $response = $this->postJson('/api/files/upload', ['file' => $file]);
+
+        $response->assertStatus(409);
+        $response->assertJson(['error' => 'A file with this content already exists']);
+    }
+
+    public function test_image_upload_generates_thumbnail(): void
+    {
+        if (!extension_loaded('gd')) {
+            $this->markTestSkipped('GD extension not available');
+        }
+
+        $image = UploadedFile::fake()->image('photo.jpg', 800, 600);
+
+        $response = $this->postJson('/api/files/upload', ['file' => $image]);
+
+        $response->assertStatus(201);
+        $this->assertNotNull($response->json('thumbnail_path'));
+        $this->assertStringContainsString('thumbnails/', $response->json('thumbnail_path'));
+    }
+
+    public function test_non_image_upload_has_null_thumbnail(): void
+    {
+        $file = UploadedFile::fake()->create('data.csv', 500, 'text/csv');
+
+        $response = $this->postJson('/api/files/upload', ['file' => $file]);
+
+        $response->assertStatus(201);
+        $this->assertNull($response->json('thumbnail_path'));
+    }
+
+    public function test_download_streams_file_with_content_type(): void
+    {
+        $content = 'file content here';
+        Storage::disk('local')->put('uploads/2026/05/16/test.txt', $content);
+
+        $file = File::create([
+            'original_name' => 'test.txt',
+            'stored_path' => 'uploads/2026/05/16/test.txt',
+            'mime_type' => 'text/plain',
+            'size_bytes' => strlen($content),
+            'checksum_sha256' => hash('sha256', $content),
+        ]);
+
+        $response = $this->getJson("/api/files/{$file->id}/download");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_delete_removes_file_and_record(): void
+    {
+        Storage::disk('local')->put('uploads/2026/05/16/to-delete.txt', 'bye');
+
+        $file = File::create([
+            'original_name' => 'to-delete.txt',
+            'stored_path' => 'uploads/2026/05/16/to-delete.txt',
+            'mime_type' => 'text/plain',
+            'size_bytes' => 3,
+            'checksum_sha256' => hash('sha256', 'bye'),
+        ]);
+
+        $response = $this->deleteJson("/api/files/{$file->id}");
+
+        $response->assertStatus(204);
+        $this->assertFalse(Storage::disk('local')->exists('uploads/2026/05/16/to-delete.txt'));
+        $this->assertDatabaseMissing('files', ['id' => $file->id]);
+    }
+
+    public function test_list_returns_paginated_results(): void
+    {
+        for ($i = 0; $i < 25; $i++) {
+            $content = "content {$i}";
+            $path = "uploads/2026/05/16/file_{$i}.txt";
+            Storage::disk('local')->put($path, $content);
+            File::create([
+                'original_name' => "file_{$i}.txt",
+                'stored_path' => $path,
+                'mime_type' => 'text/plain',
+                'size_bytes' => strlen($content),
+                'checksum_sha256' => hash('sha256', $content),
+            ]);
+        }
+
+        $response = $this->getJson('/api/files?page=1');
+
+        $response->assertStatus(200);
+        $this->assertEquals(20, count($response->json('data')));
+        $this->assertEquals(25, $response->json('total'));
+    }
+
+    public function test_upload_requires_file(): void
+    {
+        $response = $this->postJson('/api/files/upload', []);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #790 â file upload system with SHA-256 checksum dedup and automatic thumbnail generation.

### Changes

- **File model** with migration: id, original_name, stored_path, mime_type, size_bytes, checksum_sha256, uploaded_by, thumbnail_path, timestamps
- **FileController** with upload, download, delete, and list endpoints
  - Files stored in storage/app/uploads/ organized by date (Y/m/d)
  - SHA-256 checksum computed on upload, duplicates rejected with 409 Conflict
  - Image uploads get automatic 200x200 thumbnail via GD library
  - Download streams file with correct Content-Type header
  - Delete removes both file from disk and database record
  - List endpoint supports pagination with 20 items per page
- **API routes** registered under /files prefix
- **9 tests** covering upload, checksum, dedup, thumbnail, download, delete, pagination, and validation

## Test plan

- [ ] Upload a file and verify database record with correct metadata
- [ ] Upload duplicate content and verify 409 Conflict
- [ ] Upload image and verify thumbnail is generated
- [ ] Upload non-image and verify null thumbnail_path
- [ ] Download file and verify correct Content-Type
- [ ] Delete file and verify removal from disk and database
- [ ] List files and verify pagination (20 per page)