### PR TITLE
Codex [ Crypto ] Fix FlashLoan fees and pool accounting

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+artifacts/
+cache/
+coverage/

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -10,11 +10,19 @@ interface IFlashLoanReceiver {
 contract FlashLoan {
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
+    uint256 public accountedPoolBalance;
     uint256 public totalFees;
     address public owner;
     bool public paused;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
     constructor(address _loanToken, uint256 _feeBPS) {
         loanToken = IERC20(_loanToken);
@@ -22,44 +30,57 @@ contract FlashLoan {
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
     function flashLoan(uint256 amount, bytes calldata data) external {
         require(!paused, "Paused");
         require(amount > 0, "Amount must be > 0");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        uint256 poolBalance = accountedPoolBalance;
+        require(poolBalance >= amount, "Insufficient pool balance");
+        require(amount <= poolBalance / 2, "Loan exceeds max amount");
+        require(loanToken.balanceOf(address(this)) >= poolBalance + totalFees, "Unsupported token balance");
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
         uint256 fee = amount * feeBPS / 10000;
+        if (fee == 0) {
+            fee = 1;
+        }
 
         loanToken.transfer(msg.sender, amount);
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(loanToken.balanceOf(address(this)) >= poolBalance + totalFees + fee, "Loan not repaid");
 
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
+        require(amount > 0, "Amount must be > 0");
         loanToken.transferFrom(msg.sender, address(this), amount);
+        accountedPoolBalance += amount;
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
         totalFees = 0;
         loanToken.transfer(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    function maxLoanAmount() external view returns (uint256) {
+        return accountedPoolBalance / 2;
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return accountedPoolBalance;
     }
 }

--- a/solidity/contracts/test/FlashLoanReceiver.sol
+++ b/solidity/contracts/test/FlashLoanReceiver.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "../FlashLoan.sol";
+import "./RebasingTestToken.sol";
+
+contract FlashLoanReceiver is IFlashLoanReceiver {
+    enum Mode {
+        Repay,
+        RebaseThenRepay,
+        DoNotRepay
+    }
+
+    IERC20 public immutable token;
+    FlashLoan public immutable lender;
+    Mode public mode;
+    uint256 public rebaseAmount;
+    uint256 public lastFee;
+
+    constructor(address _token, address _lender) {
+        token = IERC20(_token);
+        lender = FlashLoan(_lender);
+    }
+
+    function setMode(Mode _mode, uint256 _rebaseAmount) external {
+        mode = _mode;
+        rebaseAmount = _rebaseAmount;
+    }
+
+    function borrow(uint256 amount) external {
+        lender.flashLoan(amount, "");
+    }
+
+    function onFlashLoan(address, uint256 amount, uint256 fee, bytes calldata) external override {
+        require(msg.sender == address(lender), "Unexpected lender");
+        lastFee = fee;
+        if (mode == Mode.RebaseThenRepay) {
+            RebasingTestToken(address(token)).negativeRebase(address(lender), rebaseAmount);
+        }
+        if (mode != Mode.DoNotRepay) {
+            token.transfer(address(lender), amount + fee);
+        }
+    }
+}

--- a/solidity/contracts/test/RebasingTestToken.sol
+++ b/solidity/contracts/test/RebasingTestToken.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract RebasingTestToken is ERC20 {
+    constructor(uint256 initialSupply) ERC20("Rebasing Test Token", "RTEST") {
+        _mint(msg.sender, initialSupply);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function negativeRebase(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+}

--- a/solidity/contracts/test/TestToken.sol
+++ b/solidity/contracts/test/TestToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract TestToken is ERC20 {
+    constructor(uint256 initialSupply) ERC20("Test Token", "TEST") {
+        _mint(msg.sender, initialSupply);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,0 +1,9 @@
+require("@nomicfoundation/hardhat-ethers");
+
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test",
+  },
+};

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.13.5",
+    "hardhat": "^2.22.19"
+  }
+}

--- a/solidity/test/FlashLoan.test.js
+++ b/solidity/test/FlashLoan.test.js
@@ -1,0 +1,90 @@
+const assert = require("node:assert/strict");
+const { ethers } = require("hardhat");
+
+describe("FlashLoan", function () {
+  async function deploy({ rebasing = false } = {}) {
+    const [owner, depositor, stranger] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory(rebasing ? "RebasingTestToken" : "TestToken");
+    const token = await Token.deploy(1_000_000n);
+
+    const FlashLoan = await ethers.getContractFactory("FlashLoan");
+    const lender = await FlashLoan.deploy(await token.getAddress(), 100n);
+    const lenderAddress = await lender.getAddress();
+
+    await token.transfer(depositor.address, 200_000n);
+    await token.connect(depositor).approve(lenderAddress, 200_000n);
+    await lender.connect(depositor).depositToPool(100_000n);
+
+    const Receiver = await ethers.getContractFactory("FlashLoanReceiver");
+    const receiver = await Receiver.deploy(await token.getAddress(), lenderAddress);
+    await token.mint(await receiver.getAddress(), 10_000n);
+
+    return { owner, depositor, stranger, token, lender, lenderAddress, receiver };
+  }
+
+  it("charges a minimum fee of one token unit for small flash loans", async function () {
+    const { receiver, lender } = await deploy();
+
+    await receiver.borrow(1n);
+
+    assert.equal(await receiver.lastFee(), 1n);
+    assert.equal(await lender.totalFees(), 1n);
+    assert.equal(await lender.getPoolBalance(), 100_000n);
+  });
+
+  it("rejects loans that exceed half of the internally accounted pool", async function () {
+    const { receiver, lender } = await deploy();
+
+    assert.equal(await lender.maxLoanAmount(), 50_000n);
+    await assert.rejects(receiver.borrow(50_001n), /Loan exceeds max amount/);
+  });
+
+  it("uses internal accounting so direct token donations do not raise the loan cap", async function () {
+    const { owner, token, lender, lenderAddress, receiver } = await deploy();
+
+    await token.connect(owner).transfer(lenderAddress, 800_000n);
+
+    assert.equal(await token.balanceOf(lenderAddress), 900_000n);
+    assert.equal(await lender.getPoolBalance(), 100_000n);
+    assert.equal(await lender.maxLoanAmount(), 50_000n);
+    await assert.rejects(receiver.borrow(500_000n), /Insufficient pool balance/);
+  });
+
+  it("rejects repayment when a rebasing token reduces the lender balance during callback", async function () {
+    const { receiver } = await deploy({ rebasing: true });
+
+    await receiver.setMode(1, 1n);
+
+    await assert.rejects(receiver.borrow(1_000n), /Loan not repaid/);
+  });
+
+  it("pauses and unpauses flash loans through the owner", async function () {
+    const { stranger, receiver, lender } = await deploy();
+
+    await assert.rejects(lender.connect(stranger).pause(), /Not owner/);
+
+    await lender.pause();
+    assert.equal(await lender.paused(), true);
+    await assert.rejects(receiver.borrow(1n), /Paused/);
+
+    await lender.unpause();
+    assert.equal(await lender.paused(), false);
+    await receiver.borrow(1n);
+  });
+
+  it("tracks and withdraws fees without reducing accounted pool principal", async function () {
+    const { owner, token, lender, receiver } = await deploy();
+    const ownerBalanceBefore = await token.balanceOf(owner.address);
+
+    await receiver.borrow(10_000n);
+
+    assert.equal(await lender.totalFees(), 100n);
+    assert.equal(await lender.getPoolBalance(), 100_000n);
+
+    await lender.withdrawFees();
+
+    assert.equal(await lender.totalFees(), 0n);
+    assert.equal(await lender.getPoolBalance(), 100_000n);
+    assert.equal(await token.balanceOf(owner.address), ownerBalanceBefore + 100n);
+  });
+});


### PR DESCRIPTION
Summary:
- Adds a minimum one-unit flash-loan fee and a 50% internal pool loan cap.
- Tracks pool principal internally so direct token donations/rebasing balance changes do not inflate lending capacity.
- Adds owner pause/unpause controls and tests for fees, cap, internal accounting, rebasing callback behavior, and fee withdrawal.

Validation:
- npm install --no-package-lock
- npm test -- --grep FlashLoan
- git diff --check

/claim #919
