### PR TITLE
Codex [ T3 Code ] Add desktop safe storage key rotation

### DIFF
--- a/t3code/apps/desktop/package.json
+++ b/t3code/apps/desktop/package.json
@@ -10,6 +10,7 @@
     "dev:electron": "node scripts/dev-electron.mjs",
     "build": "tsdown",
     "start": "node scripts/start-electron.mjs",
+    "rotate-keys": "node scripts/start-electron.mjs rotate-keys",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "smoke-test": "node scripts/smoke-test.mjs"

--- a/t3code/apps/desktop/scripts/start-electron.mjs
+++ b/t3code/apps/desktop/scripts/start-electron.mjs
@@ -5,7 +5,7 @@ import { desktopDir, resolveElectronPath } from "./electron-launcher.mjs";
 const childEnv = { ...process.env };
 delete childEnv.ELECTRON_RUN_AS_NODE;
 
-const child = spawn(resolveElectronPath(), ["dist-electron/main.cjs"], {
+const child = spawn(resolveElectronPath(), ["dist-electron/main.cjs", ...process.argv.slice(2)], {
   stdio: "inherit",
   cwd: desktopDir,
   env: childEnv,

--- a/t3code/apps/desktop/src/main.ts
+++ b/t3code/apps/desktop/src/main.ts
@@ -2,6 +2,8 @@ import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeOS from "node:os";
+import * as Cause from "effect/Cause";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -151,4 +153,47 @@ const desktopRuntimeLayer = ElectronProtocol.layerSchemePrivileges.pipe(
   ),
 );
 
-DesktopApp.program.pipe(Effect.provide(desktopRuntimeLayer), NodeRuntime.runMain);
+const desktopSafeStorageKeyRotationCliLayer = DesktopSavedEnvironments.layer.pipe(
+  Layer.provideMerge(desktopEnvironmentLayer),
+  Layer.provideMerge(NodeServices.layer),
+  Layer.provideMerge(electronLayer),
+);
+
+const rotateSafeStorageKeysCli = Effect.gen(function* () {
+  const electronApp = yield* ElectronApp.ElectronApp;
+  yield* electronApp.whenReady;
+  yield* Console.log("Rotating desktop safe storage credential keys...");
+  const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
+  const result = yield* savedEnvironments.rotateKeys;
+  yield* Console.log(
+    [
+      `Re-encrypted ${result.reencryptedCredentials} credential${
+        result.reencryptedCredentials === 1 ? "" : "s"
+      }.`,
+      `New key version: ${result.currentKeyVersion}.`,
+      `Completed at: ${result.rotatedAt}.`,
+    ].join("\n"),
+  );
+  yield* electronApp.exit(0);
+}).pipe(
+  Effect.catchCause((cause) =>
+    Effect.gen(function* () {
+      yield* Console.error(`Failed to rotate desktop safe storage keys.\n${Cause.pretty(cause)}`);
+      const electronApp = yield* ElectronApp.ElectronApp;
+      yield* electronApp.exit(1);
+    }),
+  ),
+);
+
+const requestedCliCommand = process.argv.some(
+  (argument) => argument === "rotate-keys" || argument === "--rotate-keys",
+);
+
+if (requestedCliCommand) {
+  rotateSafeStorageKeysCli.pipe(
+    Effect.provide(desktopSafeStorageKeyRotationCliLayer),
+    NodeRuntime.runMain,
+  );
+} else {
+  DesktopApp.program.pipe(Effect.provide(desktopRuntimeLayer), NodeRuntime.runMain);
+}

--- a/t3code/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
+++ b/t3code/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
@@ -37,13 +37,32 @@ const SavedEnvironmentRegistryDocumentProbe = Schema.Struct({
 const decodeSavedEnvironmentRegistryDocumentProbe = Schema.decodeEffect(
   Schema.fromJsonString(SavedEnvironmentRegistryDocumentProbe),
 );
+const SavedEnvironmentRotationDocumentProbe = Schema.Struct({
+  records: Schema.Array(
+    Schema.Struct({
+      encryptedBearerTokenKeyVersion: Schema.optionalKey(Schema.Number),
+    }),
+  ),
+  safeStorageKeyring: Schema.Struct({
+    currentVersion: Schema.Number,
+    keys: Schema.Array(Schema.Unknown),
+  }),
+});
+const decodeSavedEnvironmentRotationDocumentProbe = Schema.decodeEffect(
+  Schema.fromJsonString(SavedEnvironmentRotationDocumentProbe),
+);
+const encodeSavedEnvironmentRegistryDocumentProbe = Schema.encodeEffect(
+  Schema.fromJsonString(SavedEnvironmentRegistryDocumentProbe),
+);
 
 function makeSafeStorageLayer(input: {
   readonly available: boolean;
   readonly availabilityError?: unknown;
   readonly encryptError?: unknown;
+  readonly encryptErrorAfter?: number;
   readonly decryptError?: unknown;
 }) {
+  let encryptCalls = 0;
   return Layer.succeed(ElectronSafeStorage.ElectronSafeStorage, {
     isEncryptionAvailable:
       input.availabilityError === undefined
@@ -53,14 +72,19 @@ function makeSafeStorageLayer(input: {
               cause: input.availabilityError,
             }),
           ),
-    encryptString: (value) =>
-      input.encryptError === undefined
-        ? Effect.succeed(textEncoder.encode(`enc:${value}`))
-        : Effect.fail(
+    encryptString: (value) => {
+      encryptCalls += 1;
+      const shouldFail =
+        input.encryptError !== undefined &&
+        (input.encryptErrorAfter === undefined || encryptCalls >= input.encryptErrorAfter);
+      return shouldFail
+        ? Effect.fail(
             new ElectronSafeStorage.ElectronSafeStorageEncryptError({
               cause: input.encryptError,
             }),
-          ),
+          )
+        : Effect.succeed(textEncoder.encode(`enc:${value}`));
+    },
     decryptString: (value) => {
       if (input.decryptError !== undefined) {
         return Effect.fail(
@@ -89,6 +113,7 @@ function makeLayer(
     readonly availableSecretStorage?: boolean;
     readonly availabilityError?: unknown;
     readonly encryptError?: unknown;
+    readonly encryptErrorAfter?: number;
     readonly decryptError?: unknown;
   },
 ) {
@@ -115,6 +140,9 @@ function makeLayer(
         available: options?.availableSecretStorage ?? true,
         availabilityError: options?.availabilityError,
         encryptError: options?.encryptError,
+        ...(options?.encryptErrorAfter === undefined
+          ? {}
+          : { encryptErrorAfter: options.encryptErrorAfter }),
         decryptError: options?.decryptError,
       }),
     ),
@@ -128,6 +156,7 @@ const withSavedEnvironments = <A, E, R>(
     readonly availableSecretStorage?: boolean;
     readonly availabilityError?: unknown;
     readonly encryptError?: unknown;
+    readonly encryptErrorAfter?: number;
     readonly decryptError?: unknown;
   },
 ) =>
@@ -341,4 +370,112 @@ describe("DesktopSavedEnvironments", () => {
       }),
     ),
   );
+
+  it.effect("tracks credential key versions and round-trips secrets after rotation", () =>
+    withSavedEnvironments(
+      Effect.gen(function* () {
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
+        yield* savedEnvironments.setRegistry([savedRegistryRecord]);
+        yield* savedEnvironments.setSecret({
+          environmentId: savedRegistryRecord.environmentId,
+          secret: "bearer-token",
+        });
+
+        const before = yield* decodeSavedEnvironmentRotationDocumentProbe(
+          yield* fileSystem.readFileString(environment.savedEnvironmentRegistryPath),
+        );
+        assert.equal(before.safeStorageKeyring.currentVersion, 1);
+        assert.equal(before.records[0]?.encryptedBearerTokenKeyVersion, 1);
+
+        const result = yield* savedEnvironments.rotateKeys;
+
+        assert.equal(result.previousKeyVersion, 1);
+        assert.equal(result.currentKeyVersion, 2);
+        assert.equal(result.reencryptedCredentials, 1);
+        assert.deepEqual(
+          yield* savedEnvironments.getSecret(savedRegistryRecord.environmentId),
+          Option.some("bearer-token"),
+        );
+
+        const after = yield* decodeSavedEnvironmentRotationDocumentProbe(
+          yield* fileSystem.readFileString(environment.savedEnvironmentRegistryPath),
+        );
+        assert.equal(after.safeStorageKeyring.currentVersion, 2);
+        assert.lengthOf(after.safeStorageKeyring.keys, 1);
+        assert.equal(after.records[0]?.encryptedBearerTokenKeyVersion, 2);
+      }),
+    ),
+  );
+
+  it.effect("keeps legacy direct safe-storage credentials readable while rotating them", () =>
+    withSavedEnvironments(
+      Effect.gen(function* () {
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
+        yield* savedEnvironments.setRegistry([savedRegistryRecord]);
+        const legacyDocument = yield* encodeSavedEnvironmentRegistryDocumentProbe({
+          version: 1,
+          records: [
+            {
+              ...savedRegistryRecord,
+              encryptedBearerToken: "ZW5jOmxlZ2FjeS10b2tlbg==",
+            },
+          ],
+        });
+        yield* fileSystem.writeFileString(
+          environment.savedEnvironmentRegistryPath,
+          `${legacyDocument}\n`,
+        );
+
+        assert.deepEqual(
+          yield* savedEnvironments.getSecret(savedRegistryRecord.environmentId),
+          Option.some("legacy-token"),
+        );
+
+        const result = yield* savedEnvironments.rotateKeys;
+
+        assert.equal(result.previousKeyVersion, null);
+        assert.equal(result.currentKeyVersion, 1);
+        assert.equal(result.reencryptedCredentials, 1);
+        assert.deepEqual(
+          yield* savedEnvironments.getSecret(savedRegistryRecord.environmentId),
+          Option.some("legacy-token"),
+        );
+      }),
+    ),
+  );
+
+  it.effect("rolls back key rotation when the new key cannot be stored", () => {
+    const cause = new Error("new key rejected");
+    return withSavedEnvironments(
+      Effect.gen(function* () {
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
+        yield* savedEnvironments.setRegistry([savedRegistryRecord]);
+        yield* savedEnvironments.setSecret({
+          environmentId: savedRegistryRecord.environmentId,
+          secret: "bearer-token",
+        });
+
+        const before = yield* fileSystem.readFileString(environment.savedEnvironmentRegistryPath);
+        const error = yield* savedEnvironments.rotateKeys.pipe(Effect.flip);
+
+        assert.instanceOf(error, ElectronSafeStorage.ElectronSafeStorageEncryptError);
+        assert.equal(error.cause, cause);
+        assert.equal(
+          yield* fileSystem.readFileString(environment.savedEnvironmentRegistryPath),
+          before,
+        );
+        assert.deepEqual(
+          yield* savedEnvironments.getSecret(savedRegistryRecord.environmentId),
+          Option.some("bearer-token"),
+        );
+      }),
+      { encryptError: cause, encryptErrorAfter: 2 },
+    );
+  });
 });

--- a/t3code/apps/desktop/src/settings/DesktopSavedEnvironments.ts
+++ b/t3code/apps/desktop/src/settings/DesktopSavedEnvironments.ts
@@ -1,7 +1,9 @@
 import { EnvironmentId, type PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
 import { fromLenientJson } from "@t3tools/shared/schemaJson";
+import * as Crypto from "node:crypto";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
@@ -26,16 +28,42 @@ interface PersistedSavedEnvironmentStorageRecord extends Omit<
 > {
   readonly desktopSsh?: PersistedSavedEnvironmentDesktopSsh;
   readonly encryptedBearerToken?: string;
+  readonly encryptedBearerTokenKeyVersion?: number;
+}
+
+interface SavedEnvironmentSafeStorageKey {
+  readonly version: number;
+  readonly encryptedKey: string;
+  readonly createdAt: string;
+}
+
+interface SavedEnvironmentSafeStorageKeyring {
+  readonly currentVersion: number;
+  readonly keys: readonly SavedEnvironmentSafeStorageKey[];
 }
 
 interface SavedEnvironmentRegistryDocument {
   readonly version: number;
   readonly records: readonly PersistedSavedEnvironmentStorageRecord[];
+  readonly safeStorageKeyring?: SavedEnvironmentSafeStorageKeyring;
 }
 
 interface SavedEnvironmentRegistryStorageDocument {
   readonly version?: number;
   readonly records?: readonly PersistedSavedEnvironmentStorageRecord[];
+  readonly safeStorageKeyring?: SavedEnvironmentSafeStorageKeyring;
+}
+
+interface EncryptedBearerTokenReference {
+  readonly encryptedBearerToken: string;
+  readonly encryptedBearerTokenKeyVersion?: number;
+}
+
+export interface DesktopSafeStorageKeyRotationResult {
+  readonly rotatedAt: string;
+  readonly previousKeyVersion: number | null;
+  readonly currentKeyVersion: number;
+  readonly reencryptedCredentials: number;
 }
 
 const DesktopSshTargetSchema = Schema.Struct({
@@ -54,11 +82,24 @@ const PersistedSavedEnvironmentStorageRecordSchema = Schema.Struct({
   lastConnectedAt: Schema.NullOr(Schema.String),
   desktopSsh: Schema.optionalKey(DesktopSshTargetSchema),
   encryptedBearerToken: Schema.optionalKey(Schema.String),
+  encryptedBearerTokenKeyVersion: Schema.optionalKey(Schema.Number),
+});
+
+const SavedEnvironmentSafeStorageKeySchema = Schema.Struct({
+  version: Schema.Number,
+  encryptedKey: Schema.String,
+  createdAt: Schema.String,
+});
+
+const SavedEnvironmentSafeStorageKeyringSchema = Schema.Struct({
+  currentVersion: Schema.Number,
+  keys: Schema.Array(SavedEnvironmentSafeStorageKeySchema),
 });
 
 const SavedEnvironmentRegistryDocumentSchema = Schema.Struct({
   version: Schema.optionalKey(Schema.Number),
   records: Schema.optionalKey(Schema.Array(PersistedSavedEnvironmentStorageRecordSchema)),
+  safeStorageKeyring: Schema.optionalKey(SavedEnvironmentSafeStorageKeyringSchema),
 });
 
 const SavedEnvironmentRegistryDocumentJson = fromLenientJson(
@@ -91,14 +132,45 @@ export class DesktopSavedEnvironmentSecretDecodeError extends Data.TaggedError(
   }
 }
 
+export class DesktopSavedEnvironmentSecretCipherError extends Data.TaggedError(
+  "DesktopSavedEnvironmentSecretCipherError",
+)<{
+  readonly cause: unknown;
+}> {
+  override get message() {
+    return "Failed to decrypt desktop saved environment secret.";
+  }
+}
+
+export class DesktopSavedEnvironmentKeyRotationUnavailableError extends Data.TaggedError(
+  "DesktopSavedEnvironmentKeyRotationUnavailableError",
+)<{}> {
+  override get message() {
+    return "Desktop safe storage encryption is unavailable.";
+  }
+}
+
 export type DesktopSavedEnvironmentsGetSecretError =
   | DesktopSavedEnvironmentSecretDecodeError
+  | DesktopSavedEnvironmentSecretCipherError
   | ElectronSafeStorage.ElectronSafeStorageAvailabilityError
   | ElectronSafeStorage.ElectronSafeStorageDecryptError;
 
 export type DesktopSavedEnvironmentsSetSecretError =
+  | DesktopSavedEnvironmentSecretDecodeError
+  | DesktopSavedEnvironmentSecretCipherError
   | DesktopSavedEnvironmentsWriteError
   | ElectronSafeStorage.ElectronSafeStorageAvailabilityError
+  | ElectronSafeStorage.ElectronSafeStorageDecryptError
+  | ElectronSafeStorage.ElectronSafeStorageEncryptError;
+
+export type DesktopSavedEnvironmentsRotateKeysError =
+  | DesktopSavedEnvironmentKeyRotationUnavailableError
+  | DesktopSavedEnvironmentSecretDecodeError
+  | DesktopSavedEnvironmentSecretCipherError
+  | DesktopSavedEnvironmentsWriteError
+  | ElectronSafeStorage.ElectronSafeStorageAvailabilityError
+  | ElectronSafeStorage.ElectronSafeStorageDecryptError
   | ElectronSafeStorage.ElectronSafeStorageEncryptError;
 
 export interface DesktopSavedEnvironmentsShape {
@@ -116,6 +188,10 @@ export interface DesktopSavedEnvironmentsShape {
   readonly removeSecret: (
     environmentId: string,
   ) => Effect.Effect<void, DesktopSavedEnvironmentsWriteError>;
+  readonly rotateKeys: Effect.Effect<
+    DesktopSafeStorageKeyRotationResult,
+    DesktopSavedEnvironmentsRotateKeysError
+  >;
 }
 
 export class DesktopSavedEnvironments extends Context.Service<
@@ -139,7 +215,7 @@ function toPersistedSavedEnvironmentRecord(
 
 function toSavedEnvironmentStorageRecord(
   record: PersistedSavedEnvironmentRecord | PersistedSavedEnvironmentStorageRecord,
-  encryptedBearerToken: Option.Option<string>,
+  encryptedBearerToken: Option.Option<EncryptedBearerTokenReference>,
 ): PersistedSavedEnvironmentStorageRecord {
   const nextRecord = {
     environmentId: record.environmentId,
@@ -156,13 +232,22 @@ function toSavedEnvironmentStorageRecord(
       onSome: (value) => ({
         ...nextRecord,
         desktopSsh,
-        encryptedBearerToken: value,
+        encryptedBearerToken: value.encryptedBearerToken,
+        ...(value.encryptedBearerTokenKeyVersion === undefined
+          ? {}
+          : { encryptedBearerTokenKeyVersion: value.encryptedBearerTokenKeyVersion }),
       }),
     });
   }
   return Option.match(encryptedBearerToken, {
     onNone: () => nextRecord,
-    onSome: (value) => ({ ...nextRecord, encryptedBearerToken: value }),
+    onSome: (value) => ({
+      ...nextRecord,
+      encryptedBearerToken: value.encryptedBearerToken,
+      ...(value.encryptedBearerTokenKeyVersion === undefined
+        ? {}
+        : { encryptedBearerTokenKeyVersion: value.encryptedBearerTokenKeyVersion }),
+    }),
   });
 }
 
@@ -172,6 +257,9 @@ function normalizeSavedEnvironmentRegistryDocument(
   return {
     version: document.version ?? 1,
     records: document.records ?? [],
+    ...(document.safeStorageKeyring === undefined
+      ? {}
+      : { safeStorageKeyring: document.safeStorageKeyring }),
   };
 }
 
@@ -218,13 +306,26 @@ function preserveExistingSecrets(
   const encryptedBearerTokenById = new Map(
     currentDocument.records.flatMap((record) =>
       record.encryptedBearerToken
-        ? [[record.environmentId, record.encryptedBearerToken] as const]
+        ? [
+            [
+              record.environmentId,
+              {
+                encryptedBearerToken: record.encryptedBearerToken,
+                ...(record.encryptedBearerTokenKeyVersion === undefined
+                  ? {}
+                  : { encryptedBearerTokenKeyVersion: record.encryptedBearerTokenKeyVersion }),
+              },
+            ] as const,
+          ]
         : [],
     ),
   );
 
   return {
     version: currentDocument.version,
+    ...(currentDocument.safeStorageKeyring === undefined
+      ? {}
+      : { safeStorageKeyring: currentDocument.safeStorageKeyring }),
     records: records.map((record) => {
       const encryptedBearerToken = encryptedBearerTokenById.get(record.environmentId);
       return toSavedEnvironmentStorageRecord(record, Option.fromNullishOr(encryptedBearerToken));
@@ -238,6 +339,223 @@ function decodeSecretBytes(
   return Effect.fromResult(Encoding.decodeBase64(encoded)).pipe(
     Effect.mapError((cause) => new DesktopSavedEnvironmentSecretDecodeError({ cause })),
   );
+}
+
+const DATA_KEY_BYTES = 32;
+const AES_GCM_IV_BYTES = 12;
+const AES_GCM_AUTH_TAG_BYTES = 16;
+const currentIsoTimestamp = DateTime.now.pipe(Effect.map(DateTime.formatIso));
+
+function encodeDataKey(value: Uint8Array): string {
+  return Buffer.from(value).toString("base64");
+}
+
+function maxKeyVersion(keyring: Option.Option<SavedEnvironmentSafeStorageKeyring>): number {
+  return Option.match(keyring, {
+    onNone: () => 0,
+    onSome: (value) =>
+      value.keys.reduce((highest, key) => Math.max(highest, key.version), value.currentVersion),
+  });
+}
+
+function findKeyEntry(
+  keyring: SavedEnvironmentSafeStorageKeyring | undefined,
+  version: number,
+): Effect.Effect<SavedEnvironmentSafeStorageKey, DesktopSavedEnvironmentSecretCipherError> {
+  const key = keyring?.keys.find((entry) => entry.version === version);
+  if (key === undefined) {
+    return Effect.fail(
+      new DesktopSavedEnvironmentSecretCipherError({
+        cause: new Error(`Missing safe storage key version ${version}.`),
+      }),
+    );
+  }
+  return Effect.succeed(key);
+}
+
+function validateDataKey(
+  value: Uint8Array,
+): Effect.Effect<Uint8Array, DesktopSavedEnvironmentSecretCipherError> {
+  if (value.byteLength !== DATA_KEY_BYTES) {
+    return Effect.fail(
+      new DesktopSavedEnvironmentSecretCipherError({
+        cause: new Error("Invalid safe storage data key length."),
+      }),
+    );
+  }
+  return Effect.succeed(value);
+}
+
+function decryptSafeStorageKey(
+  safeStorage: ElectronSafeStorage.ElectronSafeStorageShape,
+  key: SavedEnvironmentSafeStorageKey,
+): Effect.Effect<
+  Uint8Array,
+  | DesktopSavedEnvironmentSecretDecodeError
+  | DesktopSavedEnvironmentSecretCipherError
+  | ElectronSafeStorage.ElectronSafeStorageDecryptError
+> {
+  return Effect.gen(function* () {
+    const wrappedKeyBytes = yield* decodeSecretBytes(key.encryptedKey);
+    const rawKey = yield* safeStorage.decryptString(wrappedKeyBytes);
+    return yield* decodeSecretBytes(rawKey).pipe(Effect.flatMap(validateDataKey));
+  });
+}
+
+function encryptCredentialWithDataKey(
+  secret: string,
+  key: Uint8Array,
+): Effect.Effect<string, DesktopSavedEnvironmentSecretCipherError> {
+  return Effect.try({
+    try: () => {
+      const iv = Crypto.randomBytes(AES_GCM_IV_BYTES);
+      const cipher = Crypto.createCipheriv("aes-256-gcm", Buffer.from(key), iv);
+      const ciphertext = Buffer.concat([cipher.update(secret, "utf8"), cipher.final()]);
+      const authTag = cipher.getAuthTag();
+      return Buffer.concat([iv, authTag, ciphertext]).toString("base64");
+    },
+    catch: (cause) => new DesktopSavedEnvironmentSecretCipherError({ cause }),
+  });
+}
+
+function decryptCredentialWithDataKey(
+  encryptedSecret: string,
+  key: Uint8Array,
+): Effect.Effect<
+  string,
+  DesktopSavedEnvironmentSecretDecodeError | DesktopSavedEnvironmentSecretCipherError
+> {
+  return Effect.gen(function* () {
+    const payload = Buffer.from(yield* decodeSecretBytes(encryptedSecret));
+    if (payload.byteLength <= AES_GCM_IV_BYTES + AES_GCM_AUTH_TAG_BYTES) {
+      return yield* new DesktopSavedEnvironmentSecretCipherError({
+        cause: new Error("Invalid encrypted credential payload."),
+      });
+    }
+
+    return yield* Effect.try({
+      try: () => {
+        const iv = payload.subarray(0, AES_GCM_IV_BYTES);
+        const authTag = payload.subarray(
+          AES_GCM_IV_BYTES,
+          AES_GCM_IV_BYTES + AES_GCM_AUTH_TAG_BYTES,
+        );
+        const ciphertext = payload.subarray(AES_GCM_IV_BYTES + AES_GCM_AUTH_TAG_BYTES);
+        const decipher = Crypto.createDecipheriv("aes-256-gcm", Buffer.from(key), iv);
+        decipher.setAuthTag(authTag);
+        return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+      },
+      catch: (cause) => new DesktopSavedEnvironmentSecretCipherError({ cause }),
+    });
+  });
+}
+
+function generateSafeStorageKey(
+  safeStorage: ElectronSafeStorage.ElectronSafeStorageShape,
+  version: number,
+  createdAt: string,
+): Effect.Effect<
+  { readonly entry: SavedEnvironmentSafeStorageKey; readonly key: Uint8Array },
+  ElectronSafeStorage.ElectronSafeStorageEncryptError
+> {
+  return Effect.gen(function* () {
+    const key = Crypto.randomBytes(DATA_KEY_BYTES);
+    const encryptedKey = Encoding.encodeBase64(
+      yield* safeStorage.encryptString(encodeDataKey(key)),
+    );
+    return {
+      entry: {
+        version,
+        encryptedKey,
+        createdAt,
+      },
+      key,
+    };
+  });
+}
+
+function resolveCurrentDataKey(
+  safeStorage: ElectronSafeStorage.ElectronSafeStorageShape,
+  document: SavedEnvironmentRegistryDocument,
+): Effect.Effect<
+  { readonly version: number; readonly key: Uint8Array },
+  | DesktopSavedEnvironmentSecretDecodeError
+  | DesktopSavedEnvironmentSecretCipherError
+  | ElectronSafeStorage.ElectronSafeStorageDecryptError
+> {
+  return Effect.gen(function* () {
+    const keyring = document.safeStorageKeyring;
+    if (keyring === undefined) {
+      return yield* new DesktopSavedEnvironmentSecretCipherError({
+        cause: new Error("Missing safe storage keyring."),
+      });
+    }
+    const entry = yield* findKeyEntry(keyring, keyring.currentVersion);
+    const key = yield* decryptSafeStorageKey(safeStorage, entry);
+    return { version: keyring.currentVersion, key };
+  });
+}
+
+function ensureCurrentDataKey(
+  safeStorage: ElectronSafeStorage.ElectronSafeStorageShape,
+  document: SavedEnvironmentRegistryDocument,
+): Effect.Effect<
+  {
+    readonly document: SavedEnvironmentRegistryDocument;
+    readonly version: number;
+    readonly key: Uint8Array;
+  },
+  | DesktopSavedEnvironmentSecretDecodeError
+  | DesktopSavedEnvironmentSecretCipherError
+  | ElectronSafeStorage.ElectronSafeStorageDecryptError
+  | ElectronSafeStorage.ElectronSafeStorageEncryptError
+> {
+  if (document.safeStorageKeyring !== undefined) {
+    return resolveCurrentDataKey(safeStorage, document).pipe(
+      Effect.map(({ version, key }) => ({ document, version, key })),
+    );
+  }
+
+  return Effect.gen(function* () {
+    const createdAt = yield* currentIsoTimestamp;
+    const { entry, key } = yield* generateSafeStorageKey(safeStorage, 1, createdAt);
+    return {
+      document: {
+        ...document,
+        safeStorageKeyring: {
+          currentVersion: entry.version,
+          keys: [entry],
+        },
+      },
+      version: entry.version,
+      key,
+    };
+  });
+}
+
+function readRecordSecret(
+  safeStorage: ElectronSafeStorage.ElectronSafeStorageShape,
+  document: SavedEnvironmentRegistryDocument,
+  record: PersistedSavedEnvironmentStorageRecord,
+): Effect.Effect<Option.Option<string>, DesktopSavedEnvironmentsGetSecretError> {
+  return Effect.gen(function* () {
+    const encoded = Option.fromNullishOr(record.encryptedBearerToken);
+    if (Option.isNone(encoded)) {
+      return Option.none<string>();
+    }
+
+    if (record.encryptedBearerTokenKeyVersion === undefined) {
+      const secretBytes = yield* decodeSecretBytes(encoded.value);
+      return Option.some(yield* safeStorage.decryptString(secretBytes));
+    }
+
+    const keyEntry = yield* findKeyEntry(
+      document.safeStorageKeyring,
+      record.encryptedBearerTokenKeyVersion,
+    );
+    const key = yield* decryptSafeStorageKey(safeStorage, keyEntry);
+    return Option.some(yield* decryptCredentialWithDataKey(encoded.value, key));
+  });
 }
 
 export const layer = Layer.effect(
@@ -276,16 +594,12 @@ export const layer = Layer.effect(
           fileSystem,
           environment.savedEnvironmentRegistryPath,
         );
-        const encoded = Option.fromNullishOr(
-          document.records.find((record) => record.environmentId === environmentId)
-            ?.encryptedBearerToken,
-        );
-        if (Option.isNone(encoded) || !(yield* safeStorage.isEncryptionAvailable)) {
+        const record = document.records.find((record) => record.environmentId === environmentId);
+        if (record === undefined || !(yield* safeStorage.isEncryptionAvailable)) {
           return Option.none<string>();
         }
 
-        const secretBytes = yield* decodeSecretBytes(encoded.value);
-        return Option.some(yield* safeStorage.decryptString(secretBytes));
+        return yield* readRecordSecret(safeStorage, document, record);
       }),
       setSecret: Effect.fn("desktop.savedEnvironments.setSecret")(function* (input) {
         const { environmentId, secret } = input;
@@ -299,19 +613,27 @@ export const layer = Layer.effect(
           return false;
         }
 
-        const encryptedBearerToken = Encoding.encodeBase64(
-          yield* safeStorage.encryptString(secret),
-        );
+        const currentKey = yield* ensureCurrentDataKey(safeStorage, document);
+        const encryptedBearerToken = yield* encryptCredentialWithDataKey(secret, currentKey.key);
         let found = false;
         const nextDocument: SavedEnvironmentRegistryDocument = {
-          version: document.version,
-          records: document.records.map((record) => {
+          version: currentKey.document.version,
+          ...(currentKey.document.safeStorageKeyring === undefined
+            ? {}
+            : { safeStorageKeyring: currentKey.document.safeStorageKeyring }),
+          records: currentKey.document.records.map((record) => {
             if (record.environmentId !== environmentId) {
               return record;
             }
 
             found = true;
-            return toSavedEnvironmentStorageRecord(record, Option.some(encryptedBearerToken));
+            return toSavedEnvironmentStorageRecord(
+              record,
+              Option.some({
+                encryptedBearerToken,
+                encryptedBearerTokenKeyVersion: currentKey.version,
+              }),
+            );
           }),
         };
 
@@ -337,6 +659,9 @@ export const layer = Layer.effect(
 
         yield* writeDocument({
           version: document.version,
+          ...(document.safeStorageKeyring === undefined
+            ? {}
+            : { safeStorageKeyring: document.safeStorageKeyring }),
           records: document.records.map((record) => {
             if (record.environmentId !== environmentId) {
               return record;
@@ -345,6 +670,81 @@ export const layer = Layer.effect(
           }),
         });
       }),
+      rotateKeys: Effect.gen(function* () {
+        if (!(yield* safeStorage.isEncryptionAvailable)) {
+          return yield* new DesktopSavedEnvironmentKeyRotationUnavailableError();
+        }
+
+        const document = yield* readRegistryDocument(
+          fileSystem,
+          environment.savedEnvironmentRegistryPath,
+        );
+        const recordsWithSecrets = [];
+        for (const record of document.records) {
+          const secret = yield* readRecordSecret(safeStorage, document, record);
+          if (Option.isSome(secret)) {
+            recordsWithSecrets.push({ environmentId: record.environmentId, secret: secret.value });
+          }
+        }
+
+        const rotatedAt = yield* currentIsoTimestamp;
+        const previousKeyVersion = document.safeStorageKeyring?.currentVersion ?? null;
+        const currentKeyVersion =
+          maxKeyVersion(Option.fromNullishOr(document.safeStorageKeyring)) + 1;
+        const { entry, key } = yield* generateSafeStorageKey(
+          safeStorage,
+          currentKeyVersion,
+          rotatedAt,
+        );
+        const secretByEnvironmentId = new Map(
+          yield* Effect.all(
+            recordsWithSecrets.map((record) =>
+              encryptCredentialWithDataKey(record.secret, key).pipe(
+                Effect.map(
+                  (encryptedBearerToken) =>
+                    [
+                      record.environmentId,
+                      {
+                        encryptedBearerToken,
+                        encryptedBearerTokenKeyVersion: currentKeyVersion,
+                      },
+                    ] as const,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        yield* writeDocument({
+          version: document.version,
+          safeStorageKeyring: {
+            currentVersion: currentKeyVersion,
+            keys: [entry],
+          },
+          records: document.records.map((record) =>
+            toSavedEnvironmentStorageRecord(
+              toPersistedSavedEnvironmentRecord(record),
+              Option.fromNullishOr(secretByEnvironmentId.get(record.environmentId)),
+            ),
+          ),
+        });
+
+        yield* Effect.logInfo("Rotated desktop safe storage credential encryption key.").pipe(
+          Effect.annotateLogs({
+            rotatedAt,
+            previousKeyVersion: previousKeyVersion ?? "legacy",
+            currentKeyVersion,
+            reencryptedCredentials: recordsWithSecrets.length,
+          }),
+        );
+
+        return {
+          rotatedAt,
+          previousKeyVersion,
+          currentKeyVersion,
+          reencryptedCredentials: recordsWithSecrets.length,
+        };
+      }).pipe(Effect.withSpan("desktop.savedEnvironments.rotateKeys")),
     });
   }),
 );
@@ -385,6 +785,15 @@ export const layerTest = (input?: {
             nextSecrets.delete(environmentId);
             return nextSecrets;
           }),
+        rotateKeys: Effect.gen(function* () {
+          const secrets = yield* Ref.get(secretsRef);
+          return {
+            rotatedAt: yield* currentIsoTimestamp,
+            previousKeyVersion: null,
+            currentKeyVersion: 1,
+            reencryptedCredentials: secrets.size,
+          };
+        }),
       });
     }),
   );

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -13,6 +13,7 @@ import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as DesktopApplicationMenu from "./DesktopApplicationMenu.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopSavedEnvironments from "../settings/DesktopSavedEnvironments.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 
@@ -63,6 +64,28 @@ const desktopUpdatesLayer = Layer.succeed(DesktopUpdates.DesktopUpdates, {
   install: Effect.die("unexpected install"),
 } satisfies DesktopUpdates.DesktopUpdatesShape);
 
+const makeDesktopSavedEnvironmentsLayer = (
+  rotations?: Deferred.Deferred<DesktopSavedEnvironments.DesktopSafeStorageKeyRotationResult>,
+) => {
+  const rotationResult = {
+    rotatedAt: "2026-05-16T00:00:00.000Z",
+    previousKeyVersion: 1,
+    currentKeyVersion: 2,
+    reencryptedCredentials: rotations === undefined ? 0 : 1,
+  } satisfies DesktopSavedEnvironments.DesktopSafeStorageKeyRotationResult;
+  return Layer.succeed(DesktopSavedEnvironments.DesktopSavedEnvironments, {
+    getRegistry: Effect.succeed([]),
+    setRegistry: () => Effect.void,
+    getSecret: () => Effect.succeed(Option.none()),
+    setSecret: () => Effect.succeed(false),
+    removeSecret: () => Effect.void,
+    rotateKeys:
+      rotations === undefined
+        ? Effect.succeed(rotationResult)
+        : Deferred.succeed(rotations, rotationResult).pipe(Effect.as(rotationResult)),
+  } satisfies DesktopSavedEnvironments.DesktopSavedEnvironmentsShape);
+};
+
 const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
   Layer.succeed(DesktopWindow.DesktopWindow, {
     createMain: Effect.die("unexpected createMain"),
@@ -100,6 +123,7 @@ describe("DesktopApplicationMenu", () => {
           DesktopApplicationMenu.layer.pipe(
             Layer.provideMerge(makeElectronMenuLayer(applicationMenuTemplate)),
             Layer.provideMerge(makeDesktopWindowLayer(selectedAction)),
+            Layer.provideMerge(makeDesktopSavedEnvironmentsLayer()),
             Layer.provideMerge(desktopUpdatesLayer),
             Layer.provideMerge(electronDialogLayer),
             Layer.provideMerge(electronAppLayer),
@@ -127,6 +151,62 @@ describe("DesktopApplicationMenu", () => {
 
       settingsClick({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
       assert.equal(yield* Deferred.await(selectedAction), "open-settings");
+    }),
+  );
+
+  it.effect("installs a Developer menu item that confirms and rotates safe storage keys", () =>
+    Effect.gen(function* () {
+      const selectedAction = yield* Deferred.make<string>();
+      const rotations =
+        yield* Deferred.make<DesktopSavedEnvironments.DesktopSafeStorageKeyRotationResult>();
+      const applicationMenuTemplate =
+        yield* Deferred.make<readonly Electron.MenuItemConstructorOptions[]>();
+
+      yield* Effect.gen(function* () {
+        const menu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
+        yield* menu.configure;
+      }).pipe(
+        Effect.provide(
+          DesktopApplicationMenu.layer.pipe(
+            Layer.provideMerge(makeElectronMenuLayer(applicationMenuTemplate)),
+            Layer.provideMerge(makeDesktopWindowLayer(selectedAction)),
+            Layer.provideMerge(makeDesktopSavedEnvironmentsLayer(rotations)),
+            Layer.provideMerge(desktopUpdatesLayer),
+            Layer.provideMerge(
+              Layer.succeed(ElectronDialog.ElectronDialog, {
+                pickFolder: () => Effect.succeed(Option.none()),
+                confirm: () => Effect.succeed(true),
+                showMessageBox: () => Effect.succeed({ response: 0, checkboxChecked: false }),
+                showErrorBox: () => Effect.void,
+              } satisfies ElectronDialog.ElectronDialogShape),
+            ),
+            Layer.provideMerge(electronAppLayer),
+            Layer.provideMerge(
+              DesktopEnvironment.layer(environmentInput).pipe(
+                Layer.provide(Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({}))),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      const template = yield* Deferred.await(applicationMenuTemplate);
+      const developerMenu = template.find((item) => item.label === "Developer");
+      assert.isDefined(developerMenu);
+      if (!Array.isArray(developerMenu.submenu)) {
+        throw new Error("Expected Developer menu submenu to be an array.");
+      }
+      const rotateItem = developerMenu.submenu.find(
+        (item) => item.label === "Rotate Safe Storage Keys...",
+      );
+      assert.isDefined(rotateItem);
+      const rotateClick = rotateItem.click;
+      if (typeof rotateClick !== "function") {
+        throw new Error("Expected rotate menu item to have a click handler.");
+      }
+
+      rotateClick({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
+      assert.equal((yield* Deferred.await(rotations)).reencryptedCredentials, 1);
     }),
   );
 });

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -11,6 +11,7 @@ import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopSavedEnvironments from "../settings/DesktopSavedEnvironments.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 
@@ -24,6 +25,7 @@ export class DesktopApplicationMenu extends Context.Service<
 >()("t3/desktop/ApplicationMenu") {}
 
 type DesktopApplicationMenuRuntimeServices =
+  | DesktopSavedEnvironments.DesktopSavedEnvironments
   | DesktopUpdates.DesktopUpdates
   | DesktopWindow.DesktopWindow
   | ElectronDialog.ElectronDialog;
@@ -94,6 +96,34 @@ const handleCheckForUpdatesMenuClick: Effect.Effect<
   yield* checkForUpdatesFromMenu;
 }).pipe(Effect.withSpan("desktop.menu.handleCheckForUpdatesClick"));
 
+const handleRotateSafeStorageKeysMenuClick: Effect.Effect<
+  void,
+  DesktopSavedEnvironments.DesktopSavedEnvironmentsRotateKeysError,
+  DesktopSavedEnvironments.DesktopSavedEnvironments | ElectronDialog.ElectronDialog
+> = Effect.gen(function* () {
+  const electronDialog = yield* ElectronDialog.ElectronDialog;
+  const confirmed = yield* electronDialog.confirm({
+    owner: Option.none(),
+    message:
+      "Rotate the desktop safe storage encryption key and re-encrypt saved environment credentials?",
+  });
+  if (!confirmed) {
+    return;
+  }
+
+  const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
+  const result = yield* savedEnvironments.rotateKeys;
+  yield* electronDialog.showMessageBox({
+    type: "info",
+    title: "Safe storage keys rotated",
+    message: "Desktop safe storage credentials were re-encrypted.",
+    detail: `Re-encrypted ${result.reencryptedCredentials} credential${
+      result.reencryptedCredentials === 1 ? "" : "s"
+    } with key version ${result.currentKeyVersion}.`,
+    buttons: ["OK"],
+  });
+}).pipe(Effect.withSpan("desktop.menu.handleRotateSafeStorageKeysClick"));
+
 const make = Effect.gen(function* () {
   const electronApp = yield* ElectronApp.ElectronApp;
   const electronMenu = yield* ElectronMenu.ElectronMenu;
@@ -126,6 +156,9 @@ const make = Effect.gen(function* () {
     };
     const settingsClick = () => {
       runMenuEffect("open-settings", dispatchMenuAction("open-settings"));
+    };
+    const rotateSafeStorageKeysClick = () => {
+      runMenuEffect("rotate-safe-storage-keys", handleRotateSafeStorageKeysMenuClick);
     };
     const template: Electron.MenuItemConstructorOptions[] = [];
 
@@ -190,6 +223,15 @@ const make = Effect.gen(function* () {
         ],
       },
       { role: "windowMenu" },
+      {
+        label: "Developer",
+        submenu: [
+          {
+            label: "Rotate Safe Storage Keys...",
+            click: rotateSafeStorageKeysClick,
+          },
+        ],
+      },
       {
         role: "help",
         submenu: [


### PR DESCRIPTION
## Summary
- Add a versioned desktop safe-storage keyring that wraps generated data keys with Electron safeStorage and tracks each credential's key version.
- Re-encrypt saved environment credentials atomically during rotation and remove older key versions after a successful write.
- Add a Developer menu confirmation flow and desktop rotate-keys command path.
- Add tests for post-rotation round trips, legacy credential migration, rollback on rotation failure, and menu wiring.

/claim #848

## Validation
- npx --yes bun@1.3.11 fmt
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun lint
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun typecheck
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun run --filter @t3tools/desktop test -- DesktopSavedEnvironments DesktopApplicationMenu