### PR TITLE
Codex [ Crypto ] Fix SimpleSwap slippage and deadline

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract SimpleSwap {
+    uint256 private constant BPS_DENOMINATOR = 10_000;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
     uint256 public reserveA;
@@ -13,6 +15,7 @@ contract SimpleSwap {
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_fee <= BPS_DENOMINATOR, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
@@ -25,10 +28,11 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut, uint256 deadline)
+        external
+        returns (uint256 amountOut)
+    {
+        require(block.timestamp <= deadline, "Deadline expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
@@ -37,14 +41,10 @@ contract SimpleSwap {
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
+        amountOut = _getAmountOut(reserveIn, reserveOut, amountIn);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+
         inputToken.transferFrom(msg.sender, address(this), amountIn);
-
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
         outputToken.transfer(msg.sender, amountOut);
 
         if (isTokenA) {
@@ -59,11 +59,15 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-        return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+        return _getAmountOut(reserveIn, reserveOut, amountIn);
+    }
+
+    function _getAmountOut(uint256 reserveIn, uint256 reserveOut, uint256 amountIn) internal view returns (uint256) {
+        uint256 amountInWithFee = amountIn * (BPS_DENOMINATOR - fee);
+        return (reserveOut * amountInWithFee) / (reserveIn * BPS_DENOMINATOR + amountInWithFee);
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "scripts": {
+    "test": "node --test test/SimpleSwap.test.js"
+  },
+  "devDependencies": {
+    "ethers": "6.16.0",
+    "ganache": "7.9.2",
+    "solc": "0.8.35"
+  }
+}

--- a/solidity/test/SimpleSwap.test.js
+++ b/solidity/test/SimpleSwap.test.js
@@ -1,0 +1,258 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const { ethers } = require("ethers");
+const ganache = require("ganache");
+const solc = require("solc");
+
+const IERC20_SOURCE = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 value) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}
+`;
+
+const MOCK_ERC20_SOURCE = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockERC20 is IERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals = 18;
+    uint256 public override totalSupply;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "ERC20: insufficient allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "ERC20: insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}
+`;
+
+const BPS_DENOMINATOR = 10_000n;
+const FEE_BPS = 30n;
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+const compiled = compileContracts();
+
+function compileContracts() {
+  const simpleSwapPath = path.join(__dirname, "..", "contracts", "SimpleSwap.sol");
+  const input = {
+    language: "Solidity",
+    sources: {
+      "contracts/SimpleSwap.sol": {
+        content: fs.readFileSync(simpleSwapPath, "utf8"),
+      },
+      "test/MockERC20.sol": {
+        content: MOCK_ERC20_SOURCE,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(
+    solc.compile(JSON.stringify(input), {
+      import: (importPath) => {
+        if (importPath === "@openzeppelin/contracts/token/ERC20/IERC20.sol") {
+          return { contents: IERC20_SOURCE };
+        }
+        return { error: `File not found: ${importPath}` };
+      },
+    }),
+  );
+
+  const errors = (output.errors || []).filter((error) => error.severity === "error");
+  assert.equal(errors.length, 0, errors.map((error) => error.formattedMessage).join("\n"));
+
+  return {
+    SimpleSwap: artifact(output, "contracts/SimpleSwap.sol", "SimpleSwap"),
+    MockERC20: artifact(output, "test/MockERC20.sol", "MockERC20"),
+  };
+}
+
+function artifact(output, source, contractName) {
+  const contract = output.contracts[source][contractName];
+  return {
+    abi: contract.abi,
+    bytecode: `0x${contract.evm.bytecode.object}`,
+  };
+}
+
+function fixedPointAmountOut(reserveIn, reserveOut, amountIn, fee = FEE_BPS) {
+  const amountInWithFee = amountIn * (BPS_DENOMINATOR - fee);
+  return (reserveOut * amountInWithFee) / (reserveIn * BPS_DENOMINATOR + amountInWithFee);
+}
+
+function truncatedFeeAmountOut(reserveIn, reserveOut, amountIn, fee = FEE_BPS) {
+  const feeAmount = (amountIn * fee) / BPS_DENOMINATOR;
+  const amountInAfterFee = amountIn - feeAmount;
+  return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+}
+
+async function deployFixture({ reserveA = 10_000n, reserveB = 10_000n, userA = 10_000n } = {}) {
+  const ganacheProvider = ganache.provider({ logging: { quiet: true } });
+  const provider = new ethers.BrowserProvider(ganacheProvider);
+  const owner = await provider.getSigner(0);
+  const user = await provider.getSigner(1);
+  const ownerAddress = await owner.getAddress();
+  const userAddress = await user.getAddress();
+
+  const TokenFactory = new ethers.ContractFactory(
+    compiled.MockERC20.abi,
+    compiled.MockERC20.bytecode,
+    owner,
+  );
+  const tokenA = await TokenFactory.deploy("Token A", "TKA");
+  await tokenA.waitForDeployment();
+  const tokenB = await TokenFactory.deploy("Token B", "TKB");
+  await tokenB.waitForDeployment();
+
+  await (await tokenA.mint(ownerAddress, reserveA)).wait();
+  await (await tokenB.mint(ownerAddress, reserveB)).wait();
+  await (await tokenA.mint(userAddress, userA)).wait();
+
+  const SwapFactory = new ethers.ContractFactory(
+    compiled.SimpleSwap.abi,
+    compiled.SimpleSwap.bytecode,
+    owner,
+  );
+  const swap = await SwapFactory.deploy(tokenA.target, tokenB.target, FEE_BPS);
+  await swap.waitForDeployment();
+
+  await (await tokenA.approve(swap.target, reserveA)).wait();
+  await (await tokenB.approve(swap.target, reserveB)).wait();
+  await (await swap.addLiquidity(reserveA, reserveB)).wait();
+  await (await tokenA.connect(user).approve(swap.target, MAX_UINT256)).wait();
+
+  return { provider, ganacheProvider, owner, user, tokenA, tokenB, swap };
+}
+
+async function futureDeadline(provider) {
+  const block = await provider.getBlock("latest");
+  return BigInt(block.timestamp + 60);
+}
+
+async function assertRevert(promise, reason) {
+  try {
+    await promise;
+  } catch (error) {
+    const details = [
+      error.shortMessage,
+      error.reason,
+      error.message,
+      error.info ? JSON.stringify(error.info) : "",
+    ].join("\n");
+    assert.match(details, new RegExp(reason));
+    return;
+  }
+
+  assert.fail(`Expected revert: ${reason}`);
+}
+
+test("swap succeeds when minAmountOut equals the quoted output", async () => {
+  const { provider, user, tokenA, tokenB, swap } = await deployFixture();
+  const amountIn = 1_000n;
+  const expected = await swap.getAmountOut(tokenA.target, amountIn);
+  const deadline = await futureDeadline(provider);
+  const userAddress = await user.getAddress();
+  const balanceBefore = await tokenB.balanceOf(userAddress);
+
+  assert.equal(expected, fixedPointAmountOut(10_000n, 10_000n, amountIn));
+  assert.equal(
+    await swap.connect(user).swap.staticCall(tokenA.target, amountIn, expected, deadline),
+    expected,
+  );
+
+  await (await swap.connect(user).swap(tokenA.target, amountIn, expected, deadline)).wait();
+
+  assert.equal((await tokenB.balanceOf(userAddress)) - balanceBefore, expected);
+  assert.equal(await swap.reserveA(), 11_000n);
+  assert.equal(await swap.reserveB(), 10_000n - expected);
+});
+
+test("swap reverts when quoted output is below minAmountOut", async () => {
+  const { provider, user, tokenA, swap } = await deployFixture();
+  const amountIn = 1_000n;
+  const expected = await swap.getAmountOut(tokenA.target, amountIn);
+  const deadline = await futureDeadline(provider);
+
+  await assertRevert(
+    swap.connect(user).swap(tokenA.target, amountIn, expected + 1n, deadline),
+    "Slippage exceeded",
+  );
+});
+
+test("swap reverts after the caller supplied deadline", async () => {
+  const { provider, user, tokenA, swap } = await deployFixture();
+  const block = await provider.getBlock("latest");
+
+  await assertRevert(
+    swap.connect(user).swap(tokenA.target, 1_000n, 0n, BigInt(block.timestamp - 1)),
+    "Deadline expired",
+  );
+});
+
+test("getAmountOut applies basis-point fees without truncating fee to zero first", async () => {
+  const { tokenA, swap } = await deployFixture({ reserveA: 10n, reserveB: 1_000n, userA: 10n });
+  const amountIn = 5n;
+  const quote = await swap.getAmountOut(tokenA.target, amountIn);
+
+  assert.equal(quote, fixedPointAmountOut(10n, 1_000n, amountIn));
+  assert.equal(quote, 332n);
+  assert.equal(truncatedFeeAmountOut(10n, 1_000n, amountIn), 333n);
+});


### PR DESCRIPTION
/claim #913

## Issue
Closes #913

## Summary
Adds minAmountOut and deadline protection to SimpleSwap.swap, and shares fixed-point basis-point fee math between swap and getAmountOut. Adds focused Solidity-area tests for exact-output swaps, slippage reverts, expired deadlines, and small-amount fee precision.

## Acceptance criteria
- [x] swap function requires minAmountOut and reverts when slippage exceeds it
- [x] deadline parameter prevents stale transactions from executing
- [x] Fee calculation uses proper fixed-point math to avoid precision loss
- [x] Swap with exact expected output succeeds
- [x] Swap with output below minAmountOut reverts with clear error message
- [x] Expired transactions revert with deadline error
- [x] Include tests covering the fixed behavior

## Validation
- `cd solidity && npm install --no-package-lock && npm test`