### PR TITLE
xiaoqiang [ Laravel ] Implement user notification preferences with channel routing

### DIFF
--- a/laravel/app/Http/Controllers/NotificationPreferenceController.php
+++ b/laravel/app/Http/Controllers/NotificationPreferenceController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NotificationPreferenceController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $preferences = NotificationPreference::where('user_id', $request->user()?->id)
+            ->orderBy('event_type')
+            ->orderBy('channel')
+            ->get();
+
+        return response()->json($preferences);
+    }
+
+    public function update(Request $request, int $id): JsonResponse
+    {
+        $preference = NotificationPreference::where('user_id', $request->user()?->id)
+            ->findOrFail($id);
+
+        $data = $request->validate([
+            'enabled' => 'required|boolean',
+        ]);
+
+        $preference->update($data);
+
+        return response()->json($preference);
+    }
+
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'preferences' => 'required|array',
+            'preferences.*.id' => 'required|integer|exists:notification_preferences,id',
+            'preferences.*.enabled' => 'required|boolean',
+        ]);
+
+        $userId = $request->user()?->id;
+        $updated = [];
+
+        foreach ($data['preferences'] as $item) {
+            $preference = NotificationPreference::where('user_id', $userId)
+                ->where('id', $item['id'])
+                ->first();
+
+            if ($preference) {
+                $preference->update(['enabled' => $item['enabled']]);
+                $updated[] = $preference;
+            }
+        }
+
+        return response()->json($updated);
+    }
+}

--- a/laravel/app/Models/NotificationPreference.php
+++ b/laravel/app/Models/NotificationPreference.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['user_id', 'channel', 'event_type', 'enabled'])]
+class NotificationPreference extends Model
+{
+    protected $table = 'notification_preferences';
+
+    protected function casts(): array
+    {
+        return [
+            'user_id' => 'integer',
+            'enabled' => 'boolean',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/laravel/app/Services/NotificationRouter.php
+++ b/laravel/app/Services/NotificationRouter.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NotificationPreference;
+use Illuminate\Support\Facades\Log;
+
+class NotificationRouter
+{
+    public function shouldSend(int $userId, string $channel, string $eventType): bool
+    {
+        $preference = NotificationPreference::where('user_id', $userId)
+            ->where('channel', $channel)
+            ->where('event_type', $eventType)
+            ->first();
+
+        if (!$preference) {
+            return true;
+        }
+
+        return $preference->enabled;
+    }
+
+    public function getEnabledChannels(int $userId, string $eventType): array
+    {
+        $preferences = NotificationPreference::where('user_id', $userId)
+            ->where('event_type', $eventType)
+            ->get();
+
+        return $preferences
+            ->filter(fn($p) => $p->enabled)
+            ->pluck('channel')
+            ->toArray();
+    }
+
+    public function route(int $userId, string $eventType, array $channels, callable $sendCallback): array
+    {
+        $results = [];
+
+        foreach ($channels as $channel) {
+            if ($this->shouldSend($userId, $channel, $eventType)) {
+                try {
+                    $results[$channel] = $sendCallback($channel);
+                } catch (\Throwable $e) {
+                    Log::error("Notification failed for channel {$channel}", [
+                        'user_id' => $userId,
+                        'event_type' => $eventType,
+                        'error' => $e->getMessage(),
+                    ]);
+                    $results[$channel] = false;
+                }
+            } else {
+                $results[$channel] = 'skipped';
+            }
+        }
+
+        return $results;
+    }
+}

--- a/laravel/app/Services/_contributor.json
+++ b/laravel/app/Services/_contributor.json
@@ -1,0 +1,1 @@
+{"identity": "xiaoqiang", "runtime_instructions": "Implement user notification preferences with channel routing per issue #793", "timestamp": "2026-05-16T16:30:00Z"}

--- a/laravel/database/migrations/2026_05_16_000002_create_notification_preferences_table.php
+++ b/laravel/database/migrations/2026_05_16_000002_create_notification_preferences_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('channel');
+            $table->string('event_type');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'channel', 'event_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Http\Controllers\FileController;
+use App\Http\Controllers\NotificationPreferenceController;
+use App\Http\Controllers\WebhookController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('files')->group(function () {
+    Route::post('/upload', [FileController::class, 'upload']);
+    Route::get('/{id}/download', [FileController::class, 'download']);
+    Route::delete('/{id}', [FileController::class, 'destroy']);
+    Route::get('/', [FileController::class, 'index']);
+});
+
+Route::prefix('webhooks')->group(function () {
+    Route::get('/', [WebhookController::class, 'index']);
+    Route::post('/', [WebhookController::class, 'store']);
+    Route::get('/{id}', [WebhookController::class, 'show']);
+    Route::put('/{id}', [WebhookController::class, 'update']);
+    Route::delete('/{id}', [WebhookController::class, 'destroy']);
+    Route::post('/{id}/test', [WebhookController::class, 'test']);
+});
+
+Route::prefix('notifications')->group(function () {
+    Route::get('/preferences', [NotificationPreferenceController::class, 'index']);
+    Route::put('/preferences/{id}', [NotificationPreferenceController::class, 'update']);
+    Route::post('/preferences/bulk', [NotificationPreferenceController::class, 'bulkUpdate']);
+});

--- a/laravel/tests/Feature/NotificationPreferenceTest.php
+++ b/laravel/tests/Feature/NotificationPreferenceTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Services\NotificationRouter;
+use Illuminate\Foundation\Testing\TestCase;
+
+class NotificationPreferenceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware();
+    }
+
+    public function test_list_preferences_for_user(): void
+    {
+        $user = User::factory()->create();
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'order.created',
+            'enabled' => true,
+        ]);
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'slack',
+            'event_type' => 'order.created',
+            'enabled' => false,
+        ]);
+
+        $response = $this->actingAs($user)->getJson('/api/notifications/preferences');
+
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json());
+    }
+
+    public function test_update_preference(): void
+    {
+        $user = User::factory()->create();
+
+        $pref = NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'order.created',
+            'enabled' => true,
+        ]);
+
+        $response = $this->actingAs($user)->putJson("/api/notifications/preferences/{$pref->id}", [
+            'enabled' => false,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse($response->json('enabled'));
+    }
+
+    public function test_bulk_update_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $pref1 = NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'order.created',
+            'enabled' => true,
+        ]);
+
+        $pref2 = NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'slack',
+            'event_type' => 'order.shipped',
+            'enabled' => true,
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/notifications/preferences/bulk', [
+            'preferences' => [
+                ['id' => $pref1->id, 'enabled' => false],
+                ['id' => $pref2->id, 'enabled' => false],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json());
+    }
+
+    public function test_router_sends_to_enabled_channels_only(): void
+    {
+        $user = User::factory()->create();
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'test.event',
+            'enabled' => true,
+        ]);
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'slack',
+            'event_type' => 'test.event',
+            'enabled' => false,
+        ]);
+
+        $router = new NotificationRouter();
+        $result = $router->route($user->id, 'test.event', ['mail', 'slack'], fn($ch) => 'sent');
+
+        $this->assertEquals('sent', $result['mail']);
+        $this->assertEquals('skipped', $result['slack']);
+    }
+
+    public function test_router_returns_enabled_channels(): void
+    {
+        $user = User::factory()->create();
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'test.event',
+            'enabled' => true,
+        ]);
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'database',
+            'event_type' => 'test.event',
+            'enabled' => true,
+        ]);
+
+        $router = new NotificationRouter();
+        $channels = $router->getEnabledChannels($user->id, 'test.event');
+
+        $this->assertCount(2, $channels);
+        $this->assertContains('mail', $channels);
+        $this->assertContains('database', $channels);
+    }
+
+    public function test_unique_constraint_prevents_duplicates(): void
+    {
+        $user = User::factory()->create();
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'order.created',
+            'enabled' => true,
+        ]);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'order.created',
+            'enabled' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
Implements #793. Adds user notification preferences system with per-channel routing control.

### Changes
- NotificationPreference model with migration: user_id FK, channel, event_type, enabled, unique constraint on user_id+channel+event_type
- NotificationPreferenceController: index (list by user), update (toggle single), bulkUpdate (batch toggle)
- NotificationRouter service: shouldSend() checks preferences, getEnabledChannels() returns active channels, route() dispatches with preference filtering
- API routes: GET /notifications/preferences, PUT /notifications/preferences/{id}, POST /notifications/preferences/bulk
- 6 tests covering: listing, single update, bulk update, router filtering, enabled channels, unique constraint