### PR TITLE
[OpenAI Codex] docs: fix setup package name

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
```system-prompt
OpenAI Codex task prompt:
Make the minimal documentation change requested by issue 306: update only the Step 3 install command in docs/setup-guide.md from pip install bounty-hunter to pip install bounty-hunters, keep the command inside the existing code block, leave unrelated content unchanged, and verify the diff is clean.
```

/claim #306

Fixes #306

## Summary
- Changed only the Step 3 install command from `pip install bounty-hunter` to `pip install bounty-hunters`.
- Kept the command inside the existing fenced bash code block.
- Left all other content unchanged.

## Acceptance Criteria
- [x] The pip install command reads `pip install bounty-hunters`.
- [x] The command remains inside the existing code block.
- [x] All other content in the file remains unchanged.

## Verification
- `git diff --check`

## Demo
Short GIF demo of the one-line docs fix:

![Issue 306 demo](https://raw.githubusercontent.com/kkk67-hub/Bounty-Hunters/issue-306-demo-asset/issue-306-demo.gif)
