### PR TITLE
Codex [ T3 Code ] Add multi-session activity tracking

### DIFF
--- a/t3code/apps/server/src/auth/Layers/AuthControlPlane.test.ts
+++ b/t3code/apps/server/src/auth/Layers/AuthControlPlane.test.ts
@@ -1,7 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as TestClock from "effect/testing/TestClock";
 
 import type { ServerConfigShape } from "../../config.ts";
 import { ServerConfig } from "../../config.ts";
@@ -108,5 +110,26 @@ it.layer(NodeServices.layer)("AuthControlPlane", (it) => {
       expect(beforeConnect[0]?.lastConnectedAt).toBeNull();
       expect(afterConnect[0]?.lastConnectedAt).not.toBeNull();
     }).pipe(Effect.provide(makeAuthControlPlaneLayer())),
+  );
+
+  it.effect("orders listed sessions by most recent activity", () =>
+    Effect.gen(function* () {
+      const authControlPlane = yield* AuthControlPlane;
+      const sessionCredentials = yield* SessionCredentialService;
+
+      const first = yield* authControlPlane.issueSession({
+        label: "first",
+      });
+      yield* TestClock.adjust(Duration.seconds(1));
+      const second = yield* authControlPlane.issueSession({
+        label: "second",
+      });
+
+      yield* TestClock.adjust(Duration.minutes(5));
+      yield* sessionCredentials.verify(first.token);
+      const listed = yield* authControlPlane.listSessions();
+
+      expect(listed.map((entry) => entry.sessionId)).toEqual([first.sessionId, second.sessionId]);
+    }).pipe(Effect.provide(Layer.merge(makeAuthControlPlaneLayer(), TestClock.layer()))),
   );
 });

--- a/t3code/apps/server/src/auth/Layers/AuthControlPlane.ts
+++ b/t3code/apps/server/src/auth/Layers/AuthControlPlane.ts
@@ -21,13 +21,12 @@ import type {
 } from "../Services/AuthControlPlane.ts";
 
 const bySessionPriority = (left: AuthClientSession, right: AuthClientSession) => {
-  if (left.role !== right.role) {
-    return left.role === "owner" ? -1 : 1;
-  }
-  if (left.connected !== right.connected) {
-    return left.connected ? -1 : 1;
-  }
-  return right.issuedAt.epochMilliseconds - left.issuedAt.epochMilliseconds;
+  const leftLastActiveAt = left.lastActiveAt ?? left.issuedAt;
+  const rightLastActiveAt = right.lastActiveAt ?? right.issuedAt;
+  const lastActiveDelta = rightLastActiveAt.epochMilliseconds - leftLastActiveAt.epochMilliseconds;
+  return lastActiveDelta === 0
+    ? right.issuedAt.epochMilliseconds - left.issuedAt.epochMilliseconds
+    : lastActiveDelta;
 };
 
 const toAuthControlPlaneError =

--- a/t3code/apps/server/src/auth/Layers/SessionCredentialService.test.ts
+++ b/t3code/apps/server/src/auth/Layers/SessionCredentialService.test.ts
@@ -142,6 +142,9 @@ it.layer(NodeServices.layer)("SessionCredentialServiceLive", (it) => {
       expect(
         beforeRevoke.find((entry) => entry.sessionId === owner.sessionId)?.client.deviceType,
       ).toBe("desktop");
+      expect(
+        beforeRevoke.find((entry) => entry.sessionId === client.sessionId)?.lastActiveAt,
+      ).not.toBeNull();
       expect(revokedCount).toBe(1);
       expect(afterRevoke).toHaveLength(1);
       expect(afterRevoke[0]?.sessionId).toBe(owner.sessionId);
@@ -188,6 +191,51 @@ it.layer(NodeServices.layer)("SessionCredentialServiceLive", (it) => {
       expect(afterReconnect[0]?.connected).toBe(true);
       expect(afterReconnect[0]?.lastConnectedAt).not.toBeNull();
       expect(afterReconnect[0]?.lastConnectedAt?.toString()).not.toBe(firstConnectedAt?.toString());
+    }).pipe(Effect.provide(Layer.merge(makeSessionCredentialLayer(), TestClock.layer()))),
+  );
+
+  it.effect("tracks lastActiveAt on verified requests with five minute debounce", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionCredentialService;
+      const issued = yield* sessions.issue({
+        subject: "activity-test",
+        method: "bearer-session-token",
+      });
+      const initial = (yield* sessions.listActive())[0]?.lastActiveAt;
+
+      yield* TestClock.adjust(Duration.minutes(4));
+      yield* sessions.verify(issued.token);
+      const debounced = (yield* sessions.listActive())[0]?.lastActiveAt;
+
+      yield* TestClock.adjust(Duration.minutes(1));
+      yield* sessions.verify(issued.token);
+      const refreshed = (yield* sessions.listActive())[0]?.lastActiveAt;
+
+      expect(initial).not.toBeNull();
+      expect(debounced?.toString()).toBe(initial?.toString());
+      expect(refreshed?.toString()).not.toBe(initial?.toString());
+    }).pipe(Effect.provide(Layer.merge(makeSessionCredentialLayer(), TestClock.layer()))),
+  );
+
+  it.effect("sorts active sessions by lastActiveAt descending", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionCredentialService;
+      const first = yield* sessions.issue({
+        subject: "first-session",
+        method: "bearer-session-token",
+      });
+
+      yield* TestClock.adjust(Duration.seconds(1));
+      const second = yield* sessions.issue({
+        subject: "second-session",
+        method: "bearer-session-token",
+      });
+
+      yield* TestClock.adjust(Duration.minutes(5));
+      yield* sessions.verify(first.token);
+      const listed = yield* sessions.listActive();
+
+      expect(listed.map((entry) => entry.sessionId)).toEqual([first.sessionId, second.sessionId]);
     }).pipe(Effect.provide(Layer.merge(makeSessionCredentialLayer(), TestClock.layer()))),
   );
 });

--- a/t3code/apps/server/src/auth/Layers/SessionCredentialService.ts
+++ b/t3code/apps/server/src/auth/Layers/SessionCredentialService.ts
@@ -33,6 +33,7 @@ import {
 const SIGNING_SECRET_NAME = "server-signing-key";
 const DEFAULT_SESSION_TTL = Duration.days(30);
 const DEFAULT_WEBSOCKET_TOKEN_TTL = Duration.minutes(5);
+const LAST_ACTIVE_UPDATE_INTERVAL = Duration.minutes(5);
 
 const SessionClaims = Schema.Struct({
   v: Schema.Literal(1),
@@ -136,11 +137,40 @@ export const makeSessionCredentialService = Effect.gen(function* () {
           client: toClientMetadata(row.value.client),
           issuedAt: row.value.issuedAt,
           expiresAt: row.value.expiresAt,
+          lastActiveAt: row.value.lastActiveAt,
           lastConnectedAt: row.value.lastConnectedAt,
           connected: connectedSessions.has(row.value.sessionId),
         }),
       );
     });
+
+  const touchLastActive = (input: {
+    readonly sessionId: AuthSessionId;
+    readonly lastActiveAt: DateTime.DateTime | null;
+    readonly issuedAt: DateTime.DateTime;
+    readonly nowEpochMillis: number;
+  }) =>
+    Effect.gen(function* () {
+      const previousLastActiveAt = input.lastActiveAt ?? input.issuedAt;
+      const elapsedMillis = input.nowEpochMillis - previousLastActiveAt.epochMilliseconds;
+      if (elapsedMillis < Duration.toMillis(LAST_ACTIVE_UPDATE_INTERVAL)) {
+        return;
+      }
+
+      const lastActiveAt = DateTime.make(input.nowEpochMillis);
+      if (Option.isNone(lastActiveAt)) {
+        return;
+      }
+
+      yield* authSessions.setLastActiveAt({
+        sessionId: input.sessionId,
+        lastActiveAt: lastActiveAt.value,
+      });
+      const activeSession = yield* loadActiveSession(input.sessionId);
+      if (Option.isSome(activeSession)) {
+        yield* emitUpsert(activeSession.value);
+      }
+    }).pipe(Effect.ignoreCause({ log: true }));
 
   const markConnected: SessionCredentialServiceShape["markConnected"] = (sessionId) =>
     Ref.modify(connectedSessionsRef, (current) => {
@@ -242,6 +272,7 @@ export const makeSessionCredentialService = Effect.gen(function* () {
         },
         issuedAt,
         expiresAt,
+        lastActiveAt: issuedAt,
       });
       yield* emitUpsert(
         toAuthClientSession({
@@ -252,6 +283,7 @@ export const makeSessionCredentialService = Effect.gen(function* () {
           client,
           issuedAt,
           expiresAt,
+          lastActiveAt: issuedAt,
           lastConnectedAt: null,
           connected: false,
         }),
@@ -318,6 +350,13 @@ export const makeSessionCredentialService = Effect.gen(function* () {
           message: "Invalid `exp` claim",
         });
       }
+
+      yield* touchLastActive({
+        sessionId: row.value.sessionId,
+        lastActiveAt: row.value.lastActiveAt,
+        issuedAt: row.value.issuedAt,
+        nowEpochMillis: now,
+      });
 
       return {
         sessionId: claims.sid,
@@ -419,6 +458,13 @@ export const makeSessionCredentialService = Effect.gen(function* () {
         });
       }
 
+      yield* touchLastActive({
+        sessionId: row.value.sessionId,
+        lastActiveAt: row.value.lastActiveAt,
+        issuedAt: row.value.issuedAt,
+        nowEpochMillis: now,
+      });
+
       return {
         sessionId: row.value.sessionId,
         token,
@@ -454,6 +500,7 @@ export const makeSessionCredentialService = Effect.gen(function* () {
           client: toClientMetadata(row.client),
           issuedAt: row.issuedAt,
           expiresAt: row.expiresAt,
+          lastActiveAt: row.lastActiveAt,
           lastConnectedAt: row.lastConnectedAt,
           connected: connectedSessions.has(row.sessionId),
         }),

--- a/t3code/apps/server/src/auth/utils.test.ts
+++ b/t3code/apps/server/src/auth/utils.test.ts
@@ -17,10 +17,48 @@ describe("deriveAuthClientMetadata", () => {
     });
 
     expect(metadata).toMatchObject({
+      label: "Mac",
       browser: "Electron",
       deviceType: "desktop",
       ipAddress: "127.0.0.1",
       os: "macOS",
     });
+  });
+
+  it("infers a device label from mobile user agents when no label is provided", () => {
+    const metadata = deriveAuthClientMetadata({
+      request: {
+        headers: {
+          "user-agent":
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+        },
+        source: {
+          remoteAddress: "10.0.0.8",
+        },
+      } as never,
+    });
+
+    expect(metadata).toMatchObject({
+      label: "iPhone",
+      browser: "Safari",
+      deviceType: "mobile",
+      ipAddress: "10.0.0.8",
+      os: "iOS",
+    });
+  });
+
+  it("keeps explicit labels over parsed device labels", () => {
+    const metadata = deriveAuthClientMetadata({
+      label: "Workbench laptop",
+      request: {
+        headers: {
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+        },
+        source: {},
+      } as never,
+    });
+
+    expect(metadata.label).toBe("Workbench laptop");
   });
 });

--- a/t3code/apps/server/src/auth/utils.ts
+++ b/t3code/apps/server/src/auth/utils.ts
@@ -98,6 +98,38 @@ function inferOs(userAgent: string | undefined): string | undefined {
   return undefined;
 }
 
+function inferDeviceName(input: {
+  readonly userAgent: string | undefined;
+  readonly deviceType: AuthClientMetadataDeviceType;
+  readonly os: string | undefined;
+  readonly browser: string | undefined;
+}): string | undefined {
+  if (!input.userAgent) {
+    return undefined;
+  }
+
+  const normalized = input.userAgent.toLowerCase();
+  if (/iphone/.test(normalized)) return "iPhone";
+  if (/ipad/.test(normalized)) return "iPad";
+  if (/ipod/.test(normalized)) return "iPod";
+
+  const androidModel = /android[^;)]*;\s*([^;)]+)/i.exec(input.userAgent)?.[1]?.trim();
+  if (androidModel && !/^wv$/i.test(androidModel) && !/build\//i.test(androidModel)) {
+    return androidModel;
+  }
+
+  if (input.deviceType === "bot") return input.browser ?? "Automated client";
+  if (input.os === "macOS") return "Mac";
+  if (input.os === "Windows") return "Windows PC";
+  if (input.os === "Linux") return "Linux desktop";
+  if (input.os === "Android") return "Android device";
+
+  if (input.browser && input.os) {
+    return `${input.browser} on ${input.os}`;
+  }
+  return input.os ?? input.browser;
+}
+
 function readRemoteAddressFromSource(source: unknown): string | undefined {
   if (!source || typeof source !== "object") {
     return undefined;
@@ -121,11 +153,13 @@ export function deriveAuthClientMetadata(input: {
   const ipAddress = readRemoteAddressFromSource(input.request.source);
   const os = inferOs(userAgent);
   const browser = inferBrowser(userAgent);
+  const deviceType = inferDeviceType(userAgent);
+  const label = input.label ?? inferDeviceName({ userAgent, deviceType, os, browser });
   return {
-    ...(input.label ? { label: input.label } : {}),
+    ...(label ? { label } : {}),
     ...(ipAddress ? { ipAddress } : {}),
     ...(userAgent ? { userAgent } : {}),
-    deviceType: inferDeviceType(userAgent),
+    deviceType,
     ...(os ? { os } : {}),
     ...(browser ? { browser } : {}),
   };

--- a/t3code/apps/server/src/persistence/Layers/AuthSessions.ts
+++ b/t3code/apps/server/src/persistence/Layers/AuthSessions.ts
@@ -20,6 +20,7 @@ import {
   ListActiveAuthSessionsInput,
   RevokeAuthSessionInput,
   RevokeOtherAuthSessionsInput,
+  SetAuthSessionLastActiveAtInput,
   SetAuthSessionLastConnectedAtInput,
 } from "../Services/AuthSessions.ts";
 
@@ -36,6 +37,7 @@ const AuthSessionDbRow = Schema.Struct({
   clientBrowser: Schema.NullOr(Schema.String),
   issuedAt: Schema.DateTimeUtcFromString,
   expiresAt: Schema.DateTimeUtcFromString,
+  lastActiveAt: Schema.NullOr(Schema.DateTimeUtcFromString),
   lastConnectedAt: Schema.NullOr(Schema.DateTimeUtcFromString),
   revokedAt: Schema.NullOr(Schema.DateTimeUtcFromString),
 });
@@ -56,6 +58,7 @@ function toAuthSessionRecord(row: typeof AuthSessionDbRow.Type): typeof AuthSess
     },
     issuedAt: row.issuedAt,
     expiresAt: row.expiresAt,
+    lastActiveAt: row.lastActiveAt,
     lastConnectedAt: row.lastConnectedAt,
     revokedAt: row.revokedAt,
   };
@@ -88,6 +91,7 @@ const makeAuthSessionRepository = Effect.gen(function* () {
           client_browser,
           issued_at,
           expires_at,
+          last_active_at,
           revoked_at
         )
         VALUES (
@@ -103,6 +107,7 @@ const makeAuthSessionRepository = Effect.gen(function* () {
           ${input.client.browser},
           ${input.issuedAt},
           ${input.expiresAt},
+          ${input.lastActiveAt},
           NULL
         )
       `,
@@ -126,6 +131,7 @@ const makeAuthSessionRepository = Effect.gen(function* () {
           client_browser AS "clientBrowser",
           issued_at AS "issuedAt",
           expires_at AS "expiresAt",
+          last_active_at AS "lastActiveAt",
           last_connected_at AS "lastConnectedAt",
           revoked_at AS "revokedAt"
         FROM auth_sessions
@@ -151,12 +157,13 @@ const makeAuthSessionRepository = Effect.gen(function* () {
           client_browser AS "clientBrowser",
           issued_at AS "issuedAt",
           expires_at AS "expiresAt",
+          last_active_at AS "lastActiveAt",
           last_connected_at AS "lastConnectedAt",
           revoked_at AS "revokedAt"
         FROM auth_sessions
         WHERE revoked_at IS NULL
           AND expires_at > ${now}
-        ORDER BY issued_at DESC, session_id DESC
+        ORDER BY COALESCE(last_active_at, issued_at) DESC, session_id DESC
       `,
   });
 
@@ -166,6 +173,17 @@ const makeAuthSessionRepository = Effect.gen(function* () {
       sql`
         UPDATE auth_sessions
         SET last_connected_at = ${lastConnectedAt}
+        WHERE session_id = ${sessionId}
+          AND revoked_at IS NULL
+      `,
+  });
+
+  const setLastActiveAtRow = SqlSchema.void({
+    Request: SetAuthSessionLastActiveAtInput,
+    execute: ({ sessionId, lastActiveAt }) =>
+      sql`
+        UPDATE auth_sessions
+        SET last_active_at = ${lastActiveAt}
         WHERE session_id = ${sessionId}
           AND revoked_at IS NULL
       `,
@@ -266,6 +284,16 @@ const makeAuthSessionRepository = Effect.gen(function* () {
       ),
     );
 
+  const setLastActiveAt: AuthSessionRepositoryShape["setLastActiveAt"] = (input) =>
+    setLastActiveAtRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "AuthSessionRepository.setLastActiveAt:query",
+          "AuthSessionRepository.setLastActiveAt:encodeRequest",
+        ),
+      ),
+    );
+
   return {
     create,
     getById,
@@ -273,6 +301,7 @@ const makeAuthSessionRepository = Effect.gen(function* () {
     revoke,
     revokeAllExcept,
     setLastConnectedAt,
+    setLastActiveAt,
   } satisfies AuthSessionRepositoryShape;
 });
 

--- a/t3code/apps/server/src/persistence/Migrations.ts
+++ b/t3code/apps/server/src/persistence/Migrations.ts
@@ -43,6 +43,7 @@ import Migration0027 from "./Migrations/027_ProviderSessionRuntimeInstanceId.ts"
 import Migration0028 from "./Migrations/028_ProjectionThreadSessionInstanceId.ts";
 import Migration0029 from "./Migrations/029_ProjectionThreadDetailOrderingIndexes.ts";
 import Migration0030 from "./Migrations/030_ProjectionThreadShellArchiveIndexes.ts";
+import Migration0031 from "./Migrations/031_AuthSessionLastActiveAt.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -85,6 +86,7 @@ export const migrationEntries = [
   [28, "ProjectionThreadSessionInstanceId", Migration0028],
   [29, "ProjectionThreadDetailOrderingIndexes", Migration0029],
   [30, "ProjectionThreadShellArchiveIndexes", Migration0030],
+  [31, "AuthSessionLastActiveAt", Migration0031],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/t3code/apps/server/src/persistence/Migrations/031_AuthSessionLastActiveAt.test.ts
+++ b/t3code/apps/server/src/persistence/Migrations/031_AuthSessionLastActiveAt.test.ts
@@ -1,0 +1,55 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("031_AuthSessionLastActiveAt", (it) => {
+  it.effect("adds and backfills last_active_at for existing auth sessions", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 30 });
+      yield* sql`
+        INSERT INTO auth_sessions (
+          session_id,
+          subject,
+          role,
+          method,
+          issued_at,
+          expires_at,
+          last_connected_at,
+          revoked_at
+        )
+        VALUES (
+          'session-1',
+          'owner',
+          'owner',
+          'browser-session-cookie',
+          '2026-05-15T00:00:00.000Z',
+          '2026-06-15T00:00:00.000Z',
+          '2026-05-15T00:10:00.000Z',
+          NULL
+        )
+      `;
+
+      yield* runMigrations({ toMigrationInclusive: 31 });
+
+      const columns = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(auth_sessions)
+      `;
+      assert.ok(columns.some((column) => column.name === "last_active_at"));
+
+      const rows = yield* sql<{ readonly lastActiveAt: string }>`
+        SELECT last_active_at AS "lastActiveAt"
+        FROM auth_sessions
+        WHERE session_id = 'session-1'
+      `;
+      assert.equal(rows[0]?.lastActiveAt, "2026-05-15T00:10:00.000Z");
+    }),
+  );
+});

--- a/t3code/apps/server/src/persistence/Migrations/031_AuthSessionLastActiveAt.ts
+++ b/t3code/apps/server/src/persistence/Migrations/031_AuthSessionLastActiveAt.ts
@@ -1,0 +1,28 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const sessionColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(auth_sessions)
+  `;
+
+  if (!sessionColumns.some((column) => column.name === "last_active_at")) {
+    yield* sql`
+      ALTER TABLE auth_sessions
+      ADD COLUMN last_active_at TEXT
+    `;
+  }
+
+  yield* sql`
+    UPDATE auth_sessions
+    SET last_active_at = COALESCE(last_active_at, last_connected_at, issued_at)
+    WHERE last_active_at IS NULL
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_auth_sessions_active_last_active
+    ON auth_sessions(revoked_at, expires_at, last_active_at)
+  `;
+});

--- a/t3code/apps/server/src/persistence/Services/AuthSessions.ts
+++ b/t3code/apps/server/src/persistence/Services/AuthSessions.ts
@@ -24,6 +24,7 @@ export const AuthSessionRecord = Schema.Struct({
   client: AuthSessionClientMetadataRecord,
   issuedAt: Schema.DateTimeUtcFromString,
   expiresAt: Schema.DateTimeUtcFromString,
+  lastActiveAt: Schema.NullOr(Schema.DateTimeUtcFromString),
   lastConnectedAt: Schema.NullOr(Schema.DateTimeUtcFromString),
   revokedAt: Schema.NullOr(Schema.DateTimeUtcFromString),
 });
@@ -37,6 +38,7 @@ export const CreateAuthSessionInput = Schema.Struct({
   client: AuthSessionClientMetadataRecord,
   issuedAt: Schema.DateTimeUtcFromString,
   expiresAt: Schema.DateTimeUtcFromString,
+  lastActiveAt: Schema.DateTimeUtcFromString,
 });
 export type CreateAuthSessionInput = typeof CreateAuthSessionInput.Type;
 
@@ -68,6 +70,12 @@ export const SetAuthSessionLastConnectedAtInput = Schema.Struct({
 });
 export type SetAuthSessionLastConnectedAtInput = typeof SetAuthSessionLastConnectedAtInput.Type;
 
+export const SetAuthSessionLastActiveAtInput = Schema.Struct({
+  sessionId: AuthSessionId,
+  lastActiveAt: Schema.DateTimeUtcFromString,
+});
+export type SetAuthSessionLastActiveAtInput = typeof SetAuthSessionLastActiveAtInput.Type;
+
 export interface AuthSessionRepositoryShape {
   readonly create: (
     input: CreateAuthSessionInput,
@@ -86,6 +94,9 @@ export interface AuthSessionRepositoryShape {
   ) => Effect.Effect<ReadonlyArray<AuthSessionId>, AuthSessionRepositoryError>;
   readonly setLastConnectedAt: (
     input: SetAuthSessionLastConnectedAtInput,
+  ) => Effect.Effect<void, AuthSessionRepositoryError>;
+  readonly setLastActiveAt: (
+    input: SetAuthSessionLastActiveAtInput,
   ) => Effect.Effect<void, AuthSessionRepositoryError>;
 }
 

--- a/t3code/packages/contracts/src/auth.ts
+++ b/t3code/packages/contracts/src/auth.ts
@@ -174,6 +174,7 @@ export const AuthClientSession = Schema.Struct({
   client: AuthClientMetadata,
   issuedAt: Schema.DateTimeUtc,
   expiresAt: Schema.DateTimeUtc,
+  lastActiveAt: Schema.optionalKey(Schema.NullOr(Schema.DateTimeUtc)),
   lastConnectedAt: Schema.NullOr(Schema.DateTimeUtc),
   connected: Schema.Boolean,
   current: Schema.Boolean,


### PR DESCRIPTION
/claim #835

## Summary
- Add `last_active_at` persistence for auth sessions with migration backfill and active-session ordering by recent activity.
- Update session credential verification to refresh activity with a 5-minute debounce for authenticated HTTP and websocket checks.
- Infer a default device label from user-agent metadata while preserving explicit pairing labels.

## Validation
- `bun fmt`
- `bun lint` (0 errors; existing unrelated warnings only)
- `bun typecheck`
- `bun run test src/auth/Layers/SessionCredentialService.test.ts src/auth/Layers/AuthControlPlane.test.ts src/auth/utils.test.ts src/persistence/Migrations/031_AuthSessionLastActiveAt.test.ts`
- `bun run test src/server.test.ts -t "lists paired clients and revokes other sessions while keeping the owner"`

## Security note
I did not add an attribution file containing runtime/platform instructions because that would disclose private configuration.
