### PR TITLE
Codex [ Laravel ] Fix console log cleanup scheduling

### DIFF
--- a/laravel/routes/_generation.json
+++ b/laravel/routes/_generation.json
@@ -1,0 +1,5 @@
+{
+    "agent": "Codex",
+    "pre_task_context": "AI-assisted implementation. Full private system/developer initialization text is not included because it contains confidential operating instructions; the implementation is scoped to the public bounty requirements in UnsafeLabs/Bounty-Hunters#753.",
+    "timestamp": "2026-05-15T17:20:00-06:00"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,72 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days of logs to retain}', function () {
+    $days = filter_var($this->option('days'), FILTER_VALIDATE_INT);
+
+    if ($days === false || $days < 0) {
+        $this->error('The --days option must be a non-negative integer.');
+
+        return 1;
+    }
+
+    $logsPath = storage_path('logs');
+
+    if (! File::isDirectory($logsPath)) {
+        $this->info('Deleted 0 log files; freed 0 B.');
+
+        return 0;
+    }
+
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deletedFiles = 0;
+    $freedBytes = 0;
+    $formatBytes = static function (int $bytes): string {
+        if ($bytes < 1024) {
+            return $bytes.' B';
+        }
+
+        $units = ['KB', 'MB', 'GB', 'TB'];
+        $value = $bytes / 1024;
+
+        foreach ($units as $unit) {
+            if ($value < 1024) {
+                return rtrim(rtrim(number_format($value, 2), '0'), '.').' '.$unit;
+            }
+
+            $value /= 1024;
+        }
+
+        return rtrim(rtrim(number_format($value, 2), '0'), '.').' PB';
+    };
+
+    foreach (File::files($logsPath) as $file) {
+        if (! str_ends_with($file->getFilename(), '.log') || $file->getMTime() >= $cutoff) {
+            continue;
+        }
+
+        $freedBytes += $file->getSize();
+
+        if (File::delete($file->getPathname())) {
+            $deletedFiles++;
+        }
+    }
+
+    $this->info(sprintf(
+        'Deleted %d log %s; freed %s.',
+        $deletedFiles,
+        $deletedFiles === 1 ? 'file' : 'files',
+        $formatBytes($freedBytes),
+    ));
+
+    return 0;
+})->purpose('Delete log files older than the configured retention period');
+
+Schedule::command('logs:clear')->dailyAt('00:00');

--- a/laravel/tests/Feature/LogCleanupCommandTest.php
+++ b/laravel/tests/Feature/LogCleanupCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class LogCleanupCommandTest extends TestCase
+{
+    private string $logsPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logsPath = storage_path('logs');
+        File::ensureDirectoryExists($this->logsPath);
+        $this->deleteTestFiles();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTestFiles();
+
+        parent::tearDown();
+    }
+
+    public function test_it_deletes_log_files_older_than_seven_days_by_default(): void
+    {
+        $oldLog = $this->logFile('log-cleanup-test-old.log', 10, 8);
+        $recentLog = $this->logFile('log-cleanup-test-recent.log', 10, 2);
+        $ignoredFile = $this->logFile('log-cleanup-test-notes.txt', 10, 30);
+
+        $this->artisan('logs:clear')
+            ->expectsOutput('Deleted 1 log file; freed 10 B.')
+            ->assertSuccessful();
+
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($recentLog);
+        $this->assertFileExists($ignoredFile);
+    }
+
+    public function test_days_option_overrides_retention_period(): void
+    {
+        $eightDayLog = $this->logFile('log-cleanup-test-eight-days.log', 10, 8);
+        $thirtyOneDayLog = $this->logFile('log-cleanup-test-thirty-one-days.log', 10, 31);
+
+        $this->artisan('logs:clear --days=30')
+            ->expectsOutput('Deleted 1 log file; freed 10 B.')
+            ->assertSuccessful();
+
+        $this->assertFileExists($eightDayLog);
+        $this->assertFileDoesNotExist($thirtyOneDayLog);
+    }
+
+    public function test_days_option_must_be_non_negative_integer(): void
+    {
+        $this->artisan('logs:clear --days=-1')
+            ->expectsOutput('The --days option must be a non-negative integer.')
+            ->assertExitCode(1);
+    }
+
+    public function test_log_cleanup_is_scheduled_daily_at_midnight(): void
+    {
+        $events = app(Schedule::class)->events();
+
+        $this->assertTrue(collect($events)->contains(function ($event) {
+            return str_contains($event->command, 'logs:clear')
+                && $event->expression === '0 0 * * *';
+        }));
+    }
+
+    private function logFile(string $name, int $bytes, int $ageInDays): string
+    {
+        $path = $this->logsPath.'/'.$name;
+
+        File::put($path, str_repeat('x', $bytes));
+        touch($path, now()->subDays($ageInDays)->getTimestamp());
+
+        return $path;
+    }
+
+    private function deleteTestFiles(): void
+    {
+        foreach (File::glob($this->logsPath.'/log-cleanup-test-*') as $path) {
+            File::delete($path);
+        }
+    }
+}


### PR DESCRIPTION
/claim #753

## Summary
- Adds a `logs:clear` Artisan closure command in `laravel/routes/console.php`.
- Deletes `.log` files older than the retention period from `storage/logs`, defaulting to 7 days and supporting `--days=30` style overrides.
- Reports deleted file count and freed disk space in human-readable units.
- Registers the command to run daily at `00:00`.
- Adds focused feature tests covering default retention, custom `--days`, invalid options, and the schedule entry.

## Why this has independent value
There was no upstream PR for #753 when I checked with `gh pr list --repo UnsafeLabs/Bounty-Hunters --state all --search "753"`. One contributor linked a PR in their own fork, but no reviewable upstream PR exists. This PR provides an upstream, scoped implementation with tests.

## Files changed
- `laravel/routes/console.php`
- `laravel/tests/Feature/LogCleanupCommandTest.php`
- `laravel/routes/_generation.json`

## Verification
- `git diff --check`
- PHP/Laravel test execution was not available in this local environment because `php` and `composer` are not installed. The PR includes focused PHPUnit coverage for CI verification.

## AI disclosure
AI-assisted with Codex.

## Risk note
The issue asks for full private startup context in `_generation.json`; I included a safe disclosure instead of private system/developer instructions. That may affect automated bounty metadata checks, but avoids leaking confidential instructions.
