### PR TITLE
Codex [ T3 Code ] Add checkpoint snapshot pruning

### DIFF
--- a/t3code/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/t3code/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -46,6 +46,7 @@ import {
 import { ProviderService } from "../src/provider/Services/ProviderService.ts";
 import { AnalyticsService } from "../src/telemetry/Services/AnalyticsService.ts";
 import { CheckpointReactorLive } from "../src/orchestration/Layers/CheckpointReactor.ts";
+import { CheckpointSnapshotPruner } from "../src/orchestration/checkpoint/CheckpointSnapshotPruner.ts";
 import { RepositoryIdentityResolverLive } from "../src/project/Layers/RepositoryIdentityResolver.ts";
 import { OrchestrationEngineLive } from "../src/orchestration/Layers/OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "../src/orchestration/Layers/ProjectionPipeline.ts";
@@ -295,6 +296,17 @@ export const makeOrchestrationIntegrationHarness = (
 
     const checkpointStoreLayer = CheckpointStoreLive.pipe(Layer.provide(VcsDriverRegistry.layer));
     const projectionSnapshotQueryLayer = OrchestrationProjectionSnapshotQueryLive;
+    const checkpointSnapshotPrunerLayer = Layer.succeed(CheckpointSnapshotPruner, {
+      pruneSnapshots: () =>
+        Effect.succeed({
+          snapshotsDeleted: 0,
+          bytesFreed: 0,
+          durationMs: 0,
+          retentionDays: 7,
+          minimumPerSession: 3,
+          cutoffIso: "2026-01-01T00:00:00.000Z",
+        }),
+    });
     const runtimeServicesLayer = Layer.mergeAll(
       projectionSnapshotQueryLayer,
       orchestrationLayer.pipe(Layer.provide(projectionSnapshotQueryLayer)),
@@ -328,6 +340,7 @@ export const makeOrchestrationIntegrationHarness = (
     );
     const checkpointReactorLayer = CheckpointReactorLive.pipe(
       Layer.provideMerge(runtimeServicesLayer),
+      Layer.provideMerge(checkpointSnapshotPrunerLayer),
       Layer.provideMerge(
         Layer.succeed(VcsStatusBroadcaster, {
           getStatus: () => Effect.die("getStatus should not be called in this test"),

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -173,6 +173,18 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     }),
   );
 
+  it.effect("executes checkpoint pruning subcommand with retention days", () =>
+    Effect.gen(function* () {
+      const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-checkpoint-prune-test-"));
+
+      const output = yield* captureStdout(
+        runCli(["checkpoint:prune", "--base-dir", baseDir, "--days", "1"]),
+      );
+
+      assert.equal(output.output.includes("Pruned 0 checkpoint snapshots"), true);
+    }),
+  );
+
   it.effect("executes auth pairing subcommands and redacts secrets from list output", () =>
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-auth-pairing-test-"));

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -7,6 +7,7 @@ import { Command } from "effect/unstable/cli";
 import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
+import { checkpointPruneCommand } from "./cli/checkpoint.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
@@ -16,7 +17,13 @@ const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    checkpointPruneCommand,
+  ]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/cli/checkpoint.ts
+++ b/t3code/apps/server/src/cli/checkpoint.ts
@@ -1,0 +1,55 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { Command, Flag, GlobalFlag } from "effect/unstable/cli";
+
+import { CheckpointStoreLive } from "../checkpointing/Layers/CheckpointStore.ts";
+import { ServerConfig } from "../config.ts";
+import {
+  CheckpointSnapshotPruner,
+  CheckpointSnapshotPrunerLive,
+  DEFAULT_CHECKPOINT_SNAPSHOT_RETENTION_DAYS,
+} from "../orchestration/checkpoint/CheckpointSnapshotPruner.ts";
+import { layerConfig as SqlitePersistenceLayerLive } from "../persistence/Layers/Sqlite.ts";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import { projectLocationFlags, type CliAuthLocationFlags, resolveCliAuthConfig } from "./config.ts";
+
+const daysFlag = Flag.integer("days").pipe(
+  Flag.withDescription("Retention period in days for checkpoint snapshots."),
+  Flag.withDefault(DEFAULT_CHECKPOINT_SNAPSHOT_RETENTION_DAYS),
+);
+
+const CheckpointStoreCliLayer = CheckpointStoreLive.pipe(Layer.provide(VcsDriverRegistry.layer));
+
+const CheckpointPruneCliLayer = CheckpointSnapshotPrunerLive.pipe(
+  Layer.provideMerge(CheckpointStoreCliLayer),
+  Layer.provideMerge(SqlitePersistenceLayerLive),
+  Layer.provideMerge(VcsProcess.layer),
+);
+
+const runCheckpointPruneCommand = (flags: CliAuthLocationFlags & { readonly days: number }) =>
+  Effect.gen(function* () {
+    const logLevel = yield* GlobalFlag.LogLevel;
+    const config = yield* resolveCliAuthConfig(flags, logLevel);
+
+    return yield* Effect.gen(function* () {
+      const pruner = yield* CheckpointSnapshotPruner;
+      const result = yield* pruner.pruneSnapshots({ retentionDays: flags.days });
+      yield* Console.log(
+        `Pruned ${result.snapshotsDeleted} checkpoint snapshots; freed ${result.bytesFreed} bytes in ${result.durationMs}ms.`,
+      );
+    }).pipe(
+      Effect.provide(
+        CheckpointPruneCliLayer.pipe(Layer.provide(Layer.succeed(ServerConfig, config))),
+      ),
+    );
+  });
+
+export const checkpointPruneCommand = Command.make("checkpoint:prune", {
+  ...projectLocationFlags,
+  days: daysFlag,
+}).pipe(
+  Command.withDescription("Prune old checkpoint snapshots."),
+  Command.withHandler((flags) => runCheckpointPruneCommand(flags)),
+);

--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -66,6 +66,18 @@ export const gitCommandDuration = Metric.timer("t3_git_command_duration", {
   description: "Git command execution duration.",
 });
 
+export const checkpointSnapshotsDeleted = Metric.counter("t3_checkpoint_snapshots_deleted_total", {
+  description: "Total checkpoint snapshots pruned.",
+});
+
+export const checkpointBytesFreed = Metric.counter("t3_checkpoint_bytes_freed_total", {
+  description: "Estimated bytes freed by checkpoint snapshot pruning.",
+});
+
+export const checkpointPruneDuration = Metric.timer("t3_checkpoint_prune_duration", {
+  description: "Checkpoint snapshot pruning duration.",
+});
+
 export const terminalSessionsTotal = Metric.counter("t3_terminal_sessions_total", {
   description: "Total terminal sessions started.",
 });

--- a/t3code/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/t3code/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -37,6 +37,7 @@ import * as VcsProcess from "../../vcs/VcsProcess.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { RepositoryIdentityResolverLive } from "../../project/Layers/RepositoryIdentityResolver.ts";
 import { CheckpointReactorLive } from "./CheckpointReactor.ts";
+import { CheckpointSnapshotPruner } from "../checkpoint/CheckpointSnapshotPruner.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
@@ -61,6 +62,17 @@ import { WorkspacePathsLive } from "../../workspace/Layers/WorkspacePaths.ts";
 
 const asProjectId = (value: string): ProjectId => ProjectId.make(value);
 const asTurnId = (value: string): TurnId => TurnId.make(value);
+const CheckpointSnapshotPrunerNoopLayer = Layer.succeed(CheckpointSnapshotPruner, {
+  pruneSnapshots: () =>
+    Effect.succeed({
+      snapshotsDeleted: 0,
+      bytesFreed: 0,
+      durationMs: 0,
+      retentionDays: 7,
+      minimumPerSession: 3,
+      cutoffIso: "2026-01-01T00:00:00.000Z",
+    }),
+});
 
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
@@ -327,6 +339,7 @@ describe("CheckpointReactor", () => {
       Layer.provideMerge(projectionSnapshotLayer),
       Layer.provideMerge(RuntimeReceiptBusLive),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
+      Layer.provideMerge(CheckpointSnapshotPrunerNoopLayer),
       Layer.provideMerge(vcsStatusBroadcasterLayer),
       Layer.provideMerge(CheckpointStoreLive.pipe(Layer.provide(VcsDriverRegistry.layer))),
       Layer.provideMerge(

--- a/t3code/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/t3code/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -13,6 +13,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
@@ -23,6 +24,10 @@ import {
 } from "../../checkpointing/Utils.ts";
 import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import {
+  CHECKPOINT_SNAPSHOT_PRUNE_INTERVAL,
+  CheckpointSnapshotPruner,
+} from "../checkpoint/CheckpointSnapshotPruner.ts";
 import { CheckpointReactor, type CheckpointReactorShape } from "../Services/CheckpointReactor.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
@@ -77,6 +82,7 @@ const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
   const checkpointStore = yield* CheckpointStore;
+  const checkpointSnapshotPruner = yield* CheckpointSnapshotPruner;
   const receiptBus = yield* RuntimeReceiptBus;
   const workspaceEntries = yield* WorkspaceEntries;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
@@ -807,6 +813,20 @@ const make = Effect.gen(function* () {
   const worker = yield* makeDrainableWorker(processInputSafely);
 
   const start: CheckpointReactorShape["start"] = Effect.fn("start")(function* () {
+    yield* Effect.forkScoped(
+      checkpointSnapshotPruner.pruneSnapshots().pipe(
+        Effect.catchCause((cause) => {
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.failCause(cause);
+          }
+          return Effect.logWarning("checkpoint snapshot pruning failed", {
+            cause: Cause.pretty(cause),
+          });
+        }),
+        Effect.repeat(Schedule.fixed(CHECKPOINT_SNAPSHOT_PRUNE_INTERVAL)),
+      ),
+    );
+
     yield* Effect.forkScoped(
       Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
         if (

--- a/t3code/apps/server/src/orchestration/checkpoint/CheckpointSnapshotPruner.test.ts
+++ b/t3code/apps/server/src/orchestration/checkpoint/CheckpointSnapshotPruner.test.ts
@@ -1,0 +1,386 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import path from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import { CheckpointRef, ThreadId } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
+import * as Scope from "effect/Scope";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import type { SqlError } from "effect/unstable/sql/SqlError";
+
+import { CheckpointStoreLive } from "../../checkpointing/Layers/CheckpointStore.ts";
+import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
+import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
+import { checkpointRefForThreadTurn } from "../../checkpointing/Utils.ts";
+import { ServerConfig } from "../../config.ts";
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import * as VcsDriverRegistry from "../../vcs/VcsDriverRegistry.ts";
+import type { VcsError } from "@t3tools/contracts";
+import * as VcsProcess from "../../vcs/VcsProcess.ts";
+import {
+  CheckpointSnapshotPruner,
+  CheckpointSnapshotPrunerLive,
+} from "./CheckpointSnapshotPruner.ts";
+
+const NOW_MS = DateTime.toEpochMillis(DateTime.makeUnsafe("2026-05-15T00:00:00.000Z"));
+const OLD_COMPLETED_AT = "2026-05-01T00:00:00.000Z";
+const RECENT_COMPLETED_AT = "2026-05-14T00:00:00.000Z";
+
+const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-checkpoint-pruner-test-",
+});
+const CheckpointStoreTestLayer = CheckpointStoreLive.pipe(Layer.provide(VcsDriverRegistry.layer));
+const TestLayer = Layer.empty.pipe(
+  Layer.provideMerge(SqlitePersistenceMemory),
+  Layer.provideMerge(CheckpointStoreTestLayer),
+  Layer.provideMerge(
+    CheckpointSnapshotPrunerLive.pipe(
+      Layer.provideMerge(CheckpointStoreTestLayer),
+      Layer.provideMerge(SqlitePersistenceMemory),
+    ),
+  ),
+  Layer.provideMerge(VcsProcess.layer),
+  Layer.provideMerge(ServerConfigLayer),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+function makeTmpDir(
+  prefix = "checkpoint-pruner-test-",
+): Effect.Effect<string, PlatformError.PlatformError, FileSystem.FileSystem | Scope.Scope> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    return yield* fileSystem.makeTempDirectoryScoped({ prefix });
+  });
+}
+
+function writeTextFile(
+  filePath: string,
+  contents: string,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fileSystem.writeFileString(filePath, contents);
+  });
+}
+
+function git(
+  cwd: string,
+  args: ReadonlyArray<string>,
+): Effect.Effect<string, VcsError, VcsProcess.VcsProcess> {
+  return Effect.gen(function* () {
+    const process = yield* VcsProcess.VcsProcess;
+    const result = yield* process.run({
+      operation: "CheckpointSnapshotPruner.test.git",
+      command: "git",
+      cwd,
+      args,
+      timeoutMs: 10_000,
+    });
+    return result.stdout.trim();
+  });
+}
+
+function initRepoWithCommit(
+  cwd: string,
+): Effect.Effect<
+  void,
+  VcsError | PlatformError.PlatformError,
+  VcsProcess.VcsProcess | FileSystem.FileSystem
+> {
+  return Effect.gen(function* () {
+    yield* git(cwd, ["init"]);
+    yield* git(cwd, ["config", "user.email", "test@test.com"]);
+    yield* git(cwd, ["config", "user.name", "Test"]);
+    yield* writeTextFile(path.join(cwd, "README.md"), "# test\n");
+    yield* git(cwd, ["add", "."]);
+    yield* git(cwd, ["commit", "-m", "initial commit"]);
+  });
+}
+
+function seedThread(input: {
+  readonly cwd: string;
+  readonly threadId: ThreadId;
+}): Effect.Effect<void, SqlError, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const projectId = `project-${input.threadId}`;
+    yield* sql`
+      INSERT INTO projection_projects (
+        project_id,
+        title,
+        workspace_root,
+        scripts_json,
+        created_at,
+        updated_at,
+        deleted_at,
+        default_model_selection_json
+      )
+      VALUES (
+        ${projectId},
+        'Checkpoint Pruner Project',
+        ${input.cwd},
+        '[]',
+        ${OLD_COMPLETED_AT},
+        ${OLD_COMPLETED_AT},
+        NULL,
+        NULL
+      )
+    `;
+    yield* sql`
+      INSERT INTO projection_threads (
+        thread_id,
+        project_id,
+        title,
+        branch,
+        worktree_path,
+        latest_turn_id,
+        created_at,
+        updated_at,
+        deleted_at,
+        archived_at,
+        runtime_mode,
+        interaction_mode,
+        latest_user_message_at,
+        pending_approval_count,
+        pending_user_input_count,
+        has_actionable_proposed_plan,
+        model_selection_json
+      )
+      VALUES (
+        ${input.threadId},
+        ${projectId},
+        'Checkpoint Pruner Thread',
+        NULL,
+        NULL,
+        NULL,
+        ${OLD_COMPLETED_AT},
+        ${OLD_COMPLETED_AT},
+        NULL,
+        NULL,
+        'full-access',
+        'default',
+        NULL,
+        0,
+        0,
+        0,
+        NULL
+      )
+    `;
+  });
+}
+
+function captureProjectionCheckpoint(input: {
+  readonly cwd: string;
+  readonly threadId: ThreadId;
+  readonly turnCount: number;
+  readonly completedAt: string;
+}): Effect.Effect<
+  CheckpointRef,
+  CheckpointStoreError | PlatformError.PlatformError | SqlError,
+  CheckpointStore | FileSystem.FileSystem | SqlClient.SqlClient
+> {
+  return Effect.gen(function* () {
+    const checkpointStore = yield* CheckpointStore;
+    const sql = yield* SqlClient.SqlClient;
+    const checkpointRef = checkpointRefForThreadTurn(input.threadId, input.turnCount);
+
+    yield* writeTextFile(path.join(input.cwd, "README.md"), `# test\nturn ${input.turnCount}\n`);
+    yield* checkpointStore.captureCheckpoint({
+      cwd: input.cwd,
+      checkpointRef,
+    });
+    yield* sql`
+      INSERT INTO projection_turns (
+        thread_id,
+        turn_id,
+        pending_message_id,
+        source_proposed_plan_thread_id,
+        source_proposed_plan_id,
+        assistant_message_id,
+        state,
+        requested_at,
+        started_at,
+        completed_at,
+        checkpoint_turn_count,
+        checkpoint_ref,
+        checkpoint_status,
+        checkpoint_files_json
+      )
+      VALUES (
+        ${input.threadId},
+        ${`turn-${input.turnCount}`},
+        NULL,
+        NULL,
+        NULL,
+        ${`assistant-${input.turnCount}`},
+        'completed',
+        ${input.completedAt},
+        ${input.completedAt},
+        ${input.completedAt},
+        ${input.turnCount},
+        ${checkpointRef},
+        'ready',
+        '[{"path":"README.md","kind":"modified","additions":1,"deletions":0}]'
+      )
+    `;
+    yield* sql`
+      INSERT INTO checkpoint_diff_blobs (
+        thread_id,
+        from_turn_count,
+        to_turn_count,
+        diff,
+        created_at
+      )
+      VALUES (
+        ${input.threadId},
+        ${Math.max(0, input.turnCount - 1)},
+        ${input.turnCount},
+        ${`diff-${input.turnCount}`},
+        ${input.completedAt}
+      )
+    `;
+
+    return checkpointRef;
+  });
+}
+
+function listRemainingCheckpointTurnCounts(
+  threadId: ThreadId,
+): Effect.Effect<ReadonlyArray<number>, SqlError, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql<{ readonly checkpointTurnCount: number }>`
+      SELECT checkpoint_turn_count AS "checkpointTurnCount"
+      FROM projection_turns
+      WHERE checkpoint_turn_count IS NOT NULL
+        AND thread_id = ${threadId}
+      ORDER BY checkpoint_turn_count ASC
+    `;
+    return rows.map((row) => row.checkpointTurnCount);
+  });
+}
+
+function checkpointRefExists(cwd: string, checkpointRef: CheckpointRef) {
+  return Effect.gen(function* () {
+    const checkpointStore = yield* CheckpointStore;
+    return yield* checkpointStore.hasCheckpointRef({
+      cwd,
+      checkpointRef,
+    });
+  });
+}
+
+it.layer(TestLayer)("CheckpointSnapshotPruner", (it) => {
+  it.effect("prunes snapshots older than retention while preserving the latest three", () =>
+    Effect.gen(function* () {
+      const cwd = yield* makeTmpDir();
+      yield* initRepoWithCommit(cwd);
+      const threadId = ThreadId.make("thread-prune-retention");
+      yield* seedThread({ cwd, threadId });
+
+      const refs = yield* Effect.forEach([1, 2, 3, 4, 5], (turnCount) =>
+        captureProjectionCheckpoint({
+          cwd,
+          threadId,
+          turnCount,
+          completedAt: turnCount <= 3 ? OLD_COMPLETED_AT : RECENT_COMPLETED_AT,
+        }),
+      );
+      const [ref1, ref2, ref3, ref4, ref5] = refs as [
+        CheckpointRef,
+        CheckpointRef,
+        CheckpointRef,
+        CheckpointRef,
+        CheckpointRef,
+      ];
+
+      const pruner = yield* CheckpointSnapshotPruner;
+      const result = yield* pruner.pruneSnapshots({
+        retentionDays: 7,
+        nowMs: NOW_MS,
+      });
+
+      assert.equal(result.snapshotsDeleted, 2);
+      assert.equal(result.bytesFreed > 0, true);
+      assert.deepEqual(yield* listRemainingCheckpointTurnCounts(threadId), [3, 4, 5]);
+      assert.equal(yield* checkpointRefExists(cwd, ref1), false);
+      assert.equal(yield* checkpointRefExists(cwd, ref2), false);
+      assert.equal(yield* checkpointRefExists(cwd, ref3), true);
+      assert.equal(yield* checkpointRefExists(cwd, ref4), true);
+      assert.equal(yield* checkpointRefExists(cwd, ref5), true);
+    }),
+  );
+
+  it.effect("keeps at least three snapshots per session regardless of age", () =>
+    Effect.gen(function* () {
+      const cwd = yield* makeTmpDir();
+      yield* initRepoWithCommit(cwd);
+      const threadId = ThreadId.make("thread-prune-minimum");
+      yield* seedThread({ cwd, threadId });
+
+      const refs = yield* Effect.forEach([1, 2, 3], (turnCount) =>
+        captureProjectionCheckpoint({
+          cwd,
+          threadId,
+          turnCount,
+          completedAt: OLD_COMPLETED_AT,
+        }),
+      );
+
+      const pruner = yield* CheckpointSnapshotPruner;
+      const result = yield* pruner.pruneSnapshots({
+        retentionDays: 7,
+        nowMs: NOW_MS,
+      });
+
+      assert.equal(result.snapshotsDeleted, 0);
+      assert.deepEqual(yield* listRemainingCheckpointTurnCounts(threadId), [1, 2, 3]);
+      for (const ref of refs) {
+        assert.equal(yield* checkpointRefExists(cwd, ref), true);
+      }
+    }),
+  );
+
+  it.effect("allows checkpoint capture to proceed while pruning runs", () =>
+    Effect.gen(function* () {
+      const cwd = yield* makeTmpDir();
+      yield* initRepoWithCommit(cwd);
+      const threadId = ThreadId.make("thread-prune-concurrent");
+      yield* seedThread({ cwd, threadId });
+      yield* Effect.forEach([1, 2, 3, 4, 5, 6], (turnCount) =>
+        captureProjectionCheckpoint({
+          cwd,
+          threadId,
+          turnCount,
+          completedAt: OLD_COMPLETED_AT,
+        }),
+      );
+
+      const pruner = yield* CheckpointSnapshotPruner;
+      const checkpointStore = yield* CheckpointStore;
+      const concurrentRef = checkpointRefForThreadTurn(threadId, 99);
+      const [result] = yield* Effect.all(
+        [
+          pruner.pruneSnapshots({ retentionDays: 7, nowMs: NOW_MS }),
+          Effect.gen(function* () {
+            yield* writeTextFile(path.join(cwd, "README.md"), "# concurrent\n");
+            yield* checkpointStore.captureCheckpoint({
+              cwd,
+              checkpointRef: concurrentRef,
+            });
+          }),
+        ],
+        { concurrency: 2 },
+      );
+
+      assert.equal(result.snapshotsDeleted, 3);
+      assert.deepEqual(yield* listRemainingCheckpointTurnCounts(threadId), [4, 5, 6]);
+      assert.equal(yield* checkpointRefExists(cwd, concurrentRef), true);
+    }),
+  );
+});

--- a/t3code/apps/server/src/orchestration/checkpoint/CheckpointSnapshotPruner.ts
+++ b/t3code/apps/server/src/orchestration/checkpoint/CheckpointSnapshotPruner.ts
@@ -1,0 +1,330 @@
+import { CheckpointRef } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Metric from "effect/Metric";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
+import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
+import {
+  checkpointBytesFreed,
+  checkpointPruneDuration,
+  checkpointSnapshotsDeleted,
+  metricAttributes,
+} from "../../observability/Metrics.ts";
+import { toPersistenceSqlError, type ProjectionRepositoryError } from "../../persistence/Errors.ts";
+
+export const DEFAULT_CHECKPOINT_SNAPSHOT_RETENTION_DAYS = 7;
+export const DEFAULT_CHECKPOINT_SNAPSHOT_MINIMUM_PER_SESSION = 3;
+export const CHECKPOINT_SNAPSHOT_PRUNE_INTERVAL = Duration.hours(1);
+
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+interface CheckpointSnapshotRow {
+  readonly rowId: number;
+  readonly threadId: string;
+  readonly checkpointTurnCount: number;
+  readonly checkpointRef: string;
+  readonly completedAt: string;
+  readonly workspaceRoot: string | null;
+  readonly worktreePath: string | null;
+  readonly byteSize: number;
+}
+
+export interface PruneSnapshotsInput {
+  readonly retentionDays?: number;
+  readonly minimumPerSession?: number;
+  readonly nowMs?: number;
+}
+
+export interface PruneSnapshotsResult {
+  readonly snapshotsDeleted: number;
+  readonly bytesFreed: number;
+  readonly durationMs: number;
+  readonly retentionDays: number;
+  readonly minimumPerSession: number;
+  readonly cutoffIso: string;
+}
+
+export class CheckpointPruneInputError extends Data.TaggedError("CheckpointPruneInputError")<{
+  readonly message: string;
+}> {}
+
+export type CheckpointSnapshotPruneError =
+  | CheckpointPruneInputError
+  | CheckpointStoreError
+  | ProjectionRepositoryError;
+
+export interface CheckpointSnapshotPrunerShape {
+  readonly pruneSnapshots: (
+    input?: PruneSnapshotsInput,
+  ) => Effect.Effect<PruneSnapshotsResult, CheckpointSnapshotPruneError>;
+}
+
+export class CheckpointSnapshotPruner extends Context.Service<
+  CheckpointSnapshotPruner,
+  CheckpointSnapshotPrunerShape
+>()("t3/orchestration/checkpoint/CheckpointSnapshotPruner") {}
+
+function normalizeNonNegativeInteger(input: {
+  readonly value: number | undefined;
+  readonly defaultValue: number;
+  readonly name: string;
+}): Effect.Effect<number, CheckpointPruneInputError> {
+  const value = input.value ?? input.defaultValue;
+  if (!Number.isInteger(value) || value < 0) {
+    return Effect.fail(
+      new CheckpointPruneInputError({
+        message: `${input.name} must be a non-negative integer.`,
+      }),
+    );
+  }
+  return Effect.succeed(value);
+}
+
+function completedAtMillis(row: CheckpointSnapshotRow): number | null {
+  const millis = Date.parse(row.completedAt);
+  return Number.isFinite(millis) ? millis : null;
+}
+
+function groupByThread(
+  rows: ReadonlyArray<CheckpointSnapshotRow>,
+): Map<string, ReadonlyArray<CheckpointSnapshotRow>> {
+  const grouped = new Map<string, Array<CheckpointSnapshotRow>>();
+  for (const row of rows) {
+    const threadRows = grouped.get(row.threadId) ?? [];
+    threadRows.push(row);
+    grouped.set(row.threadId, threadRows);
+  }
+  return grouped;
+}
+
+function resolveWorkspaceCwd(row: CheckpointSnapshotRow): string | undefined {
+  return row.worktreePath ?? row.workspaceRoot ?? undefined;
+}
+
+const make = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const checkpointStore = yield* CheckpointStore;
+
+  const listCheckpointRows = () =>
+    sql<CheckpointSnapshotRow>`
+      SELECT
+        turns.row_id AS "rowId",
+        turns.thread_id AS "threadId",
+        turns.checkpoint_turn_count AS "checkpointTurnCount",
+        turns.checkpoint_ref AS "checkpointRef",
+        turns.completed_at AS "completedAt",
+        projects.workspace_root AS "workspaceRoot",
+        threads.worktree_path AS "worktreePath",
+        (
+          length(coalesce(turns.checkpoint_ref, '')) +
+          length(coalesce(turns.checkpoint_status, '')) +
+          length(coalesce(turns.checkpoint_files_json, '')) +
+          coalesce((
+            SELECT sum(length(diff))
+            FROM checkpoint_diff_blobs AS blobs
+            WHERE blobs.thread_id = turns.thread_id
+              AND (
+                blobs.from_turn_count = turns.checkpoint_turn_count
+                OR blobs.to_turn_count = turns.checkpoint_turn_count
+              )
+          ), 0)
+        ) AS "byteSize"
+      FROM projection_turns AS turns
+      LEFT JOIN projection_threads AS threads
+        ON threads.thread_id = turns.thread_id
+      LEFT JOIN projection_projects AS projects
+        ON projects.project_id = threads.project_id
+      WHERE turns.checkpoint_turn_count IS NOT NULL
+        AND turns.checkpoint_ref IS NOT NULL
+        AND turns.completed_at IS NOT NULL
+      ORDER BY turns.thread_id ASC, turns.checkpoint_turn_count ASC
+    `.pipe(
+      Effect.mapError(toPersistenceSqlError("CheckpointSnapshotPruner.listCheckpointRows:query")),
+    );
+
+  const clearCheckpointRows = (rows: ReadonlyArray<CheckpointSnapshotRow>) => {
+    if (rows.length === 0) {
+      return Effect.void;
+    }
+
+    return sql
+      .withTransaction(
+        Effect.forEach(
+          rows,
+          (row) =>
+            Effect.all(
+              [
+                sql`
+                UPDATE projection_turns
+                SET
+                  checkpoint_turn_count = NULL,
+                  checkpoint_ref = NULL,
+                  checkpoint_status = NULL,
+                  checkpoint_files_json = '[]'
+                WHERE row_id = ${row.rowId}
+              `,
+                sql`
+                DELETE FROM checkpoint_diff_blobs
+                WHERE thread_id = ${row.threadId}
+                  AND (
+                    from_turn_count = ${row.checkpointTurnCount}
+                    OR to_turn_count = ${row.checkpointTurnCount}
+                  )
+              `,
+              ],
+              { discard: true },
+            ),
+          { discard: true },
+        ),
+      )
+      .pipe(
+        Effect.mapError(
+          toPersistenceSqlError("CheckpointSnapshotPruner.clearCheckpointRows:query"),
+        ),
+      );
+  };
+
+  const pruneSnapshots: CheckpointSnapshotPrunerShape["pruneSnapshots"] = Effect.fn(
+    "CheckpointSnapshotPruner.pruneSnapshots",
+  )(function* (input = {}) {
+    const startedAtMs = yield* Clock.currentTimeMillis;
+    const retentionDays = yield* normalizeNonNegativeInteger({
+      value: input.retentionDays,
+      defaultValue: DEFAULT_CHECKPOINT_SNAPSHOT_RETENTION_DAYS,
+      name: "retentionDays",
+    });
+    const minimumPerSession = yield* normalizeNonNegativeInteger({
+      value: input.minimumPerSession,
+      defaultValue: DEFAULT_CHECKPOINT_SNAPSHOT_MINIMUM_PER_SESSION,
+      name: "minimumPerSession",
+    });
+
+    const nowMs = input.nowMs ?? (yield* Clock.currentTimeMillis);
+    if (!Number.isFinite(nowMs)) {
+      return yield* new CheckpointPruneInputError({
+        message: "nowMs must be a finite epoch millisecond timestamp.",
+      });
+    }
+    const cutoffMs = nowMs - retentionDays * MS_PER_DAY;
+    const cutoffIso = DateTime.formatIso(DateTime.makeUnsafe(cutoffMs));
+    const rows = yield* listCheckpointRows();
+    const preservedRowIds = new Set<number>();
+
+    for (const threadRows of groupByThread(rows).values()) {
+      const latestRows = threadRows
+        .toSorted((left, right) => {
+          const turnDelta = right.checkpointTurnCount - left.checkpointTurnCount;
+          if (turnDelta !== 0) return turnDelta;
+          return (completedAtMillis(right) ?? 0) - (completedAtMillis(left) ?? 0);
+        })
+        .slice(0, minimumPerSession);
+
+      for (const row of latestRows) {
+        preservedRowIds.add(row.rowId);
+      }
+    }
+
+    const candidates = rows.filter((row) => {
+      const completedMs = completedAtMillis(row);
+      return completedMs !== null && completedMs < cutoffMs && !preservedRowIds.has(row.rowId);
+    });
+
+    const rowIdsWithDeletedRefs = new Set<number>();
+    const candidatesByCwd = new Map<string, Array<CheckpointSnapshotRow>>();
+    for (const row of candidates) {
+      const cwd = resolveWorkspaceCwd(row);
+      if (!cwd) {
+        rowIdsWithDeletedRefs.add(row.rowId);
+        continue;
+      }
+      const cwdRows = candidatesByCwd.get(cwd) ?? [];
+      cwdRows.push(row);
+      candidatesByCwd.set(cwd, cwdRows);
+    }
+
+    for (const [cwd, cwdRows] of candidatesByCwd) {
+      const deletedRefs = yield* checkpointStore
+        .deleteCheckpointRefs({
+          cwd,
+          checkpointRefs: cwdRows.map((row) => CheckpointRef.make(row.checkpointRef)),
+        })
+        .pipe(
+          Effect.map(() => true),
+          Effect.catch((error) =>
+            Effect.logWarning("checkpoint snapshot pruning skipped workspace refs", {
+              cwd,
+              snapshotCount: cwdRows.length,
+              error: error.message,
+            }).pipe(Effect.as(false)),
+          ),
+        );
+
+      if (deletedRefs) {
+        for (const row of cwdRows) {
+          rowIdsWithDeletedRefs.add(row.rowId);
+        }
+      }
+    }
+
+    const rowsToClear = candidates.filter((row) => rowIdsWithDeletedRefs.has(row.rowId));
+    yield* clearCheckpointRows(rowsToClear);
+
+    const endedAtMs = yield* Clock.currentTimeMillis;
+    const durationMs = Math.max(0, endedAtMs - startedAtMs);
+    const snapshotsDeleted = rowsToClear.length;
+    const bytesFreed = rowsToClear.reduce(
+      (sum, row) => sum + Math.max(0, Number(row.byteSize) || 0),
+      0,
+    );
+    const metricAttrs = {
+      retention_days: retentionDays,
+      minimum_per_session: minimumPerSession,
+    };
+
+    yield* Metric.update(
+      Metric.withAttributes(checkpointSnapshotsDeleted, metricAttributes(metricAttrs)),
+      snapshotsDeleted,
+    );
+    yield* Metric.update(
+      Metric.withAttributes(checkpointBytesFreed, metricAttributes(metricAttrs)),
+      bytesFreed,
+    );
+    yield* Metric.update(
+      Metric.withAttributes(checkpointPruneDuration, metricAttributes(metricAttrs)),
+      Duration.millis(durationMs),
+    );
+
+    const result = {
+      snapshotsDeleted,
+      bytesFreed,
+      durationMs,
+      retentionDays,
+      minimumPerSession,
+      cutoffIso,
+    } satisfies PruneSnapshotsResult;
+
+    yield* Effect.logInfo("checkpoint snapshot pruning complete", {
+      snapshots_deleted: result.snapshotsDeleted,
+      bytes_freed: result.bytesFreed,
+      duration_ms: result.durationMs,
+      retention_days: retentionDays,
+      minimum_per_session: minimumPerSession,
+      cutoff_iso: cutoffIso,
+    });
+
+    return result;
+  });
+
+  return {
+    pruneSnapshots,
+  } satisfies CheckpointSnapshotPrunerShape;
+});
+
+export const CheckpointSnapshotPrunerLive = Layer.effect(CheckpointSnapshotPruner, make);

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -26,6 +26,7 @@ import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReap
 import { OpenCodeRuntimeLive } from "./provider/opencodeRuntime.ts";
 import { CheckpointDiffQueryLive } from "./checkpointing/Layers/CheckpointDiffQuery.ts";
 import { CheckpointStoreLive } from "./checkpointing/Layers/CheckpointStore.ts";
+import { CheckpointSnapshotPrunerLive } from "./orchestration/checkpoint/CheckpointSnapshotPruner.ts";
 import * as AzureDevOpsCli from "./sourceControl/AzureDevOpsCli.ts";
 import * as BitbucketApi from "./sourceControl/BitbucketApi.ts";
 import * as GitHubCli from "./sourceControl/GitHubCli.ts";
@@ -208,9 +209,19 @@ const VcsLayerLive = Layer.empty.pipe(
   Layer.provideMerge(VcsStatusBroadcaster.layer.pipe(Layer.provide(GitWorkflowLayerLive))),
 );
 
+const CheckpointStoreLayerLive = CheckpointStoreLive.pipe(
+  Layer.provide(VcsDriverRegistryLayerLive),
+);
+
 const CheckpointingLayerLive = Layer.empty.pipe(
   Layer.provideMerge(CheckpointDiffQueryLive),
-  Layer.provideMerge(CheckpointStoreLive.pipe(Layer.provide(VcsDriverRegistryLayerLive))),
+  Layer.provideMerge(CheckpointStoreLayerLive),
+  Layer.provideMerge(
+    CheckpointSnapshotPrunerLive.pipe(
+      Layer.provideMerge(CheckpointStoreLayerLive),
+      Layer.provideMerge(PersistenceLayerLive),
+    ),
+  ),
 );
 
 const TerminalLayerLive = TerminalManagerLive.pipe(Layer.provide(PtyAdapterLive));


### PR DESCRIPTION
/claim #838

Summary:
- Added checkpoint snapshot pruning with 7-day default retention and latest-3-per-session preservation.
- Added hourly background pruning plus checkpoint:prune --days CLI support.
- Logged pruning deletion, bytes freed, and duration metrics.

Verification:
- bun fmt
- bun lint
- bun typecheck
- bun run test