### PR TITLE
Codex [ T3 Code ] Add Playwright E2E tests

### DIFF
--- a/t3code/bun.lock
+++ b/t3code/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@effect/language-service": "catalog:",
         "@oxlint/plugins": "^1.63.0",
+        "@playwright/test": "1.58.2",
         "@types/node": "catalog:",
         "oxfmt": "^0.40.0",
         "oxlint": "^1.63.0",
@@ -17,7 +18,7 @@
     },
     "apps/desktop": {
       "name": "@t3tools/desktop",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "@t3tools/contracts": "workspace:*",
@@ -50,7 +51,7 @@
     },
     "apps/server": {
       "name": "t3",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "bin": {
         "t3": "./dist/bin.mjs",
       },
@@ -83,7 +84,7 @@
     },
     "apps/web": {
       "name": "@t3tools/web",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "@dnd-kit/core": "^6.3.1",
@@ -165,7 +166,7 @@
     },
     "packages/contracts": {
       "name": "@t3tools/contracts",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -719,6 +720,8 @@
     "@pierre/diffs": ["@pierre/diffs@1.1.20", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-lLi+3sLCm3QDd5/aLO9pw+WbF6UzhrkWm2oTZ5WZJTGemOyUNRJ4DDhcEKmVusu4C4bXx9Nssh6fF+wQcapb5w=="],
 
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 

--- a/t3code/package.json
+++ b/t3code/package.json
@@ -44,6 +44,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "oxlint --report-unused-disable-directives",
     "test": "turbo run test",
+    "test:e2e": "playwright test",
     "test:desktop-smoke": "turbo run smoke-test --filter=@t3tools/desktop",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
@@ -63,6 +64,7 @@
   "devDependencies": {
     "@effect/language-service": "catalog:",
     "@oxlint/plugins": "^1.63.0",
+    "@playwright/test": "1.58.2",
     "@types/node": "catalog:",
     "oxfmt": "^0.40.0",
     "oxlint": "^1.63.0",

--- a/t3code/playwright.config.ts
+++ b/t3code/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = "http://127.0.0.1:5733";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "HOST=127.0.0.1 PORT=5733 VITE_HOSTED_APP_CHANNEL=latest bun run --cwd apps/web dev",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/t3code/tests/e2e/app-loads.spec.ts
+++ b/t3code/tests/e2e/app-loads.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+test("loads the app shell without browser errors", async ({ page }) => {
+  const failures: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      failures.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => {
+    failures.push(error.message);
+  });
+
+  await page.goto("/");
+
+  await expect(page).toHaveTitle(/T3 Code/u);
+  await expect(page.getByTestId("command-palette-trigger")).toBeVisible();
+  await expect(page.getByText("Projects", { exact: true })).toBeVisible();
+  await expect(page.getByText("No projects yet", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+  expect(failures).toEqual([]);
+});

--- a/t3code/tests/e2e/command-palette.spec.ts
+++ b/t3code/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test("opens the command palette with the keyboard shortcut and filters commands", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.keyboard.press("ControlOrMeta+K");
+
+  const palette = page.getByTestId("command-palette");
+  await expect(palette).toBeVisible();
+
+  await page.getByPlaceholder("Search commands, projects, and threads...").fill("settings");
+
+  await expect(palette.getByText("Open settings", { exact: true })).toBeVisible();
+  await expect(palette.getByText("Add project", { exact: true })).toBeHidden();
+
+  await palette.getByText("Open settings", { exact: true }).click();
+  await expect(page).toHaveURL(/\/settings\/general$/u);
+  await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
+});

--- a/t3code/tests/e2e/sidebar-navigation.spec.ts
+++ b/t3code/tests/e2e/sidebar-navigation.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+test("clicks settings sidebar items and updates the main content", async ({ page }) => {
+  await page.goto("/settings/general");
+  await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Keybindings" }).click();
+  await expect(page).toHaveURL(/\/settings\/keybindings$/u);
+  await expect(page.getByRole("heading", { name: "Keybindings" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Providers" }).click();
+  await expect(page).toHaveURL(/\/settings\/providers$/u);
+  await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Source Control" }).click();
+  await expect(page).toHaveURL(/\/settings\/source-control$/u);
+  await expect(page.getByRole("heading", { name: "Server environment" })).toBeVisible();
+});


### PR DESCRIPTION
/claim #847

## Summary
- Add root Playwright E2E config for the T3 web dev server in hosted-static mode.
- Add browser E2E coverage for app shell loading, command palette keyboard search, and settings sidebar navigation.
- Add `test:e2e` script and root `@playwright/test` runner dependency aligned with the existing Playwright version.

## Validation
- `npx --yes -p node@24.13.1 -p bun@1.3.11 bun run test:e2e`
- `npx --yes -p node@24.13.1 -p bun@1.3.11 bun run fmt`
- `npx --yes -p node@24.13.1 -p bun@1.3.11 bun run lint`
- `npx --yes -p node@24.13.1 -p bun@1.3.11 bun run typecheck`
- `git diff --check`

## Notes
- Did not add `_contributor.json` because it requests runtime/system prompt provenance.