### PR TITLE
fix: [ Crypto ] Fix cross-chain replay attack in CrossChainBridge signature v

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -8,7 +8,18 @@ contract CrossChainBridge {
     address public validator;
     uint256 public nonce;
 
+    string public constant NAME = "CrossChainBridge";
+    string public constant VERSION = "1";
+
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "Transfer(address recipient,uint256 amount,uint256 nonce)"
+    );
+
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public nonces;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -24,33 +35,52 @@ contract CrossChainBridge {
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(amount > 0, "Amount must be > 0");
+        require(transferNonce == nonces[recipient], "Invalid nonce");
+
+        bytes32 transferHash = hashTransfer(recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
+        nonces[recipient]++;
         bridgeToken.transfer(recipient, amount);
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    function domainSeparator() public view returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes(NAME)),
+            keccak256(bytes(VERSION)),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function hashTransfer(address recipient, uint256 amount, uint256 transferNonce) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce
+        ));
+
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator(), structHash));
+    }
+
+    function getNonce(address account) external view returns (uint256) {
+        return nonces[account];
+    }
+
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -66,12 +96,9 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature");
         return recovered == validator;
     }
 


### PR DESCRIPTION
Fixes #920

FIXED

**Bug corrected:** `TRANSFER_TYPEHASH` and its `abi.encode` call included `chainId` and `verifyingContract` inside the struct hash. Per EIP-712, those fields belong **only** in the domain separator — encoding them again in the struct violates the spec, causes wallets (MetaMask, Ledger, etc.) to fail structured-data display, and defeats the stated goal of "better wallet UX."

---

**Full review summary:**

| Check | Result |
|---|---|
| `block.chainid` in signed hash (cross-chain replay) | ✅ Present in domain separator |
| Per-recipient nonce (same-chain replay) | ✅ `nonces[recipient]` i

## Changed Files
- `solidity/contracts/CrossChainBridge.sol`

## Test Results
```
('No test suite detected.', False)
```
