### PR TITLE
Fix Create Bounty API method

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
Fixes #304.\n\nUpdates the Create Bounty endpoint documentation from GET /bounties to POST /bounties, matching the issue request.\n\nVerification:\n- Confirmed the diff only changes the Create Bounty endpoint method in docs/api-reference.md