### PR TITLE
Codex [ FastAPI ] Implement standardized pagination

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -9,6 +9,9 @@ from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
+from .pagination import PaginatedResponse as PaginatedResponse
+from .pagination import Paginator as Paginator
+from .pagination import paginate as paginate
 from .param_functions import Body as Body
 from .param_functions import Cookie as Cookie
 from .param_functions import Depends as Depends

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,150 @@
+import base64
+import binascii
+import json
+import math
+from collections.abc import Sequence
+from typing import Annotated, Any, Generic, TypeVar
+
+from pydantic import BaseModel, Field
+
+from .param_functions import Query
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
+    total: int = Field(ge=0)
+    page: int = Field(ge=1)
+    page_size: int = Field(ge=1)
+    total_pages: int = Field(ge=0)
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+class Paginator:
+    def __init__(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 20,
+        cursor: str | None = None,
+        max_page_size: int = 100,
+    ) -> None:
+        self.default_page_size = self._positive_int(page_size, default=20)
+        self.max_page_size = self._positive_int(max_page_size, default=100)
+        self.page_size = min(self.default_page_size, self.max_page_size)
+        self.cursor = cursor
+        self.page = self._positive_int(page, default=1)
+        self.offset = self._offset_from_cursor(cursor)
+        if cursor is None:
+            self.offset = (self.page - 1) * self.page_size
+        else:
+            self.page = (self.offset // self.page_size) + 1
+
+    @property
+    def skip(self) -> int:
+        return self.offset
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    def apply_to_query(self, query: Any) -> Any:
+        return query.offset(self.offset).limit(self.limit)
+
+    def paginate_query(
+        self, query: Any, *, total: int | None = None, cursor: bool = False
+    ) -> PaginatedResponse[Any]:
+        if total is None:
+            total = int(query.count())
+        paginated_query = self.apply_to_query(query)
+        all_method = getattr(paginated_query, "all", None)
+        items = all_method() if all_method is not None else list(paginated_query)
+        return self.create_response(items, total=total, cursor=cursor)
+
+    def paginate_sequence(
+        self, items: Sequence[T], *, total: int | None = None, cursor: bool = False
+    ) -> PaginatedResponse[T]:
+        if total is None:
+            total = len(items)
+        page_items = list(items[self.offset : self.offset + self.limit])
+        return self.create_response(page_items, total=total, cursor=cursor)
+
+    def create_response(
+        self, items: Sequence[T], *, total: int, cursor: bool = False
+    ) -> PaginatedResponse[T]:
+        safe_total = max(total, 0)
+        total_pages = math.ceil(safe_total / self.page_size) if safe_total else 0
+        has_next = self.offset + self.page_size < safe_total
+        has_previous = safe_total > 0 and self.offset > 0
+        next_cursor = (
+            self.encode_cursor(self.offset + self.page_size) if has_next else None
+        )
+        previous_offset = max(0, self.offset - self.page_size)
+        previous_cursor = self.encode_cursor(previous_offset) if has_previous else None
+        return PaginatedResponse(
+            items=list(items),
+            total=safe_total,
+            page=self.page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=has_next,
+            has_previous=has_previous,
+            next_cursor=next_cursor if cursor else None,
+            previous_cursor=previous_cursor if cursor else None,
+        )
+
+    @classmethod
+    def encode_cursor(cls, offset: int) -> str:
+        payload = {"offset": max(offset, 0)}
+        encoded = base64.urlsafe_b64encode(json.dumps(payload).encode())
+        return encoded.decode().rstrip("=")
+
+    @classmethod
+    def decode_cursor(cls, cursor: str | None) -> int:
+        if not cursor:
+            return 0
+        try:
+            padded_cursor = cursor + "=" * (-len(cursor) % 4)
+            payload = base64.urlsafe_b64decode(padded_cursor.encode()).decode()
+            data = json.loads(payload)
+            return max(int(data.get("offset", 0)), 0)
+        except (binascii.Error, TypeError, UnicodeDecodeError, ValueError):
+            return 0
+
+    def _offset_from_cursor(self, cursor: str | None) -> int:
+        return self.decode_cursor(cursor)
+
+    @staticmethod
+    def _positive_int(value: int, *, default: int) -> int:
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError):
+            return default
+        return int_value if int_value > 0 else default
+
+
+def paginate(
+    page: Annotated[
+        int,
+        Query(
+            description="One-based page number for offset pagination.",
+        ),
+    ] = 1,
+    page_size: Annotated[
+        int,
+        Query(
+            description="Number of items to return per page.",
+        ),
+    ] = 20,
+    cursor: Annotated[
+        str | None,
+        Query(
+            description="Encoded cursor for cursor pagination.",
+        ),
+    ] = None,
+) -> Paginator:
+    return Paginator(page=page, page_size=page_size, cursor=cursor)

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,194 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from fastapi.pagination import PaginatedResponse, Paginator, paginate
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+ITEMS = [Item(id=index, name=f"item-{index}") for index in range(1, 8)]
+
+
+def test_offset_pagination_calculates_metadata_and_items():
+    paginator = Paginator(page=2, page_size=3)
+
+    response = paginator.paginate_sequence(ITEMS)
+
+    assert paginator.skip == 3
+    assert paginator.limit == 3
+    assert response.model_dump() == {
+        "items": [
+            {"id": 4, "name": "item-4"},
+            {"id": 5, "name": "item-5"},
+            {"id": 6, "name": "item-6"},
+        ],
+        "total": 7,
+        "page": 2,
+        "page_size": 3,
+        "total_pages": 3,
+        "has_next": True,
+        "has_previous": True,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_offset_pagination_boundaries():
+    first_page = Paginator(page=1, page_size=3).paginate_sequence(ITEMS)
+    last_page = Paginator(page=3, page_size=3).paginate_sequence(ITEMS)
+
+    assert first_page.has_previous is False
+    assert first_page.has_next is True
+    assert last_page.has_previous is True
+    assert last_page.has_next is False
+    assert last_page.items == [ITEMS[-1]]
+
+
+def test_cursor_pagination_returns_encoded_navigation_cursors():
+    first_page = Paginator(page_size=3).paginate_sequence(ITEMS, cursor=True)
+
+    assert first_page.next_cursor is not None
+    assert first_page.previous_cursor is None
+
+    second_page = Paginator(
+        page_size=3, cursor=first_page.next_cursor
+    ).paginate_sequence(ITEMS, cursor=True)
+
+    assert [item.id for item in second_page.items] == [4, 5, 6]
+    assert second_page.page == 2
+    assert second_page.has_next is True
+    assert second_page.has_previous is True
+    assert second_page.next_cursor is not None
+    assert second_page.previous_cursor == Paginator.encode_cursor(0)
+
+    third_page = Paginator(
+        page_size=3, cursor=second_page.next_cursor
+    ).paginate_sequence(ITEMS, cursor=True)
+
+    assert [item.id for item in third_page.items] == [7]
+    assert third_page.page == 3
+    assert third_page.has_next is False
+    assert third_page.has_previous is True
+    assert third_page.next_cursor is None
+    assert third_page.previous_cursor == Paginator.encode_cursor(3)
+
+
+def test_invalid_page_and_page_size_use_sensible_defaults():
+    response = Paginator(page=-2, page_size=0).paginate_sequence(ITEMS)
+
+    assert response.page == 1
+    assert response.page_size == 20
+    assert response.total_pages == 1
+    assert response.has_next is False
+    assert response.has_previous is False
+    assert response.items == ITEMS
+
+
+def test_empty_results_are_paginated_without_navigation():
+    response = Paginator(page=0, page_size=3).paginate_sequence([])
+
+    assert response.model_dump() == {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "page_size": 3,
+        "total_pages": 0,
+        "has_next": False,
+        "has_previous": False,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_paginate_dependency_reads_query_parameters():
+    app = FastAPI()
+
+    @app.get("/items", response_model=PaginatedResponse[Item])
+    def read_items(paginator: Annotated[Paginator, Depends(paginate)]):
+        return paginator.paginate_sequence(ITEMS)
+
+    client = TestClient(app)
+
+    response = client.get("/items?page=2&page_size=2")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {"id": 3, "name": "item-3"},
+            {"id": 4, "name": "item-4"},
+        ],
+        "total": 7,
+        "page": 2,
+        "page_size": 2,
+        "total_pages": 4,
+        "has_next": True,
+        "has_previous": True,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_paginated_response_is_generic_over_pydantic_models():
+    response = PaginatedResponse[Item](
+        items=[Item(id=1, name="item-1")],
+        total=1,
+        page=1,
+        page_size=20,
+        total_pages=1,
+        has_next=False,
+        has_previous=False,
+    )
+
+    assert response.model_dump()["items"] == [{"id": 1, "name": "item-1"}]
+
+
+def test_apply_to_query_uses_offset_and_limit():
+    class Query:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int]] = []
+
+        def offset(self, value: int) -> "Query":
+            self.calls.append(("offset", value))
+            return self
+
+        def limit(self, value: int) -> "Query":
+            self.calls.append(("limit", value))
+            return self
+
+    query = Query()
+
+    assert Paginator(page=3, page_size=10).apply_to_query(query) is query
+    assert query.calls == [("offset", 20), ("limit", 10)]
+
+
+def test_paginate_query_supports_sqlalchemy_style_query_objects():
+    class Query:
+        def __init__(self, items: list[Item]) -> None:
+            self.items = items
+            self.start = 0
+            self.stop = len(items)
+
+        def count(self) -> int:
+            return len(self.items)
+
+        def offset(self, value: int) -> "Query":
+            self.start = value
+            return self
+
+        def limit(self, value: int) -> "Query":
+            self.stop = self.start + value
+            return self
+
+        def all(self) -> list[Item]:
+            return self.items[self.start : self.stop]
+
+    response = Paginator(page=2, page_size=2).paginate_query(Query(ITEMS))
+
+    assert [item.id for item in response.items] == [3, 4]
+    assert response.total == 7
+    assert response.total_pages == 4


### PR DESCRIPTION
/claim #802

## Summary
- Add `fastapi.pagination` with `Paginator`, `paginate`, and generic `PaginatedResponse[T]`.
- Support offset metadata, cursor navigation cursors, sequence pagination, and SQLAlchemy-style query pagination helpers.
- Export pagination helpers from `fastapi` and add focused coverage for defaults, edge cases, dependency injection, cursor navigation, and query objects.

## Validation
- `uv run pytest tests/test_pagination.py`
- `uv run ruff check fastapi/__init__.py fastapi/pagination.py tests/test_pagination.py`
- `uv run ruff format --check fastapi/__init__.py fastapi/pagination.py tests/test_pagination.py`
- `python -m compileall -q fastapi/fastapi/__init__.py fastapi/fastapi/pagination.py fastapi/tests/test_pagination.py`
- `git diff --check`