### PR TITLE
Codex [ T3 Code ] Add Effect.Stream Codex turn streaming

### DIFF
--- a/t3code/packages/effect-codex-app-server/src/client.test.ts
+++ b/t3code/packages/effect-codex-app-server/src/client.test.ts
@@ -1,19 +1,55 @@
 import * as Exit from "effect/Exit";
+import * as Duration from "effect/Duration";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 
 import * as CodexClient from "./client.ts";
+import * as CodexError from "./errors.ts";
+import { makeInMemoryStdio } from "./_internal/stdio.ts";
 
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/codex-app-server-mock-peer.ts"),
 );
+const encodeUnknownJsonString = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
+const decodeJson = Schema.decodeEffect(Schema.UnknownFromJsonString);
+const encoder = new TextEncoder();
+
+const encodeJsonl = (value: unknown) => encoder.encode(`${encodeUnknownJsonString(value)}\n`);
+
+const turnStartParams = {
+  threadId: "thread-1",
+  input: [
+    {
+      type: "text" as const,
+      text: "Generate a concise answer.",
+    },
+  ],
+};
+
+const turn = (status: "completed" | "interrupted" | "failed" | "inProgress") => ({
+  id: "turn-1",
+  items: [],
+  status,
+});
+
+const turnStartResponse = {
+  turn: turn("completed"),
+};
+
+const takeJsonOutput = (output: Queue.Dequeue<string>) =>
+  Queue.take(output).pipe(Effect.flatMap(decodeJson));
 
 it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
   const makeHandle = () =>
@@ -150,5 +186,304 @@ it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
 
       assert.equal(initialized.userAgent, "mock-codex-app-server");
     }),
+  );
+
+  it.effect("streams turn events in order and preserves the non-streaming response", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { stdio, input, output } = yield* makeInMemoryStdio();
+        const client = yield* CodexClient.make(stdio);
+
+        const streamFiber = yield* client
+          .streamTurn(turnStartParams, {
+            chunkTimeoutAfter: "5 seconds",
+            chunkWarningAfter: "1 second",
+            queueCapacity: 2,
+          })
+          .pipe(Stream.runCollect, Effect.forkScoped);
+
+        const startRequest = (yield* takeJsonOutput(output)) as {
+          readonly id: number;
+          readonly method: string;
+          readonly params: unknown;
+        };
+        assert.deepEqual(startRequest, {
+          id: 1,
+          method: "turn/start",
+          params: turnStartParams,
+        });
+
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "turn/started",
+            params: {
+              threadId: "thread-1",
+              turn: turn("inProgress"),
+            },
+          }),
+        );
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "item/agentMessage/delta",
+            params: {
+              delta: "Hello",
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          }),
+        );
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "item/agentMessage/delta",
+            params: {
+              delta: " world",
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          }),
+        );
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turn: turn("completed"),
+            },
+          }),
+        );
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            id: startRequest.id,
+            result: turnStartResponse,
+          }),
+        );
+
+        const events = yield* Fiber.join(streamFiber);
+        assert.deepEqual(
+          events.map((event) => event._tag),
+          [
+            "TurnStarted",
+            "AgentMessageDelta",
+            "AgentMessageDelta",
+            "TurnCompleted",
+            "TurnStartResponse",
+          ],
+        );
+        assert.deepEqual(
+          events
+            .filter((event) => event._tag === "AgentMessageDelta")
+            .map((event) => event.textDelta),
+          ["Hello", " world"],
+        );
+        assert.deepEqual(events.at(-1), {
+          _tag: "TurnStartResponse",
+          method: "turn/start",
+          response: turnStartResponse,
+        });
+
+        const nonStreamingFiber = yield* client
+          .request("turn/start", turnStartParams)
+          .pipe(Effect.forkScoped);
+        const nonStreamingRequest = (yield* takeJsonOutput(output)) as { readonly id: number };
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            id: nonStreamingRequest.id,
+            result: turnStartResponse,
+          }),
+        );
+        assert.deepEqual(yield* Fiber.join(nonStreamingFiber), turnStartResponse);
+      }),
+    ),
+  );
+
+  it.effect("applies backpressure through a bounded stream queue", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { stdio, input, output } = yield* makeInMemoryStdio();
+        const client = yield* CodexClient.make(stdio);
+        const observedDeltas = yield* Ref.make<Array<string>>([]);
+
+        const streamFiber = yield* client
+          .streamTurn(turnStartParams, {
+            chunkTimeoutAfter: "5 seconds",
+            chunkWarningAfter: "1 second",
+            queueCapacity: 1,
+          })
+          .pipe(
+            Stream.runForEach(() => Effect.sleep(Duration.millis(1_000))),
+            Effect.forkScoped,
+          );
+
+        yield* client.handleServerNotification("item/agentMessage/delta", (payload) =>
+          Ref.update(observedDeltas, (current) => [...current, payload.delta]),
+        );
+
+        const startRequest = (yield* takeJsonOutput(output)) as { readonly id: number };
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "turn/started",
+            params: {
+              threadId: "thread-1",
+              turn: turn("inProgress"),
+            },
+          }),
+        );
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "item/agentMessage/delta",
+            params: {
+              delta: "one",
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          }),
+        );
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "item/agentMessage/delta",
+            params: {
+              delta: "two",
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          }),
+        );
+        yield* Effect.yieldNow;
+        assert.deepEqual(yield* Ref.get(observedDeltas), ["one"]);
+
+        yield* TestClock.adjust(Duration.millis(1_000));
+        yield* Effect.yieldNow;
+        assert.deepEqual(yield* Ref.get(observedDeltas), ["one", "two"]);
+
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            id: startRequest.id,
+            result: turnStartResponse,
+          }),
+        );
+        yield* TestClock.adjust(Duration.millis(3_000));
+        yield* Fiber.join(streamFiber);
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
+  it.effect("emits a warning event before failing an idle stream", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { stdio, output } = yield* makeInMemoryStdio();
+        const client = yield* CodexClient.make(stdio);
+
+        const streamFiber = yield* client
+          .streamTurn(turnStartParams, {
+            chunkTimeoutAfter: "4 seconds",
+            chunkWarningAfter: "1 second",
+          })
+          .pipe(Stream.runCollect, Effect.forkScoped);
+
+        yield* takeJsonOutput(output);
+        yield* TestClock.adjust(Duration.millis(1_000));
+        yield* TestClock.adjust(Duration.millis(3_000));
+
+        const error = yield* Fiber.join(streamFiber).pipe(Effect.flip);
+        assert.instanceOf(error, CodexError.CodexAppServerStreamTimeoutError);
+        assert.equal(error.threadId, "thread-1");
+
+        const warningFiber = yield* client
+          .streamTurn(turnStartParams, {
+            chunkTimeoutAfter: "4 seconds",
+            chunkWarningAfter: "1 second",
+          })
+          .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped);
+
+        yield* takeJsonOutput(output);
+        yield* TestClock.adjust(Duration.millis(1_000));
+        const warnings = yield* Fiber.join(warningFiber);
+        assert.deepEqual(warnings, [
+          {
+            _tag: "ChunkTimeoutWarning",
+            idleForMillis: 1_000,
+            method: "turn/start",
+            message:
+              "No Codex stream chunk received for 1000ms; continuing to wait up to 4000ms total.",
+            threadId: "thread-1",
+            timeoutMillis: 4_000,
+            turnId: undefined,
+          },
+        ]);
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
+  it.effect("interrupts the upstream turn when the stream aborts", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { stdio, input, output } = yield* makeInMemoryStdio();
+        const client = yield* CodexClient.make(stdio);
+        const abortController = new AbortController();
+
+        const streamFiber = yield* client
+          .streamTurn(turnStartParams, {
+            abortSignal: abortController.signal,
+            chunkTimeoutAfter: "5 seconds",
+            chunkWarningAfter: "1 second",
+          })
+          .pipe(Stream.runCollect, Effect.forkScoped);
+
+        yield* takeJsonOutput(output);
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            method: "turn/started",
+            params: {
+              threadId: "thread-1",
+              turn: turn("inProgress"),
+            },
+          }),
+        );
+        yield* Effect.yieldNow;
+        abortController.abort();
+
+        const interruptRequest = (yield* takeJsonOutput(output)) as {
+          readonly id: number;
+          readonly method: string;
+          readonly params: unknown;
+        };
+        assert.deepEqual(interruptRequest, {
+          id: 2,
+          method: "turn/interrupt",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        });
+        yield* Queue.offer(
+          input,
+          encodeJsonl({
+            id: interruptRequest.id,
+            result: {},
+          }),
+        );
+
+        const events = yield* Fiber.join(streamFiber);
+        assert.deepEqual(
+          events.map((event) => event._tag),
+          ["TurnStarted"],
+        );
+      }),
+    ),
   );
 });

--- a/t3code/packages/effect-codex-app-server/src/client.ts
+++ b/t3code/packages/effect-codex-app-server/src/client.ts
@@ -1,9 +1,16 @@
+import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stdio from "effect/Stdio";
+import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as CodexRpc from "./_generated/meta.gen.ts";
@@ -18,6 +25,9 @@ import {
 import { makeChildStdio, makeTerminationError } from "./_internal/stdio.ts";
 
 const DEFAULT_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
+const DEFAULT_TURN_STREAM_QUEUE_CAPACITY = 16;
+const DEFAULT_TURN_STREAM_CHUNK_WARNING_AFTER = "30 seconds" as const;
+const DEFAULT_TURN_STREAM_CHUNK_TIMEOUT_AFTER = "120 seconds" as const;
 
 export interface CodexAppServerClientOptions {
   readonly logIncoming?: boolean;
@@ -36,6 +46,45 @@ interface CodexAppServerClientRaw {
   readonly respondError: CodexProtocol.CodexAppServerPatchedProtocol["respondError"];
 }
 
+export type CodexAppServerTurnStreamEvent =
+  | {
+      readonly _tag: "TurnStarted";
+      readonly method: "turn/started";
+      readonly payload: CodexRpc.ServerNotificationParamsByMethod["turn/started"];
+    }
+  | {
+      readonly _tag: "AgentMessageDelta";
+      readonly method: "item/agentMessage/delta";
+      readonly payload: CodexRpc.ServerNotificationParamsByMethod["item/agentMessage/delta"];
+      readonly textDelta: string;
+    }
+  | {
+      readonly _tag: "TurnCompleted";
+      readonly method: "turn/completed";
+      readonly payload: CodexRpc.ServerNotificationParamsByMethod["turn/completed"];
+    }
+  | {
+      readonly _tag: "ChunkTimeoutWarning";
+      readonly idleForMillis: number;
+      readonly method: "turn/start";
+      readonly message: string;
+      readonly threadId: string;
+      readonly timeoutMillis: number;
+      readonly turnId: string | undefined;
+    }
+  | {
+      readonly _tag: "TurnStartResponse";
+      readonly method: "turn/start";
+      readonly response: CodexRpc.ClientRequestResponsesByMethod["turn/start"];
+    };
+
+export interface CodexAppServerTurnStreamOptions {
+  readonly abortSignal?: AbortSignal;
+  readonly chunkTimeoutAfter?: Duration.Input;
+  readonly chunkWarningAfter?: Duration.Input;
+  readonly queueCapacity?: number;
+}
+
 export interface CodexAppServerClientShape {
   readonly raw: CodexAppServerClientRaw;
   readonly request: <M extends CodexRpc.ClientRequestMethod>(
@@ -46,6 +95,10 @@ export interface CodexAppServerClientShape {
     method: M,
     payload: CodexRpc.ClientNotificationParamsByMethod[M],
   ) => Effect.Effect<void, CodexError.CodexAppServerError>;
+  readonly streamTurn: (
+    payload: CodexRpc.ClientRequestParamsByMethod["turn/start"],
+    options?: CodexAppServerTurnStreamOptions,
+  ) => Stream.Stream<CodexAppServerTurnStreamEvent, CodexError.CodexAppServerError>;
   readonly handleServerRequest: <M extends CodexRpc.ServerRequestMethod>(
     method: M,
     handler: (
@@ -83,6 +136,19 @@ type ServerRequestHandler = (
 type ServerNotificationHandler = (
   payload: unknown,
 ) => Effect.Effect<void, CodexError.CodexAppServerError>;
+
+const durationMillis = (input: Duration.Input): number =>
+  Duration.toMillis(Duration.fromInputUnsafe(input));
+
+const awaitAbortSignal = (signal: AbortSignal): Effect.Effect<void> =>
+  signal.aborted
+    ? Effect.void
+    : Effect.promise(
+        () =>
+          new Promise<void>((resolve) => {
+            signal.addEventListener("abort", () => resolve(), { once: true });
+          }),
+      );
 
 export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make")(function* (
   stdio: Stdio.Stdio,
@@ -136,6 +202,27 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
         CodexRpc.ClientNotificationParamsByMethod[M]
       >
     | undefined => CodexRpc.CLIENT_NOTIFICATION_PARAMS[method] as never;
+
+  const registerServerNotificationHandler = <M extends CodexRpc.ServerNotificationMethod>(
+    method: M,
+    handler: (
+      payload: CodexRpc.ServerNotificationParamsByMethod[M],
+    ) => Effect.Effect<void, CodexError.CodexAppServerError>,
+  ): Effect.Effect<Effect.Effect<void>> =>
+    Effect.sync(() => {
+      const registered = handler as ServerNotificationHandler;
+      const current = notificationHandlers.get(method) ?? [];
+      notificationHandlers.set(method, [...current, registered]);
+      return Effect.sync(() => {
+        const handlers = notificationHandlers.get(method) ?? [];
+        const next = handlers.filter((candidate) => candidate !== registered);
+        if (next.length === 0) {
+          notificationHandlers.delete(method);
+          return;
+        }
+        notificationHandlers.set(method, next);
+      });
+    });
 
   const dispatchNotification = (
     notification: CodexProtocol.CodexAppServerIncomingNotification,
@@ -218,6 +305,192 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
       Effect.flatMap((encoded) => transport.notify(method, encoded)),
     );
 
+  const streamTurn = (
+    payload: CodexRpc.ClientRequestParamsByMethod["turn/start"],
+    streamOptions: CodexAppServerTurnStreamOptions = {},
+  ): Stream.Stream<CodexAppServerTurnStreamEvent, CodexError.CodexAppServerError> =>
+    Stream.unwrap(
+      Effect.gen(function* () {
+        const chunkWarningMillis = durationMillis(
+          streamOptions.chunkWarningAfter ?? DEFAULT_TURN_STREAM_CHUNK_WARNING_AFTER,
+        );
+        const chunkTimeoutMillis = durationMillis(
+          streamOptions.chunkTimeoutAfter ?? DEFAULT_TURN_STREAM_CHUNK_TIMEOUT_AFTER,
+        );
+        const afterWarningTimeoutMillis = Math.max(0, chunkTimeoutMillis - chunkWarningMillis);
+        const queueCapacity = Math.max(
+          1,
+          Math.trunc(streamOptions.queueCapacity ?? DEFAULT_TURN_STREAM_QUEUE_CAPACITY),
+        );
+        const streamQueue = yield* Queue.bounded<
+          CodexAppServerTurnStreamEvent,
+          CodexError.CodexAppServerError | Cause.Done
+        >(queueCapacity);
+        const turnIdRef = yield* Ref.make<string | undefined>(undefined);
+        const warnedRef = yield* Ref.make(false);
+        const doneRef = yield* Ref.make(false);
+
+        const endStream = Ref.set(doneRef, true).pipe(
+          Effect.andThen(Queue.end(streamQueue)),
+          Effect.asVoid,
+        );
+
+        const failStream = (error: CodexError.CodexAppServerError) =>
+          Ref.set(doneRef, true).pipe(
+            Effect.andThen(Queue.fail(streamQueue, error)),
+            Effect.asVoid,
+          );
+
+        const offerEvent = (event: CodexAppServerTurnStreamEvent) =>
+          Queue.offer(streamQueue, event).pipe(Effect.asVoid);
+
+        const matchesTurn = (threadId: string, turnId: string) =>
+          Effect.map(Ref.get(turnIdRef), (currentTurnId) => {
+            if (threadId !== payload.threadId) {
+              return false;
+            }
+            return currentTurnId === undefined || currentTurnId === turnId;
+          });
+
+        const rememberTurnId = (turnId: string) =>
+          Ref.update(turnIdRef, (current) => current ?? turnId);
+
+        const interruptActiveTurn = Effect.gen(function* () {
+          const turnId = yield* Ref.get(turnIdRef);
+          if (!turnId) {
+            return;
+          }
+          yield* request("turn/interrupt", {
+            threadId: payload.threadId,
+            turnId,
+          }).pipe(Effect.ignore, Effect.forkDetach({ startImmediately: true }));
+        });
+
+        const unregisterStarted = yield* registerServerNotificationHandler(
+          "turn/started",
+          (started) =>
+            Effect.gen(function* () {
+              if (!(yield* matchesTurn(started.threadId, started.turn.id))) {
+                return;
+              }
+              yield* rememberTurnId(started.turn.id);
+              yield* offerEvent({
+                _tag: "TurnStarted",
+                method: "turn/started",
+                payload: started,
+              });
+            }),
+        );
+
+        const unregisterDelta = yield* registerServerNotificationHandler(
+          "item/agentMessage/delta",
+          (delta) =>
+            Effect.gen(function* () {
+              if (!(yield* matchesTurn(delta.threadId, delta.turnId))) {
+                return;
+              }
+              yield* rememberTurnId(delta.turnId);
+              yield* offerEvent({
+                _tag: "AgentMessageDelta",
+                method: "item/agentMessage/delta",
+                payload: delta,
+                textDelta: delta.delta,
+              });
+            }),
+        );
+
+        const unregisterCompleted = yield* registerServerNotificationHandler(
+          "turn/completed",
+          (completed) =>
+            Effect.gen(function* () {
+              if (!(yield* matchesTurn(completed.threadId, completed.turn.id))) {
+                return;
+              }
+              yield* rememberTurnId(completed.turn.id);
+              yield* offerEvent({
+                _tag: "TurnCompleted",
+                method: "turn/completed",
+                payload: completed,
+              });
+            }),
+        );
+
+        const requestFiber = yield* request("turn/start", payload).pipe(
+          Effect.flatMap((response) =>
+            rememberTurnId(response.turn.id).pipe(
+              Effect.andThen(
+                offerEvent({
+                  _tag: "TurnStartResponse",
+                  method: "turn/start",
+                  response,
+                }),
+              ),
+            ),
+          ),
+          Effect.andThen(endStream),
+          Effect.catch(failStream),
+          Effect.forkScoped,
+        );
+
+        if (streamOptions.abortSignal) {
+          yield* awaitAbortSignal(streamOptions.abortSignal).pipe(
+            Effect.andThen(interruptActiveTurn),
+            Effect.andThen(endStream),
+            Effect.forkScoped,
+          );
+        }
+
+        const cleanup = Effect.gen(function* () {
+          yield* unregisterStarted;
+          yield* unregisterDelta;
+          yield* unregisterCompleted;
+          const done = yield* Ref.get(doneRef);
+          if (!done) {
+            yield* interruptActiveTurn;
+          }
+          yield* Fiber.interrupt(requestFiber).pipe(Effect.ignore);
+          yield* Queue.shutdown(streamQueue).pipe(Effect.ignore);
+        });
+
+        const takeNext = Effect.gen(function* () {
+          const alreadyWarned = yield* Ref.get(warnedRef);
+          const timeoutMillis = alreadyWarned ? afterWarningTimeoutMillis : chunkWarningMillis;
+          const maybeEvent = yield* Queue.take(streamQueue).pipe(
+            Effect.timeoutOption(Duration.millis(timeoutMillis)),
+          );
+
+          if (Option.isSome(maybeEvent)) {
+            yield* Ref.set(warnedRef, false);
+            return maybeEvent.value;
+          }
+
+          const turnId = yield* Ref.get(turnIdRef);
+          if (!alreadyWarned) {
+            yield* Ref.set(warnedRef, true);
+            return {
+              _tag: "ChunkTimeoutWarning",
+              idleForMillis: chunkWarningMillis,
+              method: "turn/start",
+              message: `No Codex stream chunk received for ${chunkWarningMillis}ms; continuing to wait up to ${chunkTimeoutMillis}ms total.`,
+              threadId: payload.threadId,
+              timeoutMillis: chunkTimeoutMillis,
+              turnId,
+            } satisfies CodexAppServerTurnStreamEvent;
+          }
+
+          return yield* new CodexError.CodexAppServerStreamTimeoutError({
+            idleForMillis: chunkTimeoutMillis,
+            method: "turn/start",
+            threadId: payload.threadId,
+            timeoutMillis: chunkTimeoutMillis,
+            ...(turnId ? { turnId } : {}),
+          });
+        });
+
+        return Stream.fromEffectRepeat(takeNext).pipe(Stream.ensuring(cleanup));
+      }),
+    );
+
   return CodexAppServerClient.of({
     raw: {
       notifications: transport.incomingNotifications,
@@ -229,16 +502,13 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
     },
     request,
     notify,
+    streamTurn,
     handleServerRequest: (method, handler) =>
       Effect.sync(() => {
         requestHandlers.set(method, handler as ServerRequestHandler);
       }),
     handleServerNotification: (method, handler) =>
-      Effect.sync(() => {
-        const current = notificationHandlers.get(method) ?? [];
-        current.push(handler as ServerNotificationHandler);
-        notificationHandlers.set(method, current);
-      }),
+      registerServerNotificationHandler(method, handler).pipe(Effect.asVoid),
     handleUnknownServerRequest: (handler) =>
       Effect.sync(() => {
         unknownRequestHandler = handler;

--- a/t3code/packages/effect-codex-app-server/src/errors.ts
+++ b/t3code/packages/effect-codex-app-server/src/errors.ts
@@ -58,6 +58,21 @@ export class CodexAppServerTransportError extends Schema.TaggedErrorClass<CodexA
   }
 }
 
+export class CodexAppServerStreamTimeoutError extends Schema.TaggedErrorClass<CodexAppServerStreamTimeoutError>()(
+  "CodexAppServerStreamTimeoutError",
+  {
+    idleForMillis: Schema.Number,
+    method: Schema.String,
+    threadId: Schema.String,
+    timeoutMillis: Schema.Number,
+    turnId: Schema.optional(Schema.String),
+  },
+) {
+  override get message() {
+    return `Codex App Server stream for ${this.method} on thread ${this.threadId} timed out after ${this.timeoutMillis}ms without a chunk`;
+  }
+}
+
 export class CodexAppServerRequestError extends Schema.TaggedErrorClass<CodexAppServerRequestError>()(
   "CodexAppServerRequestError",
   {
@@ -139,6 +154,7 @@ export const CodexAppServerError = Schema.Union([
   CodexAppServerSpawnError,
   CodexAppServerProcessExitedError,
   CodexAppServerProtocolParseError,
+  CodexAppServerStreamTimeoutError,
   CodexAppServerTransportError,
 ]);
 


### PR DESCRIPTION
## Summary
- Add `streamTurn` to the Effect Codex app-server client, returning typed `Effect.Stream` events for turn start, assistant deltas, turn completion, timeout warnings, and final `turn/start` response.
- Use a bounded queue behind notification handlers so slow consumers apply backpressure to upstream notification dispatch.
- Add per-chunk warning/failure timeouts and abort-signal upstream `turn/interrupt` handling.
- Add focused tests for ordered collection/non-streaming parity, slow-consumer backpressure, timeout warning/failure, and abort cancellation.

## Validation
- `npx -p node@24.13.1 -p bun@1.3.11 bun fmt`
- `npx -p node@24.13.1 -p bun@1.3.11 bun lint` (passes with existing warnings outside this package)
- `npx -p node@24.13.1 -p bun@1.3.11 bun typecheck`
- `npx -p node@24.13.1 -p bun@1.3.11 bun run --filter effect-codex-app-server test`

/claim #845