### PR TITLE
Codex [ T3 Code ] Fix orchestration interrupt checkpointing

### DIFF
--- a/t3code/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/t3code/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -10,13 +10,16 @@ import {
   ProviderInstanceId,
 } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Metric from "effect/Metric";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { describe, expect, it } from "vitest";
 
 import { PersistenceSqlError } from "../../persistence/Errors.ts";
@@ -73,6 +76,36 @@ async function createOrchestrationSystem() {
   };
 }
 
+async function createOrchestrationSystemWithProjection(
+  projectionPipeline: OrchestrationProjectionPipelineShape,
+  options?: { readonly useTestClock?: boolean },
+) {
+  const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
+    prefix: "t3-orchestration-engine-interrupt-test-",
+  });
+  const orchestrationLayer = OrchestrationEngineLive.pipe(
+    Layer.provide(OrchestrationProjectionSnapshotQueryLive),
+    Layer.provide(Layer.succeed(OrchestrationProjectionPipeline, projectionPipeline)),
+    Layer.provide(OrchestrationEventStoreLive),
+    Layer.provide(OrchestrationCommandReceiptRepositoryLive),
+    Layer.provide(RepositoryIdentityResolverLive),
+    Layer.provide(SqlitePersistenceMemory),
+    Layer.provideMerge(ServerConfigLayer),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  const runtime = ManagedRuntime.make(
+    options?.useTestClock
+      ? orchestrationLayer.pipe(Layer.provideMerge(TestClock.layer()))
+      : orchestrationLayer,
+  );
+  const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
+  return {
+    engine,
+    run: <A, E>(effect: Effect.Effect<A, E>) => runtime.runPromise(effect),
+    dispose: () => runtime.dispose(),
+  };
+}
+
 function now() {
   return "2026-01-01T00:00:00.000Z";
 }
@@ -89,6 +122,121 @@ const hasMetricSnapshot = (
   );
 
 describe("OrchestrationEngine", () => {
+  it("checkpoints command state when the dispatch fiber is interrupted by the client", async () => {
+    const projectionStarted = Effect.runSync(Deferred.make<void>());
+    const projectionPipeline: OrchestrationProjectionPipelineShape = {
+      bootstrap: Effect.void,
+      projectEvent: () =>
+        Deferred.succeed(projectionStarted, undefined).pipe(Effect.andThen(Effect.never)),
+    };
+    const system = await createOrchestrationSystemWithProjection(projectionPipeline);
+    const command = {
+      type: "project.create" as const,
+      commandId: CommandId.make("cmd-client-interrupt-project-create"),
+      projectId: asProjectId("project-client-interrupt"),
+      title: "Client Interrupt Project",
+      workspaceRoot: "/tmp/project-client-interrupt",
+      defaultModelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5-codex",
+      },
+      createdAt: now(),
+    };
+
+    try {
+      const checkpoint = await system.run(
+        Effect.gen(function* () {
+          const dispatchFiber = yield* Effect.forkScoped(system.engine.dispatch(command));
+          yield* Deferred.await(projectionStarted);
+          yield* Fiber.interrupt(dispatchFiber);
+          return yield* system.engine.getInterruptedCommandCheckpoint!(command.commandId);
+        }).pipe(Effect.scoped),
+      );
+
+      expect(Option.isSome(checkpoint)).toBe(true);
+      if (Option.isSome(checkpoint)) {
+        expect(checkpoint.value.commandId).toBe(command.commandId);
+        expect(checkpoint.value.commandType).toBe("project.create");
+        expect(checkpoint.value.reason).toBe("dispatch-interrupted");
+        expect(checkpoint.value.fiberId).toBeGreaterThanOrEqual(0);
+        expect(checkpoint.value.partialState.snapshotSequence).toBe(0);
+      }
+    } finally {
+      await system.dispose();
+    }
+  });
+
+  it("allows timeout-interrupted commands to be queried and resumed with TestClock", async () => {
+    const projectionStarted = Effect.runSync(Deferred.make<void>());
+    const projectionPipeline: OrchestrationProjectionPipelineShape = {
+      bootstrap: Effect.void,
+      projectEvent: () =>
+        Deferred.succeed(projectionStarted, undefined).pipe(
+          Effect.andThen(Effect.sleep("1 minute")),
+        ),
+    };
+    const system = await createOrchestrationSystemWithProjection(projectionPipeline, {
+      useTestClock: true,
+    });
+    const command = {
+      type: "project.create" as const,
+      commandId: CommandId.make("cmd-timeout-interrupt-project-create"),
+      projectId: asProjectId("project-timeout-interrupt"),
+      title: "Timeout Interrupt Project",
+      workspaceRoot: "/tmp/project-timeout-interrupt",
+      defaultModelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5-codex",
+      },
+      createdAt: now(),
+    };
+
+    try {
+      const result = await system.run(
+        Effect.gen(function* () {
+          const dispatchFiber = yield* Effect.forkScoped(
+            system.engine.dispatch(command).pipe(Effect.timeoutOption("50 millis")),
+          );
+          yield* Deferred.await(projectionStarted);
+          yield* TestClock.adjust("50 millis");
+          const timedDispatchResult = yield* Fiber.join(dispatchFiber);
+          const interruptedCheckpoint = yield* system.engine.getInterruptedCommandCheckpoint!(
+            command.commandId,
+          );
+          const resumeFiber = yield* Effect.forkScoped(
+            system.engine.resumeInterruptedCommand!(command.commandId),
+          );
+          yield* TestClock.adjust("1 minute");
+          const resumedResult = yield* Fiber.join(resumeFiber);
+          const checkpointAfterResume = yield* system.engine.getInterruptedCommandCheckpoint!(
+            command.commandId,
+          );
+          return {
+            timedDispatchResult,
+            interruptedCheckpoint,
+            resumedResult,
+            checkpointAfterResume,
+          };
+        }).pipe(Effect.scoped),
+      );
+
+      expect(Option.isNone(result.timedDispatchResult)).toBe(true);
+      expect(Option.isSome(result.interruptedCheckpoint)).toBe(true);
+      if (Option.isSome(result.interruptedCheckpoint)) {
+        expect(result.interruptedCheckpoint.value.commandId).toBe(command.commandId);
+        expect(result.interruptedCheckpoint.value.reason).toBe("dispatch-interrupted");
+        expect(result.interruptedCheckpoint.value.partialState.snapshotSequence).toBe(0);
+      }
+      expect(Option.isSome(result.resumedResult)).toBe(true);
+      if (Option.isSome(result.resumedResult)) {
+        expect(result.resumedResult.value.sequence).toBe(1);
+      }
+      expect(Option.isNone(result.checkpointAfterResume)).toBe(true);
+    } finally {
+      await system.dispose();
+    }
+  });
+
   it("bootstraps command handling from persisted projections without reading the full snapshot", async () => {
     let nextSequence = 8;
     const eventStore: OrchestrationEventStoreShape = {

--- a/t3code/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/t3code/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -42,6 +42,7 @@ import { OrchestrationProjectionPipeline } from "../Services/ProjectionPipeline.
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
   OrchestrationEngineService,
+  type OrchestrationInterruptedCommandCheckpoint,
   type OrchestrationEngineShape,
 } from "../Services/OrchestrationEngine.ts";
 const isOrchestrationCommandPreviouslyRejectedError = Schema.is(
@@ -87,6 +88,10 @@ const makeOrchestrationEngine = Effect.gen(function* () {
 
   const commandQueue = yield* Queue.unbounded<CommandEnvelope>();
   const eventPubSub = yield* PubSub.unbounded<OrchestrationEvent>();
+  const interruptedCommandCheckpoints = new Map<
+    OrchestrationCommand["commandId"],
+    OrchestrationInterruptedCommandCheckpoint
+  >();
 
   const projectEventsOntoReadModel = (
     baseReadModel: OrchestrationReadModel,
@@ -98,6 +103,46 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         nextReadModel = yield* projectEvent(nextReadModel, event);
       }
       return nextReadModel;
+    });
+
+  const recordInterruptedCommandCheckpoint = (input: {
+    readonly command: OrchestrationCommand;
+    readonly aggregateRef: ReturnType<typeof commandToAggregateRef>;
+    readonly reason: OrchestrationInterruptedCommandCheckpoint["reason"];
+    readonly fiberId: number;
+    readonly interruptors: ReadonlySet<number>;
+  }) =>
+    Effect.gen(function* () {
+      const interruptedAt = yield* nowIso;
+      const checkpoint: OrchestrationInterruptedCommandCheckpoint = {
+        commandId: input.command.commandId,
+        commandType: input.command.type,
+        command: structuredClone(input.command),
+        aggregateKind: input.aggregateRef.aggregateKind,
+        aggregateId: input.aggregateRef.aggregateId,
+        interruptedAt,
+        fiberId: input.fiberId,
+        interruptingFiberIds: Array.from(input.interruptors).toSorted(
+          (left, right) => left - right,
+        ),
+        reason: input.reason,
+        partialState: {
+          snapshotSequence: commandReadModel.snapshotSequence,
+          readModel: structuredClone(commandReadModel),
+        },
+      };
+      interruptedCommandCheckpoints.set(input.command.commandId, checkpoint);
+      yield* Effect.logWarning("orchestration command interrupted; checkpoint captured").pipe(
+        Effect.annotateLogs({
+          commandId: input.command.commandId,
+          commandType: input.command.type,
+          fiberId: input.fiberId,
+          interruptingFiberIds: checkpoint.interruptingFiberIds.join(","),
+          interruptedAt,
+          snapshotSequence: commandReadModel.snapshotSequence,
+          reason: input.reason,
+        }),
+      );
     });
 
   const processEnvelope = (envelope: CommandEnvelope): Effect.Effect<void> => {
@@ -122,6 +167,17 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         yield* PubSub.publish(eventPubSub, persistedEvent);
       }
     });
+
+    const onCommandProcessingInterrupted = (interruptors: ReadonlySet<number>) =>
+      Effect.withFiber((fiber) =>
+        recordInterruptedCommandCheckpoint({
+          command: envelope.command,
+          aggregateRef,
+          reason: "processing-interrupted",
+          fiberId: fiber.id,
+          interruptors,
+        }),
+      );
 
     return Effect.exit(
       Effect.gen(function* () {
@@ -216,7 +272,10 @@ const makeOrchestrationEngine = Effect.gen(function* () {
           }
         }
         return { sequence: committedCommand.lastSequence };
-      }).pipe(Effect.withSpan(`orchestration.command.${envelope.command.type}`)),
+      }).pipe(
+        Effect.withSpan(`orchestration.command.${envelope.command.type}`),
+        Effect.onInterrupt(onCommandProcessingInterrupted),
+      ),
     ).pipe(
       Effect.flatMap((exit) =>
         Effect.gen(function* () {
@@ -244,6 +303,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
           );
 
           if (Exit.isSuccess(exit)) {
+            interruptedCommandCheckpoints.delete(envelope.command.commandId);
             yield* Deferred.succeed(envelope.result, exit.value);
             return;
           }
@@ -299,17 +359,49 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   const dispatch: OrchestrationEngineShape["dispatch"] = (command) =>
     Effect.gen(function* () {
       const result = yield* Deferred.make<{ sequence: number }, OrchestrationDispatchError>();
+      const aggregateRef = commandToAggregateRef(command);
       yield* Queue.offer(commandQueue, {
         command,
         result,
         startedAtMs: yield* Clock.currentTimeMillis,
       });
-      return yield* Deferred.await(result);
+      return yield* Deferred.await(result).pipe(
+        Effect.onInterrupt((interruptors) =>
+          Effect.withFiber((fiber) =>
+            recordInterruptedCommandCheckpoint({
+              command,
+              aggregateRef,
+              reason: "dispatch-interrupted",
+              fiberId: fiber.id,
+              interruptors,
+            }),
+          ),
+        ),
+      );
+    });
+
+  const getInterruptedCommandCheckpoint: NonNullable<
+    OrchestrationEngineShape["getInterruptedCommandCheckpoint"]
+  > = (commandId) =>
+    Effect.sync(() => Option.fromUndefinedOr(interruptedCommandCheckpoints.get(commandId)));
+
+  const resumeInterruptedCommand: NonNullable<
+    OrchestrationEngineShape["resumeInterruptedCommand"]
+  > = (commandId) =>
+    Effect.gen(function* () {
+      const checkpoint = interruptedCommandCheckpoints.get(commandId);
+      if (!checkpoint) {
+        return Option.none();
+      }
+      const result = yield* dispatch(checkpoint.command);
+      return Option.some(result);
     });
 
   return {
     readEvents,
     dispatch,
+    getInterruptedCommandCheckpoint,
+    resumeInterruptedCommand,
     // Each access creates a fresh PubSub subscription so that multiple
     // consumers (wsServer, ProviderRuntimeIngestion, CheckpointReactor, etc.)
     // each independently receive all domain events.

--- a/t3code/apps/server/src/orchestration/Services/OrchestrationEngine.ts
+++ b/t3code/apps/server/src/orchestration/Services/OrchestrationEngine.ts
@@ -10,13 +10,36 @@
  *
  * @module OrchestrationEngineService
  */
-import type { OrchestrationCommand, OrchestrationEvent } from "@t3tools/contracts";
+import type {
+  OrchestrationCommand,
+  OrchestrationEvent,
+  OrchestrationReadModel,
+  ProjectId,
+  ThreadId,
+} from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
+import type * as Option from "effect/Option";
 import type * as Stream from "effect/Stream";
 
 import type { OrchestrationDispatchError } from "../Errors.ts";
 import type { OrchestrationEventStoreError } from "../../persistence/Errors.ts";
+
+export interface OrchestrationInterruptedCommandCheckpoint {
+  readonly commandId: OrchestrationCommand["commandId"];
+  readonly commandType: OrchestrationCommand["type"];
+  readonly command: OrchestrationCommand;
+  readonly aggregateKind: "project" | "thread";
+  readonly aggregateId: ProjectId | ThreadId;
+  readonly interruptedAt: string;
+  readonly fiberId: number;
+  readonly interruptingFiberIds: ReadonlyArray<number>;
+  readonly reason: "dispatch-interrupted" | "processing-interrupted";
+  readonly partialState: {
+    readonly snapshotSequence: number;
+    readonly readModel: OrchestrationReadModel;
+  };
+}
 
 /**
  * OrchestrationEngineShape - Service API for orchestration command and event flow.
@@ -44,6 +67,25 @@ export interface OrchestrationEngineShape {
   readonly dispatch: (
     command: OrchestrationCommand,
   ) => Effect.Effect<{ sequence: number }, OrchestrationDispatchError, never>;
+
+  /**
+   * Read the latest interrupt checkpoint for a command, if command handling was
+   * interrupted before the caller observed completion.
+   */
+  readonly getInterruptedCommandCheckpoint?: (
+    commandId: OrchestrationCommand["commandId"],
+  ) => Effect.Effect<Option.Option<OrchestrationInterruptedCommandCheckpoint>>;
+
+  /**
+   * Re-dispatch the command stored in an interrupt checkpoint.
+   *
+   * Normal command receipt deduplication makes this safe after the original
+   * command eventually commits; reconnecting callers receive the accepted
+   * sequence instead of duplicating domain events.
+   */
+  readonly resumeInterruptedCommand?: (
+    commandId: OrchestrationCommand["commandId"],
+  ) => Effect.Effect<Option.Option<{ sequence: number }>, OrchestrationDispatchError, never>;
 
   /**
    * Stream persisted domain events in dispatch order.


### PR DESCRIPTION
/claim #818

Summary:
- Add interrupt checkpoint capture around orchestration command dispatch and processing.
- Store interrupted command state for query/resume and clear it after successful completion.
- Cover client interrupt and timeout interrupt paths with TestClock-based tests.

Verification:
- bun fmt
- bun lint
- bun typecheck
- bun run test