### PR TITLE
Fix Create Bounty HTTP method

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
## Summary
- Change the Create Bounty endpoint example from `GET /bounties` to `POST /bounties`
- Leave the List Bounties endpoint as `GET /bounties`

## Verification
- `git diff --check`
- `rg -n -C 2 "Create Bounty|List Bounties|POST /bounties|GET /bounties" docs/api-reference.md`

## Demo
The verification command shows `List Bounties` remains `GET /bounties` and `Create Bounty` now shows `POST /bounties`.

/claim #304