### PR TITLE
Codex [ T3 Code ] Add gzip and brotli HTTP compression

### DIFF
--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,6 +1,19 @@
+import { brotliDecompressSync, gzipSync, gunzipSync } from "node:zlib";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { describe, expect, it } from "vitest";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import {
+  compressHttpResponse,
+  decodeCompressedHttpRequest,
+  httpCompressionMiddleware,
+  isHttpCompressionSkippableContentType,
+  isLoopbackHostname,
+  resolveDevRedirectUrl,
+  resolveHttpCompressionLevel,
+  selectHttpResponseCompressionEncoding,
+} from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +36,153 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("http compression", () => {
+  const makeRequest = (acceptEncoding: string) =>
+    HttpServerRequest.fromWeb(
+      new Request("http://localhost/api/test", {
+        headers: { "accept-encoding": acceptEncoding },
+      }),
+    );
+
+  it("prefers brotli over gzip when both are accepted", () => {
+    expect(selectHttpResponseCompressionEncoding("gzip, br")).toBe("br");
+    expect(selectHttpResponseCompressionEncoding("gzip")).toBe("gzip");
+    expect(selectHttpResponseCompressionEncoding("br;q=0, gzip;q=1")).toBe("gzip");
+  });
+
+  it("resolves compression level from the first supported environment variable", () => {
+    expect(resolveHttpCompressionLevel({ T3CODE_HTTP_COMPRESSION_LEVEL: "9" })).toBe(9);
+    expect(resolveHttpCompressionLevel({ T3_HTTP_COMPRESSION_LEVEL: "50" })).toBe(11);
+    expect(resolveHttpCompressionLevel({ HTTP_COMPRESSION_LEVEL: "bad" })).toBe(4);
+  });
+
+  it("skips image and archive content types", () => {
+    expect(isHttpCompressionSkippableContentType("image/png")).toBe(true);
+    expect(isHttpCompressionSkippableContentType("application/zip")).toBe(true);
+    expect(isHttpCompressionSkippableContentType("application/json")).toBe(false);
+  });
+
+  it("compresses responses over 1KB with brotli and sets headers", async () => {
+    const response = HttpServerResponse.jsonUnsafe({
+      payload: "x".repeat(2048),
+    });
+
+    const compressedResponse = await Effect.runPromise(
+      compressHttpResponse(makeRequest("gzip, br"), response, 4),
+    );
+
+    expect(compressedResponse.headers["content-encoding"]).toBe("br");
+    expect(compressedResponse.headers.vary).toBe("Accept-Encoding");
+    expect(compressedResponse.body._tag).toBe("Uint8Array");
+    if (compressedResponse.body._tag === "Uint8Array") {
+      const decompressed = brotliDecompressSync(compressedResponse.body.body).toString("utf8");
+      expect(JSON.parse(decompressed)).toEqual({ payload: "x".repeat(2048) });
+    }
+  });
+
+  it("compresses responses over 1KB with gzip when brotli is unavailable", async () => {
+    const response = HttpServerResponse.text("x".repeat(2048), {
+      contentType: "text/plain",
+    });
+
+    const compressedResponse = await Effect.runPromise(
+      compressHttpResponse(makeRequest("gzip"), response, 4),
+    );
+
+    expect(compressedResponse.headers["content-encoding"]).toBe("gzip");
+    expect(compressedResponse.body._tag).toBe("Uint8Array");
+    if (compressedResponse.body._tag === "Uint8Array") {
+      expect(gunzipSync(compressedResponse.body.body).toString("utf8")).toBe("x".repeat(2048));
+    }
+  });
+
+  it("compresses stream responses with a known length", async () => {
+    const response = HttpServerResponse.stream(
+      Stream.succeed(new TextEncoder().encode("x".repeat(2048))),
+      {
+        contentType: "text/plain",
+        contentLength: 2048,
+      },
+    );
+
+    const compressedResponse = await Effect.runPromise(
+      compressHttpResponse(makeRequest("gzip"), response, 4),
+    );
+
+    expect(compressedResponse.headers["content-encoding"]).toBe("gzip");
+    expect(compressedResponse.body._tag).toBe("Uint8Array");
+    if (compressedResponse.body._tag === "Uint8Array") {
+      expect(gunzipSync(compressedResponse.body.body).toString("utf8")).toBe("x".repeat(2048));
+    }
+  });
+
+  it("skips responses under 1KB and already-compressed content types", async () => {
+    const smallResponse = HttpServerResponse.jsonUnsafe({ payload: "small" });
+    const imageResponse = HttpServerResponse.uint8Array(new Uint8Array(2048), {
+      contentType: "image/png",
+    });
+
+    expect(await Effect.runPromise(compressHttpResponse(makeRequest("br"), smallResponse))).toBe(
+      smallResponse,
+    );
+    expect(await Effect.runPromise(compressHttpResponse(makeRequest("br"), imageResponse))).toBe(
+      imageResponse,
+    );
+  });
+
+  it("decompresses incoming gzip request bodies before handler processing", async () => {
+    const body = JSON.stringify({ message: "hello" });
+    const request = HttpServerRequest.fromWeb(
+      new Request("http://localhost/api/test", {
+        method: "POST",
+        headers: {
+          "content-encoding": "gzip",
+          "content-type": "application/json",
+        },
+        body: gzipSync(body),
+      }),
+    );
+
+    const result = await Effect.runPromise(decodeCompressedHttpRequest(request));
+
+    expect(result._tag).toBe("Request");
+    if (result._tag === "Request") {
+      expect(result.request.headers["content-encoding"]).toBeUndefined();
+      expect(await Effect.runPromise(result.request.json)).toEqual({ message: "hello" });
+    }
+  });
+
+  it("applies request decompression before running middleware handler", async () => {
+    const body = JSON.stringify({ message: "from middleware" });
+    const request = HttpServerRequest.fromWeb(
+      new Request("http://localhost/api/test", {
+        method: "POST",
+        headers: {
+          "content-encoding": "gzip",
+          "content-type": "application/json",
+        },
+        body: gzipSync(body),
+      }),
+    );
+
+    const handler = Effect.gen(function* () {
+      const currentRequest = yield* HttpServerRequest.HttpServerRequest;
+      return HttpServerResponse.jsonUnsafe(yield* currentRequest.json.pipe(Effect.orDie));
+    });
+    const response = await Effect.runPromise(
+      httpCompressionMiddleware(handler).pipe(
+        Effect.provideService(HttpServerRequest.HttpServerRequest, request),
+      ),
+    );
+
+    expect(response.body._tag).toBe("Uint8Array");
+    if (response.body._tag === "Uint8Array") {
+      expect(JSON.parse(new TextDecoder().decode(response.body.body))).toEqual({
+        message: "from middleware",
+      });
+    }
   });
 });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,10 +1,22 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
+import { Buffer } from "node:buffer";
+import { promisify } from "node:util";
+import {
+  brotliCompress,
+  brotliDecompress,
+  constants as zlibConstants,
+  gzip,
+  gunzip,
+  type BrotliOptions,
+  type ZlibOptions,
+} from "node:zlib";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
 import { cast } from "effect/Function";
 import {
   HttpBody,
@@ -14,6 +26,7 @@ import {
   HttpServerResponse,
   HttpServerRequest,
 } from "effect/unstable/http";
+import * as Headers from "effect/unstable/http/Headers";
 import { OtlpTracer } from "effect/unstable/observability";
 
 import {
@@ -38,12 +51,359 @@ const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
+const HTTP_COMPRESSION_MIN_BYTES = 1024;
+const DEFAULT_HTTP_COMPRESSION_LEVEL = 4;
+const HTTP_COMPRESSION_LEVEL_ENV_NAMES = [
+  "T3CODE_HTTP_COMPRESSION_LEVEL",
+  "T3_HTTP_COMPRESSION_LEVEL",
+  "HTTP_COMPRESSION_LEVEL",
+] as const;
+
+type HttpCompressionEncoding = "br" | "gzip";
+
+type DecodedHttpRequestResult =
+  | {
+      readonly _tag: "Request";
+      readonly request: HttpServerRequest.HttpServerRequest;
+    }
+  | {
+      readonly _tag: "Response";
+      readonly response: HttpServerResponse.HttpServerResponse;
+    };
+
+class HttpCompressionError extends Data.TaggedError("HttpCompressionError")<{
+  readonly cause: unknown;
+}> {}
+
+const gzipAsync = promisify(gzip) as (input: Buffer, options: ZlibOptions) => Promise<Buffer>;
+const gunzipAsync = promisify(gunzip) as (input: Buffer) => Promise<Buffer>;
+const brotliCompressAsync = promisify(brotliCompress) as (
+  input: Buffer,
+  options: BrotliOptions,
+) => Promise<Buffer>;
+const brotliDecompressAsync = promisify(brotliDecompress) as (input: Buffer) => Promise<Buffer>;
 
 export const browserApiCorsLayer = HttpRouter.cors({
   allowedMethods: [...browserApiCorsAllowedMethods],
   allowedHeaders: [...browserApiCorsAllowedHeaders],
   maxAge: 600,
 });
+
+export function resolveHttpCompressionLevel(env: NodeJS.ProcessEnv = process.env): number {
+  const rawLevel = HTTP_COMPRESSION_LEVEL_ENV_NAMES.map((name) => env[name]).find(
+    (value): value is string => value !== undefined && value.trim().length > 0,
+  );
+  if (!rawLevel) {
+    return DEFAULT_HTTP_COMPRESSION_LEVEL;
+  }
+
+  const parsedLevel = Number.parseInt(rawLevel, 10);
+  if (!Number.isFinite(parsedLevel)) {
+    return DEFAULT_HTTP_COMPRESSION_LEVEL;
+  }
+
+  return Math.max(
+    zlibConstants.Z_NO_COMPRESSION,
+    Math.min(zlibConstants.BROTLI_MAX_QUALITY, parsedLevel),
+  );
+}
+
+export function selectHttpResponseCompressionEncoding(
+  acceptEncoding: string | undefined,
+): HttpCompressionEncoding | undefined {
+  if (!acceptEncoding) {
+    return undefined;
+  }
+
+  const accepted = new Map<string, number>();
+  for (const rawPart of acceptEncoding.split(",")) {
+    const [rawEncoding, ...rawParameters] = rawPart.trim().split(";");
+    const encoding = rawEncoding?.trim().toLowerCase();
+    if (!encoding) {
+      continue;
+    }
+
+    const qParameter = rawParameters
+      .map((parameter) => parameter.trim())
+      .find((parameter) => parameter.toLowerCase().startsWith("q="));
+    const qValue = qParameter ? Number.parseFloat(qParameter.slice(2)) : 1;
+    accepted.set(encoding, Number.isFinite(qValue) ? qValue : 0);
+  }
+
+  const wildcardQuality = accepted.get("*");
+  const brQuality = accepted.get("br") ?? wildcardQuality ?? 0;
+  if (brQuality > 0) {
+    return "br";
+  }
+
+  const gzipQuality = accepted.get("gzip") ?? wildcardQuality ?? 0;
+  return gzipQuality > 0 ? "gzip" : undefined;
+}
+
+export function isHttpCompressionSkippableContentType(contentType: string | undefined): boolean {
+  if (!contentType) {
+    return true;
+  }
+
+  const mediaType = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (
+    mediaType.startsWith("image/") ||
+    mediaType.startsWith("audio/") ||
+    mediaType.startsWith("video/")
+  ) {
+    return true;
+  }
+
+  return (
+    mediaType === "application/octet-stream" ||
+    mediaType === "application/gzip" ||
+    mediaType === "application/x-gzip" ||
+    mediaType === "application/zip" ||
+    mediaType === "application/x-zip-compressed" ||
+    mediaType === "application/x-7z-compressed" ||
+    mediaType === "application/x-rar-compressed" ||
+    mediaType === "application/x-tar" ||
+    mediaType === "application/x-bzip2" ||
+    mediaType === "application/x-xz" ||
+    mediaType === "application/zstd" ||
+    mediaType === "font/woff" ||
+    mediaType === "font/woff2"
+  );
+}
+
+function appendVaryHeader(existingVary: string | undefined, value: string): string {
+  if (!existingVary) {
+    return value;
+  }
+
+  const values = existingVary.split(",").map((part) => part.trim().toLowerCase());
+  return values.includes(value.toLowerCase()) ? existingVary : `${existingVary}, ${value}`;
+}
+
+function normalizeContentEncoding(contentEncoding: string | undefined): string | undefined {
+  const normalizedEncoding = contentEncoding?.trim().toLowerCase();
+  return normalizedEncoding && normalizedEncoding !== "identity" ? normalizedEncoding : undefined;
+}
+
+function makeAbsoluteRequestUrl(request: HttpServerRequest.HttpServerRequest): string {
+  if (/^https?:\/\//i.test(request.originalUrl)) {
+    return request.originalUrl;
+  }
+
+  const host = request.headers.host ?? "localhost";
+  const path = request.originalUrl.startsWith("/")
+    ? request.originalUrl
+    : `/${request.originalUrl}`;
+  return `http://${host}${path}`;
+}
+
+function makeRequestHeadersForDecodedBody(
+  request: HttpServerRequest.HttpServerRequest,
+  decodedBody: Uint8Array,
+): Headers.Headers {
+  return Headers.remove(
+    Headers.set(request.headers, "content-length", decodedBody.byteLength.toString()),
+    "content-encoding",
+  );
+}
+
+function decodeHttpRequestBody(
+  encoding: string,
+  body: Uint8Array,
+): Effect.Effect<Uint8Array, HttpCompressionError> {
+  const buffer = Buffer.from(body);
+  if (encoding === "gzip") {
+    return Effect.tryPromise({
+      try: () => gunzipAsync(buffer),
+      catch: (cause) => new HttpCompressionError({ cause }),
+    });
+  }
+  if (encoding === "br") {
+    return Effect.tryPromise({
+      try: () => brotliDecompressAsync(buffer),
+      catch: (cause) => new HttpCompressionError({ cause }),
+    });
+  }
+  return Effect.fail(
+    new HttpCompressionError({ cause: `Unsupported content encoding: ${encoding}` }),
+  );
+}
+
+export function decodeCompressedHttpRequest(
+  request: HttpServerRequest.HttpServerRequest,
+): Effect.Effect<DecodedHttpRequestResult> {
+  const encoding = normalizeContentEncoding(request.headers["content-encoding"]);
+  if (!encoding) {
+    return Effect.succeed({ _tag: "Request", request });
+  }
+
+  if (encoding !== "gzip" && encoding !== "br") {
+    return Effect.succeed({
+      _tag: "Response",
+      response: HttpServerResponse.text("Unsupported Content-Encoding", { status: 415 }),
+    });
+  }
+
+  return Effect.gen(function* () {
+    const encodedBody = yield* request.arrayBuffer.pipe(
+      Effect.map((body) => new Uint8Array(body)),
+      Effect.catch(() => Effect.succeed(null)),
+    );
+    if (!encodedBody) {
+      return {
+        _tag: "Response",
+        response: HttpServerResponse.text("Invalid compressed request body", { status: 400 }),
+      } satisfies DecodedHttpRequestResult;
+    }
+
+    const decodedBody = yield* decodeHttpRequestBody(encoding, encodedBody).pipe(
+      Effect.catch(() => Effect.succeed(null)),
+    );
+    if (!decodedBody) {
+      return {
+        _tag: "Response",
+        response: HttpServerResponse.text("Invalid compressed request body", { status: 400 }),
+      } satisfies DecodedHttpRequestResult;
+    }
+
+    const headers = makeRequestHeadersForDecodedBody(request, decodedBody);
+    const decodedRequest = HttpServerRequest.fromWeb(
+      new Request(makeAbsoluteRequestUrl(request), {
+        method: request.method,
+        headers: new globalThis.Headers(headers),
+        body: decodedBody,
+      }),
+    ).modify({
+      url: request.url,
+      headers,
+      remoteAddress: request.remoteAddress,
+    });
+
+    return {
+      _tag: "Request",
+      request: decodedRequest,
+    } satisfies DecodedHttpRequestResult;
+  });
+}
+
+function compressHttpResponseBody(
+  encoding: HttpCompressionEncoding,
+  body: Uint8Array,
+  level: number,
+): Effect.Effect<Uint8Array, HttpCompressionError> {
+  const input = Buffer.from(body);
+  if (encoding === "br") {
+    return Effect.tryPromise({
+      try: () =>
+        brotliCompressAsync(input, {
+          params: {
+            [zlibConstants.BROTLI_PARAM_QUALITY]: Math.min(zlibConstants.BROTLI_MAX_QUALITY, level),
+          },
+        }),
+      catch: (cause) => new HttpCompressionError({ cause }),
+    });
+  }
+
+  return Effect.tryPromise({
+    try: () =>
+      gzipAsync(input, {
+        level: Math.min(zlibConstants.Z_BEST_COMPRESSION, level),
+      }),
+    catch: (cause) => new HttpCompressionError({ cause }),
+  });
+}
+
+export function compressHttpResponse(
+  request: HttpServerRequest.HttpServerRequest,
+  response: HttpServerResponse.HttpServerResponse,
+  level: number = resolveHttpCompressionLevel(),
+): Effect.Effect<HttpServerResponse.HttpServerResponse> {
+  const responseBody = response.body;
+  const contentLength =
+    responseBody._tag === "Uint8Array" || responseBody._tag === "Stream"
+      ? responseBody.contentLength
+      : undefined;
+  const contentType =
+    responseBody._tag === "Uint8Array" || responseBody._tag === "Stream"
+      ? responseBody.contentType
+      : undefined;
+  if (
+    request.method === "HEAD" ||
+    response.status < 200 ||
+    response.status === 204 ||
+    response.status === 304 ||
+    response.headers["content-encoding"] !== undefined ||
+    contentLength === undefined ||
+    contentLength <= HTTP_COMPRESSION_MIN_BYTES ||
+    isHttpCompressionSkippableContentType(contentType)
+  ) {
+    return Effect.succeed(response);
+  }
+
+  const encoding = selectHttpResponseCompressionEncoding(request.headers["accept-encoding"]);
+  if (!encoding) {
+    return Effect.succeed(response);
+  }
+
+  const responseBytes =
+    responseBody._tag === "Uint8Array"
+      ? Effect.succeed(responseBody.body)
+      : responseBody._tag === "Stream"
+        ? Stream.mkUint8Array(
+            Stream.mapError(responseBody.stream, (cause) => new HttpCompressionError({ cause })),
+          ).pipe(Effect.catch(() => Effect.succeed(null)))
+        : Effect.succeed(null);
+
+  return responseBytes.pipe(
+    Effect.flatMap((body) => {
+      if (!body) {
+        return Effect.succeed(response);
+      }
+
+      return compressHttpResponseBody(encoding, body, level).pipe(
+        Effect.map((compressedBody) =>
+          HttpServerResponse.uint8Array(compressedBody, {
+            status: response.status,
+            statusText: response.statusText,
+            cookies: response.cookies,
+            contentType,
+            headers: {
+              ...response.headers,
+              "content-encoding": encoding,
+              vary: appendVaryHeader(response.headers.vary, "Accept-Encoding"),
+            },
+          }),
+        ),
+        Effect.catch(() => Effect.succeed(response)),
+      );
+    }),
+  );
+}
+
+export function httpCompressionMiddleware<E, R>(
+  effect: Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>,
+): Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  E,
+  HttpServerRequest.HttpServerRequest | Exclude<R, HttpServerRequest.HttpServerRequest>
+> {
+  return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const decodedRequest = yield* decodeCompressedHttpRequest(request);
+    if (decodedRequest._tag === "Response") {
+      return decodedRequest.response;
+    }
+
+    const response = yield* effect.pipe(
+      Effect.provideService(HttpServerRequest.HttpServerRequest, decodedRequest.request),
+    );
+    return yield* compressHttpResponse(decodedRequest.request, response);
+  });
+}
+
+export const httpCompressionMiddlewareLayer = HttpRouter.use((router) =>
+  router.addGlobalMiddleware(httpCompressionMiddleware),
+);
 
 export function isLoopbackHostname(hostname: string): boolean {
   const normalizedHostname = hostname

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -10,6 +10,7 @@ import {
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  httpCompressionMiddlewareLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -294,6 +295,7 @@ const RuntimeServicesLive = ServerRuntimeStartupLive.pipe(
 );
 
 export const makeRoutesLayer = Layer.mergeAll(
+  httpCompressionMiddlewareLayer,
   authBearerBootstrapRouteLayer,
   authBootstrapRouteLayer,
   authClientsRevokeOthersRouteLayer,


### PR DESCRIPTION
/claim #863

## Summary
- Add Effect HTTP middleware for gzip/brotli response compression with brotli preference and configurable compression level.
- Decode gzip/brotli request bodies before route handlers read them.
- Skip small responses and already-compressed media/archive content types.

## Validation
- PATH="/Users/gindondin/.npm/_npx/387698761821791d/node_modules/node/bin:/Users/gindondin/.npm/_npx/6b41d1ab8d6987af/node_modules/.bin:$PATH" bun fmt
- PATH="/Users/gindondin/.npm/_npx/387698761821791d/node_modules/node/bin:/Users/gindondin/.npm/_npx/6b41d1ab8d6987af/node_modules/.bin:$PATH" bun lint
- PATH="/Users/gindondin/.npm/_npx/387698761821791d/node_modules/node/bin:/Users/gindondin/.npm/_npx/6b41d1ab8d6987af/node_modules/.bin:$PATH" bun typecheck
- PATH="/Users/gindondin/.npm/_npx/387698761821791d/node_modules/node/bin:/Users/gindondin/.npm/_npx/6b41d1ab8d6987af/node_modules/.bin:$PATH" bun run test src/http.test.ts (from t3code/apps/server)
