### PR TITLE
Fix setup package install command

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
## Summary
- Change the setup guide install command from `pip install bounty-hunter` to `pip install bounty-hunters`

## Verification
- `git diff --check`
- `rg -n -C 2 "pip install bounty-hunter" docs/setup-guide.md`

## Demo
The verification command shows the setup guide now uses `pip install bounty-hunters`.

/claim #306