### PR TITLE
Codex [ T3 Code ] Add provider API response caching

### DIFF
--- a/t3code/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/t3code/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -37,6 +37,7 @@ import { makeAdapterRegistryMock } from "../src/provider/testUtils/providerAdapt
 import { ProviderAdapterRegistry } from "../src/provider/Services/ProviderAdapterRegistry.ts";
 import { ProviderSessionDirectoryLive } from "../src/provider/Layers/ProviderSessionDirectory.ts";
 import { ServerSettingsService } from "../src/serverSettings.ts";
+import { ProviderCacheLive } from "../src/services/ProviderCache.ts";
 import { makeProviderServiceLive } from "../src/provider/Layers/ProviderService.ts";
 import { makeCodexAdapter } from "../src/provider/Layers/CodexAdapter.ts";
 import {
@@ -370,6 +371,7 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(orchestrationReactorLayer),
       Layer.provide(persistenceLayer),
       Layer.provideMerge(RepositoryIdentityResolverLive),
+      Layer.provideMerge(ProviderCacheLive),
       Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(ServerConfig.layerTest(workspaceDir, rootDir)),
       Layer.provideMerge(NodeServices.layer),

--- a/t3code/apps/server/integration/providerService.integration.test.ts
+++ b/t3code/apps/server/integration/providerService.integration.test.ts
@@ -23,6 +23,7 @@ import {
   type ProviderServiceShape,
 } from "../src/provider/Services/ProviderService.ts";
 import { ServerSettingsService } from "../src/serverSettings.ts";
+import { ProviderCacheLive } from "../src/services/ProviderCache.ts";
 import { AnalyticsService } from "../src/telemetry/Services/AnalyticsService.ts";
 import { SqlitePersistenceMemory } from "../src/persistence/Layers/Sqlite.ts";
 import { ProviderSessionRuntimeRepositoryLive } from "../src/persistence/Layers/ProviderSessionRuntime.ts";
@@ -70,6 +71,7 @@ const makeIntegrationFixture = Effect.gen(function* () {
     directoryLayer,
     Layer.succeed(ProviderAdapterRegistry, registry),
     ServerSettingsService.layerTest(DEFAULT_SERVER_SETTINGS),
+    ProviderCacheLive,
     AnalyticsService.layerTest,
     Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers),
   ).pipe(Layer.provide(SqlitePersistenceMemory));

--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -58,6 +58,13 @@ export const providerRuntimeEventsTotal = Metric.counter("t3_provider_runtime_ev
   description: "Total canonical provider runtime events processed.",
 });
 
+export const providerApiCacheRequestsTotal = Metric.counter(
+  "t3_provider_api_cache_requests_total",
+  {
+    description: "Total provider API cache lookups by cache type and hit/miss result.",
+  },
+);
+
 export const gitCommandsTotal = Metric.counter("t3_git_commands_total", {
   description: "Total git commands executed by the server runtime.",
 });

--- a/t3code/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -44,6 +44,7 @@ import {
 } from "./ProviderRegistry.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService, type ServerSettingsShape } from "../../serverSettings.ts";
+import { ProviderCacheLive } from "../../services/ProviderCache.ts";
 import { readProviderStatusCache, resolveProviderStatusCachePath } from "../providerStatusCache.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
@@ -729,6 +730,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const runtimeServices = yield* Layer.build(
             ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderCacheLive),
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
@@ -823,6 +825,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const runtimeServices = yield* Layer.build(
             ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderCacheLive),
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
@@ -927,6 +930,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const runtimeServices = yield* Layer.build(
             ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderCacheLive),
               Layer.provideMerge(instanceRegistryLayer),
               Layer.provideMerge(
                 ServerConfig.layerTest(process.cwd(), {
@@ -1019,6 +1023,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
           const scope = yield* Scope.make();
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(ProviderCacheLive),
             Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
             Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
             Layer.provideMerge(
@@ -1094,6 +1099,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
           const scope = yield* Scope.make();
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(ProviderCacheLive),
             Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
             Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
             Layer.provideMerge(
@@ -1197,6 +1203,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
           const scope = yield* Scope.make();
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(ProviderCacheLive),
             Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
             Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
             Layer.provideMerge(
@@ -1248,6 +1255,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
             const scope = yield* Scope.make();
             yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
             const providerRegistryLayer = ProviderRegistryLive.pipe(
+              Layer.provideMerge(ProviderCacheLive),
               Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
               Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
               Layer.provideMerge(

--- a/t3code/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -41,6 +41,7 @@ import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
 
 import { ServerConfig } from "../../config.ts";
+import { ProviderCache } from "../../services/ProviderCache.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
 import {
@@ -188,6 +189,7 @@ export const ProviderRegistryLive = Layer.effect(
   ProviderRegistry,
   Effect.gen(function* () {
     const instanceRegistry = yield* ProviderInstanceRegistry;
+    const providerCache = yield* ProviderCache;
     const config = yield* ServerConfig;
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -430,13 +432,15 @@ export const ProviderRegistryLive = Layer.effect(
     const refreshOneSource = Effect.fn("refreshOneSource")(function* (
       providerSource: ProviderSnapshotSource,
     ) {
-      return yield* providerSource.refresh.pipe(
-        Effect.flatMap((nextProvider) =>
-          correlateSnapshotWithSource(providerSource, nextProvider).pipe(
-            Effect.flatMap(syncProvider),
+      return yield* providerCache
+        .getModelList(providerSource, providerSource.refresh)
+        .pipe(
+          Effect.flatMap((nextProvider) =>
+            correlateSnapshotWithSource(providerSource, nextProvider).pipe(
+              Effect.flatMap(syncProvider),
+            ),
           ),
-        ),
-      );
+        );
     });
 
     const refreshAll = Effect.fn("refreshAll")(function* () {
@@ -541,6 +545,20 @@ export const ProviderRegistryLive = Layer.effect(
           }
           newlyAdded.push([instanceId, instance] as const);
         }
+
+        const invalidatedIds = new Set<ProviderInstanceId>(
+          newlyAdded.map(([instanceId]) => instanceId),
+        );
+        for (const [instanceId] of previousSubs) {
+          if (!nextByInstance.has(instanceId)) {
+            invalidatedIds.add(instanceId);
+          }
+        }
+        yield* Effect.forEach(
+          invalidatedIds,
+          (instanceId) => providerCache.invalidateProvider(instanceId),
+          { discard: true },
+        );
 
         // Fork long-lived subscriptions to each new/rebuilt instance's
         // change stream BEFORE kicking off refreshes — if the driver's

--- a/t3code/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -60,6 +60,7 @@ import {
   SqlitePersistenceMemory,
 } from "../../persistence/Layers/Sqlite.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { ProviderCacheLive } from "../../services/ProviderCache.ts";
 import { AnalyticsService } from "../../telemetry/Services/AnalyticsService.ts";
 import { makeAdapterRegistryMock } from "../testUtils/providerAdapterRegistryMock.ts";
 
@@ -293,6 +294,7 @@ function makeProviderServiceLayer() {
         Layer.provide(providerAdapterLayer),
         Layer.provide(directoryLayer),
         Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(ProviderCacheLive),
         Layer.provideMerge(AnalyticsService.layerTest),
         Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
       ),
@@ -336,6 +338,7 @@ it.effect("ProviderServiceLive catches stopAll failures during shutdown", () =>
         Layer.provide(providerAdapterLayer),
         Layer.provide(directoryLayer),
         Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(ProviderCacheLive),
         Layer.provideMerge(AnalyticsService.layerTest),
         Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
       ),
@@ -389,6 +392,7 @@ it.effect("ProviderServiceLive rejects new sessions for disabled providers", () 
       Layer.provide(providerAdapterLayer),
       Layer.provide(directoryLayer),
       Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(ProviderCacheLive),
       Layer.provide(AnalyticsService.layerTest),
       Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
     );
@@ -465,6 +469,7 @@ it.effect(
         Layer.provide(providerAdapterLayer),
         Layer.provide(directoryLayer),
         Layer.provide(serverSettingsLayer),
+        Layer.provide(ProviderCacheLive),
         Layer.provide(AnalyticsService.layerTest),
         Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
       );
@@ -527,6 +532,7 @@ it.effect("ProviderServiceLive rejects new sessions for disabled custom instance
       Layer.provide(providerAdapterLayer),
       Layer.provide(directoryLayer),
       Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(ProviderCacheLive),
       Layer.provide(AnalyticsService.layerTest),
       Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
     );
@@ -577,6 +583,7 @@ it.effect("ProviderServiceLive writes canonical events to the emitting thread se
       Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
       Layer.provide(directoryLayer),
       Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(ProviderCacheLive),
       Layer.provide(AnalyticsService.layerTest),
       Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
     );
@@ -632,6 +639,7 @@ it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", (
       Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
       Layer.provide(directoryLayer),
       Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(ProviderCacheLive),
       Layer.provide(AnalyticsService.layerTest),
       Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
     );
@@ -691,6 +699,7 @@ it.effect(
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, firstRegistry)),
         Layer.provide(firstDirectoryLayer),
         Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(ProviderCacheLive),
         Layer.provide(AnalyticsService.layerTest),
         Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
       );
@@ -743,6 +752,7 @@ it.effect(
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, secondRegistry)),
         Layer.provide(secondDirectoryLayer),
         Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(ProviderCacheLive),
         Layer.provide(AnalyticsService.layerTest),
         Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
       );
@@ -1245,6 +1255,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, firstRegistry)),
         Layer.provide(firstDirectoryLayer),
         Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(ProviderCacheLive),
         Layer.provide(AnalyticsService.layerTest),
         Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
       );
@@ -1276,6 +1287,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, secondRegistry)),
         Layer.provide(secondDirectoryLayer),
         Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(ProviderCacheLive),
         Layer.provide(AnalyticsService.layerTest),
         Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
       );
@@ -1335,6 +1347,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
           Layer.provide(Layer.succeed(ProviderAdapterRegistry, firstRegistry)),
           Layer.provide(firstDirectoryLayer),
           Layer.provide(defaultServerSettingsLayer),
+          Layer.provide(ProviderCacheLive),
           Layer.provide(AnalyticsService.layerTest),
           Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
         );
@@ -1361,6 +1374,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
           Layer.provide(Layer.succeed(ProviderAdapterRegistry, secondRegistry)),
           Layer.provide(secondDirectoryLayer),
           Layer.provide(defaultServerSettingsLayer),
+          Layer.provide(ProviderCacheLive),
           Layer.provide(AnalyticsService.layerTest),
           Layer.provide(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
         );

--- a/t3code/apps/server/src/provider/Layers/ProviderService.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderService.ts
@@ -49,6 +49,7 @@ import { type ProviderAdapterError, ProviderValidationError } from "../Errors.ts
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
+import { ProviderCache } from "../../services/ProviderCache.ts";
 import {
   ProviderSessionDirectory,
   type ProviderRuntimeBinding,
@@ -202,6 +203,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
 ) {
   const analytics = yield* Effect.service(AnalyticsService);
   const eventLoggers = yield* ProviderEventLoggers;
+  const providerCache = yield* ProviderCache;
   // Options-provided logger wins (test overrides); otherwise we take whatever
   // the `ProviderEventLoggers` tag exposes — `undefined` means "no canonical
   // log writer is attached", which downstream code already handles as a
@@ -930,7 +932,16 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   );
 
   const getCapabilities: ProviderServiceShape["getCapabilities"] = (instanceId) =>
-    registry.getByInstance(instanceId).pipe(Effect.map((adapter) => adapter.capabilities));
+    registry
+      .getInstanceInfo(instanceId)
+      .pipe(
+        Effect.flatMap((info) =>
+          providerCache.getCapabilities(
+            { instanceId, driverKind: info.driverKind },
+            registry.getByInstance(instanceId).pipe(Effect.map((adapter) => adapter.capabilities)),
+          ),
+        ),
+      );
 
   const getInstanceInfo: ProviderServiceShape["getInstanceInfo"] = (instanceId) =>
     registry.getInstanceInfo(instanceId);

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -43,6 +43,7 @@ import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderComma
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
+import { ProviderCacheLive } from "./services/ProviderCache.ts";
 import { ServerSettingsLive } from "./serverSettings.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
 import { RepositoryIdentityResolverLive } from "./project/Layers/RepositoryIdentityResolver.ts";
@@ -252,6 +253,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(PersistenceLayerLive),
   Layer.provideMerge(KeybindingsLive),
   Layer.provideMerge(ProviderRegistryLive),
+  Layer.provideMerge(ProviderCacheLive),
   // The instance registry is the new routing keystone — text generation,
   // adapter lookup, and runtime ingestion all resolve `ProviderInstanceId`
   // through this layer. Built-in drivers come from `BUILT_IN_DRIVERS`;

--- a/t3code/apps/server/src/services/ProviderCache.test.ts
+++ b/t3code/apps/server/src/services/ProviderCache.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, assert } from "@effect/vitest";
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Metric from "effect/Metric";
+import * as Ref from "effect/Ref";
+import type * as Scope from "effect/Scope";
+import * as TestClock from "effect/testing/TestClock";
+
+import { ProviderCache, makeProviderCacheLive } from "./ProviderCache.ts";
+
+const codexDriver = ProviderDriverKind.make("codex");
+const codexInstanceId = ProviderInstanceId.make("codex");
+
+const makeProvider = (checkedAt: string): ServerProvider => ({
+  instanceId: codexInstanceId,
+  driver: codexDriver,
+  status: "ready",
+  enabled: true,
+  installed: true,
+  auth: { status: "authenticated" },
+  checkedAt,
+  version: "1.0.0",
+  models: [
+    {
+      slug: `model-${checkedAt}`,
+      name: `Model ${checkedAt}`,
+      isCustom: false,
+      capabilities: null,
+    },
+  ],
+  slashCommands: [],
+  skills: [],
+});
+
+const cacheLayer = makeProviderCacheLive({
+  capacity: 16,
+  modelListTtl: Duration.seconds(1),
+  capabilitiesTtl: Duration.seconds(1),
+});
+const testLayer = Layer.mergeAll(cacheLayer, TestClock.layer());
+
+const runWithCache = <A, E>(effect: Effect.Effect<A, E, ProviderCache | Scope.Scope>) =>
+  Effect.scoped(effect).pipe(Effect.provide(testLayer));
+
+const hasMetricSnapshot = (
+  snapshots: ReadonlyArray<Metric.Metric.Snapshot>,
+  attributes: Readonly<Record<string, string>>,
+) =>
+  snapshots.some(
+    (snapshot) =>
+      snapshot.id === "t3_provider_api_cache_requests_total" &&
+      Object.entries(attributes).every(([key, value]) => snapshot.attributes?.[key] === value),
+  );
+
+describe("ProviderCache", () => {
+  it.effect("serves provider model lists from cache within TTL and refreshes after expiry", () =>
+    runWithCache(
+      Effect.gen(function* () {
+        const cache = yield* ProviderCache;
+        const calls = yield* Ref.make(0);
+        const lookup = Ref.updateAndGet(calls, (count) => count + 1).pipe(
+          Effect.map((count) => makeProvider(`2026-01-01T00:00:0${count}.000Z`)),
+        );
+
+        const first = yield* cache.getModelList(
+          { instanceId: codexInstanceId, driverKind: codexDriver },
+          lookup,
+        );
+        const second = yield* cache.getModelList(
+          { instanceId: codexInstanceId, driverKind: codexDriver },
+          lookup,
+        );
+
+        assert.equal(first.checkedAt, second.checkedAt);
+        assert.equal(yield* Ref.get(calls), 1);
+
+        yield* TestClock.adjust("1001 millis");
+        const third = yield* cache.getModelList(
+          { instanceId: codexInstanceId, driverKind: codexDriver },
+          lookup,
+        );
+
+        assert.notEqual(third.checkedAt, first.checkedAt);
+        assert.equal(yield* Ref.get(calls), 2);
+      }),
+    ),
+  );
+
+  it.effect("invalidates model and capabilities entries for one provider instance", () =>
+    runWithCache(
+      Effect.gen(function* () {
+        const cache = yield* ProviderCache;
+        const modelCalls = yield* Ref.make(0);
+        const capabilityCalls = yield* Ref.make(0);
+        const modelLookup = Ref.updateAndGet(modelCalls, (count) => count + 1).pipe(
+          Effect.map((count) => makeProvider(`2026-01-01T00:00:0${count}.000Z`)),
+        );
+        const capabilityLookup = Ref.updateAndGet(capabilityCalls, (count) => count + 1).pipe(
+          Effect.as({ sessionModelSwitch: "in-session" as const }),
+        );
+
+        yield* cache.getModelList(
+          { instanceId: codexInstanceId, driverKind: codexDriver },
+          modelLookup,
+        );
+        yield* cache.getCapabilities({ instanceId: codexInstanceId }, capabilityLookup);
+        yield* cache.getModelList(
+          { instanceId: codexInstanceId, driverKind: codexDriver },
+          modelLookup,
+        );
+        yield* cache.getCapabilities({ instanceId: codexInstanceId }, capabilityLookup);
+
+        assert.equal(yield* Ref.get(modelCalls), 1);
+        assert.equal(yield* Ref.get(capabilityCalls), 1);
+
+        yield* cache.invalidateProvider(codexInstanceId);
+        yield* cache.getModelList(
+          { instanceId: codexInstanceId, driverKind: codexDriver },
+          modelLookup,
+        );
+        yield* cache.getCapabilities({ instanceId: codexInstanceId }, capabilityLookup);
+
+        assert.equal(yield* Ref.get(modelCalls), 2);
+        assert.equal(yield* Ref.get(capabilityCalls), 2);
+      }),
+    ),
+  );
+
+  it.effect("deduplicates concurrent model list misses through Effect.Cache", () =>
+    runWithCache(
+      Effect.gen(function* () {
+        const cache = yield* ProviderCache;
+        const calls = yield* Ref.make(0);
+        const releaseLookup = yield* Deferred.make<void>();
+        const lookup = Ref.update(calls, (count) => count + 1).pipe(
+          Effect.andThen(Deferred.await(releaseLookup)),
+          Effect.as(makeProvider("2026-01-01T00:00:01.000Z")),
+        );
+
+        const first = yield* cache
+          .getModelList({ instanceId: codexInstanceId, driverKind: codexDriver }, lookup)
+          .pipe(Effect.forkScoped);
+        yield* Effect.yieldNow;
+        const second = yield* cache
+          .getModelList({ instanceId: codexInstanceId, driverKind: codexDriver }, lookup)
+          .pipe(Effect.forkScoped);
+        yield* Effect.yieldNow;
+
+        assert.equal(yield* Ref.get(calls), 1);
+
+        yield* Deferred.succeed(releaseLookup, undefined);
+        const [firstProvider, secondProvider] = yield* Effect.all(
+          [Fiber.join(first), Fiber.join(second)],
+          { concurrency: "unbounded" },
+        );
+
+        assert.equal(firstProvider.checkedAt, secondProvider.checkedAt);
+        assert.equal(yield* Ref.get(calls), 1);
+      }),
+    ),
+  );
+
+  it.effect("records cache hit and miss metrics", () =>
+    runWithCache(
+      Effect.gen(function* () {
+        const cache = yield* ProviderCache;
+        const lookup = Effect.succeed(makeProvider("2026-01-01T00:00:01.000Z"));
+
+        yield* cache.getModelList({ instanceId: codexInstanceId, driverKind: codexDriver }, lookup);
+        yield* cache.getModelList({ instanceId: codexInstanceId, driverKind: codexDriver }, lookup);
+
+        const snapshots = yield* Metric.snapshot;
+        assert.equal(
+          hasMetricSnapshot(snapshots, {
+            cache: "models",
+            result: "miss",
+            instanceId: String(codexInstanceId),
+            provider: String(codexDriver),
+          }),
+          true,
+        );
+        assert.equal(
+          hasMetricSnapshot(snapshots, {
+            cache: "models",
+            result: "hit",
+            instanceId: String(codexInstanceId),
+            provider: String(codexDriver),
+          }),
+          true,
+        );
+      }),
+    ),
+  );
+});

--- a/t3code/apps/server/src/services/ProviderCache.ts
+++ b/t3code/apps/server/src/services/ProviderCache.ts
@@ -1,0 +1,177 @@
+import {
+  ProviderDriverKind,
+  type ProviderInstanceId,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+import { increment, providerApiCacheRequestsTotal } from "../observability/Metrics.ts";
+import type { ProviderServiceError } from "../provider/Errors.ts";
+import type { ProviderAdapterCapabilities } from "../provider/Services/ProviderAdapter.ts";
+
+export const DEFAULT_PROVIDER_MODEL_LIST_CACHE_TTL = Duration.minutes(5);
+export const DEFAULT_PROVIDER_CAPABILITIES_CACHE_TTL = Duration.minutes(15);
+export const DEFAULT_PROVIDER_CACHE_CAPACITY = 512;
+
+type ProviderCacheKind = "models" | "capabilities";
+type ProviderCacheResult = "hit" | "miss";
+
+export interface ProviderCacheOptions {
+  readonly modelListTtl?: Duration.Input;
+  readonly capabilitiesTtl?: Duration.Input;
+  readonly capacity?: number;
+}
+
+export interface ProviderCacheShape {
+  readonly getModelList: (
+    input: {
+      readonly instanceId: ProviderInstanceId;
+      readonly driverKind: ProviderDriverKind;
+    },
+    lookup: Effect.Effect<ServerProvider>,
+  ) => Effect.Effect<ServerProvider>;
+
+  readonly getCapabilities: (
+    input: {
+      readonly instanceId: ProviderInstanceId;
+      readonly driverKind?: ProviderDriverKind | undefined;
+    },
+    lookup: Effect.Effect<ProviderAdapterCapabilities, ProviderServiceError>,
+  ) => Effect.Effect<ProviderAdapterCapabilities, ProviderServiceError>;
+
+  readonly invalidateProvider: (instanceId: ProviderInstanceId) => Effect.Effect<void>;
+  readonly invalidateAll: Effect.Effect<void>;
+}
+
+export class ProviderCache extends Context.Service<ProviderCache, ProviderCacheShape>()(
+  "t3/services/ProviderCache",
+) {}
+
+const cacheKey = (kind: ProviderCacheKind, instanceId: ProviderInstanceId) =>
+  `${kind}:${String(instanceId)}`;
+
+const recordCacheRequest = (input: {
+  readonly kind: ProviderCacheKind;
+  readonly result: ProviderCacheResult;
+  readonly instanceId: ProviderInstanceId;
+  readonly driverKind?: ProviderDriverKind | undefined;
+}) =>
+  increment(providerApiCacheRequestsTotal, {
+    cache: input.kind,
+    result: input.result,
+    instanceId: input.instanceId,
+    ...(input.driverKind !== undefined ? { provider: input.driverKind } : {}),
+  });
+
+const missingLookup = (kind: ProviderCacheKind, key: string) =>
+  Effect.die(new Error(`ProviderCache ${kind} lookup missing for key '${key}'.`));
+
+const successTtl =
+  (ttl: Duration.Duration) =>
+  <A, E>(exit: Exit.Exit<A, E>): Duration.Duration =>
+    Exit.isSuccess(exit) ? ttl : Duration.zero;
+
+const makeProviderCache = (options: ProviderCacheOptions = {}) =>
+  Effect.gen(function* () {
+    const capacity = options.capacity ?? DEFAULT_PROVIDER_CACHE_CAPACITY;
+    const modelListTtl =
+      options.modelListTtl !== undefined
+        ? Duration.fromInputUnsafe(options.modelListTtl)
+        : DEFAULT_PROVIDER_MODEL_LIST_CACHE_TTL;
+    const capabilitiesTtl =
+      options.capabilitiesTtl !== undefined
+        ? Duration.fromInputUnsafe(options.capabilitiesTtl)
+        : DEFAULT_PROVIDER_CAPABILITIES_CACHE_TTL;
+
+    const modelLookups = yield* Ref.make<ReadonlyMap<string, Effect.Effect<ServerProvider>>>(
+      new Map(),
+    );
+    const capabilitiesLookups = yield* Ref.make<
+      ReadonlyMap<string, Effect.Effect<ProviderAdapterCapabilities, ProviderServiceError>>
+    >(new Map());
+
+    const modelCache = yield* Cache.makeWith<string, ServerProvider>(
+      (key) =>
+        Ref.get(modelLookups).pipe(
+          Effect.flatMap((lookups) => lookups.get(key) ?? missingLookup("models", key)),
+        ),
+      {
+        capacity,
+        timeToLive: successTtl(modelListTtl),
+      },
+    );
+    const capabilitiesCache = yield* Cache.makeWith<
+      string,
+      ProviderAdapterCapabilities,
+      ProviderServiceError
+    >(
+      (key) =>
+        Ref.get(capabilitiesLookups).pipe(
+          Effect.flatMap((lookups) => lookups.get(key) ?? missingLookup("capabilities", key)),
+        ),
+      {
+        capacity,
+        timeToLive: successTtl(capabilitiesTtl),
+      },
+    );
+
+    const getModelList: ProviderCacheShape["getModelList"] = (input, lookup) => {
+      const key = cacheKey("models", input.instanceId);
+      return Effect.gen(function* () {
+        yield* Ref.update(modelLookups, (lookups) => new Map(lookups).set(key, lookup));
+        const hit = yield* Cache.has(modelCache, key);
+        yield* recordCacheRequest({
+          kind: "models",
+          result: hit ? "hit" : "miss",
+          instanceId: input.instanceId,
+          driverKind: input.driverKind,
+        });
+        return yield* Cache.get(modelCache, key);
+      });
+    };
+
+    const getCapabilities: ProviderCacheShape["getCapabilities"] = (input, lookup) => {
+      const key = cacheKey("capabilities", input.instanceId);
+      return Effect.gen(function* () {
+        yield* Ref.update(capabilitiesLookups, (lookups) => new Map(lookups).set(key, lookup));
+        const hit = yield* Cache.has(capabilitiesCache, key);
+        yield* recordCacheRequest({
+          kind: "capabilities",
+          result: hit ? "hit" : "miss",
+          instanceId: input.instanceId,
+          driverKind: input.driverKind,
+        });
+        return yield* Cache.get(capabilitiesCache, key);
+      });
+    };
+
+    const invalidateProvider: ProviderCacheShape["invalidateProvider"] = (instanceId) =>
+      Effect.all(
+        [
+          Cache.invalidate(modelCache, cacheKey("models", instanceId)),
+          Cache.invalidate(capabilitiesCache, cacheKey("capabilities", instanceId)),
+        ],
+        { discard: true },
+      );
+
+    return {
+      getModelList,
+      getCapabilities,
+      invalidateProvider,
+      invalidateAll: Effect.all(
+        [Cache.invalidateAll(modelCache), Cache.invalidateAll(capabilitiesCache)],
+        { discard: true },
+      ),
+    } satisfies ProviderCacheShape;
+  });
+
+export const makeProviderCacheLive = (options?: ProviderCacheOptions) =>
+  Layer.effect(ProviderCache, makeProviderCache(options));
+
+export const ProviderCacheLive = makeProviderCacheLive();


### PR DESCRIPTION
## Summary
- Add an Effect.Cache-backed ProviderCache service with configurable model-list and capability TTLs plus bounded capacity.
- Route provider refresh/model-list calls and provider capability reads through the cache.
- Invalidate per-provider cache entries when provider instances are added, rebuilt, or removed, and expose cache hit/miss metrics.
- Add focused tests for TTL expiry, invalidation, concurrent miss dedupe, and metrics.

/claim #865

## Validation
- npx -p node@24.15.0 -p bun@1.3.11 bun run fmt
- npx -p node@24.15.0 -p bun@1.3.11 bun run lint
- npx -p node@24.15.0 -p bun@1.3.11 bun run typecheck
- npx -p node@24.15.0 -p bun@1.3.11 bun run --cwd apps/server test src/services/ProviderCache.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderRegistry.test.ts
- npx -p node@24.15.0 -p bun@1.3.11 bun run --cwd apps/server test
