### PR TITLE
Codex [ T3 Code ] Add IPC message queuing for backend reconnects

### DIFF
--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -15,7 +15,7 @@ import * as Stream from "effect/Stream";
 
 import { type WsRpcProtocolClient } from "./protocol";
 import { resetWsReconnectBackoff } from "./wsConnectionState";
-import { WsTransport } from "./wsTransport";
+import { WsTransport, type WsTransportConnectionStateObservable } from "./wsTransport";
 
 type RpcTag = keyof WsRpcProtocolClient & string;
 type RpcMethod<TTag extends RpcTag> = WsRpcProtocolClient[TTag];
@@ -55,6 +55,7 @@ interface GitRunStackedActionOptions {
 
 export interface WsRpcClient {
   readonly dispose: () => Promise<void>;
+  readonly connectionState: WsTransportConnectionStateObservable;
   readonly reconnect: () => Promise<void>;
   readonly isHeartbeatFresh: () => boolean;
   readonly terminal: {
@@ -158,6 +159,7 @@ export interface WsRpcClient {
 export function createWsRpcClient(transport: WsTransport): WsRpcClient {
   return {
     dispose: () => transport.dispose(),
+    connectionState: transport.connectionState,
     reconnect: async () => {
       resetWsReconnectBackoff();
       await transport.reconnect();

--- a/t3code/apps/web/src/rpc/wsTransport.test.ts
+++ b/t3code/apps/web/src/rpc/wsTransport.test.ts
@@ -17,7 +17,11 @@ import {
   getWsConnectionUiState,
   resetWsConnectionStateForTests,
 } from "../rpc/wsConnectionState";
-import { WsTransport } from "./wsTransport";
+import {
+  WsTransport,
+  WsTransportRequestQueueOverflowError,
+  WsTransportRequestTimeoutError,
+} from "./wsTransport";
 
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 
@@ -115,6 +119,32 @@ function createTransport(...args: ConstructorParameters<typeof WsTransport>): Ws
   const transport = new WsTransport(...args);
   transports.push(transport);
   return transport;
+}
+
+function upsertKeybindingRequest(transport: WsTransport, key: string) {
+  return transport.request((client) =>
+    client[WS_METHODS.serverUpsertKeybinding]({
+      command: "terminal.toggle",
+      key,
+    }),
+  );
+}
+
+function resolveUpsertRequest(socket: MockWebSocket, sentIndex: number) {
+  const requestMessage = JSON.parse(socket.sent[sentIndex] ?? "{}") as { id: string };
+  socket.serverMessage(
+    JSON.stringify({
+      _tag: "Exit",
+      requestId: requestMessage.id,
+      exit: {
+        _tag: "Success",
+        value: {
+          keybindings: [],
+          issues: [],
+        },
+      },
+    }),
+  );
 }
 
 beforeEach(() => {
@@ -403,6 +433,186 @@ describe("WsTransport", () => {
       issues: [],
     });
 
+    await transport.dispose();
+  });
+
+  it("queues unary requests while reconnecting and flushes them in FIFO order", async () => {
+    const transport = createTransport("ws://localhost:3020", undefined, {
+      requestQueueMaxAgeMs: 2_000,
+    });
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    const firstSocket = getSocket();
+    firstSocket.open();
+
+    await waitFor(() => {
+      expect(transport.connectionState.getSnapshot()).toBe("connected");
+    });
+
+    firstSocket.close(1012, "service restart");
+
+    await waitFor(() => {
+      expect(transport.connectionState.getSnapshot()).toBe("reconnecting");
+    });
+
+    const firstQueuedRequest = upsertKeybindingRequest(transport, "ctrl+1");
+    const secondQueuedRequest = upsertKeybindingRequest(transport, "ctrl+2");
+
+    expect(firstSocket.sent).toHaveLength(0);
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(2);
+    }, 2_000);
+
+    const secondSocket = getSocket();
+    secondSocket.open();
+
+    await waitFor(() => {
+      expect(secondSocket.sent).toHaveLength(1);
+    });
+
+    const thirdQueuedRequest = upsertKeybindingRequest(transport, "ctrl+3");
+    expect(secondSocket.sent).toHaveLength(1);
+
+    expect(JSON.parse(secondSocket.sent[0] ?? "{}")).toMatchObject({
+      payload: { key: "ctrl+1" },
+    });
+    resolveUpsertRequest(secondSocket, 0);
+    await expect(firstQueuedRequest).resolves.toEqual({
+      keybindings: [],
+      issues: [],
+    });
+
+    await waitFor(() => {
+      expect(secondSocket.sent).toHaveLength(2);
+    });
+    expect(JSON.parse(secondSocket.sent[1] ?? "{}")).toMatchObject({
+      payload: { key: "ctrl+2" },
+    });
+    resolveUpsertRequest(secondSocket, 1);
+    await expect(secondQueuedRequest).resolves.toEqual({
+      keybindings: [],
+      issues: [],
+    });
+
+    await waitFor(() => {
+      expect(secondSocket.sent).toHaveLength(3);
+    });
+    expect(JSON.parse(secondSocket.sent[2] ?? "{}")).toMatchObject({
+      payload: { key: "ctrl+3" },
+    });
+    resolveUpsertRequest(secondSocket, 2);
+    await expect(thirdQueuedRequest).resolves.toEqual({
+      keybindings: [],
+      issues: [],
+    });
+
+    await transport.dispose();
+  });
+
+  it("drops the oldest queued unary request when the reconnect queue is full", async () => {
+    const transport = createTransport("ws://localhost:3020", undefined, {
+      requestQueueMaxAgeMs: 2_000,
+      requestQueueMaxSize: 2,
+    });
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    const firstQueuedRequest = upsertKeybindingRequest(transport, "ctrl+1");
+    const secondQueuedRequest = upsertKeybindingRequest(transport, "ctrl+2");
+    const thirdQueuedRequest = upsertKeybindingRequest(transport, "ctrl+3");
+
+    await expect(firstQueuedRequest).rejects.toBeInstanceOf(WsTransportRequestQueueOverflowError);
+
+    const socket = getSocket();
+    socket.open();
+
+    await waitFor(() => {
+      expect(socket.sent).toHaveLength(1);
+    });
+    expect(JSON.parse(socket.sent[0] ?? "{}")).toMatchObject({
+      payload: { key: "ctrl+2" },
+    });
+    resolveUpsertRequest(socket, 0);
+    await expect(secondQueuedRequest).resolves.toEqual({
+      keybindings: [],
+      issues: [],
+    });
+
+    await waitFor(() => {
+      expect(socket.sent).toHaveLength(2);
+    });
+    expect(JSON.parse(socket.sent[1] ?? "{}")).toMatchObject({
+      payload: { key: "ctrl+3" },
+    });
+    resolveUpsertRequest(socket, 1);
+    await expect(thirdQueuedRequest).resolves.toEqual({
+      keybindings: [],
+      issues: [],
+    });
+
+    await transport.dispose();
+  });
+
+  it("expires queued unary requests that outlive the reconnect queue age limit", async () => {
+    const transport = createTransport("ws://localhost:3020", undefined, {
+      requestQueueMaxAgeMs: 20,
+    });
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    await expect(upsertKeybindingRequest(transport, "ctrl+1")).rejects.toBeInstanceOf(
+      WsTransportRequestTimeoutError,
+    );
+
+    expect(getSocket().sent).toHaveLength(0);
+    await transport.dispose();
+  });
+
+  it("exposes connection state changes for UI subscribers", async () => {
+    const transport = createTransport("ws://localhost:3020");
+    const states: string[] = [];
+    const unsubscribe = transport.connectionState.subscribe((state) => {
+      states.push(state);
+    });
+
+    expect(transport.connectionState.getSnapshot()).toBe("disconnected");
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    const firstSocket = getSocket();
+    firstSocket.open();
+
+    await waitFor(() => {
+      expect(states).toContain("connected");
+    });
+
+    firstSocket.close(1012, "service restart");
+
+    await waitFor(() => {
+      expect(states).toContain("reconnecting");
+    });
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(2);
+    }, 2_000);
+
+    getSocket().open();
+
+    await waitFor(() => {
+      expect(states.at(-1)).toBe("connected");
+    });
+
+    unsubscribe();
     await transport.dispose();
   });
 
@@ -1175,6 +1385,7 @@ describe("WsTransport", () => {
           }) => Promise<void>;
         }
       ).closeSession,
+      rejectQueuedRequests: vi.fn(),
     } as unknown as WsTransport;
 
     void WsTransport.prototype.dispose.call(transport);

--- a/t3code/apps/web/src/rpc/wsTransport.ts
+++ b/t3code/apps/web/src/rpc/wsTransport.ts
@@ -30,6 +30,20 @@ interface RequestOptions {
   readonly timeout?: Option.Option<Duration.Input>;
 }
 
+export type WsTransportConnectionState = "connected" | "disconnected" | "reconnecting";
+
+export interface WsTransportConnectionStateObservable {
+  readonly getSnapshot: () => WsTransportConnectionState;
+  readonly subscribe: (listener: (state: WsTransportConnectionState) => void) => () => void;
+}
+
+export interface WsTransportQueueOptions {
+  readonly requestQueueMaxAgeMs?: number;
+  readonly requestQueueMaxSize?: number;
+}
+
+export const WS_TRANSPORT_DEFAULT_REQUEST_QUEUE_MAX_AGE_MS = 30_000;
+export const WS_TRANSPORT_DEFAULT_REQUEST_QUEUE_MAX_SIZE = 100;
 const DEFAULT_SUBSCRIPTION_RETRY_DELAY_MS = Duration.millis(250);
 const NOOP: () => void = () => undefined;
 
@@ -45,6 +59,30 @@ interface StreamRequestStartInfo {
   readonly stream: boolean;
 }
 
+interface QueuedRequest<TSuccess> {
+  readonly createdAt: number;
+  readonly execute: () => Promise<TSuccess>;
+  readonly reject: (error: unknown) => void;
+  readonly resolve: (value: TSuccess) => void;
+  readonly timeout: ReturnType<typeof setTimeout>;
+}
+
+export class WsTransportRequestTimeoutError extends Error {
+  override readonly name = "WsTransportRequestTimeoutError";
+
+  constructor(readonly maxAgeMs: number) {
+    super(`WebSocket RPC request timed out after ${maxAgeMs}ms in the reconnect queue.`);
+  }
+}
+
+export class WsTransportRequestQueueOverflowError extends Error {
+  override readonly name = "WsTransportRequestQueueOverflowError";
+
+  constructor(readonly maxSize: number) {
+    super(`WebSocket RPC reconnect queue exceeded its max size of ${maxSize}.`);
+  }
+}
+
 function formatErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim().length > 0) {
     return error.message;
@@ -55,22 +93,45 @@ function formatErrorMessage(error: unknown): string {
 export class WsTransport {
   private readonly url: WsRpcProtocolSocketUrlProvider;
   private readonly lifecycleHandlers: WsProtocolLifecycleHandlers | undefined;
+  private readonly queueMaxAgeMs: number;
+  private readonly queueMaxSize: number;
   private disposed = false;
   private hasReportedTransportDisconnect = false;
+  private hasConnected = false;
   private intentionalCloseDepth = 0;
+  private currentConnectionState: WsTransportConnectionState = "disconnected";
+  private flushingQueuedRequests = false;
   private reconnectChain: Promise<void> = Promise.resolve();
   private nextSessionId = 0;
   private activeSessionId = 0;
   private session: TransportSession;
   private lastHeartbeatPongAt = 0;
+  private readonly connectionStateListeners = new Set<
+    (state: WsTransportConnectionState) => void
+  >();
+  private readonly queuedRequests: Array<QueuedRequest<unknown>> = [];
   private readonly streamRequestStartListeners = new Set<(info: StreamRequestStartInfo) => void>();
+  readonly connectionState: WsTransportConnectionStateObservable = {
+    getSnapshot: () => this.currentConnectionState,
+    subscribe: (listener) => {
+      this.connectionStateListeners.add(listener);
+      return () => {
+        this.connectionStateListeners.delete(listener);
+      };
+    },
+  };
 
   constructor(
     url: WsRpcProtocolSocketUrlProvider,
     lifecycleHandlers?: WsProtocolLifecycleHandlers,
+    queueOptions?: WsTransportQueueOptions,
   ) {
     this.url = url;
-    this.lifecycleHandlers = lifecycleHandlers;
+    this.lifecycleHandlers = this.withQueueLifecycle(lifecycleHandlers);
+    this.queueMaxAgeMs =
+      queueOptions?.requestQueueMaxAgeMs ?? WS_TRANSPORT_DEFAULT_REQUEST_QUEUE_MAX_AGE_MS;
+    this.queueMaxSize =
+      queueOptions?.requestQueueMaxSize ?? WS_TRANSPORT_DEFAULT_REQUEST_QUEUE_MAX_SIZE;
     this.session = this.createSession();
   }
 
@@ -82,9 +143,17 @@ export class WsTransport {
       throw new Error("Transport disposed");
     }
 
-    const session = this.session;
-    const client = await session.clientPromise;
-    return await session.runtime.runPromise(Effect.suspend(() => execute(client)));
+    const runRequest = async () => {
+      const session = this.session;
+      const client = await session.clientPromise;
+      return await session.runtime.runPromise(Effect.suspend(() => execute(client)));
+    };
+
+    if (this.shouldQueueRequests()) {
+      return await this.enqueueRequest(runRequest);
+    }
+
+    return await runRequest();
   }
 
   async requestStream<TValue>(
@@ -208,6 +277,7 @@ export class WsTransport {
 
       clearAllTrackedRpcRequests();
       this.lastHeartbeatPongAt = 0;
+      this.setConnectionState("reconnecting");
       const previousSession = this.session;
       this.session = this.createSession();
       await this.closeSession(previousSession);
@@ -226,6 +296,7 @@ export class WsTransport {
       return;
     }
     this.disposed = true;
+    this.rejectQueuedRequests(new Error("Transport disposed"));
     await this.closeSession(this.session);
   }
 
@@ -272,6 +343,147 @@ export class WsTransport {
       runtime,
       clientScope,
       clientPromise: runtime.runPromise(Scope.provide(clientScope)(makeWsRpcProtocolClient)),
+    };
+  }
+
+  private enqueueRequest<TSuccess>(execute: () => Promise<TSuccess>): Promise<TSuccess> {
+    this.expireQueuedRequests(Date.now());
+    while (this.queuedRequests.length >= this.queueMaxSize) {
+      const dropped = this.queuedRequests.shift();
+      if (!dropped) {
+        break;
+      }
+      clearTimeout(dropped.timeout);
+      dropped.reject(new WsTransportRequestQueueOverflowError(this.queueMaxSize));
+    }
+
+    return new Promise<TSuccess>((resolve, reject) => {
+      let queued: QueuedRequest<TSuccess>;
+      queued = {
+        createdAt: Date.now(),
+        execute,
+        reject,
+        resolve,
+        timeout: setTimeout(() => {
+          const index = this.queuedRequests.indexOf(queued as QueuedRequest<unknown>);
+          if (index >= 0) {
+            this.queuedRequests.splice(index, 1);
+          }
+          reject(new WsTransportRequestTimeoutError(this.queueMaxAgeMs));
+        }, this.queueMaxAgeMs),
+      };
+      this.queuedRequests.push(queued as QueuedRequest<unknown>);
+    });
+  }
+
+  private expireQueuedRequests(now: number) {
+    for (let index = 0; index < this.queuedRequests.length; ) {
+      const queued = this.queuedRequests[index];
+      if (!queued || now - queued.createdAt <= this.queueMaxAgeMs) {
+        index += 1;
+        continue;
+      }
+      this.queuedRequests.splice(index, 1);
+      clearTimeout(queued.timeout);
+      queued.reject(new WsTransportRequestTimeoutError(this.queueMaxAgeMs));
+    }
+  }
+
+  private flushQueuedRequests() {
+    if (
+      this.disposed ||
+      this.flushingQueuedRequests ||
+      this.currentConnectionState !== "connected"
+    ) {
+      return;
+    }
+
+    this.flushingQueuedRequests = true;
+    void (async () => {
+      try {
+        for (;;) {
+          this.expireQueuedRequests(Date.now());
+          const queued = this.queuedRequests.shift();
+          if (!queued) {
+            return;
+          }
+          if (this.disposed) {
+            clearTimeout(queued.timeout);
+            queued.reject(new Error("Transport disposed"));
+            continue;
+          }
+          if (this.currentConnectionState !== "connected") {
+            this.queuedRequests.unshift(queued);
+            return;
+          }
+
+          clearTimeout(queued.timeout);
+          try {
+            queued.resolve(await queued.execute());
+          } catch (error) {
+            queued.reject(error);
+          }
+        }
+      } finally {
+        this.flushingQueuedRequests = false;
+        if (this.currentConnectionState === "connected" && this.queuedRequests.length > 0) {
+          this.flushQueuedRequests();
+        }
+      }
+    })();
+  }
+
+  private rejectQueuedRequests(error: unknown) {
+    for (const queued of this.queuedRequests.splice(0)) {
+      clearTimeout(queued.timeout);
+      queued.reject(error);
+    }
+  }
+
+  private setConnectionState(state: WsTransportConnectionState) {
+    if (this.currentConnectionState === state) {
+      return;
+    }
+    this.currentConnectionState = state;
+    for (const listener of this.connectionStateListeners) {
+      try {
+        listener(state);
+      } catch {
+        // Listener failures should not affect transport recovery.
+      }
+    }
+  }
+
+  private shouldQueueRequests() {
+    return (
+      this.currentConnectionState !== "connected" ||
+      this.flushingQueuedRequests ||
+      this.queuedRequests.length > 0
+    );
+  }
+
+  private withQueueLifecycle(
+    handlers?: WsProtocolLifecycleHandlers,
+  ): WsProtocolLifecycleHandlers | undefined {
+    return {
+      ...handlers,
+      onOpen: () => {
+        this.hasConnected = true;
+        this.setConnectionState("connected");
+        handlers?.onOpen?.();
+        this.flushQueuedRequests();
+      },
+      onError: (message) => {
+        this.setConnectionState(this.hasConnected ? "reconnecting" : "disconnected");
+        handlers?.onError?.(message);
+        this.expireQueuedRequests(Date.now());
+      },
+      onClose: (details, context) => {
+        if (!context.intentional) {
+          this.setConnectionState(this.hasConnected ? "reconnecting" : "disconnected");
+        }
+        handlers?.onClose?.(details, context);
+      },
     };
   }
 


### PR DESCRIPTION
Summary:
- Adds a bounded FIFO reconnect queue for unary WebSocket RPC requests while the backend is disconnected or reconnecting.
- Expires queued requests with a typed timeout error and drops oldest entries when the queue reaches its max size.
- Exposes transport/client connectionState subscriptions for UI status surfaces.

Validation:
- npx -p node@24.13.1 -p bun@1.3.11 bun run fmt apps/web/src/rpc/wsTransport.ts apps/web/src/rpc/wsTransport.test.ts apps/web/src/rpc/wsRpcClient.ts
- npx -p node@24.13.1 -p bun@1.3.11 bun run lint apps/web/src/rpc/wsTransport.ts apps/web/src/rpc/wsTransport.test.ts apps/web/src/rpc/wsRpcClient.ts
- npx -p node@24.13.1 -p bun@1.3.11 bun run typecheck
- npx -p node@24.13.1 -p bun@1.3.11 bun run --filter @t3tools/web test src/rpc/wsTransport.test.ts src/rpc/wsRpcClient.test.ts
- git diff --check

/claim #826
