### PR TITLE
Codex [ T3 Code ] Add CLI version command

### DIFF
--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -33,10 +33,13 @@ import {
 import { WorkspacePathsLive } from "./workspace/Layers/WorkspacePaths.ts";
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore.ts";
 import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
+import packageJson from "../package.json" with { type: "json" };
+import { formatVersionInfo, runtimeLabel } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
-const runCli = (args: ReadonlyArray<string>) => Command.runWith(cli, { version: "0.0.0" })(args);
+const runCli = (args: ReadonlyArray<string>) =>
+  Command.runWith(cli, { version: packageJson.version })(args);
 const runCliWithRuntime = (args: ReadonlyArray<string>) =>
   runCli(args).pipe(Effect.provide(CliRuntimeLayer));
 
@@ -153,6 +156,42 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
   it.effect("accepts the built-in lowercase log-level flag values", () =>
     runCliWithRuntime(["--log-level", "debug", "--version"]),
   );
+
+  it.effect("prints package version through the root --version flag", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["--version"]));
+      assert.equal(output, `t3 v${packageJson.version}`);
+    }),
+  );
+
+  it.effect("prints detailed version information", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["version"]));
+      assert.match(
+        output,
+        new RegExp(
+          `^t3code v${packageJson.version.replaceAll(".", "\\.")} \\((bun|node) [^,]+, ${process.platform} ${process.arch}\\)$`,
+        ),
+      );
+    }),
+  );
+
+  it("formats runtime version details", () => {
+    assert.equal(
+      formatVersionInfo({
+        version: "0.1.0",
+        runtime: "bun 1.3.11",
+        platform: "darwin",
+        arch: "arm64",
+      }),
+      "t3code v0.1.0 (bun 1.3.11, darwin arm64)",
+    );
+    assert.equal(
+      runtimeLabel({ node: "24.13.1", bun: "1.3.11" } as NodeJS.ProcessVersions),
+      "bun 1.3.11",
+    );
+    assert.equal(runtimeLabel({ node: "24.13.1" } as NodeJS.ProcessVersions), "node 24.13.1");
+  });
 
   it.effect("accepts canonical --no-<flag> boolean negation", () =>
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -10,13 +10,20 @@ import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { versionCommand } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    versionCommand,
+  ]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,34 @@
+import * as Console from "effect/Console";
+import { Command } from "effect/unstable/cli";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+export function runtimeLabel(versions: NodeJS.ProcessVersions = process.versions): string {
+  const bunVersion = versions.bun;
+  if (typeof bunVersion === "string" && bunVersion.length > 0) {
+    return `bun ${bunVersion}`;
+  }
+  return `node ${versions.node}`;
+}
+
+export function formatVersionInfo(input: {
+  readonly version: string;
+  readonly runtime: string;
+  readonly platform: NodeJS.Platform | string;
+  readonly arch: NodeJS.Architecture | string;
+}): string {
+  return `t3code v${input.version} (${input.runtime}, ${input.platform} ${input.arch})`;
+}
+
+export const currentVersionInfo = () =>
+  formatVersionInfo({
+    version: packageJson.version,
+    runtime: runtimeLabel(),
+    platform: process.platform,
+    arch: process.arch,
+  });
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print T3 Code version and runtime details."),
+  Command.withHandler(() => Console.log(currentVersionInfo())),
+);


### PR DESCRIPTION
/claim #821

Summary:
- Add a `version` subcommand that prints package version, runtime, platform, and architecture.
- Keep root `--version` wired to package.json through Effect CLI version support.
- Add focused CLI tests for root version output, detailed version output, and version formatting.

Validation:
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun install
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun fmt
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun lint
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun typecheck
- npx --yes -p node@24.13.1 -p bun@1.3.11 bun run --cwd apps/server test src/bin.test.ts
- git diff --check
