### PR TITLE
Codex [ Crypto ] Fix tx.origin phishing in GovernanceToken delegation

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,4 @@
+artifacts/
+cache/
+node_modules/
+package-lock.json

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -23,40 +24,47 @@ contract GovernanceToken is ERC20 {
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        require(msg.sender != to, "Cannot delegate to self");
+
+        uint256 senderBalance = balanceOf(msg.sender);
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= senderBalance;
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += senderBalance;
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 
     function getVotingPower(address account) public view returns (uint256) {
-        return balanceOf(account) + delegatedPower[account];
+        uint256 ownPower = delegates[account] == address(0) ? balanceOf(account) : 0;
+        return ownPower + delegatedPower[account];
+    }
+
+    function _transferOwnership(address newOwner) internal override {
+        super._transferOwnership(newOwner);
+        admin = newOwner;
     }
 
     function createProposal(string calldata description, uint256 duration) external returns (uint256) {

--- a/solidity/contracts/test/GovernanceTokenHarness.sol
+++ b/solidity/contracts/test/GovernanceTokenHarness.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../GovernanceToken.sol";
+
+contract GovernanceTokenPhishing {
+    GovernanceToken private immutable token;
+
+    constructor(GovernanceToken token_) {
+        token = token_;
+    }
+
+    function phishDelegate(address to) external {
+        token.delegateVote(to);
+    }
+
+    function phishSnapshot() external {
+        token.snapshot();
+    }
+}
+
+contract GovernanceTokenDelegationWallet {
+    GovernanceToken private immutable token;
+
+    constructor(GovernanceToken token_) {
+        token = token_;
+    }
+
+    function delegateTo(address to) external {
+        token.delegateVote(to);
+    }
+}

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,0 +1,10 @@
+require("@nomicfoundation/hardhat-chai-matchers");
+require("@nomicfoundation/hardhat-ethers");
+
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test"
+  }
+};

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "2.1.2",
+    "@nomicfoundation/hardhat-ethers": "3.1.3",
+    "@openzeppelin/contracts": "5.6.1",
+    "chai": "4.5.0",
+    "ethers": "6.16.0",
+    "hardhat": "2.28.6"
+  }
+}

--- a/solidity/test/GovernanceToken.test.js
+++ b/solidity/test/GovernanceToken.test.js
@@ -1,0 +1,90 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("GovernanceToken", function () {
+  async function deployToken() {
+    const [owner, victim, delegate, attacker] = await ethers.getSigners();
+    const GovernanceToken = await ethers.getContractFactory("GovernanceToken");
+    const token = await GovernanceToken.deploy(ethers.parseEther("1000"));
+    await token.waitForDeployment();
+
+    return { owner, victim, delegate, attacker, token };
+  }
+
+  it("delegates and revokes voting power for the direct caller", async function () {
+    const { victim, delegate, token } = await deployToken();
+    const amount = ethers.parseEther("100");
+
+    await token.transfer(victim.address, amount);
+    await token.connect(victim).delegateVote(delegate.address);
+
+    expect(await token.delegates(victim.address)).to.equal(delegate.address);
+    expect(await token.delegatedPower(delegate.address)).to.equal(amount);
+    expect(await token.getVotingPower(victim.address)).to.equal(0);
+    expect(await token.getVotingPower(delegate.address)).to.equal(amount);
+
+    await token.connect(victim).revokeDelegate();
+
+    expect(await token.delegates(victim.address)).to.equal(ethers.ZeroAddress);
+    expect(await token.delegatedPower(delegate.address)).to.equal(0);
+    expect(await token.getVotingPower(victim.address)).to.equal(amount);
+  });
+
+  it("does not let a phishing contract delegate a victim's votes", async function () {
+    const { victim, attacker, token } = await deployToken();
+    const amount = ethers.parseEther("100");
+    const GovernanceTokenPhishing = await ethers.getContractFactory(
+      "GovernanceTokenPhishing"
+    );
+    const phishing = await GovernanceTokenPhishing.connect(attacker).deploy(
+      await token.getAddress()
+    );
+    await phishing.waitForDeployment();
+
+    await token.transfer(victim.address, amount);
+    await phishing.connect(victim).phishDelegate(attacker.address);
+
+    expect(await token.delegates(victim.address)).to.equal(ethers.ZeroAddress);
+    expect(await token.delegatedPower(attacker.address)).to.equal(0);
+    expect(await token.getVotingPower(attacker.address)).to.equal(0);
+    expect(await token.delegates(await phishing.getAddress())).to.equal(
+      attacker.address
+    );
+  });
+
+  it("allows a legitimate contract wallet to delegate its own token balance", async function () {
+    const { delegate, token } = await deployToken();
+    const amount = ethers.parseEther("75");
+    const GovernanceTokenDelegationWallet = await ethers.getContractFactory(
+      "GovernanceTokenDelegationWallet"
+    );
+    const wallet = await GovernanceTokenDelegationWallet.deploy(
+      await token.getAddress()
+    );
+    await wallet.waitForDeployment();
+    const walletAddress = await wallet.getAddress();
+
+    await token.transfer(walletAddress, amount);
+    await wallet.delegateTo(delegate.address);
+
+    expect(await token.delegates(walletAddress)).to.equal(delegate.address);
+    expect(await token.delegatedPower(delegate.address)).to.equal(amount);
+    expect(await token.getVotingPower(walletAddress)).to.equal(0);
+    expect(await token.getVotingPower(delegate.address)).to.equal(amount);
+  });
+
+  it("restricts snapshots to the token owner", async function () {
+    const { owner, victim, attacker, token } = await deployToken();
+    const GovernanceTokenPhishing = await ethers.getContractFactory(
+      "GovernanceTokenPhishing"
+    );
+    const phishing = await GovernanceTokenPhishing.connect(attacker).deploy(
+      await token.getAddress()
+    );
+    await phishing.waitForDeployment();
+
+    await expect(token.connect(owner).snapshot()).not.to.be.reverted;
+    await expect(token.connect(victim).snapshot()).to.be.reverted;
+    await expect(phishing.connect(owner).phishSnapshot()).to.be.reverted;
+  });
+});


### PR DESCRIPTION
/claim #912

## Issue
Closes #912

## Summary
Replaces origin-based delegation and snapshot authorization with caller-based checks and OpenZeppelin Ownable. Adds focused Solidity tests for phishing-contract delegation, legitimate contract-wallet delegation, revocation, and owner-only snapshots.

## Acceptance criteria
- [x] No usage of tx.origin remains in the contract
- [x] All authorization checks use msg.sender
- [x] onlyOwner modifier protects admin functions
- [x] Delegated voting still works correctly through legitimate contract interactions
- [x] Add a test that deploys a phishing contract and verifies it cannot delegate votes
- [x] Existing governance proposal and voting tests pass unchanged
- [x] Vote power calculation avoids double-counting delegated-away balances

## Validation
- npm test