### PR TITLE
Codex [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -1,41 +1,54 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-contract LiquidityPool is ERC20 {
+contract LiquidityPool {
+    string public constant name = "LP Token";
+    string public constant symbol = "LP";
+    uint8 public constant decimals = 18;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
 
     uint256 public reserveA;
     uint256 public reserveB;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
-    constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
+    constructor(address _tokenA, address _tokenB) {
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(amountA > 0 && amountB > 0, "Amounts must be > 0");
 
-        if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+        if (totalSupply == 0) {
+            uint256 initialLiquidity = sqrt(amountA * amountB);
+            require(initialLiquidity > MINIMUM_LIQUIDITY, "Insufficient initial liquidity");
+
+            lpTokens = initialLiquidity - MINIMUM_LIQUIDITY;
+            _mint(address(0), MINIMUM_LIQUIDITY);
         } else {
-            uint256 lpFromA = amountA * totalSupply() / reserveA;
-            uint256 lpFromB = amountB * totalSupply() / reserveB;
+            uint256 lpFromA = amountA * totalSupply / reserveA;
+            uint256 lpFromB = amountB * totalSupply / reserveB;
             lpTokens = lpFromA < lpFromB ? lpFromA : lpFromB;
         }
 
         require(lpTokens > 0, "Insufficient liquidity");
+        require(tokenA.transferFrom(msg.sender, address(this), amountA), "Token A transfer failed");
+        require(tokenB.transferFrom(msg.sender, address(this), amountB), "Token B transfer failed");
+
         _mint(msg.sender, lpTokens);
 
         reserveA += amountA;
@@ -44,27 +57,78 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
-        require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
+        require(balanceOf[msg.sender] >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        uint256 supply = totalSupply;
+        amountA = lpTokens * reserveA / supply;
+        amountB = lpTokens * reserveB / supply;
+        require(amountA > 0 && amountB > 0, "Insufficient liquidity burned");
 
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
 
         reserveA -= amountA;
         reserveB -= amountB;
 
+        require(tokenA.transfer(msg.sender, amountA), "Token A transfer failed");
+        require(tokenB.transfer(msg.sender, amountB), "Token B transfer failed");
+
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            require(allowed >= amount, "ERC20: insufficient allowance");
+            allowance[from][msg.sender] = allowed - amount;
+            emit Approval(from, msg.sender, allowance[from][msg.sender]);
+        }
+
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(from != address(0), "ERC20: transfer from zero");
+        require(to != address(0), "ERC20: transfer to zero");
+        require(balanceOf[from] >= amount, "ERC20: transfer amount exceeds balance");
+
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+
+    function _mint(address to, uint256 amount) internal {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _burn(address from, uint256 amount) internal {
+        require(from != address(0), "ERC20: burn from zero");
+        require(balanceOf[from] >= amount, "ERC20: burn amount exceeds balance");
+
+        balanceOf[from] -= amount;
+        totalSupply -= amount;
+        emit Transfer(from, address(0), amount);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,0 +1,9 @@
+require("@nomicfoundation/hardhat-ethers");
+
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test"
+  }
+};

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.13.5",
+    "hardhat": "^2.22.19"
+  }
+}

--- a/solidity/test/LiquidityPool.test.js
+++ b/solidity/test/LiquidityPool.test.js
@@ -1,0 +1,127 @@
+const assert = require("node:assert/strict");
+const { ethers } = require("hardhat");
+
+const MINIMUM_LIQUIDITY = 1000n;
+
+describe("LiquidityPool", function () {
+  async function deployPool() {
+    const [owner, first, second, donor] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("GovernanceToken");
+    const tokenA = await Token.deploy(10_000_000n);
+    const tokenB = await Token.deploy(10_000_000n);
+
+    const Pool = await ethers.getContractFactory("LiquidityPool");
+    const pool = await Pool.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+    const poolAddress = await pool.getAddress();
+
+    for (const user of [first, second, donor]) {
+      await tokenA.transfer(user.address, 2_000_000n);
+      await tokenB.transfer(user.address, 2_000_000n);
+      await tokenA.connect(user).approve(poolAddress, 2_000_000n);
+      await tokenB.connect(user).approve(poolAddress, 2_000_000n);
+    }
+
+    return { owner, first, second, donor, tokenA, tokenB, pool, poolAddress };
+  }
+
+  it("locks MINIMUM_LIQUIDITY at address(0) on the first deposit", async function () {
+    const { first, pool } = await deployPool();
+    const deposit = 1_000_000n;
+
+    await pool.connect(first).addLiquidity(deposit, deposit);
+
+    assert.equal(await pool.balanceOf(ethers.ZeroAddress), MINIMUM_LIQUIDITY);
+    assert.equal(await pool.balanceOf(first.address), deposit - MINIMUM_LIQUIDITY);
+    assert.equal(await pool.totalSupply(), deposit);
+    assert.equal(await pool.reserveA(), deposit);
+    assert.equal(await pool.reserveB(), deposit);
+  });
+
+  it("rejects first deposits too small to absorb the permanent lock", async function () {
+    const { first, pool } = await deployPool();
+
+    await assert.rejects(
+      pool.connect(first).addLiquidity(MINIMUM_LIQUIDITY, MINIMUM_LIQUIDITY),
+      /Insufficient initial liquidity/
+    );
+  });
+
+  it("mints later deposits from internal reserves instead of donated balances", async function () {
+    const { first, second, donor, tokenA, tokenB, pool, poolAddress } = await deployPool();
+    const seed = 1001n;
+    const donation = 1_000_000n;
+
+    await pool.connect(first).addLiquidity(seed, seed);
+    assert.equal(await pool.balanceOf(first.address), 1n);
+
+    await tokenA.connect(donor).transfer(poolAddress, donation);
+    await tokenB.connect(donor).transfer(poolAddress, donation);
+
+    await pool.connect(second).addLiquidity(seed, seed);
+
+    assert.equal(await pool.balanceOf(second.address), seed);
+    assert.equal(await pool.reserveA(), seed * 2n);
+    assert.equal(await pool.reserveB(), seed * 2n);
+    assert.equal(await tokenA.balanceOf(poolAddress), donation + seed * 2n);
+    assert.equal(await tokenB.balanceOf(poolAddress), donation + seed * 2n);
+  });
+
+  it("removes liquidity using internal reserves so direct donations cannot be stolen", async function () {
+    const { first, donor, tokenA, tokenB, pool, poolAddress } = await deployPool();
+    const deposit = 1_000_000n;
+    const donation = 500_000n;
+
+    await pool.connect(first).addLiquidity(deposit, deposit);
+    await tokenA.connect(donor).transfer(poolAddress, donation);
+    await tokenB.connect(donor).transfer(poolAddress, donation);
+
+    const lpBalance = await pool.balanceOf(first.address);
+    const [amountA, amountB] = await pool.connect(first).removeLiquidity.staticCall(lpBalance);
+
+    assert.equal(amountA, deposit - MINIMUM_LIQUIDITY);
+    assert.equal(amountB, deposit - MINIMUM_LIQUIDITY);
+
+    await pool.connect(first).removeLiquidity(lpBalance);
+
+    assert.equal(await pool.reserveA(), MINIMUM_LIQUIDITY);
+    assert.equal(await pool.reserveB(), MINIMUM_LIQUIDITY);
+    assert.equal(await tokenA.balanceOf(poolAddress), donation + MINIMUM_LIQUIDITY);
+    assert.equal(await tokenB.balanceOf(poolAddress), donation + MINIMUM_LIQUIDITY);
+  });
+
+  it("syncs reserves to actual balances after an explicit recovery call", async function () {
+    const { first, donor, tokenA, tokenB, pool, poolAddress } = await deployPool();
+    const deposit = 1_000_000n;
+    const donationA = 500_000n;
+    const donationB = 250_000n;
+
+    await pool.connect(first).addLiquidity(deposit, deposit);
+    await tokenA.connect(donor).transfer(poolAddress, donationA);
+    await tokenB.connect(donor).transfer(poolAddress, donationB);
+
+    assert.equal(await pool.reserveA(), deposit);
+    assert.equal(await pool.reserveB(), deposit);
+
+    const receipt = await (await pool.sync()).wait();
+    const syncEvent = receipt.logs
+      .map((log) => {
+        try {
+          return pool.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .find((event) => event && event.name === "Sync");
+
+    assert(syncEvent);
+    assert.equal(syncEvent.args.reserveA, deposit + donationA);
+    assert.equal(syncEvent.args.reserveB, deposit + donationB);
+    assert.equal(await pool.reserveA(), deposit + donationA);
+    assert.equal(await pool.reserveB(), deposit + donationB);
+
+    const lpBalance = await pool.balanceOf(first.address);
+    const [amountA, amountB] = await pool.connect(first).removeLiquidity.staticCall(lpBalance);
+    assert.equal(amountA, (lpBalance * (deposit + donationA)) / deposit);
+    assert.equal(amountB, (lpBalance * (deposit + donationB)) / deposit);
+  });
+});


### PR DESCRIPTION
/claim #918

## Issue
Closes #918

## Summary
Locks the first-deposit minimum LP liquidity at address(0), prices later deposits and withdrawals from internal reserves, and adds explicit sync recovery for donated balances.

## Acceptance criteria
- [x] First deposit locks MINIMUM_LIQUIDITY tokens at address(0)
- [x] First depositor receives LP tokens minus the locked amount
- [x] Subsequent deposits use the correct proportional formula
- [x] removeLiquidity uses internal reserves, not balanceOf
- [x] sync function updates reserves and emits a Sync event
- [x] Direct token transfers to the pool do not affect LP token pricing
- [x] Tests cover first deposit lock, price manipulation attempt, donation attack via direct transfer, and sync recovery

## Validation
- [x] cd solidity && npm install --no-package-lock && npm test