### PR TITLE
Codex [ Crypto ] Fix TokenVesting overflow

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,3 @@
+artifacts/
+cache/
+node_modules/

--- a/solidity/contracts/TokenVesting.sol
+++ b/solidity/contracts/TokenVesting.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract TokenVesting {
     IERC20 public token;
@@ -26,6 +27,10 @@ contract TokenVesting {
         uint256 _cliffDuration,
         uint256 _vestingDuration
     ) {
+        require(_vestingDuration > 0, "Invalid duration");
+        require(_cliffDuration <= _vestingDuration, "Invalid cliff");
+        require(_start <= type(uint256).max - _cliffDuration, "Invalid cliff");
+
         token = IERC20(_token);
         beneficiary = _beneficiary;
         owner = msg.sender;
@@ -35,22 +40,33 @@ contract TokenVesting {
         duration = _vestingDuration;
     }
 
-    // BUG: Overflow risk for large allocations — totalAllocation * elapsed can exceed uint256
     function vestedAmount() public view returns (uint256) {
-        if (block.timestamp < cliff) return 0;
-        if (block.timestamp >= start + duration) return totalAllocation;
+        return _vestedAmount(block.timestamp);
+    }
 
-        uint256 elapsed = block.timestamp - start;
-        // This multiplication can overflow for large totalAllocation values
-        return totalAllocation * elapsed / duration;
+    function _vestedAmount(uint256 timestamp) internal view returns (uint256) {
+        if (timestamp < cliff) return 0;
+
+        uint256 elapsed = timestamp - start;
+        if (elapsed >= duration) return totalAllocation;
+
+        uint256 vested = (totalAllocation / duration) * elapsed;
+        uint256 remainder = totalAllocation % duration;
+        if (remainder > 0) {
+            vested += Math.mulDiv(remainder, elapsed, duration);
+        }
+        return vested;
     }
 
     function claimable() public view returns (uint256) {
-        return vestedAmount() - claimed;
+        uint256 vested = vestedAmount();
+        if (vested <= claimed) return 0;
+        return vested - claimed;
     }
 
     function claim() external {
         require(msg.sender == beneficiary, "Not beneficiary");
+        require(!revoked, "Vesting revoked");
         uint256 amount = claimable();
         require(amount > 0, "Nothing to claim");
         claimed += amount;
@@ -58,19 +74,17 @@ contract TokenVesting {
         emit TokensClaimed(beneficiary, amount);
     }
 
-    // BUG: Incorrect unvested calculation during cliff period
     function revoke() external {
         require(msg.sender == owner, "Not owner");
         require(!revoked, "Already revoked");
         revoked = true;
 
         uint256 vested = vestedAmount();
-        // BUG: Should be totalAllocation - claimed, not totalAllocation - vested
-        // during cliff, vested is 0 but user may have claimed nothing
-        uint256 unvested = totalAllocation - vested;
+        uint256 claimableAmount = vested > claimed ? vested - claimed : 0;
+        uint256 unvested = totalAllocation - claimed - claimableAmount;
 
-        if (vested > claimed) {
-            token.transfer(beneficiary, vested - claimed);
+        if (claimableAmount > 0) {
+            token.transfer(beneficiary, claimableAmount);
         }
         token.transfer(owner, unvested);
         emit VestingRevoked(beneficiary, unvested);

--- a/solidity/contracts/test/TokenVestingHarness.sol
+++ b/solidity/contracts/test/TokenVestingHarness.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../TokenVesting.sol";
+
+contract TokenVestingHarness is TokenVesting {
+    constructor(
+        address token_,
+        address beneficiary_,
+        uint256 totalAllocation_,
+        uint256 start_,
+        uint256 cliffDuration_,
+        uint256 vestingDuration_
+    )
+        TokenVesting(
+            token_,
+            beneficiary_,
+            totalAllocation_,
+            start_,
+            cliffDuration_,
+            vestingDuration_
+        )
+    {}
+
+    function vestedAmountAt(uint256 timestamp) external view returns (uint256) {
+        return _vestedAmount(timestamp);
+    }
+}

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,0 +1,9 @@
+require("@nomicfoundation/hardhat-ethers");
+
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test"
+  }
+};

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.13.5",
+    "hardhat": "^2.22.19"
+  }
+}

--- a/solidity/test/TokenVesting.test.js
+++ b/solidity/test/TokenVesting.test.js
@@ -1,0 +1,137 @@
+const assert = require("node:assert/strict");
+const { ethers, network } = require("hardhat");
+
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+describe("TokenVesting", function () {
+  async function deployToken(initialSupply) {
+    const Token = await ethers.getContractFactory("GovernanceToken");
+    return Token.deploy(initialSupply);
+  }
+
+  async function deployVesting({
+    allocation,
+    start,
+    cliffDuration = 0n,
+    duration,
+    harness = false
+  }) {
+    const [owner, beneficiary] = await ethers.getSigners();
+    const token = await deployToken(allocation);
+    const Vesting = await ethers.getContractFactory(harness ? "TokenVestingHarness" : "TokenVesting");
+    const vesting = await Vesting.deploy(
+      await token.getAddress(),
+      beneficiary.address,
+      allocation,
+      start,
+      cliffDuration,
+      duration
+    );
+    return { owner, beneficiary, token, vesting };
+  }
+
+  async function latestTimestamp() {
+    const block = await ethers.provider.getBlock("latest");
+    return BigInt(block.timestamp);
+  }
+
+  async function setNextBlockTimestamp(timestamp) {
+    await network.provider.send("evm_setNextBlockTimestamp", [Number(timestamp)]);
+  }
+
+  it("does not overflow when the equivalent totalAllocation * elapsed product exceeds uint256", async function () {
+    const allocation = 1_000_000_000n * 10n ** 18n;
+    const duration = MAX_UINT256;
+    const elapsed = MAX_UINT256 / allocation + 1n;
+    assert(allocation * elapsed > MAX_UINT256);
+
+    const { vesting } = await deployVesting({
+      allocation,
+      start: 0n,
+      duration,
+      harness: true
+    });
+
+    const expected = allocation * elapsed / duration;
+    assert.equal(await vesting.vestedAmountAt(elapsed), expected);
+  });
+
+  it("keeps the linear vesting curve within one token unit while preserving remainders", async function () {
+    const allocation = 1_000_000_000n * 10n ** 18n + 123n;
+    const duration = 997n;
+    const { vesting } = await deployVesting({
+      allocation,
+      start: 0n,
+      duration,
+      harness: true
+    });
+
+    for (let elapsed = 0n; elapsed < duration; elapsed += 37n) {
+      const expected = allocation * elapsed / duration;
+      const actual = await vesting.vestedAmountAt(elapsed);
+      const delta = actual > expected ? actual - expected : expected - actual;
+      assert(delta <= 1n, `elapsed ${elapsed}: expected ${expected}, got ${actual}`);
+    }
+
+    assert.equal(await vesting.vestedAmountAt(duration), allocation);
+  });
+
+  it("allows the beneficiary to claim the full allocation at vesting completion", async function () {
+    const allocation = 1_000_000_000n * 10n ** 18n + 1n;
+    const duration = 365n * 24n * 60n * 60n;
+    const start = await latestTimestamp() + 100n;
+    const { beneficiary, token, vesting } = await deployVesting({ allocation, start, duration });
+    const vestingAddress = await vesting.getAddress();
+    await token.transfer(vestingAddress, allocation);
+
+    await setNextBlockTimestamp(start + duration);
+    await vesting.connect(beneficiary).claim();
+
+    assert.equal(await token.balanceOf(beneficiary.address), allocation);
+    assert.equal(await vesting.claimed(), allocation);
+    assert.equal(await vesting.claimable(), 0n);
+  });
+
+  it("returns the whole unclaimed allocation to the owner when revoked during the cliff", async function () {
+    const allocation = 1_000_000n;
+    const duration = 1_000n;
+    const cliffDuration = 200n;
+    const start = await latestTimestamp() + 100n;
+    const { owner, beneficiary, token, vesting } = await deployVesting({
+      allocation,
+      start,
+      cliffDuration,
+      duration
+    });
+    const vestingAddress = await vesting.getAddress();
+    await token.transfer(vestingAddress, allocation);
+    const ownerBalanceBefore = await token.balanceOf(owner.address);
+
+    await vesting.revoke();
+
+    assert.equal(await token.balanceOf(vestingAddress), 0n);
+    assert.equal(await token.balanceOf(beneficiary.address), 0n);
+    assert.equal(await token.balanceOf(owner.address), ownerBalanceBefore + allocation);
+  });
+
+  it("returns only truly unvested tokens after partial vesting and prior claims", async function () {
+    const allocation = 1_000n;
+    const duration = 1_000n;
+    const start = await latestTimestamp() + 100n;
+    const { owner, beneficiary, token, vesting } = await deployVesting({ allocation, start, duration });
+    const vestingAddress = await vesting.getAddress();
+    await token.transfer(vestingAddress, allocation);
+    const ownerBalanceBefore = await token.balanceOf(owner.address);
+
+    await setNextBlockTimestamp(start + 250n);
+    await vesting.connect(beneficiary).claim();
+    assert.equal(await token.balanceOf(beneficiary.address), 250n);
+
+    await setNextBlockTimestamp(start + 400n);
+    await vesting.revoke();
+
+    assert.equal(await token.balanceOf(beneficiary.address), 400n);
+    assert.equal(await token.balanceOf(owner.address), ownerBalanceBefore + 600n);
+    assert.equal(await token.balanceOf(vestingAddress), 0n);
+  });
+});


### PR DESCRIPTION
/claim #917

## Issue
Closes #917

## Summary
Fixes TokenVesting vesting math by splitting quotient and remainder calculations, using Math.mulDiv for remainder precision without overflowing intermediate products. Revoke now pays only still-unclaimed vested tokens to the beneficiary and returns only the unvested balance to the owner.

## Acceptance criteria
- [x] Vesting calculation does not overflow for allocations up to 1 billion tokens with 18 decimals
- [x] Remainder handling ensures total claimed equals total allocation at vesting end
- [x] Revocation during cliff period returns correct unvested amount
- [x] Revocation after partial vesting returns only truly unvested tokens
- [x] Linear vesting curve is accurate to within 1 token unit over the full period
- [x] Add tests for maximum allocation overflow, cliff period revocation, post-cliff revocation, full vesting completion, remainder accuracy

## Validation
- `npm test` from `solidity`