### PR TITLE
Codex [ T3 Code ] Add Prometheus metrics endpoint

### DIFF
--- a/t3code/apps/server/src/diagnostics/PrometheusMetrics.test.ts
+++ b/t3code/apps/server/src/diagnostics/PrometheusMetrics.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPrometheusMetricsRegistry,
+  isMetricsAuthDisabled,
+  renderPrometheusMetrics,
+} from "./PrometheusMetrics.ts";
+
+describe("Prometheus metrics", () => {
+  it("renders the expected Prometheus exposition format", () => {
+    const registry = createPrometheusMetricsRegistry();
+    registry.recordRpcRequest({ method: "server.getConfig", durationSeconds: 0.12 });
+    registry.recordGitOperation("status");
+
+    const output = renderPrometheusMetrics({
+      activeSessions: 2,
+      memoryUsageBytes: 4096,
+      snapshot: registry.snapshot(),
+    });
+
+    expect(output).toContain("# HELP active_sessions Current connected client sessions.");
+    expect(output).toContain("# TYPE active_sessions gauge");
+    expect(output).toContain("active_sessions 2");
+    expect(output).toContain("# TYPE rpc_requests_total counter");
+    expect(output).toContain('rpc_requests_total{method="server.getConfig"} 1');
+    expect(output).toContain("# TYPE rpc_duration_seconds histogram");
+    expect(output).toContain('rpc_duration_seconds_bucket{le="+Inf",method="server.getConfig"} 1');
+    expect(output).toContain('rpc_duration_seconds_count{method="server.getConfig"} 1');
+    expect(output).toContain('git_operations_total{operation="status"} 1');
+    expect(output).toContain("memory_usage_bytes 4096");
+    expect(output.endsWith("\n")).toBe(true);
+  });
+
+  it("increments RPC and Git counters across repeated observations", () => {
+    const registry = createPrometheusMetricsRegistry();
+    registry.recordRpcRequest({ method: "thread.dispatch", durationSeconds: 0.1 });
+    registry.recordRpcRequest({ method: "thread.dispatch", durationSeconds: 0.2 });
+    registry.recordGitOperation("commit");
+    registry.recordGitOperation("commit");
+
+    const output = renderPrometheusMetrics({
+      activeSessions: 0,
+      memoryUsageBytes: 1,
+      snapshot: registry.snapshot(),
+    });
+
+    expect(output).toContain('rpc_requests_total{method="thread.dispatch"} 2');
+    expect(output).toContain('rpc_duration_seconds_count{method="thread.dispatch"} 2');
+    expect(output).toContain('rpc_duration_seconds_sum{method="thread.dispatch"} 0.3');
+    expect(output).toContain('git_operations_total{operation="commit"} 2');
+  });
+
+  it("escapes label values and reads the metrics auth toggle", () => {
+    const registry = createPrometheusMetricsRegistry();
+    registry.recordRpcRequest({ method: 'server."quoted"\\method\nline', durationSeconds: 0 });
+
+    const output = renderPrometheusMetrics({
+      activeSessions: 0,
+      memoryUsageBytes: 1,
+      snapshot: registry.snapshot(),
+    });
+
+    expect(output).toContain('method="server.\\"quoted\\"\\\\method\\nline"');
+    expect(isMetricsAuthDisabled({ METRICS_AUTH_DISABLED: "true" })).toBe(true);
+    expect(isMetricsAuthDisabled({ METRICS_AUTH_DISABLED: "false" })).toBe(false);
+    expect(isMetricsAuthDisabled({})).toBe(false);
+  });
+});

--- a/t3code/apps/server/src/diagnostics/PrometheusMetrics.ts
+++ b/t3code/apps/server/src/diagnostics/PrometheusMetrics.ts
@@ -1,0 +1,245 @@
+import * as Effect from "effect/Effect";
+
+export const PROMETHEUS_METRICS_PATH = "/metrics";
+export const PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+const DEFAULT_RPC_DURATION_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+] as const;
+
+interface CounterSnapshot {
+  readonly labels: Readonly<Record<string, string>>;
+  readonly value: number;
+}
+
+interface HistogramSnapshot {
+  readonly labels: Readonly<Record<string, string>>;
+  readonly buckets: ReadonlyArray<{
+    readonly le: number;
+    readonly count: number;
+  }>;
+  readonly count: number;
+  readonly sum: number;
+}
+
+export interface PrometheusMetricsSnapshot {
+  readonly rpcRequests: ReadonlyArray<CounterSnapshot>;
+  readonly rpcDurations: ReadonlyArray<HistogramSnapshot>;
+  readonly gitOperations: ReadonlyArray<CounterSnapshot>;
+}
+
+interface RpcMetricState {
+  count: number;
+  sum: number;
+  readonly bucketCounts: Map<number, number>;
+}
+
+export class PrometheusMetricsRegistry {
+  private readonly rpcMetrics = new Map<string, RpcMetricState>();
+  private readonly gitOperations = new Map<string, number>();
+
+  recordRpcRequest(input: { readonly method: string; readonly durationSeconds: number }): void {
+    const method = input.method.trim() || "unknown";
+    const durationSeconds = normalizeMetricValue(input.durationSeconds);
+    const state = this.rpcMetrics.get(method) ?? {
+      count: 0,
+      sum: 0,
+      bucketCounts: new Map(DEFAULT_RPC_DURATION_BUCKETS.map((bucket) => [bucket, 0])),
+    };
+
+    state.count += 1;
+    state.sum += durationSeconds;
+    for (const bucket of DEFAULT_RPC_DURATION_BUCKETS) {
+      if (durationSeconds <= bucket) {
+        state.bucketCounts.set(bucket, (state.bucketCounts.get(bucket) ?? 0) + 1);
+      }
+    }
+    this.rpcMetrics.set(method, state);
+  }
+
+  recordGitOperation(operation: string): void {
+    const normalizedOperation = operation.trim() || "unknown";
+    this.gitOperations.set(
+      normalizedOperation,
+      (this.gitOperations.get(normalizedOperation) ?? 0) + 1,
+    );
+  }
+
+  snapshot(): PrometheusMetricsSnapshot {
+    return {
+      rpcRequests: [...this.rpcMetrics.entries()]
+        .map(([method, state]) => ({
+          labels: { method },
+          value: state.count,
+        }))
+        .toSorted(sortCounterSnapshots),
+      rpcDurations: [...this.rpcMetrics.entries()]
+        .map(([method, state]) => ({
+          labels: { method },
+          buckets: DEFAULT_RPC_DURATION_BUCKETS.map((bucket) => ({
+            le: bucket,
+            count: state.bucketCounts.get(bucket) ?? 0,
+          })),
+          count: state.count,
+          sum: state.sum,
+        }))
+        .toSorted(sortHistogramSnapshots),
+      gitOperations: [...this.gitOperations.entries()]
+        .map(([operation, value]) => ({
+          labels: { operation },
+          value,
+        }))
+        .toSorted(sortCounterSnapshots),
+    };
+  }
+
+  reset(): void {
+    this.rpcMetrics.clear();
+    this.gitOperations.clear();
+  }
+}
+
+export const prometheusMetricsRegistry = new PrometheusMetricsRegistry();
+
+export function createPrometheusMetricsRegistry(): PrometheusMetricsRegistry {
+  return new PrometheusMetricsRegistry();
+}
+
+export function isMetricsAuthDisabled(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  return env.METRICS_AUTH_DISABLED?.trim().toLowerCase() === "true";
+}
+
+export function recordPrometheusRpcRequest(input: {
+  readonly method: string;
+  readonly elapsedNanos: bigint;
+}): Effect.Effect<void> {
+  return Effect.sync(() => {
+    prometheusMetricsRegistry.recordRpcRequest({
+      method: input.method,
+      durationSeconds: Number(input.elapsedNanos) / 1_000_000_000,
+    });
+  });
+}
+
+export function recordPrometheusGitOperation(operation: string): Effect.Effect<void> {
+  return Effect.sync(() => {
+    prometheusMetricsRegistry.recordGitOperation(operation);
+  });
+}
+
+export function renderPrometheusMetrics(input: {
+  readonly activeSessions: number;
+  readonly memoryUsageBytes: number;
+  readonly snapshot?: PrometheusMetricsSnapshot;
+}): string {
+  const snapshot = input.snapshot ?? prometheusMetricsRegistry.snapshot();
+  const lines: string[] = [];
+
+  appendHelpAndType(lines, "active_sessions", "Current connected client sessions.", "gauge");
+  lines.push(`active_sessions ${formatMetricNumber(input.activeSessions)}`);
+  lines.push("");
+
+  appendHelpAndType(
+    lines,
+    "rpc_requests_total",
+    "Total WebSocket RPC requests handled by method.",
+    "counter",
+  );
+  for (const counter of snapshot.rpcRequests) {
+    lines.push(
+      `rpc_requests_total${formatLabels(counter.labels)} ${formatMetricNumber(counter.value)}`,
+    );
+  }
+  lines.push("");
+
+  appendHelpAndType(
+    lines,
+    "rpc_duration_seconds",
+    "WebSocket RPC request duration in seconds.",
+    "histogram",
+  );
+  for (const histogram of snapshot.rpcDurations) {
+    for (const bucket of histogram.buckets) {
+      lines.push(
+        `rpc_duration_seconds_bucket${formatLabels({
+          ...histogram.labels,
+          le: formatBucketBoundary(bucket.le),
+        })} ${formatMetricNumber(bucket.count)}`,
+      );
+    }
+    lines.push(
+      `rpc_duration_seconds_bucket${formatLabels({
+        ...histogram.labels,
+        le: "+Inf",
+      })} ${formatMetricNumber(histogram.count)}`,
+    );
+    lines.push(
+      `rpc_duration_seconds_sum${formatLabels(histogram.labels)} ${formatMetricNumber(histogram.sum)}`,
+    );
+    lines.push(
+      `rpc_duration_seconds_count${formatLabels(histogram.labels)} ${formatMetricNumber(histogram.count)}`,
+    );
+  }
+  lines.push("");
+
+  appendHelpAndType(lines, "git_operations_total", "Total Git operations executed.", "counter");
+  for (const counter of snapshot.gitOperations) {
+    lines.push(
+      `git_operations_total${formatLabels(counter.labels)} ${formatMetricNumber(counter.value)}`,
+    );
+  }
+  lines.push("");
+
+  appendHelpAndType(lines, "memory_usage_bytes", "Current process RSS memory usage.", "gauge");
+  lines.push(`memory_usage_bytes ${formatMetricNumber(input.memoryUsageBytes)}`);
+  lines.push("");
+
+  return `${lines.join("\n")}\n`;
+}
+
+function appendHelpAndType(
+  lines: string[],
+  name: string,
+  help: string,
+  type: "counter" | "gauge" | "histogram",
+): void {
+  lines.push(`# HELP ${name} ${help}`);
+  lines.push(`# TYPE ${name} ${type}`);
+}
+
+function formatLabels(labels: Readonly<Record<string, string>>): string {
+  const entries = Object.entries(labels).toSorted(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries.map(([key, value]) => `${key}="${escapeLabelValue(value)}"`).join(",")}}`;
+}
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+function formatBucketBoundary(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toString();
+}
+
+function normalizeMetricValue(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function formatMetricNumber(value: number): string {
+  const normalized = normalizeMetricValue(value);
+  return Number.isInteger(normalized)
+    ? normalized.toString()
+    : Number.parseFloat(normalized.toPrecision(15)).toString();
+}
+
+function sortCounterSnapshots(left: CounterSnapshot, right: CounterSnapshot): number {
+  return JSON.stringify(left.labels).localeCompare(JSON.stringify(right.labels));
+}
+
+function sortHistogramSnapshots(left: HistogramSnapshot, right: HistogramSnapshot): number {
+  return JSON.stringify(left.labels).localeCompare(JSON.stringify(right.labels));
+}

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -26,7 +26,14 @@ import { resolveStaticDir, ServerConfig } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
+import { SessionCredentialService } from "./auth/Services/SessionCredentialService.ts";
 import { respondToAuthError } from "./auth/http.ts";
+import {
+  isMetricsAuthDisabled,
+  PROMETHEUS_CONTENT_TYPE,
+  PROMETHEUS_METRICS_PATH,
+  renderPrometheusMetrics,
+} from "./diagnostics/PrometheusMetrics.ts";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
 import {
   browserApiCorsAllowedHeaders,
@@ -132,6 +139,42 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
           Effect.succeed(HttpServerResponse.text("Trace export failed.", { status: 502 })),
         ),
       );
+  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+);
+
+export const prometheusMetricsRouteLayer = HttpRouter.add(
+  "GET",
+  PROMETHEUS_METRICS_PATH,
+  Effect.gen(function* () {
+    if (!isMetricsAuthDisabled()) {
+      yield* requireAuthenticatedRequest;
+    }
+
+    const sessions = yield* SessionCredentialService;
+    const activeSessions = yield* sessions.listActive().pipe(
+      Effect.map(
+        (clientSessions) =>
+          clientSessions.filter((clientSession) => clientSession.connected).length,
+      ),
+      Effect.catch((cause) =>
+        Effect.logWarning("Failed to collect active session metric", {
+          cause,
+        }).pipe(Effect.as(0)),
+      ),
+    );
+
+    const memoryUsageBytes = process.memoryUsage().rss;
+
+    return HttpServerResponse.text(
+      renderPrometheusMetrics({
+        activeSessions,
+        memoryUsageBytes,
+      }),
+      {
+        status: 200,
+        contentType: PROMETHEUS_CONTENT_TYPE,
+      },
+    );
   }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
 );
 

--- a/t3code/apps/server/src/observability/RpcInstrumentation.ts
+++ b/t3code/apps/server/src/observability/RpcInstrumentation.ts
@@ -9,6 +9,7 @@ import * as Stream from "effect/Stream";
 
 import { outcomeFromExit } from "./Attributes.ts";
 import { metricAttributes, rpcRequestDuration, rpcRequestsTotal, withMetrics } from "./Metrics.ts";
+import { recordPrometheusRpcRequest } from "../diagnostics/PrometheusMetrics.ts";
 
 const RPC_SPAN_PREFIX = "ws.rpc";
 const DEFAULT_RPC_SPAN_ATTRIBUTES = {
@@ -84,6 +85,7 @@ const recordRpcStreamMetrics = <E>(
       ),
       1,
     );
+    yield* recordPrometheusRpcRequest({ method, elapsedNanos });
   });
 
 export const observeRpcEffect = <A, E, R>(
@@ -91,18 +93,39 @@ export const observeRpcEffect = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
   traceAttributes?: Readonly<Record<string, unknown>>,
 ): Effect.Effect<A, E, R> => {
-  const instrumented = effect.pipe(
-    withMetrics({
-      counter: rpcRequestsTotal,
-      timer: rpcRequestDuration,
-      attributes: {
-        method,
-      },
-    }),
+  const instrumented = withPrometheusRpcMetrics(
+    method,
+    effect.pipe(
+      withMetrics({
+        counter: rpcRequestsTotal,
+        timer: rpcRequestDuration,
+        attributes: {
+          method,
+        },
+      }),
+    ),
   );
 
   return withRpcEffectTracing(method, instrumented, traceAttributes);
 };
+
+const withPrometheusRpcMetrics = <A, E, R>(
+  method: string,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.gen(function* () {
+    const startedAt = yield* Clock.currentTimeNanos;
+    const exit = yield* Effect.exit(effect);
+    const endedAt = yield* Clock.currentTimeNanos;
+    const elapsedNanos = endedAt > startedAt ? endedAt - startedAt : 0n;
+
+    yield* recordPrometheusRpcRequest({ method, elapsedNanos });
+
+    if (Exit.isSuccess(exit)) {
+      return exit.value;
+    }
+    return yield* Effect.failCause(exit.cause);
+  });
 
 export const observeRpcStream = <A, E, R>(
   method: string,

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -6,6 +6,7 @@ import { ServerConfig } from "./config.ts";
 import {
   attachmentsRouteLayer,
   otlpTracesProxyRouteLayer,
+  prometheusMetricsRouteLayer,
   projectFaviconRouteLayer,
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
@@ -308,6 +309,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   orchestrationDispatchRouteLayer,
   orchestrationSnapshotRouteLayer,
   otlpTracesProxyRouteLayer,
+  prometheusMetricsRouteLayer,
   projectFaviconRouteLayer,
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -20,6 +20,7 @@ import { GitCommandError, type VcsRef } from "@t3tools/contracts";
 import { dedupeRemoteBranchesWithLocalMatches } from "@t3tools/shared/git";
 import { compactTraceAttributes } from "@t3tools/shared/observability";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
+import { recordPrometheusGitOperation } from "../diagnostics/PrometheusMetrics.ts";
 import { gitCommandDuration, gitCommandsTotal, withMetrics } from "../observability/Metrics.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 import {
@@ -714,6 +715,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
 
   const execute: GitVcsDriver.GitVcsDriverShape["execute"] = (input) =>
     executeRaw(input).pipe(
+      Effect.ensuring(recordPrometheusGitOperation(input.operation)),
       withMetrics({
         counter: gitCommandsTotal,
         timer: gitCommandDuration,


### PR DESCRIPTION
/claim #833

Summary:
- Add authenticated /metrics endpoint with METRICS_AUTH_DISABLED=true bypass.
- Export Prometheus metrics for active sessions, RPC request totals/durations, Git operations, and RSS memory usage.
- Add Prometheus formatter and counter increment tests.

Validation:
- bun run fmt
- bun run lint
- bun run typecheck
- bun run test src/diagnostics/PrometheusMetrics.test.ts
- bun run test src/observability/RpcInstrumentation.test.ts
- bun run test src/vcs/GitVcsDriverCore.test.ts
- bun run test src/http.test.ts