### PR TITLE
Codex [ FastAPI ] Add HTTPBasic brute force protection

### DIFF
--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,9 @@
 import binascii
+import hmac
+import time
 from base64 import b64decode
+from hashlib import pbkdf2_hmac
+from math import ceil
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +14,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -217,6 +221,118 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    def __init__(
+        self,
+        *,
+        max_attempts: Annotated[
+            int,
+            Doc("Maximum failed login attempts per client IP before lockout."),
+        ] = 5,
+        window_seconds: Annotated[
+            int,
+            Doc("Number of seconds failed attempts remain in the lockout window."),
+        ] = 60,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        if window_seconds < 1:
+            raise ValueError("window_seconds must be >= 1")
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self._failed_attempts: dict[str, list[float]] = {}
+
+    @staticmethod
+    def verify_password(
+        plain_password: str,
+        password_hash: str,
+        *,
+        salt: str | bytes = b"",
+        iterations: int = 390000,
+    ) -> bool:
+        if password_hash.startswith("pbkdf2_sha256$"):
+            _algorithm, raw_iterations, raw_salt, expected_hash = password_hash.split(
+                "$", 3
+            )
+            iterations = int(raw_iterations)
+            salt = raw_salt
+            candidate_hash = pbkdf2_hmac(
+                "sha256",
+                plain_password.encode("utf-8"),
+                salt.encode("utf-8"),
+                iterations,
+            ).hex()
+            return hmac.compare_digest(candidate_hash, expected_hash)
+        candidate_hash = pbkdf2_hmac(
+            "sha256",
+            plain_password.encode("utf-8"),
+            salt.encode("utf-8") if isinstance(salt, str) else salt,
+            iterations,
+        ).hex()
+        return hmac.compare_digest(candidate_hash, password_hash)
+
+    def _client_ip(self, request: Request) -> str:
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            return forwarded_for.split(",", 1)[0].strip()
+        if request.client:
+            return request.client.host
+        return "unknown"
+
+    def _active_failures(self, client_ip: str, now: float) -> list[float]:
+        window_start = now - self.window_seconds
+        failures = [
+            timestamp
+            for timestamp in self._failed_attempts.get(client_ip, [])
+            if timestamp > window_start
+        ]
+        if failures:
+            self._failed_attempts[client_ip] = failures
+        else:
+            self._failed_attempts.pop(client_ip, None)
+        return failures
+
+    def _retry_after(self, failures: list[float], now: float) -> int:
+        if not failures:
+            return self.window_seconds
+        retry_after = ceil(failures[0] + self.window_seconds - now)
+        return max(retry_after, 1)
+
+    def _raise_locked(self, retry_after: int) -> None:
+        raise HTTPException(
+            status_code=HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many authentication attempts",
+            headers={
+                "Retry-After": str(retry_after),
+                **self.make_authenticate_headers(),
+            },
+        )
+
+    def record_failure(self, request: Request) -> None:
+        client_ip = self._client_ip(request)
+        now = time.monotonic()
+        failures = self._active_failures(client_ip, now)
+        failures.append(now)
+        self._failed_attempts[client_ip] = failures
+        if len(failures) >= self.max_attempts:
+            self._raise_locked(self._retry_after(failures, now))
+
+    def reset_attempts(self, request: Request) -> None:
+        self._failed_attempts.pop(self._client_ip(request), None)
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        client_ip = self._client_ip(request)
+        now = time.monotonic()
+        failures = self._active_failures(client_ip, now)
+        if len(failures) >= self.max_attempts:
+            self._raise_locked(self._retry_after(failures, now))
+        return await super().__call__(request)
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_security_http_basic_with_protection.py
+++ b/fastapi/tests/test_security_http_basic_with_protection.py
@@ -1,0 +1,119 @@
+from hashlib import pbkdf2_hmac
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+
+def make_client(max_attempts: int = 2, window_seconds: int = 60):
+    app = FastAPI()
+    security = HTTPBasicWithProtection(
+        max_attempts=max_attempts,
+        window_seconds=window_seconds,
+    )
+
+    @app.get("/protected")
+    def protected(
+        request: Request,
+        credentials: HTTPBasicCredentials = Depends(security),
+    ):
+        if credentials.username != "john" or not security.verify_password(
+            credentials.password,
+            pbkdf2_hmac(
+                "sha256",
+                b"secret",
+                b"salt",
+                1000,
+            ).hex(),
+            salt="salt",
+            iterations=1000,
+        ):
+            security.record_failure(request)
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+        security.reset_attempts(request)
+        return {"username": credentials.username}
+
+    return TestClient(app)
+
+
+def test_failed_attempts_are_tracked_per_client_ip_until_lockout():
+    client = make_client()
+
+    response = client.get(
+        "/protected",
+        auth=("john", "wrong"),
+        headers={"X-Forwarded-For": "198.51.100.1"},
+    )
+    assert response.status_code == 401
+
+    response = client.get(
+        "/protected",
+        auth=("john", "wrong"),
+        headers={"X-Forwarded-For": "198.51.100.1"},
+    )
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "60"
+
+
+def test_failed_attempts_are_isolated_by_client_ip():
+    client = make_client(max_attempts=1)
+
+    locked = client.get(
+        "/protected",
+        auth=("john", "wrong"),
+        headers={"X-Forwarded-For": "198.51.100.1"},
+    )
+    assert locked.status_code == 429
+
+    allowed = client.get(
+        "/protected",
+        auth=("john", "secret"),
+        headers={"X-Forwarded-For": "198.51.100.2"},
+    )
+    assert allowed.status_code == 200
+
+
+def test_successful_authentication_resets_failed_attempts():
+    client = make_client(max_attempts=2)
+    headers = {"X-Forwarded-For": "198.51.100.10"}
+
+    failed = client.get("/protected", auth=("john", "wrong"), headers=headers)
+    assert failed.status_code == 401
+
+    successful = client.get("/protected", auth=("john", "secret"), headers=headers)
+    assert successful.status_code == 200
+
+    failed_again = client.get("/protected", auth=("john", "wrong"), headers=headers)
+    assert failed_again.status_code == 401
+
+
+def test_password_verification_supports_pbkdf2_metadata_and_constant_time_compare(
+    monkeypatch,
+):
+    calls: list[tuple[str, str]] = []
+
+    def compare_digest(left: str, right: str) -> bool:
+        calls.append((left, right))
+        return left == right
+
+    monkeypatch.setattr("fastapi.security.http.hmac.compare_digest", compare_digest)
+    expected_hash = pbkdf2_hmac("sha256", b"secret", b"salt", 1000).hex()
+
+    assert HTTPBasicWithProtection.verify_password(
+        "secret",
+        f"pbkdf2_sha256$1000$salt${expected_hash}",
+    )
+    assert not HTTPBasicWithProtection.verify_password(
+        "wrong",
+        f"pbkdf2_sha256$1000$salt${expected_hash}",
+    )
+    assert len(calls) == 2
+
+
+def test_existing_http_basic_behavior_is_unchanged():
+    client = make_client()
+
+    response = client.get("/protected")
+
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "Basic"


### PR DESCRIPTION
Summary:
- Adds HTTPBasicWithProtection without changing existing HTTPBasic behavior.
- Tracks failed attempts per client IP, returns 429 with Retry-After on lockout, and resets attempts after successful authentication.
- Adds PBKDF2 password hash verification with timing-safe comparison and focused tests.

Validation:
- uv run pytest tests/test_security_http_basic_with_protection.py -q
- uv run ruff check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_with_protection.py
- uv run ruff format --check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_with_protection.py
- uv run python -m compileall -q fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_with_protection.py
- git diff --check

/claim #800
