### PR TITLE
Codex [ FastAPI ] Add OAuth2 refresh token support

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,9 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security.oauth2 import (
+    OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh,
+)
+from .security.oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,69 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    This is a dependency class to collect the `refresh_token` as form data for an
+    OAuth2 refresh token flow.
+    """
+
+    def __init__(
+        self,
+        *,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 spec requires the fixed string "refresh_token" for the
+                refresh token grant.
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                The refresh token used to obtain a new access token.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                A single string with several scopes separated by spaces.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 client identifier sent as a form field.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                Optional OAuth2 client secret sent as a form field.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +605,72 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password flow for bearer tokens that also declares a refresh endpoint.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        refresh_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new one.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                The OAuth2 scopes that would be required by the path operations.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                Automatically error when the Authorization header is missing or invalid.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            tokenUrl=tokenUrl,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+            refreshUrl=refresh_url,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -1,0 +1,116 @@
+from fastapi import (
+    Depends,
+    FastAPI,
+    OAuth2PasswordBearerWithRefresh,
+    OAuth2RefreshRequestForm,
+    Security,
+)
+from fastapi.security import (
+    OAuth2PasswordBearerWithRefresh as SecurityOAuth2PasswordBearerWithRefresh,
+)
+from fastapi.security import (
+    OAuth2RefreshRequestForm as SecurityOAuth2RefreshRequestForm,
+)
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="/token",
+    refresh_url="/refresh",
+    scopes={"items": "Read items"},
+)
+
+
+@app.get("/items/")
+async def read_items(token: str = Security(oauth2_scheme)):
+    return {"token": token}
+
+
+@app.post("/refresh")
+async def refresh_token(form_data: OAuth2RefreshRequestForm = Depends()):
+    return {
+        "grant_type": form_data.grant_type,
+        "refresh_token": form_data.refresh_token,
+        "scopes": form_data.scopes,
+        "client_id": form_data.client_id,
+        "client_secret": form_data.client_secret,
+    }
+
+
+client = TestClient(app)
+
+
+def test_root_and_security_exports():
+    assert OAuth2PasswordBearerWithRefresh is SecurityOAuth2PasswordBearerWithRefresh
+    assert OAuth2RefreshRequestForm is SecurityOAuth2RefreshRequestForm
+
+
+def test_password_bearer_with_refresh_token():
+    response = client.get("/items/", headers={"Authorization": "Bearer testtoken"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"token": "testtoken"}
+
+
+def test_password_bearer_with_refresh_no_token():
+    response = client.get("/items/")
+    assert response.status_code == 401, response.text
+    assert response.json() == {"detail": "Not authenticated"}
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_refresh_request_form():
+    response = client.post(
+        "/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-token-value",
+            "scope": "items profile",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-token-value",
+        "scopes": ["items", "profile"],
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+    }
+
+
+def test_refresh_request_form_rejects_other_grant_type():
+    response = client.post(
+        "/refresh",
+        data={"grant_type": "password", "refresh_token": "refresh-token-value"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == [
+        {
+            "type": "string_pattern_mismatch",
+            "loc": ["body", "grant_type"],
+            "msg": "String should match pattern '^refresh_token$'",
+            "input": "password",
+            "ctx": {"pattern": "^refresh_token$"},
+        }
+    ]
+
+
+def test_openapi_schema_includes_refresh_url():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    openapi_schema = response.json()
+    password_flow = openapi_schema["components"]["securitySchemes"][
+        "OAuth2PasswordBearerWithRefresh"
+    ]["flows"]["password"]
+    assert password_flow == {
+        "scopes": {"items": "Read items"},
+        "tokenUrl": "/token",
+        "refreshUrl": "/refresh",
+    }
+    refresh_schema = openapi_schema["components"]["schemas"][
+        "Body_refresh_token_refresh_post"
+    ]
+    assert refresh_schema["required"] == ["grant_type", "refresh_token"]
+    assert refresh_schema["properties"]["grant_type"]["pattern"] == "^refresh_token$"


### PR DESCRIPTION
/claim #758

Summary:
- Add OAuth2RefreshRequestForm for refresh_token grant form parsing and validation.
- Add OAuth2PasswordBearerWithRefresh as a drop-in bearer dependency that exposes refreshUrl in OpenAPI.
- Export the refresh helpers and cover refresh flow plus existing bearer behavior.

Validation:
- uv run ruff format fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py
- uv run pytest tests/test_security_oauth2_refresh.py tests/test_security_oauth2.py tests/test_security_oauth2_password_bearer_optional.py tests/test_security_oauth2_password_bearer_optional_description.py -q
- uv run ruff check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py
- uv run ruff format --check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py
- uv run python -m compileall -q fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py
- git diff --check
