### PR TITLE
Codex [ Laravel ] Implement webhook system with signature verification and retry queue

### DIFF
--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+
+class WebhookController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(Webhook::query()->latest()->get());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'url' => ['required', 'url', 'max:2048'],
+            'secret' => ['sometimes', 'string', 'min:16', 'max:255'],
+            'events' => ['required', 'array', 'min:1'],
+            'events.*' => ['required', 'string', 'max:255'],
+            'active' => ['sometimes', 'boolean'],
+        ]);
+
+        $webhook = Webhook::query()->create([
+            ...$validated,
+            'secret' => $validated['secret'] ?? Str::random(64),
+            'active' => $validated['active'] ?? true,
+        ]);
+
+        return response()->json($webhook, 201);
+    }
+
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json($webhook->load('deliveries'));
+    }
+
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $validated = $request->validate([
+            'url' => ['sometimes', 'url', 'max:2048'],
+            'secret' => ['sometimes', 'string', 'min:16', 'max:255'],
+            'events' => ['sometimes', 'array', 'min:1'],
+            'events.*' => ['required_with:events', 'string', 'max:255'],
+            'active' => ['sometimes', 'boolean'],
+        ]);
+
+        $webhook->update($validated);
+
+        return response()->json($webhook->refresh());
+    }
+
+    public function destroy(Webhook $webhook): Response
+    {
+        $webhook->delete();
+
+        return response()->noContent();
+    }
+}

--- a/laravel/app/Jobs/DispatchWebhookJob.php
+++ b/laravel/app/Jobs/DispatchWebhookJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use RuntimeException;
+
+class DispatchWebhookJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = WebhookDispatcher::MAX_ATTEMPTS;
+
+    public function __construct(public int $deliveryId)
+    {
+        //
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [2, 4, 8, 16, 32];
+    }
+
+    public function handle(WebhookDispatcher $dispatcher): void
+    {
+        $delivery = WebhookDelivery::query()->findOrFail($this->deliveryId);
+        $delivery = $dispatcher->send($delivery);
+
+        if ($delivery->delivered_at === null && $delivery->attempts < WebhookDispatcher::MAX_ATTEMPTS) {
+            throw new RuntimeException("Webhook delivery {$delivery->id} failed.");
+        }
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable(['url', 'secret', 'events', 'active'])]
+class Webhook extends Model
+{
+    /**
+     * @return HasMany<WebhookDelivery, $this>
+     */
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    /**
+     * @param  Builder<Webhook>  $query
+     * @return Builder<Webhook>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+
+    public function listensTo(string $event): bool
+    {
+        $events = $this->events ?? [];
+
+        return $this->active && (in_array($event, $events, true) || in_array('*', $events, true));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'events' => 'array',
+            'active' => 'boolean',
+        ];
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'webhook_id',
+    'event',
+    'payload',
+    'response_code',
+    'attempts',
+    'next_retry_at',
+    'delivered_at',
+])]
+class WebhookDelivery extends Model
+{
+    /**
+     * @return BelongsTo<Webhook, $this>
+     */
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'response_code' => 'integer',
+            'attempts' => 'integer',
+            'next_retry_at' => 'datetime',
+            'delivered_at' => 'datetime',
+        ];
+    }
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+class WebhookDispatcher
+{
+    public const MAX_ATTEMPTS = 5;
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return Collection<int, WebhookDelivery>
+     */
+    public function dispatch(string $event, array $payload): Collection
+    {
+        return Webhook::active()
+            ->get()
+            ->filter(fn (Webhook $webhook): bool => $webhook->listensTo($event))
+            ->map(function (Webhook $webhook) use ($event, $payload): WebhookDelivery {
+                $delivery = $this->createDelivery($webhook, $event, $payload);
+
+                DispatchWebhookJob::dispatch($delivery->id);
+
+                return $delivery;
+            })
+            ->values();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function createDelivery(Webhook $webhook, string $event, array $payload): WebhookDelivery
+    {
+        return $webhook->deliveries()->create([
+            'event' => $event,
+            'payload' => $payload,
+            'attempts' => 0,
+        ]);
+    }
+
+    public function send(WebhookDelivery $delivery): WebhookDelivery
+    {
+        $delivery->loadMissing('webhook');
+
+        $webhook = $delivery->webhook;
+        $payload = $delivery->payload ?? [];
+        $encodedPayload = $this->encodePayload($payload);
+        $attempts = $delivery->attempts + 1;
+        $responseCode = null;
+        $deliveredAt = null;
+
+        try {
+            $response = Http::withHeaders([
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'X-Webhook-Event' => $delivery->event,
+                'X-Webhook-Signature' => $this->generateSignature($webhook->secret, $encodedPayload),
+            ])->withBody($encodedPayload, 'application/json')->post($webhook->url);
+
+            $responseCode = $response->status();
+            $deliveredAt = $response->successful() ? CarbonImmutable::now() : null;
+        } catch (ConnectionException) {
+            $responseCode = null;
+        }
+
+        $delivery->forceFill([
+            'response_code' => $responseCode,
+            'attempts' => $attempts,
+            'next_retry_at' => $deliveredAt === null && $attempts < self::MAX_ATTEMPTS
+                ? $this->calculateNextRetryAt($attempts)
+                : null,
+            'delivered_at' => $deliveredAt,
+        ])->save();
+
+        return $delivery->refresh();
+    }
+
+    /**
+     * @param  array<string, mixed>|string  $payload
+     */
+    public function generateSignature(string $secret, array|string $payload): string
+    {
+        return hash_hmac(
+            'sha256',
+            is_string($payload) ? $payload : $this->encodePayload($payload),
+            $secret
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>|string  $payload
+     */
+    public function verifySignature(string $secret, array|string $payload, string $signature): bool
+    {
+        return hash_equals($this->generateSignature($secret, $payload), $signature);
+    }
+
+    public function calculateBackoffSeconds(int $attempt): int
+    {
+        return 2 ** max(1, $attempt);
+    }
+
+    public function calculateNextRetryAt(int $attempt): CarbonImmutable
+    {
+        return CarbonImmutable::now()->addSeconds($this->calculateBackoffSeconds($attempt));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function encodePayload(array $payload): string
+    {
+        return json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2026_05_16_000000_create_webhooks_table.php
+++ b/laravel/database/migrations/2026_05_16_000000_create_webhooks_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+
+            $table->index('active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/database/migrations/2026_05_16_000001_create_webhook_deliveries_table.php
+++ b/laravel/database/migrations/2026_05_16_000001_create_webhook_deliveries_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event')->index();
+            $table->json('payload');
+            $table->unsignedSmallInteger('response_code')->nullable();
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable()->index();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['webhook_id', 'event']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\WebhookController;
+use Illuminate\Support\Facades\Route;
+
+Route::apiResource('webhooks', WebhookController::class);

--- a/laravel/tests/Feature/WebhookControllerTest.php
+++ b/laravel/tests/Feature/WebhookControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Webhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebhookControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_webhook_crud_endpoints_work(): void
+    {
+        $createResponse = $this->postJson('/api/webhooks', [
+            'url' => 'https://example.com/webhooks/orders',
+            'events' => ['order.created'],
+        ]);
+
+        $createResponse
+            ->assertCreated()
+            ->assertJsonPath('url', 'https://example.com/webhooks/orders')
+            ->assertJsonPath('events', ['order.created'])
+            ->assertJsonPath('active', true);
+
+        $webhookId = $createResponse->json('id');
+        $this->assertDatabaseHas('webhooks', [
+            'id' => $webhookId,
+            'url' => 'https://example.com/webhooks/orders',
+            'active' => true,
+        ]);
+
+        $this->getJson('/api/webhooks')
+            ->assertOk()
+            ->assertJsonFragment(['url' => 'https://example.com/webhooks/orders']);
+
+        $this->patchJson("/api/webhooks/{$webhookId}", [
+            'events' => ['order.created', 'order.shipped'],
+            'active' => false,
+        ])
+            ->assertOk()
+            ->assertJsonPath('events', ['order.created', 'order.shipped'])
+            ->assertJsonPath('active', false);
+
+        $this->getJson("/api/webhooks/{$webhookId}")
+            ->assertOk()
+            ->assertJsonPath('id', $webhookId)
+            ->assertJsonPath('deliveries', []);
+
+        $this->deleteJson("/api/webhooks/{$webhookId}")->assertNoContent();
+        $this->assertDatabaseMissing('webhooks', ['id' => $webhookId]);
+    }
+
+    public function test_webhook_creation_accepts_explicit_secret(): void
+    {
+        $this->postJson('/api/webhooks', [
+            'url' => 'https://example.com/webhooks/manual-secret',
+            'secret' => 'explicit-secret-value',
+            'events' => ['customer.updated'],
+            'active' => false,
+        ])
+            ->assertCreated()
+            ->assertJsonPath('secret', 'explicit-secret-value')
+            ->assertJsonPath('active', false);
+
+        $this->assertDatabaseHas('webhooks', [
+            'url' => 'https://example.com/webhooks/manual-secret',
+            'secret' => 'explicit-secret-value',
+            'active' => false,
+        ]);
+    }
+
+    public function test_webhook_delete_cascades_delivery_history(): void
+    {
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhooks/cascade',
+            'secret' => 'cascade-secret-value',
+            'events' => ['order.cancelled'],
+            'active' => true,
+        ]);
+
+        $delivery = $webhook->deliveries()->create([
+            'event' => 'order.cancelled',
+            'payload' => ['id' => 9],
+            'attempts' => 1,
+        ]);
+
+        $this->deleteJson("/api/webhooks/{$webhook->id}")->assertNoContent();
+
+        $this->assertDatabaseMissing('webhook_deliveries', ['id' => $delivery->id]);
+    }
+}

--- a/laravel/tests/Feature/WebhookDispatcherTest.php
+++ b/laravel/tests/Feature/WebhookDispatcherTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Services\WebhookDispatcher;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_dispatch_creates_delivery_records_and_queues_matching_active_webhooks(): void
+    {
+        Queue::fake();
+
+        $matchingWebhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhooks/matching',
+            'secret' => 'matching-secret-value',
+            'events' => ['invoice.created'],
+            'active' => true,
+        ]);
+        Webhook::query()->create([
+            'url' => 'https://example.com/webhooks/inactive',
+            'secret' => 'inactive-secret-value',
+            'events' => ['invoice.created'],
+            'active' => false,
+        ]);
+        Webhook::query()->create([
+            'url' => 'https://example.com/webhooks/other-event',
+            'secret' => 'other-event-secret',
+            'events' => ['invoice.paid'],
+            'active' => true,
+        ]);
+
+        $deliveries = (new WebhookDispatcher)->dispatch('invoice.created', ['invoice_id' => 123]);
+
+        $this->assertCount(1, $deliveries);
+        $this->assertDatabaseHas('webhook_deliveries', [
+            'webhook_id' => $matchingWebhook->id,
+            'event' => 'invoice.created',
+            'attempts' => 0,
+        ]);
+
+        Queue::assertPushed(
+            DispatchWebhookJob::class,
+            fn (DispatchWebhookJob $job): bool => $job->deliveryId === $deliveries->first()->id
+        );
+    }
+
+    public function test_send_posts_signed_json_and_records_successful_delivery(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-16 12:00:00'));
+        Http::fake([
+            'https://example.com/webhooks/success' => Http::response(['ok' => true], 204),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhooks/success',
+            'secret' => 'success-secret-value',
+            'events' => ['invoice.paid'],
+            'active' => true,
+        ]);
+        $delivery = $webhook->deliveries()->create([
+            'event' => 'invoice.paid',
+            'payload' => ['invoice_id' => 456],
+            'attempts' => 0,
+        ]);
+
+        $dispatcher = new WebhookDispatcher;
+        $updatedDelivery = $dispatcher->send($delivery);
+
+        $expectedPayload = $dispatcher->encodePayload(['invoice_id' => 456]);
+        $expectedSignature = $dispatcher->generateSignature('success-secret-value', $expectedPayload);
+
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://example.com/webhooks/success'
+            && $request->body() === $expectedPayload
+            && $request->hasHeader('X-Webhook-Event', 'invoice.paid')
+            && $request->hasHeader('X-Webhook-Signature', $expectedSignature));
+
+        $this->assertSame(1, $updatedDelivery->attempts);
+        $this->assertSame(204, $updatedDelivery->response_code);
+        $this->assertNull($updatedDelivery->next_retry_at);
+        $this->assertTrue($updatedDelivery->delivered_at->equalTo(CarbonImmutable::now()));
+    }
+
+    public function test_send_records_failed_delivery_and_next_retry_time(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-16 12:00:00'));
+        Http::fake([
+            'https://example.com/webhooks/fail' => Http::response(['error' => true], 500),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhooks/fail',
+            'secret' => 'failure-secret-value',
+            'events' => ['invoice.failed'],
+            'active' => true,
+        ]);
+        $delivery = $webhook->deliveries()->create([
+            'event' => 'invoice.failed',
+            'payload' => ['invoice_id' => 789],
+            'attempts' => 0,
+        ]);
+
+        $updatedDelivery = (new WebhookDispatcher)->send($delivery);
+
+        $this->assertSame(1, $updatedDelivery->attempts);
+        $this->assertSame(500, $updatedDelivery->response_code);
+        $this->assertTrue(
+            CarbonImmutable::parse('2026-05-16 12:00:02')->equalTo($updatedDelivery->next_retry_at)
+        );
+        $this->assertNull($updatedDelivery->delivered_at);
+    }
+
+    public function test_failed_final_attempt_does_not_schedule_another_retry(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-16 12:00:00'));
+        Http::fake([
+            'https://example.com/webhooks/final-fail' => Http::response([], 503),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhooks/final-fail',
+            'secret' => 'final-failure-secret-value',
+            'events' => ['invoice.failed'],
+            'active' => true,
+        ]);
+        $delivery = $webhook->deliveries()->create([
+            'event' => 'invoice.failed',
+            'payload' => ['invoice_id' => 999],
+            'attempts' => WebhookDispatcher::MAX_ATTEMPTS - 1,
+        ]);
+
+        $updatedDelivery = (new WebhookDispatcher)->send($delivery);
+
+        $this->assertSame(WebhookDispatcher::MAX_ATTEMPTS, $updatedDelivery->attempts);
+        $this->assertSame(503, $updatedDelivery->response_code);
+        $this->assertNull($updatedDelivery->next_retry_at);
+        $this->assertNull($updatedDelivery->delivered_at);
+    }
+}

--- a/laravel/tests/Unit/WebhookDispatcherTest.php
+++ b/laravel/tests/Unit/WebhookDispatcherTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Services\WebhookDispatcher;
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_signature_generation_uses_hmac_sha256_over_encoded_payload(): void
+    {
+        $dispatcher = new WebhookDispatcher;
+        $payload = [
+            'event' => 'invoice.paid',
+            'invoice_id' => 42,
+            'callback_url' => 'https://example.com/hooks/invoices',
+        ];
+
+        $signature = $dispatcher->generateSignature('super-secret-key', $payload);
+
+        $this->assertSame(
+            hash_hmac(
+                'sha256',
+                json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+                'super-secret-key'
+            ),
+            $signature
+        );
+    }
+
+    public function test_signature_verification_uses_constant_time_comparison(): void
+    {
+        $dispatcher = new WebhookDispatcher;
+        $payload = ['event' => 'invoice.paid', 'invoice_id' => 42];
+        $signature = $dispatcher->generateSignature('super-secret-key', $payload);
+
+        $this->assertTrue($dispatcher->verifySignature('super-secret-key', $payload, $signature));
+        $this->assertFalse($dispatcher->verifySignature('super-secret-key', $payload, str_repeat('0', 64)));
+    }
+
+    public function test_retry_timing_uses_exponential_backoff(): void
+    {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('2026-05-16 00:00:00'));
+
+        $dispatcher = new WebhookDispatcher;
+
+        $this->assertSame([2, 4, 8, 16, 32], [
+            $dispatcher->calculateBackoffSeconds(1),
+            $dispatcher->calculateBackoffSeconds(2),
+            $dispatcher->calculateBackoffSeconds(3),
+            $dispatcher->calculateBackoffSeconds(4),
+            $dispatcher->calculateBackoffSeconds(5),
+        ]);
+
+        $this->assertTrue(
+            CarbonImmutable::parse('2026-05-16 00:00:08')->equalTo($dispatcher->calculateNextRetryAt(3))
+        );
+    }
+
+    public function test_dispatch_job_limits_attempts_and_uses_exponential_backoff(): void
+    {
+        $job = new DispatchWebhookJob(123);
+
+        $this->assertSame(WebhookDispatcher::MAX_ATTEMPTS, $job->tries);
+        $this->assertSame([2, 4, 8, 16, 32], $job->backoff());
+    }
+}


### PR DESCRIPTION
 /claim #754

## Summary
- Add Webhook and WebhookDelivery models, migrations, and relationships
- Add a WebhookDispatcher service that stores delivery records, signs exact JSON request bodies with HMAC-SHA256, verifies signatures with hash_equals, and calculates retry timing
- Add DispatchWebhookJob with five-attempt exponential backoff retry behavior
- Add API CRUD endpoints for webhooks and focused feature/unit coverage

## Validation
- git diff --cached --check
- Not run: php artisan test / Pint because this local environment does not have PHP, Composer, or Docker available
