### PR TITLE
Codex [ Crypto ] Fix MultiSigWallet confirmation race condition

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,3 @@
+artifacts/
+cache/
+node_modules/

--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.20;
 
 contract MultiSigWallet {
+    uint256 private constant _NOT_EXECUTING = 1;
+    uint256 private constant _EXECUTING = 2;
+
     address[] public owners;
     uint256 public required;
     uint256 public transactionCount;
+    uint256 private executionStatus = _NOT_EXECUTING;
 
     struct Transaction {
         address to;
@@ -13,8 +17,16 @@ contract MultiSigWallet {
         bool executed;
     }
 
+    struct Confirmation {
+        bool confirmed;
+        uint256 confirmedAtBlock;
+        uint256 revokedAtBlock;
+    }
+
     mapping(uint256 => Transaction) public transactions;
-    mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => Confirmation)) private confirmationRecords;
+    mapping(uint256 => uint256) private confirmationCounts;
+    mapping(uint256 => uint256) private lastRevocationBlocks;
     mapping(address => bool) public isOwner;
 
     event Submitted(uint256 indexed txId);
@@ -24,6 +36,18 @@ contract MultiSigWallet {
 
     modifier onlyOwner() {
         require(isOwner[msg.sender], "Not owner");
+        _;
+    }
+
+    modifier nonReentrantExecution() {
+        require(executionStatus != _EXECUTING, "Reentrant execution");
+        executionStatus = _EXECUTING;
+        _;
+        executionStatus = _NOT_EXECUTING;
+    }
+
+    modifier transactionExists(uint256 txId) {
+        require(txId < transactionCount, "Transaction does not exist");
         _;
     }
 
@@ -37,8 +61,12 @@ contract MultiSigWallet {
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid target");
+        if (data.length > 0) {
+            require(to.code.length > 0, "Target not contract");
+        }
+
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
@@ -50,38 +78,71 @@ contract MultiSigWallet {
         return txId;
     }
 
-    function confirmTransaction(uint256 txId) external onlyOwner {
+    function confirmTransaction(uint256 txId) external onlyOwner transactionExists(txId) {
         require(!transactions[txId].executed, "Already executed");
-        require(!confirmations[txId][msg.sender], "Already confirmed");
-        confirmations[txId][msg.sender] = true;
+        Confirmation storage confirmation = confirmationRecords[txId][msg.sender];
+        require(!confirmation.confirmed, "Already confirmed");
+        confirmation.confirmed = true;
+        confirmation.confirmedAtBlock = block.number;
+        confirmationCounts[txId]++;
         emit Confirmed(txId, msg.sender);
     }
 
-    function revokeConfirmation(uint256 txId) external onlyOwner {
+    function revokeConfirmation(uint256 txId) external onlyOwner transactionExists(txId) {
         require(!transactions[txId].executed, "Already executed");
-        require(confirmations[txId][msg.sender], "Not confirmed");
-        confirmations[txId][msg.sender] = false;
+        Confirmation storage confirmation = confirmationRecords[txId][msg.sender];
+        require(confirmation.confirmed, "Not confirmed");
+        confirmation.confirmed = false;
+        confirmation.revokedAtBlock = block.number;
+        lastRevocationBlocks[txId] = block.number;
+        confirmationCounts[txId]--;
         emit Revoked(txId, msg.sender);
     }
 
+    function confirmations(uint256 txId, address owner) external view returns (bool) {
+        return confirmationRecords[txId][owner].confirmed;
+    }
+
+    function isConfirmedAtBlock(uint256 txId, address owner, uint256 blockNumber) public view returns (bool) {
+        Confirmation memory confirmation = confirmationRecords[txId][owner];
+        if (confirmation.confirmedAtBlock == 0 || confirmation.confirmedAtBlock > blockNumber) {
+            return false;
+        }
+
+        if (confirmation.revokedAtBlock == 0 || confirmation.confirmedAtBlock > confirmation.revokedAtBlock) {
+            return true;
+        }
+
+        if (confirmation.confirmed && confirmation.confirmedAtBlock == confirmation.revokedAtBlock) {
+            return blockNumber > confirmation.revokedAtBlock;
+        }
+
+        return confirmation.revokedAtBlock > blockNumber;
+    }
+
     function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
+        return confirmationCounts[txId];
+    }
+
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
         for (uint256 i = 0; i < owners.length; i++) {
-            if (confirmations[txId][owners[i]]) count++;
+            if (isConfirmedAtBlock(txId, owners[i], blockNumber)) count++;
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
+    function executeTransaction(uint256 txId) external onlyOwner transactionExists(txId) nonReentrantExecution {
         require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
+        require(confirmationCounts[txId] >= required, "Not enough confirmations");
 
         Transaction storage txn = transactions[txId];
-        txn.executed = true;
+        uint256 executionBlock = block.number;
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
         require(success, "Execution failed");
+        require(confirmationCounts[txId] >= required, "Confirmations revoked");
+        require(lastRevocationBlocks[txId] < executionBlock, "Confirmations revoked");
 
+        txn.executed = true;
         emit Executed(txId);
     }
 

--- a/solidity/contracts/test/MultiSigRevokeTarget.sol
+++ b/solidity/contracts/test/MultiSigRevokeTarget.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IMultiSigWallet {
+    function confirmTransaction(uint256 txId) external;
+    function revokeConfirmation(uint256 txId) external;
+}
+
+contract MultiSigRevokeTarget {
+    IMultiSigWallet public wallet;
+    uint256 public transactionId;
+    bool public callbackReached;
+
+    function setWallet(address walletAddress) external {
+        require(address(wallet) == address(0), "Wallet set");
+        wallet = IMultiSigWallet(walletAddress);
+    }
+
+    function setTransactionId(uint256 txId) external {
+        transactionId = txId;
+    }
+
+    function confirmTransaction(uint256 txId) external {
+        wallet.confirmTransaction(txId);
+    }
+
+    function revokeConfirmation(uint256 txId) external {
+        wallet.revokeConfirmation(txId);
+    }
+
+    function revokeDuringExecution() external {
+        callbackReached = true;
+        wallet.revokeConfirmation(transactionId);
+    }
+}

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,0 +1,9 @@
+require("@nomicfoundation/hardhat-ethers");
+
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test"
+  }
+};

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.13.5",
+    "hardhat": "^2.22.19"
+  }
+}

--- a/solidity/test/MultiSigWallet.test.js
+++ b/solidity/test/MultiSigWallet.test.js
@@ -1,0 +1,116 @@
+const assert = require("node:assert/strict");
+const { ethers } = require("hardhat");
+
+describe("MultiSigWallet", function () {
+  async function deployWallet(required = 2) {
+    const [ownerA, ownerB, ownerC, recipient] = await ethers.getSigners();
+    const Wallet = await ethers.getContractFactory("MultiSigWallet");
+    const wallet = await Wallet.deploy([ownerA.address, ownerB.address, ownerC.address], required);
+
+    return { ownerA, ownerB, ownerC, recipient, wallet };
+  }
+
+  async function submit(wallet, signer, to, value = 0n, data = "0x") {
+    const tx = await wallet.connect(signer).submitTransaction(to, value, data);
+    const receipt = await tx.wait();
+
+    return receipt.logs.find((log) => log.fragment && log.fragment.name === "Submitted").args.txId;
+  }
+
+  it("rejects zero-address targets and calldata sent to non-contract targets", async function () {
+    const { ownerA, recipient, wallet } = await deployWallet();
+
+    await assert.rejects(
+      wallet.connect(ownerA).submitTransaction(ethers.ZeroAddress, 0, "0x"),
+      /Invalid target/
+    );
+
+    await assert.rejects(
+      wallet.connect(ownerA).submitTransaction(recipient.address, 0, "0x1234"),
+      /Target not contract/
+    );
+  });
+
+  it("preserves submit, confirm, execute, and revoke flows", async function () {
+    const { ownerA, ownerB, recipient, wallet } = await deployWallet();
+    await ownerA.sendTransaction({ to: await wallet.getAddress(), value: ethers.parseEther("1") });
+
+    const transferValue = ethers.parseEther("0.1");
+    const txId = await submit(wallet, ownerA, recipient.address, transferValue);
+    await wallet.connect(ownerA).confirmTransaction(txId);
+    await wallet.connect(ownerB).confirmTransaction(txId);
+
+    await wallet.connect(ownerA).executeTransaction(txId);
+
+    assert.equal((await wallet.transactions(txId)).executed, true);
+
+    const revokeTxId = await submit(wallet, ownerA, recipient.address, 1n);
+    await wallet.connect(ownerA).confirmTransaction(revokeTxId);
+    assert.equal(await wallet.getConfirmationCount(revokeTxId), 1n);
+
+    await wallet.connect(ownerA).revokeConfirmation(revokeTxId);
+    assert.equal(await wallet.getConfirmationCount(revokeTxId), 0n);
+    assert.equal(await wallet.confirmations(revokeTxId, ownerA.address), false);
+  });
+
+  it("tracks confirmations by block and rejects front-run revocations before execution", async function () {
+    const { ownerA, ownerB, recipient, wallet } = await deployWallet();
+    const txId = await submit(wallet, ownerA, recipient.address, 0);
+
+    const confirmTx = await wallet.connect(ownerA).confirmTransaction(txId);
+    const confirmReceipt = await confirmTx.wait();
+    await wallet.connect(ownerB).confirmTransaction(txId);
+
+    assert.equal(await wallet.isConfirmedAtBlock(txId, ownerA.address, confirmReceipt.blockNumber), true);
+
+    const revokeTx = await wallet.connect(ownerB).revokeConfirmation(txId);
+    const revokeReceipt = await revokeTx.wait();
+
+    assert.equal(await wallet.isConfirmedAtBlock(txId, ownerB.address, revokeReceipt.blockNumber), false);
+    assert.equal(await wallet.getConfirmationCountAtBlock(txId, revokeReceipt.blockNumber), 1n);
+
+    await assert.rejects(
+      wallet.connect(ownerA).executeTransaction(txId),
+      /Not enough confirmations/
+    );
+  });
+
+  it("reverts execution if a callback revokes a required confirmation", async function () {
+    const [ownerA] = await ethers.getSigners();
+    const Target = await ethers.getContractFactory("MultiSigRevokeTarget");
+    const target = await Target.deploy();
+
+    const Wallet = await ethers.getContractFactory("MultiSigWallet");
+    const wallet = await Wallet.deploy([ownerA.address, await target.getAddress()], 2);
+    await target.setWallet(await wallet.getAddress());
+
+    const data = target.interface.encodeFunctionData("revokeDuringExecution");
+    const txId = await submit(wallet, ownerA, await target.getAddress(), 0n, data);
+    await target.setTransactionId(txId);
+
+    await wallet.connect(ownerA).confirmTransaction(txId);
+    await target.confirmTransaction(txId);
+
+    await assert.rejects(
+      wallet.connect(ownerA).executeTransaction(txId),
+      /Confirmations revoked/
+    );
+
+    assert.equal((await wallet.transactions(txId)).executed, false);
+    assert.equal(await wallet.confirmations(txId, await target.getAddress()), true);
+    assert.equal(await target.callbackReached(), false);
+  });
+
+  it("keeps simple ETH transfer execution under 100,000 gas", async function () {
+    const { ownerA, ownerB, recipient, wallet } = await deployWallet();
+    await ownerA.sendTransaction({ to: await wallet.getAddress(), value: ethers.parseEther("1") });
+
+    const txId = await submit(wallet, ownerA, recipient.address, ethers.parseEther("0.01"));
+    await wallet.connect(ownerA).confirmTransaction(txId);
+    await wallet.connect(ownerB).confirmTransaction(txId);
+
+    const receipt = await (await wallet.connect(ownerA).executeTransaction(txId)).wait();
+
+    assert.ok(receipt.gasUsed < 100000n, `gas used ${receipt.gasUsed}`);
+  });
+});


### PR DESCRIPTION
## Issue
Closes #916

/claim #916

## Summary
Adds block-aware confirmation records, execution reentrancy protection, and post-callback confirmation validation for MultiSigWallet. Also rejects zero-address submissions and calldata sent to non-contract targets.

## Acceptance criteria
- [x] Transaction cannot execute if confirmations are revoked during the execution callback
- [x] Block-level confirmation check prevents front-running attacks
- [x] Zero-address transactions are rejected
- [x] Existing multi-sig flows work: submit, confirm, execute, revoke
- [x] Gas cost for executeTransaction does not exceed 100,000 gas for a simple ETH transfer
- [x] Add tests for: confirmation revocation during callback, front-running revocation, zero-address rejection