### PR TITLE
Codex [ T3 Code ] Implement automatic token refresh in ACP client

### DIFF
--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -9,6 +9,7 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
+import { TestClock } from "effect/testing";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -24,9 +25,79 @@ const InitializeRequest = jsonRpcRequest("initialize", AcpSchema.InitializeReque
 const InitializeResponse = jsonRpcResponse(AcpSchema.InitializeResponse);
 const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
+const JsonRpcId = Schema.Union([Schema.Number, Schema.String]);
+const JsonRpcAnyRequest = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: JsonRpcId,
+  method: Schema.String,
+  params: Schema.Unknown,
+  headers: Schema.Array(Schema.Unknown),
+});
+const JsonRpcAnyResponse = jsonRpcResponse(Schema.Unknown);
+const JsonRpcErrorResponse = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: JsonRpcId,
+  error: AcpSchema.Error,
+});
+const isAuthenticationError = Schema.is(AcpError.AuthenticationError);
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/acp-mock-peer.ts"),
 );
+
+type JsonRpcAnyRequest = typeof JsonRpcAnyRequest.Type;
+
+const decodeAnyRequest = Schema.decodeEffect(Schema.fromJsonString(JsonRpcAnyRequest));
+
+const takeRpcRequest = (output: Queue.Dequeue<string>) =>
+  Queue.take(output).pipe(Effect.flatMap((message) => decodeAnyRequest(message)));
+
+const respondSuccess = (
+  input: Queue.Enqueue<Uint8Array, Cause.Done<void>>,
+  request: JsonRpcAnyRequest,
+  result: unknown,
+) =>
+  encodeJsonl(JsonRpcAnyResponse, {
+    jsonrpc: "2.0",
+    id: request.id,
+    result,
+  }).pipe(Effect.flatMap((message) => Queue.offer(input, message)));
+
+const respondError = (
+  input: Queue.Enqueue<Uint8Array, Cause.Done<void>>,
+  request: JsonRpcAnyRequest,
+  error: AcpSchema.Error,
+) =>
+  encodeJsonl(JsonRpcErrorResponse, {
+    jsonrpc: "2.0",
+    id: request.id,
+    error,
+  }).pipe(Effect.flatMap((message) => Queue.offer(input, message)));
+
+const respondAuthRequired = (
+  input: Queue.Enqueue<Uint8Array, Cause.Done<void>>,
+  request: JsonRpcAnyRequest,
+) =>
+  respondError(
+    input,
+    request,
+    AcpError.AcpRequestError.authRequired("Session expired", { status: 401 }).toProtocolError(),
+  );
+
+function requestParam(request: JsonRpcAnyRequest, key: string): unknown {
+  if (typeof request.params !== "object" || request.params === null) {
+    assert.fail(`Expected ${request.method} params to be an object`);
+  }
+  return (request.params as Readonly<Record<string, unknown>>)[key];
+}
+
+function failureIsAuthenticationError(exit: Exit.Exit<unknown, AcpError.AcpError>) {
+  return (
+    Exit.isFailure(exit) &&
+    exit.cause.reasons.some(
+      (reason) => Cause.isFailReason(reason) && isAuthenticationError(reason.error),
+    )
+  );
+}
 
 it.layer(NodeServices.layer)("effect-acp client", (it) => {
   const makeHandle = (env?: Record<string, string>) =>
@@ -444,6 +515,179 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
       yield* Fiber.join(initializeFiber);
       assert.deepEqual(yield* Fiber.join(extFiber), { ok: true });
       yield* Scope.close(scope, Exit.void);
+    }),
+  );
+
+  it.effect("refreshes authentication once and replays queued requests on the new session", () =>
+    Effect.gen(function* () {
+      const expiredSessions = yield* Ref.make<Array<string>>([]);
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+
+      yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.make(stdio, {
+          onSessionExpired: (sessionId) =>
+            Ref.update(expiredSessions, (current) => [...current, sessionId]),
+        }).pipe(Effect.provideService(Scope.Scope, scope));
+
+        const authFiber = yield* acp.agent
+          .authenticate({ methodId: "cursor_login" })
+          .pipe(Effect.forkScoped);
+        const authRequest = yield* takeRpcRequest(output);
+        assert.equal(authRequest.method, "authenticate");
+        assert.equal(requestParam(authRequest, "methodId"), "cursor_login");
+        yield* respondSuccess(input, authRequest, {
+          _meta: {
+            accessToken: "access-1",
+            refreshToken: "refresh-1",
+          },
+        });
+        yield* Fiber.join(authFiber);
+
+        const sessionFiber = yield* acp.agent
+          .createSession({ cwd: process.cwd(), mcpServers: [] })
+          .pipe(Effect.forkScoped);
+        const sessionRequest = yield* takeRpcRequest(output);
+        assert.equal(sessionRequest.method, "session/new");
+        yield* respondSuccess(input, sessionRequest, { sessionId: "session-1" });
+        assert.equal((yield* Fiber.join(sessionFiber)).sessionId, "session-1");
+
+        const firstPromptFiber = yield* acp.agent
+          .prompt({
+            sessionId: "session-1",
+            prompt: [{ type: "text", text: "first" }],
+          })
+          .pipe(Effect.forkScoped);
+        const secondPromptFiber = yield* acp.agent
+          .prompt({
+            sessionId: "session-1",
+            prompt: [{ type: "text", text: "second" }],
+          })
+          .pipe(Effect.forkScoped);
+
+        const firstPromptRequest = yield* takeRpcRequest(output);
+        const secondPromptRequest = yield* takeRpcRequest(output);
+        assert.equal(firstPromptRequest.method, "session/prompt");
+        assert.equal(secondPromptRequest.method, "session/prompt");
+        assert.equal(requestParam(firstPromptRequest, "sessionId"), "session-1");
+        assert.equal(requestParam(secondPromptRequest, "sessionId"), "session-1");
+
+        yield* Effect.all(
+          [
+            respondAuthRequired(input, firstPromptRequest),
+            respondAuthRequired(input, secondPromptRequest),
+          ],
+          { discard: true },
+        );
+
+        const refreshAuthRequest = yield* takeRpcRequest(output);
+        assert.equal(refreshAuthRequest.method, "authenticate");
+        assert.deepEqual(yield* Ref.get(expiredSessions), ["session-1"]);
+        const refreshMeta = requestParam(refreshAuthRequest, "_meta");
+        assert.equal(
+          typeof refreshMeta === "object" && refreshMeta !== null
+            ? (refreshMeta as Readonly<Record<string, unknown>>).refreshToken
+            : undefined,
+          "refresh-1",
+        );
+        yield* respondSuccess(input, refreshAuthRequest, {
+          _meta: {
+            accessToken: "access-2",
+            refreshToken: "refresh-2",
+          },
+        });
+
+        const closeRequest = yield* takeRpcRequest(output);
+        assert.equal(closeRequest.method, "session/close");
+        assert.equal(requestParam(closeRequest, "sessionId"), "session-1");
+        yield* respondSuccess(input, closeRequest, {});
+
+        const recreatedSessionRequest = yield* takeRpcRequest(output);
+        assert.equal(recreatedSessionRequest.method, "session/new");
+        yield* respondSuccess(input, recreatedSessionRequest, { sessionId: "session-2" });
+
+        const firstRetryRequest = yield* takeRpcRequest(output);
+        const secondRetryRequest = yield* takeRpcRequest(output);
+        assert.equal(firstRetryRequest.method, "session/prompt");
+        assert.equal(secondRetryRequest.method, "session/prompt");
+        assert.equal(requestParam(firstRetryRequest, "sessionId"), "session-2");
+        assert.equal(requestParam(secondRetryRequest, "sessionId"), "session-2");
+        yield* respondSuccess(input, firstRetryRequest, { stopReason: "end_turn" });
+        yield* respondSuccess(input, secondRetryRequest, { stopReason: "end_turn" });
+
+        assert.equal((yield* Fiber.join(firstPromptFiber)).stopReason, "end_turn");
+        assert.equal((yield* Fiber.join(secondPromptFiber)).stopReason, "end_turn");
+
+        yield* TestClock.adjust("0 millis").pipe(Effect.provide(TestClock.layer()));
+      }).pipe(Effect.ensuring(Scope.close(scope, Exit.void)));
+    }),
+  );
+
+  it.effect("fails all queued requests with AuthenticationError when refresh fails", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+
+      yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.make(stdio).pipe(Effect.provideService(Scope.Scope, scope));
+
+        const authFiber = yield* acp.agent
+          .authenticate({ methodId: "cursor_login" })
+          .pipe(Effect.forkScoped);
+        const authRequest = yield* takeRpcRequest(output);
+        yield* respondSuccess(input, authRequest, {
+          _meta: {
+            accessToken: "access-1",
+            refreshToken: "refresh-1",
+          },
+        });
+        yield* Fiber.join(authFiber);
+
+        const sessionFiber = yield* acp.agent
+          .createSession({ cwd: process.cwd(), mcpServers: [] })
+          .pipe(Effect.forkScoped);
+        const sessionRequest = yield* takeRpcRequest(output);
+        yield* respondSuccess(input, sessionRequest, { sessionId: "session-1" });
+        yield* Fiber.join(sessionFiber);
+
+        const firstPromptFiber = yield* Effect.exit(
+          acp.agent.prompt({
+            sessionId: "session-1",
+            prompt: [{ type: "text", text: "first" }],
+          }),
+        ).pipe(Effect.forkScoped);
+        const secondPromptFiber = yield* Effect.exit(
+          acp.agent.prompt({
+            sessionId: "session-1",
+            prompt: [{ type: "text", text: "second" }],
+          }),
+        ).pipe(Effect.forkScoped);
+
+        const firstPromptRequest = yield* takeRpcRequest(output);
+        const secondPromptRequest = yield* takeRpcRequest(output);
+        yield* Effect.all(
+          [
+            respondAuthRequired(input, firstPromptRequest),
+            respondAuthRequired(input, secondPromptRequest),
+          ],
+          { discard: true },
+        );
+
+        const refreshAuthRequest = yield* takeRpcRequest(output);
+        assert.equal(refreshAuthRequest.method, "authenticate");
+        yield* respondError(
+          input,
+          refreshAuthRequest,
+          AcpError.AcpRequestError.authRequired("Refresh rejected", {
+            status: 401,
+          }).toProtocolError(),
+        );
+
+        assert.equal(failureIsAuthenticationError(yield* Fiber.join(firstPromptFiber)), true);
+        assert.equal(failureIsAuthenticationError(yield* Fiber.join(secondPromptFiber)), true);
+
+        yield* TestClock.adjust("0 millis").pipe(Effect.provide(TestClock.layer()));
+      }).pipe(Effect.ensuring(Scope.close(scope, Exit.void)));
     }),
   );
 });

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -1,8 +1,11 @@
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Stdio from "effect/Stdio";
 import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
+import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
@@ -22,10 +25,14 @@ import {
 } from "./_internal/shared.ts";
 import { makeChildStdio, makeTerminationError } from "./_internal/stdio.ts";
 
+const isAcpRequestError = Schema.is(AcpError.AcpRequestError);
+const isAuthenticationError = Schema.is(AcpError.AuthenticationError);
+
 export interface AcpClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
+  readonly onSessionExpired?: (sessionId: string) => Effect.Effect<void, AcpError.AcpError>;
 }
 
 type AcpClientRaw = {
@@ -306,6 +313,38 @@ interface BufferedNotificationHandler<A> {
   readonly pending: Array<A>;
 }
 
+interface AcpAuthState {
+  readonly authenticatePayload?: AcpSchema.AuthenticateRequest;
+  readonly accessToken?: string;
+  readonly refreshToken?: string;
+}
+
+type AcpSessionSetupState =
+  | {
+      readonly _tag: "create";
+      readonly payload: AcpSchema.NewSessionRequest;
+      readonly sessionId: string;
+    }
+  | {
+      readonly _tag: "load";
+      readonly payload: AcpSchema.LoadSessionRequest;
+      readonly sessionId: string;
+    }
+  | {
+      readonly _tag: "resume";
+      readonly payload: AcpSchema.ResumeSessionRequest;
+      readonly sessionId: string;
+    };
+
+type AcpRefreshState =
+  | { readonly _tag: "Idle" }
+  | {
+      readonly _tag: "Refreshing";
+      readonly deferred: Deferred.Deferred<void, AcpError.AuthenticationError>;
+    };
+
+const tokenRefreshRetrySchedule = Schedule.recurs(1);
+
 export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpClientOptions = {},
@@ -330,6 +369,9 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   let unknownExtNotificationHandler:
     | ((method: string, params: unknown) => Effect.Effect<void, AcpError.AcpError>)
     | undefined;
+  const authStateRef = yield* Ref.make<AcpAuthState>({});
+  const sessionStateRef = yield* Ref.make<AcpSessionSetupState | undefined>(undefined);
+  const refreshStateRef = yield* Ref.make<AcpRefreshState>({ _tag: "Idle" });
 
   const runNotificationHandlers = <A>(
     registration: BufferedNotificationHandler<A>,
@@ -456,26 +498,247 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     generateRequestId: () => nextRpcRequestId++ as never,
   }).pipe(Effect.provideService(RpcClient.Protocol, transport.clientProtocol));
 
+  const rememberAuthState = (
+    payload: AcpSchema.AuthenticateRequest,
+    response: AcpSchema.AuthenticateResponse,
+  ) =>
+    Ref.update(authStateRef, (current) => {
+      const tokens = extractAuthTokens(response);
+      return {
+        authenticatePayload: payload,
+        ...(tokens.accessToken !== undefined
+          ? { accessToken: tokens.accessToken }
+          : current.accessToken !== undefined
+            ? { accessToken: current.accessToken }
+            : {}),
+        ...(tokens.refreshToken !== undefined
+          ? { refreshToken: tokens.refreshToken }
+          : current.refreshToken !== undefined
+            ? { refreshToken: current.refreshToken }
+            : {}),
+      } satisfies AcpAuthState;
+    });
+
+  const rememberCreatedSession = (
+    payload: AcpSchema.NewSessionRequest,
+    response: AcpSchema.NewSessionResponse,
+  ) =>
+    Ref.set(sessionStateRef, {
+      _tag: "create",
+      payload,
+      sessionId: response.sessionId,
+    });
+
+  const rememberLoadedSession = (payload: AcpSchema.LoadSessionRequest) =>
+    Ref.set(sessionStateRef, {
+      _tag: "load",
+      payload,
+      sessionId: payload.sessionId,
+    });
+
+  const rememberResumedSession = (payload: AcpSchema.ResumeSessionRequest) =>
+    Ref.set(sessionStateRef, {
+      _tag: "resume",
+      payload,
+      sessionId: payload.sessionId,
+    });
+
+  const authenticateDirect = (payload: AcpSchema.AuthenticateRequest) =>
+    callRpc(rpc[AGENT_METHODS.authenticate](payload)).pipe(
+      Effect.tap((response) => rememberAuthState(payload, response)),
+    );
+
+  const closeSessionDirect = (payload: AcpSchema.CloseSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_close](payload));
+
+  const createSessionDirect = (payload: AcpSchema.NewSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_new](payload)).pipe(
+      Effect.tap((response) => rememberCreatedSession(payload, response)),
+    );
+
+  const loadSessionDirect = (payload: AcpSchema.LoadSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_load](payload)).pipe(
+      Effect.tap(() => rememberLoadedSession(payload)),
+    );
+
+  const resumeSessionDirect = (payload: AcpSchema.ResumeSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_resume](payload)).pipe(
+      Effect.tap(() => rememberResumedSession(payload)),
+    );
+
+  const closeSessionTracked = (payload: AcpSchema.CloseSessionRequest) =>
+    closeSessionDirect(payload).pipe(
+      Effect.tap(() =>
+        Ref.update(sessionStateRef, (state) =>
+          state?.sessionId === payload.sessionId ? undefined : state,
+        ),
+      ),
+    );
+
+  const refreshAuth = (expiredSessionId: string | undefined) =>
+    Effect.gen(function* () {
+      const currentSession = yield* Ref.get(sessionStateRef);
+      if (
+        expiredSessionId !== undefined &&
+        currentSession !== undefined &&
+        currentSession.sessionId !== expiredSessionId
+      ) {
+        return;
+      }
+
+      if (expiredSessionId !== undefined && options.onSessionExpired) {
+        yield* options.onSessionExpired(expiredSessionId);
+      }
+
+      const authState = yield* Ref.get(authStateRef);
+      if (!authState.authenticatePayload) {
+        return yield* makeAuthenticationError(
+          "Cannot refresh ACP authentication without a previous authenticate request",
+          expiredSessionId,
+        );
+      }
+
+      const refreshPayload = withRefreshToken(authState.authenticatePayload, authState);
+      yield* authenticateDirect(refreshPayload);
+
+      yield* Effect.scoped(
+        Effect.acquireRelease(cleanupExpiredSession(expiredSessionId), () => Effect.void).pipe(
+          Effect.flatMap(() => restartSession()),
+        ),
+      );
+    }).pipe(
+      Effect.mapError((error) =>
+        isAuthenticationError(error)
+          ? error
+          : makeAuthenticationError("ACP re-authentication failed", expiredSessionId, error),
+      ),
+    );
+
+  const requestRefresh = (expiredSessionId: string | undefined) =>
+    Effect.gen(function* () {
+      const deferred = yield* Deferred.make<void, AcpError.AuthenticationError>();
+      const effect = yield* Ref.modify(refreshStateRef, (state) => {
+        if (state._tag === "Refreshing") {
+          return [Deferred.await(state.deferred), state] as const;
+        }
+        return [
+          refreshAuth(expiredSessionId).pipe(
+            Effect.matchEffect({
+              onFailure: (error) =>
+                Deferred.fail(deferred, error).pipe(Effect.andThen(Effect.fail(error))),
+              onSuccess: () => Deferred.succeed(deferred, undefined).pipe(Effect.asVoid),
+            }),
+            Effect.onInterrupt(() => Deferred.interrupt(deferred).pipe(Effect.asVoid)),
+            Effect.ensuring(Ref.set(refreshStateRef, { _tag: "Idle" })),
+          ),
+          { _tag: "Refreshing", deferred } satisfies AcpRefreshState,
+        ] as const;
+      });
+      return yield* effect;
+    });
+
+  const cleanupExpiredSession = (expiredSessionId: string | undefined) =>
+    expiredSessionId === undefined
+      ? Effect.void
+      : closeSessionDirect({ sessionId: expiredSessionId }).pipe(Effect.asVoid);
+
+  const restartSession = () =>
+    Ref.get(sessionStateRef).pipe(
+      Effect.flatMap((state) => {
+        switch (state?._tag) {
+          case "create":
+            return createSessionDirect(state.payload).pipe(Effect.asVoid);
+          case "load":
+            return loadSessionDirect(state.payload).pipe(Effect.asVoid);
+          case "resume":
+            return resumeSessionDirect(state.payload).pipe(Effect.asVoid);
+          case undefined:
+            return Effect.void;
+        }
+      }),
+    );
+
+  const withAuthRetry = <Payload, Result>(
+    payload: Payload,
+    run: (payload: Payload) => Effect.Effect<Result, AcpError.AcpError>,
+  ) =>
+    Effect.suspend(() => {
+      let refreshed = false;
+      let expiredSessionId: string | undefined;
+      const operation = Effect.gen(function* () {
+        const requestPayload = refreshed
+          ? yield* payloadWithCurrentSession(payload, expiredSessionId, sessionStateRef)
+          : payload;
+        return yield* run(requestPayload).pipe(
+          Effect.catchIf(isUnauthorizedError, (error) =>
+            Effect.gen(function* () {
+              if (refreshed) {
+                return yield* error;
+              }
+              refreshed = true;
+              expiredSessionId =
+                sessionIdFromPayload(payload) ?? (yield* activeSessionId(sessionStateRef));
+              yield* requestRefresh(expiredSessionId);
+              return yield* error;
+            }),
+          ),
+        );
+      });
+      return operation.pipe(
+        Effect.retry({
+          schedule: tokenRefreshRetrySchedule,
+          while: isUnauthorizedError,
+        }),
+      );
+    });
+
   return AcpClient.of({
     raw: {
       notifications: transport.incoming,
-      request: transport.request,
+      request: (method, payload) =>
+        withAuthRetry(payload, (nextPayload) => transport.request(method, nextPayload)),
       notify: transport.notify,
     },
     agent: {
       initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
-      authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
-      logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
-      closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      authenticate: authenticateDirect,
+      logout: (payload) =>
+        callRpc(rpc[AGENT_METHODS.logout](payload)).pipe(
+          Effect.tap(() =>
+            Effect.all(
+              [
+                Ref.set(authStateRef, {}),
+                Ref.set(sessionStateRef, undefined),
+                Ref.set(refreshStateRef, { _tag: "Idle" }),
+              ],
+              { discard: true },
+            ),
+          ),
+        ),
+      createSession: (payload) => withAuthRetry(payload, createSessionDirect),
+      loadSession: (payload) => withAuthRetry(payload, loadSessionDirect),
+      listSessions: (payload) =>
+        withAuthRetry(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_list](nextPayload)),
+        ),
+      forkSession: (payload) =>
+        withAuthRetry(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_fork](nextPayload)),
+        ),
+      resumeSession: (payload) => withAuthRetry(payload, resumeSessionDirect),
+      closeSession: closeSessionTracked,
+      setSessionModel: (payload) =>
+        withAuthRetry(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_set_model](nextPayload)),
+        ),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        withAuthRetry(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_set_config_option](nextPayload)),
+        ),
+      prompt: (payload) =>
+        withAuthRetry(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_prompt](nextPayload)),
+        ),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>
@@ -567,3 +830,124 @@ export const layerChildProcess = (
   const terminationError = makeTerminationError(handle);
   return Layer.effect(AcpClient, make(stdio, options, terminationError));
 };
+
+function extractAuthTokens(response: AcpSchema.AuthenticateResponse): {
+  readonly accessToken?: string;
+  readonly refreshToken?: string;
+} {
+  const meta = response._meta;
+  if (!isRecord(meta)) {
+    return {};
+  }
+  const accessToken = readString(meta, "accessToken", "access_token");
+  const refreshToken = readString(meta, "refreshToken", "refresh_token");
+  return {
+    ...(accessToken !== undefined ? { accessToken } : {}),
+    ...(refreshToken !== undefined ? { refreshToken } : {}),
+  };
+}
+
+function withRefreshToken(
+  payload: AcpSchema.AuthenticateRequest,
+  state: AcpAuthState,
+): AcpSchema.AuthenticateRequest {
+  if (state.refreshToken === undefined) {
+    return payload;
+  }
+  return {
+    ...payload,
+    _meta: {
+      ...(isRecord(payload._meta) ? payload._meta : {}),
+      refreshToken: state.refreshToken,
+    },
+  };
+}
+
+function isUnauthorizedError(error: AcpError.AcpError): error is AcpError.AcpRequestError {
+  if (!isAcpRequestError(error)) {
+    return false;
+  }
+  return (
+    error.code === -32000 ||
+    isUnauthorizedStatus(error.data) ||
+    error.errorMessage.includes("401") ||
+    error.errorMessage.toLowerCase().includes("unauthorized")
+  );
+}
+
+function isUnauthorizedStatus(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.status === 401 ||
+    value.statusCode === 401 ||
+    value.code === 401 ||
+    value.status === "401" ||
+    value.statusCode === "401" ||
+    value.code === "401"
+  );
+}
+
+function sessionIdFromPayload(payload: unknown): string | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+  return typeof payload.sessionId === "string" ? payload.sessionId : undefined;
+}
+
+function activeSessionId(
+  sessionStateRef: Ref.Ref<AcpSessionSetupState | undefined>,
+): Effect.Effect<string | undefined> {
+  return Ref.get(sessionStateRef).pipe(Effect.map((state) => state?.sessionId));
+}
+
+function payloadWithCurrentSession<Payload>(
+  payload: Payload,
+  expiredSessionId: string | undefined,
+  sessionStateRef: Ref.Ref<AcpSessionSetupState | undefined>,
+): Effect.Effect<Payload> {
+  if (expiredSessionId === undefined || !isRecord(payload)) {
+    return Effect.succeed(payload);
+  }
+  if (payload.sessionId !== expiredSessionId) {
+    return Effect.succeed(payload);
+  }
+  return Ref.get(sessionStateRef).pipe(
+    Effect.map((state) => {
+      if (state === undefined || state.sessionId === expiredSessionId) {
+        return payload;
+      }
+      return Object.assign({}, payload, { sessionId: state.sessionId }) as Payload;
+    }),
+  );
+}
+
+function makeAuthenticationError(
+  detail: string,
+  sessionId: string | undefined,
+  cause?: unknown,
+): AcpError.AuthenticationError {
+  return new AcpError.AuthenticationError({
+    detail,
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(cause !== undefined ? { cause } : {}),
+  });
+}
+
+function readString(
+  record: Readonly<Record<string, unknown>>,
+  ...keys: ReadonlyArray<string>
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/t3code/packages/effect-acp/src/errors.ts
+++ b/t3code/packages/effect-acp/src/errors.ts
@@ -128,8 +128,24 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
   }
 }
 
+export class AuthenticationError extends Schema.TaggedErrorClass<AuthenticationError>()(
+  "AuthenticationError",
+  {
+    detail: Schema.String,
+    sessionId: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect),
+  },
+) {
+  override get message() {
+    return this.sessionId === undefined
+      ? this.detail
+      : `${this.detail} for ACP session ${this.sessionId}`;
+  }
+}
+
 export const AcpError = Schema.Union([
   AcpRequestError,
+  AuthenticationError,
   AcpSpawnError,
   AcpProcessExitedError,
   AcpProtocolParseError,

--- a/t3code/packages/effect-acp/src/protocol.ts
+++ b/t3code/packages/effect-acp/src/protocol.ts
@@ -338,7 +338,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
       case "Request":
         return handleRequestEncoded(message);
       case "Exit":
-        return handleExitEncoded(message);
+        return handleExitEncoded(normalizeProtocolErrorExit(message));
       case "Chunk":
         return Ref.get(extPending).pipe(
           Effect.flatMap((pending) =>
@@ -520,6 +520,39 @@ function isProtocolError(
     "message" in value &&
     typeof value.message === "string"
   );
+}
+
+function normalizeProtocolErrorExit(
+  message: RpcMessage.ResponseExitEncoded,
+): RpcMessage.ResponseExitEncoded {
+  if (message.exit._tag !== "Failure") {
+    return message;
+  }
+
+  let normalized = false;
+  const cause = message.exit.cause.map((entry) => {
+    if (entry._tag === "Die" && isProtocolError(entry.defect)) {
+      normalized = true;
+      return {
+        _tag: "Fail" as const,
+        error: entry.defect,
+      };
+    }
+    return entry;
+  });
+
+  if (!normalized) {
+    return message;
+  }
+
+  return {
+    _tag: "Exit",
+    requestId: message.requestId,
+    exit: {
+      _tag: "Failure",
+      cause,
+    },
+  };
 }
 
 function normalizeToRequestError(error: AcpError.AcpError): AcpError.AcpRequestError {


### PR DESCRIPTION
/claim #829

## Summary
- Add ACP client auth/session state with separate access and refresh token tracking.
- Retry one 401/auth-required request through a shared refresh flow with `onSessionExpired`, re-authentication, acquire/release session cleanup, session recreation, and queued request replay.
- Normalize plain JSON-RPC protocol errors so unauthorized responses remain typed for retry handling.

## Validation
- `bun run fmt`
- `bun run lint` (run with Node 24.13.1/Bun 1.3.11; exits 0 with existing unrelated warnings)
- `bun run typecheck`
- `bun run --filter effect-acp test`

Note: I did not add `.provenance.json` because the requested `config_snapshot` would expose private instructions. No provenance, audit, prompt, token, secret, browser-state, or private-data files are included.