### PR TITLE
Hermes [ FastAPI ] Implement standardized pagination with offset and cursor support

### DIFF
--- a/fastapi/.attribution.json
+++ b/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Hermes",
+  "platform_config": "Hermes Agent running as cron job for algojogacor — AI-powered open-source PR agent for Arya Rizky. Model: DeepSeek V4 Pro. Cron: hourly oss-pr-agent run.",
+  "date": "2026-05-16T06:00:00+00:00"
+}

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,361 @@
+"""Standardized pagination for FastAPI.
+
+Provides offset-based and cursor-based pagination that works with any
+SQLAlchemy or Pydantic-based data source, returning standardized
+paginated responses via dependency injection.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
+
+from fastapi import Depends, Query
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    """Standardized paginated response wrapping any Pydantic model."""
+
+    items: list[T] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    page: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1)
+    total_pages: int = Field(default=0, ge=0)
+    has_next: bool = Field(default=False)
+    has_previous: bool = Field(default=False)
+
+
+class CursorPaginatedResponse(BaseModel, Generic[T]):
+    """Cursor-based paginated response with opaque cursor navigation."""
+
+    items: list[T] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    next_cursor: str | None = Field(default=None)
+    previous_cursor: str | None = Field(default=None)
+    has_next: bool = Field(default=False)
+    has_previous: bool = Field(default=False)
+
+
+class OffsetParams:
+    """Dependency-injectable offset pagination parameters.
+
+    Usage:
+        @app.get("/items")
+        def list_items(pagination: OffsetParams = Depends()):
+            ...
+    """
+
+    def __init__(
+        self,
+        page: Annotated[
+            int,
+            Query(
+                ge=1,
+                description="Page number (1-indexed)",
+            ),
+        ] = 1,
+        page_size: Annotated[
+            int,
+            Query(
+                ge=1,
+                le=100,
+                description="Number of items per page",
+            ),
+        ] = 20,
+    ) -> None:
+        self.page = page
+        self.page_size = page_size
+
+    @property
+    def offset(self) -> int:
+        """Calculated offset for SQL / slice operations."""
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        """Alias for page_size — commonly used in ORMs."""
+        return self.page_size
+
+
+class CursorParams:
+    """Dependency-injectable cursor pagination parameters.
+
+    Usage:
+        @app.get("/items")
+        def list_items(pagination: CursorParams = Depends()):
+            ...
+    """
+
+    def __init__(
+        self,
+        cursor: Annotated[
+            str | None,
+            Query(
+                description="Opaque cursor for the next/previous page",
+            ),
+        ] = None,
+        page_size: Annotated[
+            int,
+            Query(
+                ge=1,
+                le=100,
+                description="Number of items per page",
+            ),
+        ] = 20,
+        direction: Annotated[
+            str,
+            Query(
+                pattern="^(next|previous)$",
+                description="Pagination direction: 'next' or 'previous'",
+            ),
+        ] = "next",
+    ) -> None:
+        self.cursor = cursor
+        self.page_size = page_size
+        self.direction = direction
+
+    def decode_cursor(self) -> dict[str, Any] | None:
+        """Decode the opaque cursor into its constituent values."""
+        if self.cursor is None:
+            return None
+        try:
+            decoded = base64.urlsafe_b64decode(self.cursor.encode()).decode()
+            return json.loads(decoded)
+        except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+            return None
+
+    @staticmethod
+    def encode_cursor(data: dict[str, Any]) -> str:
+        """Encode a dictionary into an opaque cursor string."""
+        raw = json.dumps(data, separators=(",", ":"), sort_keys=True)
+        return base64.urlsafe_b64encode(raw.encode()).decode()
+
+
+class Paginator:
+    """Applies offset-based pagination to an iterable of items.
+
+    This is a utility class for use within route handlers when you
+    have fetched data from a database or external source and want
+    to produce a ``PaginatedResponse``.
+
+    Usage:
+        items = db.query(MyModel).all()
+        paginator = Paginator(items, offset_params)
+        return paginator.response()
+
+        # With a custom Pydantic model
+        return paginator.response(model=MySchema)
+    """
+
+    def __init__(
+        self,
+        items: list[Any],
+        params: OffsetParams,
+    ) -> None:
+        self._all_items = items
+        self._params = params
+
+    @property
+    def total(self) -> int:
+        return len(self._all_items)
+
+    @property
+    def total_pages(self) -> int:
+        if self._params.page_size == 0:
+            return 0
+        return max(1, (self.total + self._params.page_size - 1) // self._params.page_size)
+
+    @property
+    def page_items(self) -> list[Any]:
+        start = self._params.offset
+        end = start + self._params.limit
+        return self._all_items[start:end]
+
+    def _convert_item(self, item: Any, model: type[BaseModel]) -> BaseModel:
+        """Convert a raw item to the target Pydantic model."""
+        if isinstance(item, model):
+            return item
+        if isinstance(item, BaseModel):
+            return model.model_validate(item.model_dump())
+        if isinstance(item, dict):
+            return model.model_validate(item)
+        return model.model_validate(item)
+
+    def response(self, *, model: type[BaseModel] | None = None) -> PaginatedResponse[Any]:
+        """Build the standardized ``PaginatedResponse``.
+
+        If ``model`` is provided, each item is validated and serialized
+        through the Pydantic model. Otherwise raw items are returned.
+        """
+        items = self.page_items
+        if model is not None:
+            items = [self._convert_item(item, model) for item in items]
+
+        return PaginatedResponse(
+            items=items,
+            total=self.total,
+            page=self._params.page,
+            page_size=self._params.page_size,
+            total_pages=self.total_pages,
+            has_next=self._params.page < self.total_pages,
+            has_previous=self._params.page > 1,
+        )
+
+
+class CursorPaginator:
+    """Applies cursor-based pagination to a sorted iterable.
+
+    Items must be sorted by a unique, monotonically-ordered field
+    (e.g. ``id``, ``created_at``). The cursor encodes the field
+    value of the boundary item.
+
+    Usage:
+        items = sorted(db.query(MyModel).all(), key=lambda x: x.id)
+        paginator = CursorPaginator(items, cursor_params, cursor_field="id")
+        return paginator.response()
+    """
+
+    def __init__(
+        self,
+        items: list[Any],
+        params: CursorParams,
+        cursor_field: str = "id",
+    ) -> None:
+        if not items:
+            self._all_items: list[Any] = []
+        else:
+            # Ensure items are sortable by cursor_field
+            self._all_items = sorted(items, key=lambda x: getattr(x, cursor_field))
+
+        self._params = params
+        self._cursor_field = cursor_field
+
+    @property
+    def total(self) -> int:
+        return len(self._all_items)
+
+    @property
+    def page_items(self) -> list[Any]:
+        if not self._all_items:
+            return []
+
+        decoded = self._params.decode_cursor()
+        limit = self._params.page_size
+
+        if decoded is not None and self._cursor_field in decoded:
+            cursor_value = decoded[self._cursor_field]
+            if self._params.direction == "next":
+                # Return items AFTER the cursor value, ascending
+                items = [i for i in self._all_items if getattr(i, self._cursor_field) > cursor_value]
+                return items[:limit]
+            else:
+                # Return items BEFORE the cursor value — take the
+                # *last* `limit` items so they appear in natural order.
+                items = [i for i in self._all_items if getattr(i, self._cursor_field) < cursor_value]
+                return items[-limit:] if len(items) > limit else items
+
+        # No cursor — return first page
+        return self._all_items[:limit]
+
+    @property
+    def has_next(self) -> bool:
+        items = self.page_items
+        if not items or not self._all_items:
+            return False
+        last_in_page = getattr(items[-1], self._cursor_field)
+        last_overall = getattr(self._all_items[-1], self._cursor_field)
+        return last_in_page < last_overall
+
+    @property
+    def has_previous(self) -> bool:
+        decoded = self._params.decode_cursor()
+        if decoded is None:
+            return False
+        if self._params.direction == "next":
+            # If we have a cursor, there are items before it
+            if not self._all_items:
+                return False
+            first_overall = getattr(self._all_items[0], self._cursor_field)
+            return decoded.get(self._cursor_field, first_overall) > first_overall
+        # For "previous" direction, there may be more before
+        items = self.page_items
+        if not items or not self._all_items:
+            return False
+        first_in_page = getattr(items[0], self._cursor_field)
+        first_overall = getattr(self._all_items[0], self._cursor_field)
+        return first_in_page > first_overall
+
+    def _build_cursor(self, item: Any) -> str:
+        return self._params.encode_cursor({self._cursor_field: getattr(item, self._cursor_field)})
+
+    def _convert_item(self, item: Any, model: type[BaseModel]) -> BaseModel:
+        """Convert a raw item to the target Pydantic model."""
+        if isinstance(item, model):
+            return item
+        if isinstance(item, BaseModel):
+            return model.model_validate(item.model_dump())
+        if isinstance(item, dict):
+            return model.model_validate(item)
+        return model.model_validate(item)
+
+    def response(
+        self, *, model: type[BaseModel] | None = None
+    ) -> CursorPaginatedResponse[Any]:
+        """Build the standardized ``CursorPaginatedResponse``."""
+        items = self.page_items
+        if model is not None:
+            items = [self._convert_item(item, model) for item in items]
+
+        next_cursor: str | None = None
+        previous_cursor: str | None = None
+
+        if items:
+            # Next cursor points to the last item in this page
+            next_cursor = self._build_cursor(items[-1]) if self.has_next else None
+            # Previous cursor points to the first item in this page
+            previous_cursor = self._build_cursor(items[0]) if self.has_previous else None
+
+        return CursorPaginatedResponse(
+            items=items,
+            total=self.total,
+            next_cursor=next_cursor,
+            previous_cursor=previous_cursor,
+            has_next=self.has_next,
+            has_previous=self.has_previous,
+        )
+
+
+def paginate(
+    params: Annotated[OffsetParams, Depends()],
+) -> OffsetParams:
+    """Dependency that injects ``OffsetParams`` into any route.
+
+    Usage:
+        @app.get("/items")
+        def list_items(pagination: OffsetParams = Depends(paginate)):
+            items = get_all_items()
+            paginator = Paginator(items, pagination)
+            return paginator.response()
+    """
+    return params
+
+
+def paginate_cursor(
+    params: Annotated[CursorParams, Depends()],
+) -> CursorParams:
+    """Dependency that injects ``CursorParams`` into any route.
+
+    Usage:
+        @app.get("/items/cursor")
+        def list_items_cursor(pagination: CursorParams = Depends(paginate_cursor)):
+            items = get_all_items()
+            paginator = CursorPaginator(items, pagination)
+            return paginator.response()
+    """
+    return params

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,402 @@
+"""Tests for FastAPI pagination module.
+
+Covers offset-based and cursor-based pagination, dependency injection,
+edge cases, and Pydantic model wrapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from fastapi import Depends, FastAPI
+from fastapi.pagination import (
+    CursorPaginatedResponse,
+    CursorPaginator,
+    CursorParams,
+    OffsetParams,
+    PaginatedResponse,
+    Paginator,
+    paginate,
+    paginate_cursor,
+)
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+class ItemOut(BaseModel):
+    id: int
+    name: str
+
+
+SAMPLE_DATA: list[dict[str, Any]] = [
+    {"id": i, "name": f"item-{i:03d}"} for i in range(1, 101)
+]
+
+
+@pytest.fixture
+def sample_items() -> list[dict[str, Any]]:
+    return [dict(d) for d in SAMPLE_DATA]
+
+
+@pytest.fixture
+def sample_models() -> list[Item]:
+    return [Item(**d) for d in SAMPLE_DATA]
+
+
+# ---------------------------------------------------------------------------
+# OffsetParams unit tests
+# ---------------------------------------------------------------------------
+
+class TestOffsetParams:
+    def test_defaults(self):
+        p = OffsetParams()
+        assert p.page == 1
+        assert p.page_size == 20
+        assert p.offset == 0
+        assert p.limit == 20
+
+    def test_page_2(self):
+        p = OffsetParams(page=2, page_size=10)
+        assert p.offset == 10
+        assert p.limit == 10
+
+    def test_page_5(self):
+        p = OffsetParams(page=5, page_size=25)
+        assert p.offset == 100
+        assert p.limit == 25
+
+
+# ---------------------------------------------------------------------------
+# Paginator offset tests
+# ---------------------------------------------------------------------------
+
+class TestPaginator:
+    def test_first_page(self, sample_items):
+        params = OffsetParams(page=1, page_size=10)
+        paginator = Paginator(sample_items, params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 10
+        assert resp.items[0]["id"] == 1
+        assert resp.total == 100
+        assert resp.page == 1
+        assert resp.page_size == 10
+        assert resp.total_pages == 10
+        assert resp.has_next is True
+        assert resp.has_previous is False
+
+    def test_last_page(self, sample_items):
+        params = OffsetParams(page=10, page_size=10)
+        paginator = Paginator(sample_items, params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 10
+        assert resp.items[-1]["id"] == 100
+        assert resp.total_pages == 10
+        assert resp.has_next is False
+        assert resp.has_previous is True
+
+    def test_middle_page(self, sample_items):
+        params = OffsetParams(page=5, page_size=10)
+        paginator = Paginator(sample_items, params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 10
+        assert resp.items[0]["id"] == 41
+        assert resp.items[-1]["id"] == 50
+        assert resp.has_next is True
+        assert resp.has_previous is True
+
+    def test_partial_last_page(self, sample_items):
+        params = OffsetParams(page=4, page_size=30)
+        paginator = Paginator(sample_items, params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 10  # 100 items, page 4 of 30 = items 91-100
+        assert resp.total_pages == 4
+        assert resp.has_next is False
+        assert resp.has_previous is True
+
+    def test_empty_items(self):
+        params = OffsetParams(page=1, page_size=10)
+        paginator = Paginator([], params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 0
+        assert resp.total == 0
+        assert resp.total_pages == 1  # at least 1 page even when empty
+        assert resp.has_next is False
+        assert resp.has_previous is False
+
+    def test_page_beyond_range(self, sample_items):
+        """Requesting page 99 of 100 items at size 10 should return empty."""
+        params = OffsetParams(page=99, page_size=10)
+        paginator = Paginator(sample_items, params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 0
+        assert resp.total == 100
+        assert resp.page == 99
+        assert resp.has_next is False
+
+    def test_single_item_per_page(self, sample_items):
+        params = OffsetParams(page=50, page_size=1)
+        paginator = Paginator(sample_items, params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 1
+        assert resp.items[0]["id"] == 50
+        assert resp.total_pages == 100
+
+    def test_model_serialization(self, sample_models):
+        params = OffsetParams(page=1, page_size=5)
+        paginator = Paginator(sample_models, params)
+        resp = paginator.response(model=ItemOut)
+
+        assert len(resp.items) == 5
+        assert isinstance(resp.items[0], ItemOut)
+        assert resp.items[0].id == 1
+
+    def test_all_items_single_page(self, sample_items):
+        params = OffsetParams(page=1, page_size=200)
+        paginator = Paginator(sample_items, params)
+        resp = paginator.response()
+
+        assert len(resp.items) == 100
+        assert resp.total_pages == 1
+        assert resp.has_next is False
+        assert resp.has_previous is False
+
+
+# ---------------------------------------------------------------------------
+# CursorParams unit tests
+# ---------------------------------------------------------------------------
+
+class TestCursorParams:
+    def test_defaults(self):
+        p = CursorParams()
+        assert p.cursor is None
+        assert p.page_size == 20
+        assert p.direction == "next"
+
+    def test_decode_none(self):
+        p = CursorParams(cursor=None)
+        assert p.decode_cursor() is None
+
+    def test_encode_decode_roundtrip(self):
+        data = {"id": 42}
+        encoded = CursorParams.encode_cursor(data)
+        p = CursorParams(cursor=encoded)
+        assert p.decode_cursor() == data
+
+    def test_decode_invalid_cursor(self):
+        p = CursorParams(cursor="not-valid-base64!!!")
+        assert p.decode_cursor() is None
+
+
+# ---------------------------------------------------------------------------
+# CursorPaginator tests
+# ---------------------------------------------------------------------------
+
+class TestCursorPaginator:
+    def test_first_page_no_cursor(self, sample_models):
+        params = CursorParams(page_size=10)
+        paginator = CursorPaginator(sample_models, params, cursor_field="id")
+        resp = paginator.response()
+
+        assert len(resp.items) == 10
+        assert resp.items[0].id == 1
+        assert resp.items[-1].id == 10
+        assert resp.total == 100
+        assert resp.has_next is True
+        assert resp.has_previous is False
+        assert resp.next_cursor is not None
+        assert resp.previous_cursor is None
+
+    def test_next_page_with_cursor(self, sample_models):
+        # Get first page
+        params1 = CursorParams(page_size=10)
+        paginator1 = CursorPaginator(sample_models, params1, cursor_field="id")
+        resp1 = paginator1.response()
+
+        assert resp1.next_cursor is not None
+
+        # Use cursor for next page
+        params2 = CursorParams(cursor=resp1.next_cursor, page_size=10, direction="next")
+        paginator2 = CursorPaginator(sample_models, params2, cursor_field="id")
+        resp2 = paginator2.response()
+
+        assert len(resp2.items) == 10
+        assert resp2.items[0].id == 11
+        assert resp2.items[-1].id == 20
+        assert resp2.has_previous is True
+        assert resp2.previous_cursor is not None
+
+    def test_previous_page_with_cursor(self, sample_models):
+        # Get second page first
+        params1 = CursorParams(page_size=10)
+        paginator1 = CursorPaginator(sample_models, params1, cursor_field="id")
+        resp1 = paginator1.response()
+
+        # Get second page
+        params2 = CursorParams(cursor=resp1.next_cursor, page_size=10, direction="next")
+        paginator2 = CursorPaginator(sample_models, params2, cursor_field="id")
+        resp2 = paginator2.response()
+
+        # Go back
+        params3 = CursorParams(cursor=resp2.previous_cursor, page_size=10, direction="previous")
+        paginator3 = CursorPaginator(sample_models, params3, cursor_field="id")
+        resp3 = paginator3.response()
+
+        assert len(resp3.items) == 10
+        assert resp3.items[-1].id == 10  # previous: items < 11, reversed, top 10
+
+    def test_last_page_no_next(self, sample_models):
+        # Navigate to last
+        params = CursorParams(page_size=100)
+        paginator = CursorPaginator(sample_models, params, cursor_field="id")
+        resp = paginator.response()
+
+        assert resp.has_next is False
+        assert resp.next_cursor is None
+
+    def test_empty_items(self):
+        params = CursorParams(page_size=10)
+        paginator = CursorPaginator([], params, cursor_field="id")
+        resp = paginator.response()
+
+        assert len(resp.items) == 0
+        assert resp.total == 0
+        assert resp.has_next is False
+        assert resp.has_previous is False
+
+    def test_smaller_than_page_size(self, sample_models):
+        params = CursorParams(page_size=200)
+        paginator = CursorPaginator(sample_models, params, cursor_field="id")
+        resp = paginator.response()
+
+        assert len(resp.items) == 100
+        assert resp.has_next is False
+
+    def test_model_serialization(self, sample_models):
+        params = CursorParams(page_size=5)
+        paginator = CursorPaginator(sample_models, params, cursor_field="id")
+        resp = paginator.response(model=ItemOut)
+
+        assert len(resp.items) == 5
+        assert isinstance(resp.items[0], ItemOut)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — FastAPI app with dependency injection
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+
+    all_items = [Item(**d) for d in SAMPLE_DATA]
+
+    @app.get("/items/offset")
+    def list_offset(p: OffsetParams = Depends(paginate)):
+        paginator = Paginator(all_items, p)
+        return paginator.response(model=ItemOut)
+
+    @app.get("/items/cursor")
+    def list_cursor(p: CursorParams = Depends(paginate_cursor)):
+        paginator = CursorPaginator(all_items, p, cursor_field="id")
+        return paginator.response(model=ItemOut)
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+class TestIntegration:
+    def test_offset_endpoint_defaults(self, client):
+        resp = client.get("/items/offset")
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert len(data["items"]) == 20
+        assert data["total"] == 100
+        assert data["page"] == 1
+        assert data["page_size"] == 20
+        assert data["total_pages"] == 5
+        assert data["has_next"] is True
+        assert data["has_previous"] is False
+
+    def test_offset_endpoint_page_3(self, client):
+        resp = client.get("/items/offset?page=3&page_size=10")
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert len(data["items"]) == 10
+        assert data["items"][0]["id"] == 21
+        assert data["page"] == 3
+
+    def test_offset_endpoint_invalid_page_rejected_by_fastapi(self, client):
+        """FastAPI Query(ge=1) should reject page=0 with 422."""
+        resp = client.get("/items/offset?page=0")
+        assert resp.status_code == 422
+
+    def test_offset_endpoint_negative_page_rejected(self, client):
+        resp = client.get("/items/offset?page=-1")
+        assert resp.status_code == 422
+
+    def test_cursor_endpoint_defaults(self, client):
+        resp = client.get("/items/cursor")
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert len(data["items"]) == 20
+        assert data["total"] == 100
+        assert data["has_next"] is True
+        assert data["has_previous"] is False
+        assert data["next_cursor"] is not None
+        assert data["previous_cursor"] is None
+
+    def test_cursor_endpoint_paginate_forward(self, client):
+        page1 = client.get("/items/cursor?page_size=10").json()
+        cursor = page1["next_cursor"]
+
+        page2 = client.get(f"/items/cursor?cursor={cursor}&page_size=10").json()
+        assert len(page2["items"]) == 10
+        assert page2["items"][0]["id"] == 11
+        assert page2["has_previous"] is True
+
+    def test_cursor_endpoint_invalid_cursor_handled(self, client):
+        resp = client.get("/items/cursor?cursor=bad_cursor_value")
+        # Invalid cursor is treated as None — returns first page
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"][0]["id"] == 1
+
+    def test_paginated_response_serialization(self, client):
+        resp = client.get("/items/offset?page=1&page_size=5")
+        data = resp.json()
+
+        # Verify all expected fields exist
+        for key in ("items", "total", "page", "page_size", "total_pages", "has_next", "has_previous"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_cursor_response_serialization(self, client):
+        resp = client.get("/items/cursor?page_size=5")
+        data = resp.json()
+
+        for key in ("items", "total", "next_cursor", "previous_cursor", "has_next", "has_previous"):
+            assert key in data, f"Missing key: {key}"


### PR DESCRIPTION
## Summary

Implements a comprehensive pagination utility for FastAPI that provides both offset-based and cursor-based pagination through dependency injection.

## Solution

### Files Added
- **`fastapi/fastapi/pagination.py`** — Core pagination module (~360 lines)
- **`fastapi/tests/test_pagination.py`** — Comprehensive test suite (32 tests)
- **`fastapi/.attribution.json`** — Attribution metadata

### Components

**Models:**
- `PaginatedResponse[T]` — Generic Pydantic model with: items, total, page, page_size, total_pages, has_next, has_previous
- `CursorPaginatedResponse[T]` — Generic model with: items, total, next_cursor, previous_cursor, has_next, has_previous

**Parameter Classes (dependency-injectable):**
- `OffsetParams` — Accepts page/page_size via Query parameters with validation (ge=1, le=100)
- `CursorParams` — Accepts cursor/page_size/direction with base64 cursor encode/decode

**Paginator Classes:**
- `Paginator` — Wraps any iterable, applies offset/limit, produces PaginatedResponse
- `CursorPaginator` — Wraps sorted iterable, navigates by cursor_field, produces CursorPaginatedResponse

**Dependency Functions:**
- `paginate()` — Injects OffsetParams via Depends
- `paginate_cursor()` — Injects CursorParams via Depends

## Testing

All 32 tests pass:
- Offset pagination: first/middle/last/partial pages, edge cases (empty, beyond range, single-item)
- Cursor pagination: forward/backward navigation, cursor encoding/decoding, empty items
- Model serialization: both offset and cursor with custom Pydantic output models
- Integration: FastAPI TestClient with dependency injection on real endpoints
- Boundary flags: has_next/has_previous verified at all page positions
- Validation: FastAPI Query(ge=1) rejects page=0 and negative pages (422 responses)
- Graceful degradation: invalid cursors treated as None (returns first page)