### PR TITLE
Codex [ Crypto ] Fix PriceOracle staleness and fallback

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,21 +14,19 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed feed, uint256 updatedAt);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
         (
             uint80 roundId,
             int256 price,
@@ -37,9 +35,15 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        _validateRound(roundId, price, updatedAt, answeredInRound);
+
+        if (_isStale(updatedAt)) {
+            require(address(fallbackFeed) != address(0), "Fallback not set");
+            emit StalePrice(address(primaryFeed), updatedAt);
+            (price, updatedAt) = _getValidatedPrice(fallbackFeed);
+        }
+
+        emit PriceQueried(price, updatedAt);
 
         return price;
     }
@@ -51,5 +55,40 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+    }
+
+    function _getValidatedPrice(AggregatorV3Interface feed) internal view returns (int256, uint256) {
+        (
+            uint80 roundId,
+            int256 price,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        _validateRound(roundId, price, updatedAt, answeredInRound);
+        require(!_isStale(updatedAt), "Stale price");
+
+        return (price, updatedAt);
+    }
+
+    function _validateRound(
+        uint80 roundId,
+        int256 price,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) internal view {
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(price > 0, "Invalid price");
+        require(updatedAt <= block.timestamp, "Invalid timestamp");
+    }
+
+    function _isStale(uint256 updatedAt) internal view returns (bool) {
+        return block.timestamp - updatedAt >= MAX_STALENESS;
     }
 }

--- a/solidity/test/PriceOracle.test.js
+++ b/solidity/test/PriceOracle.test.js
@@ -1,0 +1,176 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const test = require("node:test");
+
+const ganache = require("ganache");
+const solc = require("solc");
+const { ethers } = require("ethers");
+
+const ORACLE_SOURCE = readFileSync(join(__dirname, "..", "contracts", "PriceOracle.sol"), "utf8");
+const MOCK_SOURCE = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockAggregator {
+    uint80 public roundId = 1;
+    int256 public answer = 1;
+    uint256 public startedAt = 1;
+    uint256 public updatedAt = 1;
+    uint80 public answeredInRound = 1;
+    uint8 public decimals = 8;
+
+    function setRoundData(
+        uint80 _roundId,
+        int256 _answer,
+        uint256 _startedAt,
+        uint256 _updatedAt,
+        uint80 _answeredInRound
+    ) external {
+        roundId = _roundId;
+        answer = _answer;
+        startedAt = _startedAt;
+        updatedAt = _updatedAt;
+        answeredInRound = _answeredInRound;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+}
+`;
+
+const compiled = compile();
+
+function compile() {
+    const input = {
+        language: "Solidity",
+        sources: {
+            "PriceOracle.sol": { content: ORACLE_SOURCE },
+            "MockAggregator.sol": { content: MOCK_SOURCE },
+        },
+        settings: {
+            outputSelection: {
+                "*": {
+                    "*": ["abi", "evm.bytecode.object"],
+                },
+            },
+        },
+    };
+    const output = JSON.parse(solc.compile(JSON.stringify(input)));
+    const errors = (output.errors || []).filter((error) => error.severity === "error");
+    assert.equal(errors.length, 0, errors.map((error) => error.formattedMessage).join("\n"));
+    return output.contracts;
+}
+
+function artifact(contractName) {
+    const sourceName = contractName === "PriceOracle" ? "PriceOracle.sol" : "MockAggregator.sol";
+    const contract = compiled[sourceName][contractName];
+    return {
+        abi: contract.abi,
+        bytecode: `0x${contract.evm.bytecode.object}`,
+    };
+}
+
+async function deploy(contractName, signer, args = []) {
+    const { abi, bytecode } = artifact(contractName);
+    const factory = new ethers.ContractFactory(abi, bytecode, signer);
+    const contract = await factory.deploy(...args);
+    await contract.waitForDeployment();
+    return contract;
+}
+
+async function setRound(feed, roundId, answer, updatedAt, answeredInRound = roundId) {
+    await (await feed.setRoundData(roundId, answer, updatedAt, updatedAt, answeredInRound)).wait();
+}
+
+async function fixture() {
+    const eip1193Provider = ganache.provider({ logging: { quiet: true } });
+    const provider = new ethers.BrowserProvider(eip1193Provider);
+    const owner = await provider.getSigner(0);
+    const other = await provider.getSigner(1);
+    const primary = await deploy("MockAggregator", owner);
+    const fallbackFeed = await deploy("MockAggregator", owner);
+    const oracle = await deploy("PriceOracle", owner, [await primary.getAddress()]);
+    await (await oracle.setFallbackFeed(await fallbackFeed.getAddress())).wait();
+    const now = Number((await provider.getBlock("latest")).timestamp);
+
+    return { provider, owner, other, primary, fallbackFeed, oracle, now };
+}
+
+test("returns a fresh positive price from a complete primary round", async () => {
+    const { primary, fallbackFeed, oracle, now } = await fixture();
+
+    await setRound(primary, 10, 2000n, now - 60, 10);
+    await setRound(fallbackFeed, 11, 3000n, now - 60, 11);
+
+    assert.equal(await oracle.getLatestPrice.staticCall(), 2000n);
+});
+
+test("falls back and emits the stale primary timestamp when the primary price is stale", async () => {
+    const { primary, fallbackFeed, oracle, now } = await fixture();
+    const staleUpdatedAt = now - 3601;
+
+    await setRound(primary, 10, 2000n, staleUpdatedAt, 10);
+    await setRound(fallbackFeed, 11, 3000n, now - 30, 11);
+
+    assert.equal(await oracle.getLatestPrice.staticCall(), 3000n);
+
+    const receipt = await (await oracle.getLatestPrice()).wait();
+    const parsedLogs = receipt.logs.map((log) => {
+        try {
+            return oracle.interface.parseLog(log);
+        } catch {
+            return null;
+        }
+    });
+    const staleLog = parsedLogs.find((log) => log && log.name === "StalePrice");
+
+    assert.ok(staleLog, "expected StalePrice event");
+    assert.equal(staleLog.args.feed, await primary.getAddress());
+    assert.equal(staleLog.args.updatedAt, BigInt(staleUpdatedAt));
+});
+
+test("rejects zero and negative primary prices", async () => {
+    const { primary, oracle, now } = await fixture();
+
+    await setRound(primary, 10, 0n, now - 60, 10);
+    await assert.rejects(oracle.getLatestPrice.staticCall(), /Invalid price/);
+
+    await setRound(primary, 10, -1n, now - 60, 10);
+    await assert.rejects(oracle.getLatestPrice.staticCall(), /Invalid price/);
+});
+
+test("rejects incomplete primary rounds", async () => {
+    const { primary, oracle, now } = await fixture();
+
+    await setRound(primary, 10, 2000n, now - 60, 9);
+
+    await assert.rejects(oracle.getLatestPrice.staticCall(), /Incomplete round/);
+});
+
+test("reverts instead of returning a price when both feeds are stale", async () => {
+    const { primary, fallbackFeed, oracle, now } = await fixture();
+
+    await setRound(primary, 10, 2000n, now - 3601, 10);
+    await setRound(fallbackFeed, 11, 3000n, now - 3601, 11);
+
+    await assert.rejects(oracle.getLatestPrice.staticCall(), /Stale price/);
+});
+
+test("lets only the owner configure max staleness", async () => {
+    const { primary, fallbackFeed, oracle, other, now } = await fixture();
+
+    await assert.rejects(oracle.connect(other).setMaxStaleness.staticCall(60), /Not owner/);
+    await (await oracle.setMaxStaleness(60)).wait();
+
+    await setRound(primary, 10, 2000n, now - 120, 10);
+    await setRound(fallbackFeed, 11, 3000n, now - 30, 11);
+
+    assert.equal(await oracle.getLatestPrice.staticCall(), 3000n);
+});


### PR DESCRIPTION
/claim #915

## Issue
Closes #915

## Summary
Adds Chainlink round completeness, positive price, timestamp, and staleness validation to PriceOracle. When the primary feed is stale, the contract emits StalePrice with the primary update timestamp and queries an owner-configured fallback feed instead.

## Acceptance criteria
- [x] Stale prices older than 1 hour trigger fallback to a secondary oracle
- [x] Zero or negative prices revert with a clear error
- [x] Incomplete rounds are rejected
- [x] StalePrice event is emitted with the primary oracle last update timestamp
- [x] If both oracles return stale data, the function reverts instead of returning bad data
- [x] MAX_STALENESS is configurable by the contract owner
- [x] Tests mock Chainlink responses for valid price, stale price, negative/zero price, incomplete round, and both oracles stale

## Validation
- node --test solidity/test/PriceOracle.test.js (6 tests passed with solc, ganache, and ethers available)