### PR TITLE
Codex [ T3 Code ] Enable SQLite WAL mode and add Effect.Pool connection pooling

### DIFF
--- a/t3code/apps/server/src/persistence/BunSqliteClient.ts
+++ b/t3code/apps/server/src/persistence/BunSqliteClient.ts
@@ -1,0 +1,76 @@
+import * as BunSqliteClient from "@effect/sql-sqlite-bun/SqliteClient";
+import * as Config from "effect/Config";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type * as Scope from "effect/Scope";
+import * as Reactivity from "effect/unstable/reactivity/Reactivity";
+import * as Client from "effect/unstable/sql/SqlClient";
+import type { SqlError } from "effect/unstable/sql/SqlError";
+
+import {
+  makePooledSqliteClient,
+  type PooledSqliteClient,
+  type PooledSqliteOptions,
+  type SqlitePoolConfig,
+} from "./SqlitePooledClient.ts";
+
+export const TypeId: TypeId = "~local/sqlite-bun/SqliteClient";
+
+export type TypeId = "~local/sqlite-bun/SqliteClient";
+
+export const SqliteClient = Context.Service<SqliteClient>("t3/persistence/BunSqliteClient");
+
+export interface SqliteClient extends PooledSqliteClient {
+  readonly [TypeId]: TypeId;
+  readonly config: SqliteClientConfig;
+}
+
+export interface SqliteClientConfig extends PooledSqliteOptions {
+  readonly filename: string;
+  readonly readonly?: boolean | undefined;
+  readonly create?: boolean | undefined;
+  readonly readwrite?: boolean | undefined;
+  readonly disableWAL?: boolean | undefined;
+  readonly spanAttributes?: Record<string, unknown> | undefined;
+  readonly transformResultNames?: ((str: string) => string) | undefined;
+  readonly transformQueryNames?: ((str: string) => string) | undefined;
+  readonly pool?: SqlitePoolConfig | undefined;
+}
+
+const make = (
+  options: SqliteClientConfig,
+): Effect.Effect<SqliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function* () {
+    const acquireConnection = Effect.gen(function* () {
+      const client = yield* BunSqliteClient.make(options);
+      return yield* client.reserve;
+    });
+
+    const client = yield* makePooledSqliteClient(options, acquireConnection);
+    return Object.assign(client, {
+      [TypeId]: TypeId,
+      config: options,
+    });
+  });
+
+export const layerConfig = (
+  config: Config.Wrap<SqliteClientConfig>,
+): Layer.Layer<Client.SqlClient, Config.ConfigError | SqlError> =>
+  Layer.effectContext(
+    Config.unwrap(config)
+      .asEffect()
+      .pipe(
+        Effect.flatMap(make),
+        Effect.map((client) =>
+          Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
+        ),
+      ),
+  ).pipe(Layer.provide(Reactivity.layer));
+
+export const layer = (config: SqliteClientConfig): Layer.Layer<Client.SqlClient, SqlError> =>
+  Layer.effectContext(
+    Effect.map(make(config), (client) =>
+      Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
+    ),
+  ).pipe(Layer.provide(Reactivity.layer));

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -3,9 +3,11 @@ import * as Layer from "effect/Layer";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
+import type { SqlError } from "effect/unstable/sql/SqlError";
 
 import { runMigrations } from "../Migrations.ts";
 import { ServerConfig } from "../../config.ts";
+import { SQLITE_BUSY_TIMEOUT_MS, sqliteHealthCheck } from "../SqlitePooledClient.ts";
 
 type RuntimeSqliteLayerConfig = {
   readonly filename: string;
@@ -13,10 +15,10 @@ type RuntimeSqliteLayerConfig = {
 };
 
 type Loader = {
-  layer: (config: RuntimeSqliteLayerConfig) => Layer.Layer<SqlClient.SqlClient>;
+  layer: (config: RuntimeSqliteLayerConfig) => Layer.Layer<SqlClient.SqlClient, SqlError>;
 };
 const defaultSqliteClientLoaders = {
-  bun: () => import("@effect/sql-sqlite-bun/SqliteClient"),
+  bun: () => import("../BunSqliteClient.ts"),
   node: () => import("../NodeSqliteClient.ts"),
 } satisfies Record<string, () => Promise<Loader>>;
 
@@ -33,10 +35,14 @@ const setup = Layer.effectDiscard(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     yield* sql`PRAGMA journal_mode = WAL;`;
+    yield* sql.unsafe(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`, []);
+    yield* sql`PRAGMA synchronous = NORMAL;`;
     yield* sql`PRAGMA foreign_keys = ON;`;
     yield* runMigrations();
   }),
 );
+
+export const checkSqliteHealth = sqliteHealthCheck;
 
 export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(function* (
   dbPath: string,

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -1,10 +1,34 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import * as SqliteClient from "./NodeSqliteClient.ts";
 
 const layer = it.layer(SqliteClient.layerMemory());
+
+function makeTempDb() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-sqlite-pool-"));
+  return {
+    dir,
+    dbPath: path.join(dir, "state.sqlite"),
+  };
+}
+
+const withTempDb = <A, E, R>(use: (dbPath: string) => Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.sync(makeTempDb),
+    ({ dbPath }) => use(dbPath),
+    ({ dir }) =>
+      Effect.sync(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }),
+  );
 
 layer("NodeSqliteClient", (it) => {
   it.effect("runs prepared queries and returns positional values", () =>
@@ -28,3 +52,136 @@ layer("NodeSqliteClient", (it) => {
     }),
   );
 });
+
+it.effect("NodeSqliteClient configures WAL pragmas and health checks for file databases", () =>
+  withTempDb((dbPath) =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const client = yield* SqliteClient.SqliteClient;
+
+      const journalMode = yield* sql<{ readonly journal_mode: string }>`
+        PRAGMA journal_mode
+      `;
+      assert.equal(journalMode[0]?.journal_mode.toLowerCase(), "wal");
+
+      const busyTimeout = yield* sql<{ readonly timeout: number }>`
+        PRAGMA busy_timeout
+      `;
+      assert.equal(Number(busyTimeout[0]?.timeout), 5000);
+
+      const synchronous = yield* sql<{ readonly synchronous: number }>`
+        PRAGMA synchronous
+      `;
+      assert.equal(Number(synchronous[0]?.synchronous), 1);
+
+      const health = yield* client.healthCheck;
+      assert.deepEqual(health, { ok: true, details: ["ok"] });
+    }).pipe(Effect.provide(SqliteClient.layer({ filename: dbPath }))),
+  ),
+);
+
+it.effect("NodeSqliteClient grows the file-backed pool from 1 to 5 connections on demand", () =>
+  withTempDb((dbPath) =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const client = yield* SqliteClient.SqliteClient;
+
+      const initialStats = yield* client.poolStats;
+      assert.equal(initialStats.minSize, 1);
+      assert.equal(initialStats.maxSize, 5);
+      assert.ok(initialStats.activeConnections >= 1);
+      assert.ok(initialStats.activeConnections <= 5);
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* Effect.all(
+            Array.from({ length: 5 }, () => sql.reserve),
+            {
+              concurrency: "unbounded",
+              discard: true,
+            },
+          );
+
+          const heldStats = yield* client.poolStats;
+          assert.equal(heldStats.activeConnections, 5);
+          assert.equal(heldStats.acquiredConnections, 5);
+        }),
+      );
+
+      const stats = yield* client.poolStats;
+      assert.equal(stats.activeConnections, 5);
+      assert.equal(stats.availableConnections, 5);
+      assert.equal(stats.acquiredConnections, 0);
+    }).pipe(Effect.provide(SqliteClient.layer({ filename: dbPath }))),
+  ),
+);
+
+it.live("NodeSqliteClient times out connection acquisition when the pool is exhausted", () =>
+  withTempDb((dbPath) =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* sql.reserve;
+
+          const result = yield* Effect.exit(sql`SELECT 1`);
+          assert.equal(Exit.isFailure(result), true);
+        }),
+      );
+    }).pipe(
+      Effect.provide(
+        SqliteClient.layer({
+          filename: dbPath,
+          pool: {
+            maxSize: 1,
+            acquireTimeout: "20 millis",
+          },
+        }),
+      ),
+    ),
+  ),
+);
+
+it.effect(
+  "NodeSqliteClient resets returned connections and handles concurrent reads and writes",
+  () =>
+    withTempDb((dbPath) =>
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+
+        yield* sql`CREATE TABLE entries(id INTEGER PRIMARY KEY, value TEXT NOT NULL)`;
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const connection = yield* sql.reserve;
+            yield* connection.executeUnprepared("BEGIN;", [], undefined);
+            yield* connection.executeUnprepared(
+              "INSERT INTO entries(id, value) VALUES (999, 'uncommitted');",
+              [],
+              undefined,
+            );
+          }),
+        );
+
+        const leakedRows = yield* sql<{ readonly id: number }>`
+        SELECT id FROM entries WHERE id = 999
+      `;
+        assert.equal(leakedRows.length, 0);
+
+        yield* Effect.all(
+          Array.from({ length: 20 }, (_, index) =>
+            index % 2 === 0
+              ? sql`INSERT INTO entries(value) VALUES (${`value-${index}`})`
+              : sql<{ readonly count: number }>`SELECT COUNT(*) AS count FROM entries`,
+          ),
+          { concurrency: "unbounded", discard: true },
+        );
+
+        const countRows = yield* sql<{ readonly count: number }>`
+        SELECT COUNT(*) AS count FROM entries
+      `;
+        assert.equal(Number(countRows[0]?.count), 10);
+      }).pipe(Effect.provide(SqliteClient.layer({ filename: dbPath }))),
+    ),
+);

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.ts
@@ -8,22 +8,24 @@ import { DatabaseSync, type StatementSync } from "node:sqlite";
 
 import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
+import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
-import * as Fiber from "effect/Fiber";
 import { identity } from "effect/Function";
 import * as Layer from "effect/Layer";
 import * as Scope from "effect/Scope";
-import * as Semaphore from "effect/Semaphore";
-import * as Context from "effect/Context";
 import * as Stream from "effect/Stream";
 import * as Reactivity from "effect/unstable/reactivity/Reactivity";
 import * as Client from "effect/unstable/sql/SqlClient";
 import type { Connection } from "effect/unstable/sql/SqlConnection";
 import { SqlError, classifySqliteError } from "effect/unstable/sql/SqlError";
-import * as Statement from "effect/unstable/sql/Statement";
 
-const ATTR_DB_SYSTEM_NAME = "db.system.name";
+import {
+  makePooledSqliteClient,
+  type PooledSqliteClient,
+  type PooledSqliteOptions,
+  type SqlitePoolConfig,
+} from "./SqlitePooledClient.ts";
 
 export const TypeId: TypeId = "~local/sqlite-node/SqliteClient";
 
@@ -32,9 +34,14 @@ export type TypeId = "~local/sqlite-node/SqliteClient";
 /**
  * SqliteClient - Effect service tag for the sqlite SQL client.
  */
-export const SqliteClient = Context.Service<Client.SqlClient>("t3/persistence/NodeSqliteClient");
+export const SqliteClient = Context.Service<SqliteClient>("t3/persistence/NodeSqliteClient");
 
-export interface SqliteClientConfig {
+export interface SqliteClient extends PooledSqliteClient {
+  readonly [TypeId]: TypeId;
+  readonly config: SqliteClientConfig;
+}
+
+export interface SqliteClientConfig extends PooledSqliteOptions {
   readonly filename: string;
   readonly readonly?: boolean | undefined;
   readonly allowExtension?: boolean | undefined;
@@ -43,6 +50,7 @@ export interface SqliteClientConfig {
   readonly spanAttributes?: Record<string, unknown> | undefined;
   readonly transformResultNames?: ((str: string) => string) | undefined;
   readonly transformQueryNames?: ((str: string) => string) | undefined;
+  readonly pool?: SqlitePoolConfig | undefined;
 }
 
 export interface SqliteMemoryClientConfig extends Omit<
@@ -75,13 +83,8 @@ const checkNodeSqliteCompat = () => {
 const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
   options: SqliteClientConfig,
   openDatabase: () => DatabaseSync,
-): Effect.fn.Return<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> {
+): Effect.fn.Return<SqliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> {
   yield* checkNodeSqliteCompat();
-
-  const compiler = Statement.makeCompilerSqlite(options.transformQueryNames);
-  const transformRows = options.transformResultNames
-    ? Statement.defaultTransforms(options.transformResultNames).array
-    : undefined;
 
   const makeConnection = Effect.gen(function* () {
     const scope = yield* Effect.scope;
@@ -194,34 +197,16 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
     });
   });
 
-  const semaphore = yield* Semaphore.make(1);
-  const connection = yield* makeConnection;
-
-  const acquirer = semaphore.withPermits(1)(Effect.succeed(connection));
-  const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
-    const fiber = Fiber.getCurrent()!;
-    const scope = Context.getUnsafe(fiber.context, Scope.Scope);
-    return Effect.as(
-      Effect.tap(restore(semaphore.take(1)), () => Scope.addFinalizer(scope, semaphore.release(1))),
-      connection,
-    );
-  });
-
-  return yield* Client.make({
-    acquirer,
-    compiler,
-    transactionAcquirer,
-    spanAttributes: [
-      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [ATTR_DB_SYSTEM_NAME, "sqlite"],
-    ],
-    transformRows,
+  const client = yield* makePooledSqliteClient(options, makeConnection);
+  return Object.assign(client, {
+    [TypeId]: TypeId,
+    config: options,
   });
 });
 
 const make = (
   options: SqliteClientConfig,
-): Effect.Effect<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
   makeWithDatabase(
     options,
     () =>
@@ -233,7 +218,7 @@ const make = (
 
 const makeMemory = (
   config: SqliteMemoryClientConfig = {},
-): Effect.Effect<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
   makeWithDatabase(
     {
       ...config,
@@ -250,7 +235,7 @@ const makeMemory = (
 
 export const layerConfig = (
   config: Config.Wrap<SqliteClientConfig>,
-): Layer.Layer<Client.SqlClient, Config.ConfigError> =>
+): Layer.Layer<Client.SqlClient, Config.ConfigError | SqlError> =>
   Layer.effectContext(
     Config.unwrap(config)
       .asEffect()
@@ -262,14 +247,16 @@ export const layerConfig = (
       ),
   ).pipe(Layer.provide(Reactivity.layer));
 
-export const layer = (config: SqliteClientConfig): Layer.Layer<Client.SqlClient> =>
+export const layer = (config: SqliteClientConfig): Layer.Layer<Client.SqlClient, SqlError> =>
   Layer.effectContext(
     Effect.map(make(config), (client) =>
       Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
     ),
   ).pipe(Layer.provide(Reactivity.layer));
 
-export const layerMemory = (config: SqliteMemoryClientConfig = {}): Layer.Layer<Client.SqlClient> =>
+export const layerMemory = (
+  config: SqliteMemoryClientConfig = {},
+): Layer.Layer<Client.SqlClient, SqlError> =>
   Layer.effectContext(
     Effect.map(makeMemory(config), (client) =>
       Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),

--- a/t3code/apps/server/src/persistence/SqlitePooledClient.ts
+++ b/t3code/apps/server/src/persistence/SqlitePooledClient.ts
@@ -1,0 +1,272 @@
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Pool from "effect/Pool";
+import * as Semaphore from "effect/Semaphore";
+import * as Scope from "effect/Scope";
+import * as Client from "effect/unstable/sql/SqlClient";
+import type { Connection } from "effect/unstable/sql/SqlConnection";
+import { LockTimeoutError, SqlError, UnknownError } from "effect/unstable/sql/SqlError";
+import * as Statement from "effect/unstable/sql/Statement";
+import type * as Reactivity from "effect/unstable/reactivity/Reactivity";
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name";
+
+export const SQLITE_POOL_MIN_SIZE = 1;
+export const SQLITE_POOL_MAX_SIZE = 5;
+export const SQLITE_POOL_ACQUIRE_TIMEOUT = Duration.seconds(10);
+export const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+const SQLITE_POOL_TTL = Duration.minutes(5);
+
+export interface SqlitePoolConfig {
+  readonly minSize?: number | undefined;
+  readonly maxSize?: number | undefined;
+  readonly acquireTimeout?: Duration.Input | undefined;
+  readonly timeToLive?: Duration.Input | undefined;
+}
+
+export interface SqlitePoolSettings {
+  readonly minSize: number;
+  readonly maxSize: number;
+  readonly acquireTimeout: Duration.Duration;
+  readonly timeToLive: Duration.Duration;
+}
+
+export interface SqlitePoolStats {
+  readonly minSize: number;
+  readonly maxSize: number;
+  readonly activeConnections: number;
+  readonly availableConnections: number;
+  readonly acquiredConnections: number;
+  readonly waiters: number;
+}
+
+export interface SqliteHealthCheck {
+  readonly ok: boolean;
+  readonly details: ReadonlyArray<string>;
+}
+
+export interface PooledSqliteClient extends Client.SqlClient {
+  readonly poolSettings: SqlitePoolSettings;
+  readonly poolStats: Effect.Effect<SqlitePoolStats>;
+  readonly healthCheck: Effect.Effect<SqliteHealthCheck, SqlError>;
+}
+
+export interface PooledSqliteOptions {
+  readonly filename: string;
+  readonly readonly?: boolean | undefined;
+  readonly spanAttributes?: Record<string, unknown> | undefined;
+  readonly transformResultNames?: ((str: string) => string) | undefined;
+  readonly transformQueryNames?: ((str: string) => string) | undefined;
+  readonly pool?: SqlitePoolConfig | undefined;
+  readonly disableWAL?: boolean | undefined;
+}
+
+const isInMemoryDatabase = (filename: string) => filename === ":memory:";
+
+export function normalizePoolSettings(options: PooledSqliteOptions): SqlitePoolSettings {
+  if (isInMemoryDatabase(options.filename)) {
+    return {
+      minSize: 1,
+      maxSize: 1,
+      acquireTimeout: Duration.fromInputUnsafe(
+        options.pool?.acquireTimeout ?? SQLITE_POOL_ACQUIRE_TIMEOUT,
+      ),
+      timeToLive: Duration.fromInputUnsafe(options.pool?.timeToLive ?? SQLITE_POOL_TTL),
+    };
+  }
+
+  const minSize = Math.max(1, options.pool?.minSize ?? SQLITE_POOL_MIN_SIZE);
+  const maxSize = Math.max(minSize, options.pool?.maxSize ?? SQLITE_POOL_MAX_SIZE);
+
+  return {
+    minSize,
+    maxSize,
+    acquireTimeout: Duration.fromInputUnsafe(
+      options.pool?.acquireTimeout ?? SQLITE_POOL_ACQUIRE_TIMEOUT,
+    ),
+    timeToLive: Duration.fromInputUnsafe(options.pool?.timeToLive ?? SQLITE_POOL_TTL),
+  };
+}
+
+const makePoolTimeoutError = () =>
+  new SqlError({
+    reason: new LockTimeoutError({
+      cause: new Error("Timed out acquiring SQLite connection from the pool."),
+      message: "Timed out acquiring SQLite connection from the pool.",
+      operation: "pool.acquire",
+    }),
+  });
+
+const makePragmaVerificationError = (message: string, operation: string) =>
+  new SqlError({
+    reason: new UnknownError({
+      cause: new Error(message),
+      message,
+      operation,
+    }),
+  });
+
+const executePragma = (connection: Connection, sql: string) =>
+  Effect.asVoid(connection.executeUnprepared(sql, [], undefined));
+
+const readPragma = (connection: Connection, sql: string) =>
+  connection.executeUnprepared(sql, [], undefined);
+
+const firstColumnAsString = (rows: ReadonlyArray<unknown>, column: string): string | undefined => {
+  const row = rows[0];
+  if (row === undefined || row === null || typeof row !== "object") {
+    return undefined;
+  }
+  const value = (row as Record<string, unknown>)[column];
+  return value === undefined ? undefined : String(value);
+};
+
+export const configureSqliteConnection = (
+  connection: Connection,
+  options: PooledSqliteOptions,
+): Effect.Effect<void, SqlError> =>
+  Effect.gen(function* () {
+    if (!options.readonly && options.disableWAL !== true && !isInMemoryDatabase(options.filename)) {
+      const currentRows = yield* readPragma(connection, "PRAGMA journal_mode;");
+      let journalMode = firstColumnAsString(currentRows, "journal_mode")?.toLowerCase();
+      if (journalMode !== "wal") {
+        const updatedRows = yield* readPragma(connection, "PRAGMA journal_mode = WAL;");
+        journalMode = firstColumnAsString(updatedRows, "journal_mode")?.toLowerCase();
+      }
+      if (journalMode !== "wal") {
+        return yield* makePragmaVerificationError(
+          `SQLite WAL mode verification failed; journal_mode is ${journalMode ?? "unknown"}.`,
+          "pragma.journal_mode",
+        );
+      }
+    }
+
+    yield* executePragma(connection, `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+    yield* executePragma(connection, "PRAGMA synchronous = NORMAL;");
+    yield* executePragma(connection, "PRAGMA foreign_keys = ON;");
+  });
+
+const resetSqliteConnection = (connection: Connection): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* executePragma(connection, "ROLLBACK;").pipe(Effect.ignore);
+    yield* executePragma(connection, "PRAGMA reset;").pipe(Effect.ignore);
+    yield* executePragma(connection, `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`).pipe(
+      Effect.ignore,
+    );
+    yield* executePragma(connection, "PRAGMA synchronous = NORMAL;").pipe(Effect.ignore);
+    yield* executePragma(connection, "PRAGMA foreign_keys = ON;").pipe(Effect.ignore);
+  });
+
+export const sqliteHealthCheck = (
+  sql: Client.SqlClient,
+): Effect.Effect<SqliteHealthCheck, SqlError> =>
+  Effect.gen(function* () {
+    const rows = yield* sql<{ readonly integrity_check: string }>`
+      PRAGMA integrity_check
+    `;
+    const details = rows.map((row) => row.integrity_check);
+    return {
+      ok: details.length > 0 && details.every((detail) => detail === "ok"),
+      details,
+    };
+  });
+
+export const makePooledSqliteClient = <R>(
+  options: PooledSqliteOptions,
+  acquireConnection: Effect.Effect<Connection, SqlError, R>,
+): Effect.Effect<PooledSqliteClient, SqlError, R | Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function* () {
+    const poolSettings = normalizePoolSettings(options);
+    const compiler = Statement.makeCompilerSqlite(options.transformQueryNames);
+    const transformRows = options.transformResultNames
+      ? Statement.defaultTransforms(options.transformResultNames).array
+      : undefined;
+
+    const pool = yield* Pool.makeWithTTL({
+      acquire: Effect.tap(acquireConnection, (connection) =>
+        configureSqliteConnection(connection, options),
+      ),
+      min: poolSettings.minSize,
+      max: poolSettings.maxSize,
+      timeToLive: poolSettings.timeToLive,
+    });
+
+    yield* Effect.scoped(Pool.get(pool));
+    const poolGetSemaphore = yield* Semaphore.make(1);
+    const leaseSemaphore = yield* Semaphore.make(poolSettings.maxSize);
+
+    const poolStats = Effect.sync(() => {
+      let acquiredConnections = 0;
+      for (const item of pool.state.items) {
+        acquiredConnections += item.refCount;
+      }
+      return {
+        minSize: pool.config.minSize,
+        maxSize: pool.config.maxSize,
+        activeConnections: pool.state.items.size - pool.state.invalidated.size,
+        availableConnections: pool.state.available.size,
+        acquiredConnections,
+        waiters: pool.state.waiters,
+      };
+    });
+
+    const takeLease = Effect.flatMap(
+      Effect.timeoutOption(leaseSemaphore.take(1), poolSettings.acquireTimeout),
+      (lease) => (Option.isSome(lease) ? Effect.void : Effect.fail(makePoolTimeoutError())),
+    );
+
+    const acquirePooledConnection = Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        yield* restore(takeLease);
+        const poolScope = yield* Scope.make();
+        const connection = yield* restore(
+          poolGetSemaphore.withPermits(1)(Scope.provide(Pool.get(pool), poolScope)),
+        ).pipe(
+          Effect.catchCause((cause) =>
+            Effect.gen(function* () {
+              yield* Scope.close(poolScope, Exit.failCause(cause)).pipe(Effect.ignore);
+              yield* leaseSemaphore.release(1);
+              return yield* Effect.failCause(cause);
+            }),
+          ),
+        );
+        return { connection, poolScope };
+      }),
+    );
+
+    const releasePooledConnection = ({
+      connection,
+      poolScope,
+    }: {
+      readonly connection: Connection;
+      readonly poolScope: Scope.Closeable;
+    }) =>
+      Effect.gen(function* () {
+        yield* resetSqliteConnection(connection);
+        yield* Scope.close(poolScope, Exit.void);
+      }).pipe(Effect.ensuring(leaseSemaphore.release(1)));
+
+    const acquirer = Effect.map(
+      Effect.acquireRelease(acquirePooledConnection, releasePooledConnection),
+      ({ connection }) => connection,
+    );
+
+    const client = yield* Client.make({
+      acquirer,
+      compiler,
+      transactionAcquirer: acquirer,
+      spanAttributes: [
+        ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+        [ATTR_DB_SYSTEM_NAME, "sqlite"],
+      ],
+      transformRows,
+    });
+
+    return Object.assign(client, {
+      poolSettings,
+      poolStats,
+      healthCheck: sqliteHealthCheck(client),
+    });
+  });


### PR DESCRIPTION
/claim #858

## Summary
- Enable WAL, busy_timeout=5000, synchronous=NORMAL, and integrity-check health reporting for SQLite startup.
- Add shared Effect.Pool-backed SQLite pooling with min 1 / max 5 connections, release reset, and acquisition timeout.
- Cover WAL pragmas, pool growth/timeout, release reset, and concurrent read/write behavior in Node SQLite tests.

## Validation
- bun fmt
- bun lint
- bun typecheck
- bun run --cwd apps/server test src/persistence/NodeSqliteClient.test.ts
- bun run test