### PR TITLE
Codex [ T3 Code ] Add backend health monitoring and auto-restart

### DIFF
--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -23,6 +23,9 @@ import * as DesktopBackendManager from "./DesktopBackendManager.ts";
 import * as DesktopBackendConfiguration from "./DesktopBackendConfiguration.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
+import * as ElectronNotification from "../electron/ElectronNotification.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const decodeDesktopBackendBootstrap = Schema.decodeEffect(
@@ -107,6 +110,9 @@ function makeManagerLayer(input: {
   readonly backendOutputLog?: Partial<DesktopObservability.DesktopBackendOutputLogShape>;
   readonly desktopState?: DesktopState.DesktopStateShape;
   readonly desktopWindow?: Partial<DesktopWindow.DesktopWindowShape>;
+  readonly electronApp?: Partial<ElectronApp.ElectronAppShape>;
+  readonly electronDialog?: Partial<ElectronDialog.ElectronDialogShape>;
+  readonly electronNotification?: Partial<ElectronNotification.ElectronNotificationShape>;
   readonly config?: DesktopBackendManager.DesktopBackendStartConfig;
 }) {
   return DesktopBackendManager.layer.pipe(
@@ -128,6 +134,34 @@ function makeManagerLayer(input: {
           writeOutputChunk: () => Effect.void,
           ...input.backendOutputLog,
         } satisfies DesktopObservability.DesktopBackendOutputLogShape),
+        Layer.succeed(ElectronApp.ElectronApp, {
+          metadata: Effect.die("unexpected metadata"),
+          name: Effect.succeed("T3 Code"),
+          whenReady: Effect.void,
+          quit: Effect.void,
+          exit: () => Effect.void,
+          relaunch: () => Effect.void,
+          setPath: () => Effect.void,
+          setName: () => Effect.void,
+          setAboutPanelOptions: () => Effect.void,
+          setAppUserModelId: () => Effect.void,
+          setDesktopName: () => Effect.void,
+          setDockIcon: () => Effect.void,
+          appendCommandLineSwitch: () => Effect.void,
+          on: () => Effect.void,
+          ...input.electronApp,
+        } satisfies ElectronApp.ElectronAppShape),
+        Layer.succeed(ElectronDialog.ElectronDialog, {
+          pickFolder: () => Effect.succeed(Option.none()),
+          confirm: () => Effect.succeed(false),
+          showMessageBox: () => Effect.succeed({ response: 0, checkboxChecked: false }),
+          showErrorBox: () => Effect.void,
+          ...input.electronDialog,
+        } satisfies ElectronDialog.ElectronDialogShape),
+        Layer.succeed(ElectronNotification.ElectronNotification, {
+          show: () => Effect.void,
+          ...input.electronNotification,
+        } satisfies ElectronNotification.ElectronNotificationShape),
         Layer.succeed(DesktopWindow.DesktopWindow, {
           createMain: Effect.die("unexpected createMain"),
           ensureMain: Effect.die("unexpected ensureMain"),
@@ -346,6 +380,185 @@ describe("DesktopBackendManager", () => {
         assert.equal(stoppedSnapshot.ready, false);
         assert.equal(Option.isNone(stoppedSnapshot.activePid), true);
       }).pipe(Effect.provide(managerLayer));
+    }),
+  );
+
+  it.effect("restarts the backend after three failed health checks", () =>
+    Effect.gen(function* () {
+      const starts = yield* Queue.unbounded<number>();
+      const readyRuns = yield* Queue.unbounded<number>();
+      const statuses = [200, 503, 503, 503, 200];
+      let startCount = 0;
+      let readyCount = 0;
+      let notificationCount = 0;
+
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.gen(function* () {
+            startCount += 1;
+            const runNumber = startCount;
+            const exited = yield* Deferred.make<void>();
+            const close = Deferred.succeed(exited, void 0).pipe(Effect.asVoid);
+            const scope = yield* Scope.Scope;
+            yield* Scope.addFinalizer(scope, close);
+            yield* Queue.offer(starts, runNumber);
+            return makeProcess({
+              exitCode: Deferred.await(exited).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
+              kill: () => close,
+            });
+          }),
+        ),
+      );
+
+      const managerLayer = makeManagerLayer({
+        spawnerLayer,
+        httpClientLayer: httpClientLayer((request) =>
+          Effect.sync(() => {
+            assert.equal(request.url, "http://127.0.0.1:3773/.well-known/t3/environment");
+            const status = statuses.shift() ?? 200;
+            return responseForRequest(request, status);
+          }),
+        ),
+        desktopWindow: {
+          handleBackendReady: Effect.gen(function* () {
+            readyCount += 1;
+            yield* Queue.offer(readyRuns, readyCount);
+          }),
+        },
+        electronNotification: {
+          show: () =>
+            Effect.sync(() => {
+              notificationCount += 1;
+            }),
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const manager = yield* DesktopBackendManager.DesktopBackendManager;
+        yield* manager.start;
+
+        assert.equal(yield* Queue.take(starts), 1);
+        assert.equal(yield* Queue.take(readyRuns), 1);
+
+        yield* TestClock.adjust(Duration.seconds(60));
+
+        assert.equal(yield* Queue.take(starts), 2);
+        assert.equal(yield* Queue.take(readyRuns), 2);
+        assert.equal(notificationCount, 1);
+        assert.equal((yield* manager.snapshot).ready, true);
+      }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
+    }),
+  );
+
+  it.effect("stops the health monitor when the backend is stopped", () =>
+    Effect.gen(function* () {
+      const starts = yield* Queue.unbounded<number>();
+      const ready = yield* Deferred.make<void>();
+      let requestCount = 0;
+
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.gen(function* () {
+            const exited = yield* Deferred.make<void>();
+            const close = Deferred.succeed(exited, void 0).pipe(Effect.asVoid);
+            const scope = yield* Scope.Scope;
+            yield* Scope.addFinalizer(scope, close);
+            yield* Queue.offer(starts, 1);
+            return makeProcess({
+              exitCode: Deferred.await(exited).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
+              kill: () => close,
+            });
+          }),
+        ),
+      );
+
+      const managerLayer = makeManagerLayer({
+        spawnerLayer,
+        httpClientLayer: httpClientLayer((request) =>
+          Effect.sync(() => {
+            requestCount += 1;
+            return responseForRequest(request, 200);
+          }),
+        ),
+        desktopWindow: {
+          handleBackendReady: Deferred.succeed(ready, void 0).pipe(Effect.asVoid),
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const manager = yield* DesktopBackendManager.DesktopBackendManager;
+        yield* manager.start;
+        assert.equal(yield* Queue.take(starts), 1);
+        yield* Deferred.await(ready);
+
+        yield* manager.stop();
+        yield* TestClock.adjust(Duration.seconds(60));
+
+        assert.equal(requestCount, 1);
+      }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
+    }),
+  );
+
+  it.effect("offers retry or quit after automatic restarts fail three times", () =>
+    Effect.gen(function* () {
+      const starts = yield* Queue.unbounded<number>();
+      let startCount = 0;
+      let promptCount = 0;
+      let quitCount = 0;
+      let promptButtons: ReadonlyArray<string> = [];
+
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.gen(function* () {
+            startCount += 1;
+            yield* Queue.offer(starts, startCount);
+            return makeProcess({
+              exitCode:
+                startCount >= 5 ? Effect.never : Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+            });
+          }),
+        ),
+      );
+
+      const managerLayer = makeManagerLayer({
+        spawnerLayer,
+        httpClientLayer: httpClientLayer(() => Effect.never),
+        electronDialog: {
+          showMessageBox: (options) =>
+            Effect.sync(() => {
+              promptCount += 1;
+              promptButtons = options.buttons ?? [];
+              return { response: 1, checkboxChecked: false };
+            }),
+        },
+        electronApp: {
+          quit: Effect.sync(() => {
+            quitCount += 1;
+          }),
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const manager = yield* DesktopBackendManager.DesktopBackendManager;
+        yield* manager.start;
+
+        assert.equal(yield* Queue.take(starts), 1);
+        yield* TestClock.adjust(Duration.millis(500));
+        assert.equal(yield* Queue.take(starts), 2);
+        yield* TestClock.adjust(Duration.seconds(1));
+        assert.equal(yield* Queue.take(starts), 3);
+        yield* TestClock.adjust(Duration.seconds(2));
+        assert.equal(yield* Queue.take(starts), 4);
+
+        assert.equal(yield* Queue.take(starts), 5);
+        assert.equal(promptCount, 1);
+        assert.deepEqual(promptButtons, ["Quit", "Retry"]);
+        assert.equal(quitCount, 0);
+        assert.isTrue((yield* manager.snapshot).desiredRunning);
+      }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
     }),
   );
 

--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -27,10 +27,16 @@ import {
 import * as DesktopBackendConfiguration from "./DesktopBackendConfiguration.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
+import * as ElectronNotification from "../electron/ElectronNotification.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const INITIAL_RESTART_DELAY = Duration.millis(500);
 const MAX_RESTART_DELAY = Duration.seconds(10);
+const HEALTH_CHECK_INTERVAL = Duration.seconds(15);
+const HEALTH_CHECK_FAILURES_BEFORE_RESTART = 3;
+const MAX_RESTART_ATTEMPTS = 3;
 const DEFAULT_BACKEND_READINESS_TIMEOUT = Duration.minutes(1);
 const DEFAULT_BACKEND_READINESS_INTERVAL = Duration.millis(100);
 const DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT = Duration.seconds(1);
@@ -135,8 +141,15 @@ interface BackendManagerState {
   readonly active: Option.Option<ActiveBackendRun>;
   readonly restartAttempt: number;
   readonly restartFiber: Option.Option<Fiber.Fiber<void, never>>;
+  readonly healthFailureCount: number;
+  readonly healthMonitorFiber: Option.Option<Fiber.Fiber<void, never>>;
   readonly nextRunId: number;
 }
+
+type RestartAction =
+  | { readonly _tag: "skip" }
+  | { readonly _tag: "prompt" }
+  | { readonly _tag: "schedule"; readonly delay: Duration.Duration; readonly attempt: number };
 
 const initialState: BackendManagerState = {
   desiredRunning: false,
@@ -145,6 +158,8 @@ const initialState: BackendManagerState = {
   active: Option.none(),
   restartAttempt: 0,
   restartFiber: Option.none(),
+  healthFailureCount: 0,
+  healthMonitorFiber: Option.none(),
   nextRunId: 1,
 };
 
@@ -160,6 +175,8 @@ const withActiveRun =
 
 const calculateRestartDelay = (attempt: number): Duration.Duration =>
   Duration.min(Duration.times(INITIAL_RESTART_DELAY, 2 ** attempt), MAX_RESTART_DELAY);
+
+const healthCheckSchedule = Schedule.spaced(HEALTH_CHECK_INTERVAL).pipe(Schedule.jittered);
 
 const closeRun = (
   run: ActiveBackendRun,
@@ -284,6 +301,9 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
   const backendOutputLog = yield* DesktopObservability.DesktopBackendOutputLog;
   const desktopState = yield* DesktopState.DesktopState;
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const electronDialog = yield* ElectronDialog.ElectronDialog;
+  const electronNotification = yield* ElectronNotification.ElectronNotification;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
   const state = yield* Ref.make(initialState);
@@ -320,6 +340,159 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
     });
   });
 
+  const notifyBackendRestarting = Effect.fn("desktop.backendManager.notifyBackendRestarting")(
+    function* () {
+      yield* electronNotification
+        .show({
+          title: "T3 Code backend restarting",
+          body: "The local backend stopped responding. T3 Code is restarting it.",
+        })
+        .pipe(Effect.ignore);
+    },
+  );
+
+  const runHealthCheck = Effect.fn("desktop.backendManager.runHealthCheck")(function* () {
+    const current = yield* Ref.get(state);
+    const currentRun = Option.getOrUndefined(current.active);
+    if (!current.desiredRunning || !current.ready || currentRun === undefined) {
+      return;
+    }
+
+    const config = Option.getOrUndefined(current.config);
+    if (config === undefined) {
+      return;
+    }
+
+    const readinessUrl = new URL(BACKEND_READINESS_PATH, config.httpBaseUrl);
+    const client = httpClient.pipe(
+      HttpClient.filterStatusOk,
+      HttpClient.transformResponse(Effect.timeout(DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT)),
+    );
+    const probeExit = yield* client
+      .get(readinessUrl)
+      .pipe(Effect.asVoid, Effect.timeout(DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT), Effect.exit);
+
+    if (Exit.isSuccess(probeExit)) {
+      yield* Ref.update(state, (latest) => {
+        const latestRun = Option.getOrUndefined(latest.active);
+        if (latestRun?.id !== currentRun.id || latest.healthFailureCount === 0) {
+          return latest;
+        }
+        return {
+          ...latest,
+          healthFailureCount: 0,
+        };
+      });
+      return;
+    }
+
+    const consecutiveFailures = yield* Ref.modify(state, (latest) => {
+      const latestRun = Option.getOrUndefined(latest.active);
+      if (latestRun?.id !== currentRun.id || !latest.desiredRunning || !latest.ready) {
+        return [0, latest] as const;
+      }
+
+      const nextFailures = latest.healthFailureCount + 1;
+      return [
+        nextFailures,
+        {
+          ...latest,
+          healthFailureCount: nextFailures,
+        },
+      ] as const;
+    });
+    if (consecutiveFailures === 0) {
+      return;
+    }
+
+    yield* logBackendManagerWarning("desktop backend health check failed", {
+      url: readinessUrl.href,
+      consecutiveFailures,
+      cause: Cause.pretty(probeExit.cause),
+    });
+
+    if (consecutiveFailures < HEALTH_CHECK_FAILURES_BEFORE_RESTART) {
+      return;
+    }
+
+    const runToRestart = yield* Ref.modify(state, (latest) => {
+      const latestRun = Option.getOrUndefined(latest.active);
+      if (latestRun?.id !== currentRun.id || !latest.desiredRunning || !latest.ready) {
+        return [Option.none<ActiveBackendRun>(), latest] as const;
+      }
+
+      return [
+        Option.some(latestRun),
+        {
+          ...latest,
+          healthFailureCount: 0,
+        },
+      ] as const;
+    });
+
+    yield* Option.match(runToRestart, {
+      onNone: () => Effect.void,
+      onSome: Effect.fn("desktop.backendManager.restartUnhealthyBackend")(function* (run) {
+        yield* logBackendManagerError("desktop backend health checks failed; restarting backend", {
+          url: readinessUrl.href,
+          consecutiveFailures,
+        });
+        yield* closeRun(run);
+      }),
+    });
+  });
+
+  const ensureHealthMonitor = Effect.fn("desktop.backendManager.ensureHealthMonitor")(function* () {
+    const existingFiber = yield* Ref.get(state).pipe(
+      Effect.map((current) => current.healthMonitorFiber),
+    );
+    if (Option.isSome(existingFiber)) {
+      return;
+    }
+
+    const fiber = yield* Effect.forkIn(
+      Effect.sleep(HEALTH_CHECK_INTERVAL).pipe(
+        Effect.andThen(
+          runHealthCheck().pipe(
+            Effect.catchCause((cause) =>
+              logBackendManagerError("desktop backend health monitor failed", {
+                cause: Cause.pretty(cause),
+              }),
+            ),
+            Effect.repeat(healthCheckSchedule),
+            Effect.asVoid,
+          ),
+        ),
+      ),
+      parentScope,
+    );
+
+    const stored = yield* Ref.modify(state, (latest): readonly [boolean, BackendManagerState] => {
+      if (Option.isSome(latest.healthMonitorFiber)) {
+        return [false, latest];
+      }
+      return [true, { ...latest, healthMonitorFiber: Option.some(fiber) }];
+    });
+    if (!stored) {
+      yield* Fiber.interrupt(fiber).pipe(Effect.asVoid);
+    }
+  });
+
+  const cancelHealthMonitor = Effect.gen(function* () {
+    const healthMonitorFiber = yield* Ref.modify(state, (current) => [
+      current.healthMonitorFiber,
+      {
+        ...current,
+        healthMonitorFiber: Option.none<Fiber.Fiber<void, never>>(),
+      },
+    ]);
+
+    yield* Option.match(healthMonitorFiber, {
+      onNone: () => Effect.void,
+      onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
+    });
+  });
+
   const start: Effect.Effect<void> = Effect.suspend(() =>
     mutex.withPermits(1)(
       Effect.gen(function* () {
@@ -340,6 +513,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
           desiredRunning: true,
           ready: false,
           config: Option.some(config),
+          healthFailureCount: 0,
         }));
 
         if (!entryExists) {
@@ -365,9 +539,9 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
         const finalizeRun = Effect.fn("desktop.backendManager.finalizeRun")(function* (
           reason: string,
         ) {
-          yield* mutex.withPermits(1)(
+          const restart = yield* mutex.withPermits(1)(
             Effect.gen(function* () {
-              const { isCurrentRun, nextState, pid } = yield* Ref.modify(
+              const { isCurrentRun, nextState, pid, wasReady } = yield* Ref.modify(
                 state,
                 (
                   latest,
@@ -376,6 +550,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                     readonly isCurrentRun: boolean;
                     readonly nextState: BackendManagerState;
                     readonly pid: Option.Option<number>;
+                    readonly wasReady: boolean;
                   },
                   BackendManagerState,
                 ] => {
@@ -386,21 +561,25 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                         isCurrentRun: false,
                         nextState: latest,
                         pid: Option.none<number>(),
+                        wasReady: false,
                       },
                       latest,
                     ] as const;
                   }
 
+                  const wasReady = latest.ready;
                   const next = {
                     ...latest,
                     active: Option.none<ActiveBackendRun>(),
                     ready: false,
+                    healthFailureCount: 0,
                   };
                   return [
                     {
                       isCurrentRun: true,
                       nextState: next,
                       pid: currentRun.pid,
+                      wasReady,
                     },
                     next,
                   ] as const;
@@ -417,11 +596,16 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                 yield* Ref.set(desktopState.backendReady, false);
               }
 
-              if (isCurrentRun && nextState.desiredRunning) {
-                yield* scheduleRestart(reason);
-              }
+              return {
+                shouldSchedule: isCurrentRun && nextState.desiredRunning,
+                notifyUser: isCurrentRun && wasReady,
+              };
             }),
           );
+
+          if (restart.shouldSchedule) {
+            yield* scheduleRestart(reason, { notifyUser: restart.notifyUser });
+          }
         });
 
         const program = runBackendProcess({
@@ -448,6 +632,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                 {
                   ...latest,
                   restartAttempt: 0,
+                  healthFailureCount: 0,
                   ready: true,
                 },
               ] as const;
@@ -464,6 +649,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                 }),
               ),
             );
+            yield* ensureHealthMonitor();
           }),
           onReadinessFailure: (error) =>
             logBackendManagerWarning("backend readiness check failed during bootstrap", {
@@ -490,33 +676,99 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
     ),
   ).pipe(Effect.withSpan("desktop.backendManager.start"));
 
-  const scheduleRestart = Effect.fn("desktop.backendManager.scheduleRestart")(function* (
-    reason: string,
-  ) {
-    const scheduled = yield* Ref.modify(state, (latest) => {
-      if (!latest.desiredRunning || Option.isSome(latest.restartFiber)) {
-        return [Option.none<Duration.Duration>(), latest] as const;
+  const promptRestartRecovery = Effect.fn("desktop.backendManager.promptRestartRecovery")(
+    function* (reason: string) {
+      yield* logBackendManagerError("desktop backend restart limit reached", {
+        reason,
+        restartAttempts: MAX_RESTART_ATTEMPTS,
+      });
+
+      const result = yield* electronDialog.showMessageBox({
+        type: "error",
+        buttons: ["Quit", "Retry"],
+        defaultId: 1,
+        cancelId: 0,
+        noLink: true,
+        title: "T3 Code backend unavailable",
+        message: "T3 Code could not recover the local backend automatically.",
+        detail: `${reason}\n\nAutomatic restart failed 3 times. Retry manually or quit the app.`,
+      });
+
+      if (result.response === 1) {
+        yield* Ref.update(state, (latest) => ({
+          ...latest,
+          desiredRunning: true,
+          restartAttempt: 0,
+          healthFailureCount: 0,
+        }));
+        yield* Effect.forkIn(
+          start.pipe(
+            Effect.catchCause((cause) =>
+              logBackendManagerError("desktop backend manual restart failed", {
+                cause: Cause.pretty(cause),
+              }),
+            ),
+          ),
+          parentScope,
+        );
+        return;
       }
 
-      const delay = calculateRestartDelay(latest.restartAttempt);
-      return [
-        Option.some(delay),
-        {
-          ...latest,
-          restartAttempt: latest.restartAttempt + 1,
-        },
-      ] as const;
-    });
+      yield* Ref.set(desktopState.quitting, true);
+      yield* electronApp.quit;
+    },
+  );
 
-    yield* Option.match(scheduled, {
-      onNone: () => Effect.void,
-      onSome: Effect.fn("desktop.backendManager.scheduleRestartFiber")(function* (delay) {
+  const scheduleRestart = Effect.fn("desktop.backendManager.scheduleRestart")(function* (
+    reason: string,
+    options?: { readonly notifyUser?: boolean },
+  ) {
+    const action = yield* Ref.modify(
+      state,
+      (latest): readonly [RestartAction, BackendManagerState] => {
+        if (!latest.desiredRunning || Option.isSome(latest.restartFiber)) {
+          return [{ _tag: "skip" }, latest];
+        }
+
+        if (latest.restartAttempt >= MAX_RESTART_ATTEMPTS) {
+          return [
+            { _tag: "prompt" },
+            {
+              ...latest,
+              desiredRunning: false,
+              healthFailureCount: 0,
+            },
+          ];
+        }
+
+        const delay = calculateRestartDelay(latest.restartAttempt);
+        return [
+          { _tag: "schedule", delay, attempt: latest.restartAttempt + 1 },
+          {
+            ...latest,
+            restartAttempt: latest.restartAttempt + 1,
+          },
+        ];
+      },
+    );
+
+    switch (action._tag) {
+      case "skip":
+        return;
+      case "prompt":
+        yield* promptRestartRecovery(reason);
+        return;
+      case "schedule": {
+        if (options?.notifyUser === true) {
+          yield* notifyBackendRestarting();
+        }
         yield* logBackendManagerError("backend exited unexpectedly; restart scheduled", {
           reason,
-          delayMs: Duration.toMillis(delay),
+          delayMs: Duration.toMillis(action.delay),
+          restartAttempt: action.attempt,
         });
         const restartFiber = yield* Effect.forkIn(
-          Effect.sleep(delay).pipe(
+          Effect.sleep(action.delay).pipe(
             Effect.andThen(
               Ref.modify(state, (latest) => {
                 const shouldRestart = latest.desiredRunning;
@@ -546,8 +798,9 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
               }
             : latest,
         );
-      }),
-    });
+        return;
+      }
+    }
   });
 
   const stop = Effect.fn("desktop.backendManager.stop")(function* (options?: {
@@ -566,6 +819,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
             ready: false,
             active: Option.none<ActiveBackendRun>(),
             restartFiber: Option.none<Fiber.Fiber<void, never>>(),
+            healthFailureCount: 0,
           },
         ]);
         yield* Ref.set(desktopState.backendReady, false);
@@ -577,6 +831,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
       onNone: () => Effect.void,
       onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
     });
+    yield* cancelHealthMonitor;
     yield* Option.match(active, {
       onNone: () => Effect.void,
       onSome: (run) => closeRun(run, options),

--- a/t3code/apps/desktop/src/electron/ElectronNotification.ts
+++ b/t3code/apps/desktop/src/electron/ElectronNotification.ts
@@ -1,0 +1,23 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as Electron from "electron";
+
+export interface ElectronNotificationShape {
+  readonly show: (options: Electron.NotificationConstructorOptions) => Effect.Effect<void>;
+}
+
+export class ElectronNotification extends Context.Service<
+  ElectronNotification,
+  ElectronNotificationShape
+>()("t3/desktop/electron/Notification") {}
+
+const make = ElectronNotification.of({
+  show: (options) =>
+    Effect.sync(() => {
+      new Electron.Notification(options).show();
+    }),
+});
+
+export const layer = Layer.succeed(ElectronNotification, make);

--- a/t3code/apps/desktop/src/main.ts
+++ b/t3code/apps/desktop/src/main.ts
@@ -18,6 +18,7 @@ import * as DesktopIpc from "./ipc/DesktopIpc.ts";
 import * as ElectronApp from "./electron/ElectronApp.ts";
 import * as ElectronDialog from "./electron/ElectronDialog.ts";
 import * as ElectronMenu from "./electron/ElectronMenu.ts";
+import * as ElectronNotification from "./electron/ElectronNotification.ts";
 import * as ElectronProtocol from "./electron/ElectronProtocol.ts";
 import * as DesktopSecretStorage from "./electron/ElectronSafeStorage.ts";
 import * as ElectronShell from "./electron/ElectronShell.ts";
@@ -97,6 +98,7 @@ const electronLayer = Layer.mergeAll(
   ElectronApp.layer,
   ElectronDialog.layer,
   ElectronMenu.layer,
+  ElectronNotification.layer,
   ElectronProtocol.layer,
   DesktopSecretStorage.layer,
   ElectronShell.layer,

--- a/t3code/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopWindow.test.ts
@@ -177,4 +177,28 @@ describe("DesktopWindow", () => {
       }).pipe(Effect.provide(layer));
     }),
   );
+
+  it.effect("reloads an existing window when the backend becomes ready again", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(
+        Option.some(fakeWindow.window),
+      );
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady;
+
+        assert.equal(yield* Ref.get(createCount), 0);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["http://127.0.0.1:5733/"]);
+        assert.equal(fakeWindow.openDevTools.mock.calls.length, 0);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
 });

--- a/t3code/apps/desktop/src/window/DesktopWindow.ts
+++ b/t3code/apps/desktop/src/window/DesktopWindow.ts
@@ -156,6 +156,27 @@ const make = Effect.gen(function* () {
   const context = yield* Effect.context<DesktopWindowRuntimeServices>();
   const runPromise = Effect.runPromiseWith(context);
 
+  const loadApplication = Effect.fn("desktop.window.loadApplication")(function* (
+    window: Electron.BrowserWindow,
+    backendHttpUrl: URL,
+    options?: { readonly openDevTools?: boolean },
+  ) {
+    if (environment.isDevelopment) {
+      const devServerUrl = yield* resolveDesktopDevServerUrl(environment);
+      yield* Effect.sync(() => {
+        void window.loadURL(devServerUrl);
+        if (options?.openDevTools === true) {
+          window.webContents.openDevTools({ mode: "detach" });
+        }
+      });
+      return;
+    }
+
+    yield* Effect.sync(() => {
+      void window.loadURL(backendHttpUrl.href);
+    });
+  });
+
   const createWindow = Effect.fn("desktop.window.createWindow")(function* (
     backendHttpUrl: URL,
   ): Effect.fn.Return<Electron.BrowserWindow, DesktopWindowError> {
@@ -275,13 +296,7 @@ const make = Effect.gen(function* () {
       void runPromise(electronWindow.reveal(window));
     });
 
-    if (environment.isDevelopment) {
-      const devServerUrl = yield* resolveDesktopDevServerUrl(environment);
-      void window.loadURL(devServerUrl);
-      window.webContents.openDevTools({ mode: "detach" });
-    } else {
-      void window.loadURL(backendHttpUrl.href);
-    }
+    yield* loadApplication(window, backendHttpUrl, { openDevTools: true });
 
     window.on("closed", () => {
       void runPromise(electronWindow.clearMain(Option.some(window)));
@@ -336,6 +351,12 @@ const make = Effect.gen(function* () {
     handleBackendReady: Effect.gen(function* () {
       yield* Ref.set(state.backendReady, true);
       yield* logWindowInfo("backend ready", { source: "http" });
+      const existingWindow = yield* electronWindow.currentMainOrFirst;
+      if (Option.isSome(existingWindow)) {
+        const backendConfig = yield* serverExposure.backendConfig;
+        yield* loadApplication(existingWindow.value, backendConfig.httpBaseUrl);
+        return;
+      }
       yield* createMainIfBackendReady;
     }).pipe(Effect.withSpan("desktop.window.handleBackendReady")),
     dispatchMenuAction: Effect.fn("desktop.window.dispatchMenuAction")(function* (action) {


### PR DESCRIPTION
/claim #820

## Issue
Closes #820

## Summary
Adds a jittered post-readiness backend health monitor for the desktop backend, restarts the backend after three consecutive failed probes, notifies users during recovery, and caps failed automatic recovery with a retry-or-quit dialog. Successful readiness now reloads an existing desktop window so the web view reconnects after backend recovery.

## Acceptance criteria
- [x] Health checks run every 15 seconds after backend readiness is confirmed
- [x] 3 consecutive failures trigger an automatic restart
- [x] User sees a non-blocking notification during restart
- [x] Successful restart re-establishes the web view connection
- [x] If restart fails 3 times, show an error dialog with option to quit or retry manually
- [x] Health check interval uses Effect.Schedule.spaced with jitter
- [x] Existing startup flow and readiness detection are unchanged

## Validation
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --filter @t3tools/desktop typecheck`
- `bun run --filter @t3tools/desktop test`
- `git diff --check`