### PR TITLE
Codex [ Crypto ] Fix CrossChainBridge signature replay protection

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,3 @@
+artifacts/
+cache/
+node_modules/

--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,10 +4,17 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH =
+        keccak256("Transfer(address recipient,uint256 amount,uint256 nonce)");
+    bytes32 private constant NAME_HASH = keccak256("CrossChainBridge");
+    bytes32 private constant VERSION_HASH = keccak256("1");
+
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
 
+    mapping(address => uint256) public nonces;
     mapping(bytes32 => bool) public processedTransfers;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
@@ -20,37 +27,56 @@ contract CrossChainBridge {
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
+        uint256 currentNonce = nonces[msg.sender]++;
         bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        emit TransferInitiated(msg.sender, amount, targetChain, currentNonce);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(transferNonce == nonces[recipient], "Invalid nonce");
+
+        bytes32 transferHash = hashTransfer(recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
+        nonces[recipient] = transferNonce + 1;
         bridgeToken.transfer(recipient, amount);
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            NAME_HASH,
+            VERSION_HASH,
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function hashTransfer(address recipient, uint256 amount, uint256 transferNonce) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce
+        ));
+
+        return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+    }
+
+    function getNonce(address sender) external view returns (uint256) {
+        return nonces[sender];
+    }
+
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -66,12 +92,12 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        if (recovered == address(0)) {
+            return false;
+        }
+
         return recovered == validator;
     }
 

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,0 +1,9 @@
+require("@nomicfoundation/hardhat-ethers");
+
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test"
+  }
+};

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.13.5",
+    "hardhat": "^2.22.19"
+  }
+}

--- a/solidity/test/CrossChainBridge.test.js
+++ b/solidity/test/CrossChainBridge.test.js
@@ -1,0 +1,150 @@
+const assert = require("node:assert/strict");
+const { ethers } = require("hardhat");
+
+const NAME = "CrossChainBridge";
+const VERSION = "1";
+const TRANSFER_TYPES = {
+  Transfer: [
+    { name: "recipient", type: "address" },
+    { name: "amount", type: "uint256" },
+    { name: "nonce", type: "uint256" }
+  ]
+};
+
+describe("CrossChainBridge", function () {
+  async function deployBridge() {
+    const [owner, validator, recipient] = await ethers.getSigners();
+    const initialSupply = ethers.parseEther("1000000");
+    const transferAmount = ethers.parseEther("100");
+
+    const Token = await ethers.getContractFactory("GovernanceToken");
+    const token = await Token.deploy(initialSupply);
+
+    const Bridge = await ethers.getContractFactory("CrossChainBridge");
+    const bridge = await Bridge.deploy(await token.getAddress(), validator.address);
+    await token.transfer(await bridge.getAddress(), ethers.parseEther("10000"));
+
+    return { owner, validator, recipient, token, bridge, transferAmount };
+  }
+
+  async function domainFor(bridge, overrides = {}) {
+    const network = await ethers.provider.getNetwork();
+
+    return {
+      name: NAME,
+      version: VERSION,
+      chainId: overrides.chainId ?? network.chainId,
+      verifyingContract: overrides.verifyingContract ?? await bridge.getAddress()
+    };
+  }
+
+  async function signTransfer(bridge, signer, recipient, amount, nonce, overrides = {}) {
+    return signer.signTypedData(
+      await domainFor(bridge, overrides),
+      TRANSFER_TYPES,
+      { recipient, amount, nonce }
+    );
+  }
+
+  it("constructs the EIP-712 domain separator with name, version, chain id, and contract address", async function () {
+    const { bridge } = await deployBridge();
+    const expected = ethers.TypedDataEncoder.hashDomain(await domainFor(bridge));
+
+    assert.equal(await bridge.DOMAIN_SEPARATOR(), expected);
+  });
+
+  it("verifies and processes EIP-712 transfer signatures", async function () {
+    const { validator, recipient, token, bridge, transferAmount } = await deployBridge();
+    const nonce = await bridge.getNonce(recipient.address);
+    const signature = await signTransfer(bridge, validator, recipient.address, transferAmount, nonce);
+    const digest = ethers.TypedDataEncoder.hash(
+      await domainFor(bridge),
+      TRANSFER_TYPES,
+      { recipient: recipient.address, amount: transferAmount, nonce }
+    );
+
+    assert.equal(await bridge.hashTransfer(recipient.address, transferAmount, nonce), digest);
+    assert.equal(await bridge.verifySignature(digest, signature), true);
+
+    await bridge.processTransfer(recipient.address, transferAmount, nonce, signature);
+
+    assert.equal(await token.balanceOf(recipient.address), transferAmount);
+    assert.equal(await bridge.getNonce(recipient.address), nonce + 1n);
+    assert.equal(await bridge.processedTransfers(digest), true);
+  });
+
+  it("exposes per-sender nonces for initiated transfers", async function () {
+    const { owner, bridge, token, transferAmount } = await deployBridge();
+    const bridgeAddress = await bridge.getAddress();
+
+    assert.equal(await bridge.getNonce(owner.address), 0n);
+    assert.equal(await bridge.nonces(owner.address), 0n);
+
+    await token.approve(bridgeAddress, transferAmount);
+    await bridge.initiateTransfer(transferAmount, 2);
+
+    assert.equal(await bridge.getNonce(owner.address), 1n);
+    assert.equal(await bridge.nonces(owner.address), 1n);
+  });
+
+  it("rejects the same signed message when replayed on the same chain", async function () {
+    const { validator, recipient, bridge, transferAmount } = await deployBridge();
+    const nonce = await bridge.getNonce(recipient.address);
+    const signature = await signTransfer(bridge, validator, recipient.address, transferAmount, nonce);
+
+    await bridge.processTransfer(recipient.address, transferAmount, nonce, signature);
+
+    await assert.rejects(
+      bridge.processTransfer(recipient.address, transferAmount, nonce, signature),
+      /Invalid nonce/
+    );
+  });
+
+  it("rejects a message signed for a different chain", async function () {
+    const { validator, recipient, bridge, transferAmount } = await deployBridge();
+    const network = await ethers.provider.getNetwork();
+    const nonce = await bridge.getNonce(recipient.address);
+    const signature = await signTransfer(
+      bridge,
+      validator,
+      recipient.address,
+      transferAmount,
+      nonce,
+      { chainId: network.chainId + 1n }
+    );
+
+    await assert.rejects(
+      bridge.processTransfer(recipient.address, transferAmount, nonce, signature),
+      /Invalid signature/
+    );
+  });
+
+  it("rejects a message signed for another bridge contract address", async function () {
+    const { validator, recipient, token, bridge, transferAmount } = await deployBridge();
+    const Bridge = await ethers.getContractFactory("CrossChainBridge");
+    const replacementBridge = await Bridge.deploy(await token.getAddress(), validator.address);
+    await token.transfer(await replacementBridge.getAddress(), ethers.parseEther("10000"));
+
+    const nonce = await replacementBridge.getNonce(recipient.address);
+    const signature = await signTransfer(bridge, validator, recipient.address, transferAmount, nonce);
+
+    await assert.rejects(
+      replacementBridge.processTransfer(recipient.address, transferAmount, nonce, signature),
+      /Invalid signature/
+    );
+  });
+
+  it("rejects signatures whose ecrecover result is the zero address", async function () {
+    const { recipient, bridge, transferAmount } = await deployBridge();
+    const nonce = await bridge.getNonce(recipient.address);
+    const digest = await bridge.hashTransfer(recipient.address, transferAmount, nonce);
+    const zeroAddressSignature = `0x${"00".repeat(65)}`;
+
+    assert.equal(await bridge.verifySignature(digest, zeroAddressSignature), false);
+
+    await assert.rejects(
+      bridge.processTransfer(recipient.address, transferAmount, nonce, zeroAddressSignature),
+      /Invalid signature/
+    );
+  });
+});


### PR DESCRIPTION
/claim #920

## Issue
Closes #920

## Summary
Adds EIP-712 typed-data verification to CrossChainBridge and binds transfer signatures to the current chain, bridge contract address, and per-recipient nonce. Rejects zero-address ecrecover results and exposes nonce lookup for frontend signing flows.

## Acceptance criteria
- [x] Signed messages include chain ID, nonce, and contract address
- [x] Same message cannot be replayed on a different chain
- [x] Same message cannot be replayed on the same chain (nonce prevents it)
- [x] Contract upgrade/new bridge address does not allow old message replay
- [x] ecrecover zero-address result is rejected as invalid signature
- [x] EIP-712 domain separator is correctly constructed with name, version, chainId, and verifyingContract
- [x] Nonce is queryable per sender for frontend integration
- [x] Tests cover cross-chain replay, same-chain replay, post-upgrade/new-address replay, invalid signature, and EIP-712 verification

## Validation
- `npm test` in `solidity/`
- `git diff --check`