### PR TITLE
Codex [ T3 Code ] Add deep linking support via t3code:// custom protocol

### DIFF
--- a/t3code/apps/desktop/src/app/DesktopApp.ts
+++ b/t3code/apps/desktop/src/app/DesktopApp.ts
@@ -21,6 +21,7 @@ import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const DEFAULT_DESKTOP_BACKEND_PORT = 3773;
 const MAX_TCP_PORT = 65_535;
@@ -193,12 +194,20 @@ const startup = Effect.gen(function* () {
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
 
   yield* shellEnvironment.installIntoProcess;
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
   yield* desktopSettings.load;
+  const hasDeepLinkLock = yield* electronProtocol.registerDeepLinkProtocol((link) =>
+    desktopWindow.dispatchDeepLink(link),
+  );
+  if (!hasDeepLinkLock) {
+    yield* electronApp.quit;
+    return;
+  }
 
   if (environment.platform === "linux") {
     yield* electronApp.appendCommandLineSwitch("class", environment.linuxWmClass);

--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -136,6 +136,7 @@ function makeManagerLayer(input: {
           createMainIfBackendReady: Effect.void,
           handleBackendReady: Effect.void,
           dispatchMenuAction: () => Effect.void,
+          dispatchDeepLink: () => Effect.void,
           syncAppearance: Effect.void,
           ...input.desktopWindow,
         } satisfies DesktopWindow.DesktopWindowShape),

--- a/t3code/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/t3code/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -5,14 +5,31 @@ import * as Option from "effect/Option";
 import type * as Electron from "electron";
 import { beforeEach, vi } from "vitest";
 
-const { registerFileProtocolMock, registerSchemesAsPrivilegedMock, unregisterProtocolMock } =
-  vi.hoisted(() => ({
-    registerFileProtocolMock: vi.fn(),
-    registerSchemesAsPrivilegedMock: vi.fn(),
-    unregisterProtocolMock: vi.fn(),
-  }));
+const {
+  appOnMock,
+  appRemoveListenerMock,
+  requestSingleInstanceLockMock,
+  setAsDefaultProtocolClientMock,
+  registerFileProtocolMock,
+  registerSchemesAsPrivilegedMock,
+  unregisterProtocolMock,
+} = vi.hoisted(() => ({
+  appOnMock: vi.fn(),
+  appRemoveListenerMock: vi.fn(),
+  requestSingleInstanceLockMock: vi.fn(() => true),
+  setAsDefaultProtocolClientMock: vi.fn(),
+  registerFileProtocolMock: vi.fn(),
+  registerSchemesAsPrivilegedMock: vi.fn(),
+  unregisterProtocolMock: vi.fn(),
+}));
 
 vi.mock("electron", () => ({
+  app: {
+    on: appOnMock,
+    removeListener: appRemoveListenerMock,
+    requestSingleInstanceLock: requestSingleInstanceLockMock,
+    setAsDefaultProtocolClient: setAsDefaultProtocolClientMock,
+  },
   protocol: {
     registerFileProtocol: registerFileProtocolMock,
     registerSchemesAsPrivileged: registerSchemesAsPrivilegedMock,
@@ -24,6 +41,11 @@ import * as ElectronProtocol from "./ElectronProtocol.ts";
 
 describe("ElectronProtocol", () => {
   beforeEach(() => {
+    appOnMock.mockReset();
+    appRemoveListenerMock.mockReset();
+    requestSingleInstanceLockMock.mockReset();
+    requestSingleInstanceLockMock.mockReturnValue(true);
+    setAsDefaultProtocolClientMock.mockReset();
     registerFileProtocolMock.mockReset();
     registerSchemesAsPrivilegedMock.mockReset();
     unregisterProtocolMock.mockReset();
@@ -36,6 +58,67 @@ describe("ElectronProtocol", () => {
     );
     assert.isTrue(Option.isNone(ElectronProtocol.normalizeDesktopProtocolPathname("/../secret")));
   });
+
+  it("parses supported t3code deep links", () => {
+    assert.deepEqual(
+      ElectronProtocol.parseDesktopDeepLink("t3code://open/project?path=/Users/alice/repo"),
+      { type: "openProject", path: "/Users/alice/repo" },
+    );
+    assert.deepEqual(ElectronProtocol.parseDesktopDeepLink("t3code://chat/thread?id=abc123"), {
+      type: "chatThread",
+      id: "abc123",
+    });
+    assert.deepEqual(ElectronProtocol.parseDesktopDeepLink("t3code://settings"), {
+      type: "settings",
+    });
+  });
+
+  it("rejects invalid project deep links without throwing", () => {
+    assert.deepEqual(ElectronProtocol.parseDesktopDeepLink("t3code://open/project?path=../repo"), {
+      type: "error",
+      message: "Project deep link path must be absolute.",
+    });
+    assert.deepEqual(
+      ElectronProtocol.parseDesktopDeepLink("t3code://open/project?path=/Users/alice/../secret"),
+      {
+        type: "error",
+        message: "Project deep link path cannot contain '..' segments.",
+      },
+    );
+  });
+
+  it.effect("registers t3code protocol listeners and dispatches startup urls", () =>
+    Effect.gen(function* () {
+      const originalArgv = process.argv;
+      process.argv = ["electron", "main.js", "t3code://settings"];
+      const links: unknown[] = [];
+
+      try {
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
+            const hasLock = yield* electronProtocol.registerDeepLinkProtocol((link) =>
+              Effect.sync(() => {
+                links.push(link);
+              }),
+            );
+            assert.equal(hasLock, true);
+          }),
+        );
+      } finally {
+        process.argv = originalArgv;
+      }
+
+      assert.deepEqual(links, [{ type: "settings" }]);
+      assert.deepEqual(requestSingleInstanceLockMock.mock.calls, [[]]);
+      assert.deepEqual(setAsDefaultProtocolClientMock.mock.calls, [["t3code"]]);
+      assert.equal(appOnMock.mock.calls.length, 2);
+      assert.deepEqual(
+        appRemoveListenerMock.mock.calls.map((call) => call[0]),
+        ["open-url", "second-instance"],
+      );
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
 
   it.effect("registers desktop scheme privileges through a layer", () =>
     Effect.scoped(

--- a/t3code/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/t3code/apps/desktop/src/electron/ElectronProtocol.ts
@@ -10,9 +10,12 @@ import * as Scope from "effect/Scope";
 
 import * as Electron from "electron";
 
+import type { DesktopDeepLink } from "@t3tools/contracts";
+import { isUncPath, isWindowsDrivePath } from "@t3tools/shared/path";
 import { DesktopEnvironment, type DesktopEnvironmentShape } from "../app/DesktopEnvironment.ts";
 
 export const DESKTOP_SCHEME = "t3";
+export const DEEP_LINK_SCHEME = "t3code";
 
 export class ElectronProtocolRegistrationError extends Data.TaggedError(
   "ElectronProtocolRegistrationError",
@@ -49,6 +52,9 @@ export interface ElectronProtocolShape {
     ElectronProtocolRegistrationError | ElectronProtocolStaticBundleMissingError,
     FileSystem.FileSystem | DesktopEnvironment | Scope.Scope
   >;
+  readonly registerDeepLinkProtocol: <E, R>(
+    handler: (link: DesktopDeepLink) => Effect.Effect<void, E, R>,
+  ) => Effect.Effect<boolean, E, R | Scope.Scope>;
 }
 
 export class ElectronProtocol extends Context.Service<ElectronProtocol, ElectronProtocolShape>()(
@@ -67,6 +73,77 @@ export function normalizeDesktopProtocolPathname(rawPath: string): Option.Option
     segments.push(segment);
   }
   return Option.some(segments.join("/"));
+}
+
+function isDeepLinkUrl(value: string): boolean {
+  return value.toLowerCase().startsWith(`${DEEP_LINK_SCHEME}://`);
+}
+
+function collectDeepLinkUrls(argv: readonly string[]): readonly string[] {
+  return argv.filter(isDeepLinkUrl);
+}
+
+function hasTraversalSegment(value: string): boolean {
+  return value.split(/[\\/]+/).some((segment) => segment === "..");
+}
+
+function isAbsoluteProjectPath(value: string): boolean {
+  return value.startsWith("/") || isWindowsDrivePath(value) || isUncPath(value);
+}
+
+function validateProjectPath(rawPath: string | null): DesktopDeepLink {
+  const path = rawPath?.trim() ?? "";
+  if (path.length === 0) {
+    return { type: "error", message: "Project deep link is missing a path." };
+  }
+  if (path.includes("\0")) {
+    return { type: "error", message: "Project deep link path contains an invalid character." };
+  }
+  if (!isAbsoluteProjectPath(path)) {
+    return { type: "error", message: "Project deep link path must be absolute." };
+  }
+  if (hasTraversalSegment(path)) {
+    return { type: "error", message: "Project deep link path cannot contain '..' segments." };
+  }
+  return { type: "openProject", path };
+}
+
+export function parseDesktopDeepLink(rawUrl: string): DesktopDeepLink {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { type: "error", message: "Deep link URL is invalid." };
+  }
+
+  if (url.protocol !== `${DEEP_LINK_SCHEME}:`) {
+    return { type: "error", message: "Deep link protocol is not supported." };
+  }
+
+  const route = `${url.hostname}${url.pathname}`.replace(/\/+$/g, "");
+  if (route === "open/project") {
+    return validateProjectPath(url.searchParams.get("path"));
+  }
+  if (route === "chat/thread") {
+    const id = url.searchParams.get("id")?.trim() ?? "";
+    return id.length > 0
+      ? { type: "chatThread", id }
+      : { type: "error", message: "Chat thread deep link is missing an id." };
+  }
+  if (route === "settings") {
+    return { type: "settings" };
+  }
+
+  return { type: "error", message: "Deep link route is not supported." };
+}
+
+function registerDefaultDeepLinkClient(): void {
+  if (process.defaultApp && process.argv.length >= 2) {
+    Electron.app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME, process.execPath, [process.argv[1]!]);
+    return;
+  }
+
+  Electron.app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
 }
 
 const registerDesktopSchemePrivileges = Effect.sync(() => {
@@ -266,6 +343,58 @@ const make = Effect.gen(function* () {
   return ElectronProtocol.of({
     registerFileProtocol,
     registerDesktopFileProtocol,
+    registerDeepLinkProtocol: Effect.fn("desktop.electron.protocol.registerDeepLinkProtocol")(
+      function* <E, R>(
+        handler: (link: DesktopDeepLink) => Effect.Effect<void, E, R>,
+      ): Effect.fn.Return<boolean, E, R | Scope.Scope> {
+        const context = yield* Effect.context<R>();
+        const runPromise = Effect.runPromiseWith(context);
+        const dispatch = (rawUrl: string) => {
+          void runPromise(handler(parseDesktopDeepLink(rawUrl))).catch(() => undefined);
+        };
+
+        const hasSingleInstanceLock = Electron.app.requestSingleInstanceLock();
+        if (!hasSingleInstanceLock) {
+          return false;
+        }
+
+        yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            registerDefaultDeepLinkClient();
+
+            const onOpenUrl = (event: Electron.Event, rawUrl: string) => {
+              event.preventDefault();
+              dispatch(rawUrl);
+            };
+            const onSecondInstance = (
+              _event: Electron.Event,
+              argv: string[],
+              _workingDirectory: string,
+            ) => {
+              for (const rawUrl of collectDeepLinkUrls(argv)) {
+                dispatch(rawUrl);
+              }
+            };
+
+            Electron.app.on("open-url", onOpenUrl);
+            Electron.app.on("second-instance", onSecondInstance);
+
+            for (const rawUrl of collectDeepLinkUrls(process.argv)) {
+              dispatch(rawUrl);
+            }
+
+            return { onOpenUrl, onSecondInstance };
+          }),
+          ({ onOpenUrl, onSecondInstance }) =>
+            Effect.sync(() => {
+              Electron.app.removeListener("open-url", onOpenUrl);
+              Electron.app.removeListener("second-instance", onSecondInstance);
+            }),
+        );
+
+        return true;
+      },
+    ),
   });
 });
 

--- a/t3code/apps/desktop/src/ipc/channels.ts
+++ b/t3code/apps/desktop/src/ipc/channels.ts
@@ -4,6 +4,7 @@ export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
+export const DEEP_LINK_CHANNEL = "desktop:deep-link";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 export const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";

--- a/t3code/apps/desktop/src/preload.ts
+++ b/t3code/apps/desktop/src/preload.ts
@@ -1,7 +1,25 @@
-import type { DesktopBridge } from "@t3tools/contracts";
+import type { DesktopBridge, DesktopDeepLink } from "@t3tools/contracts";
 import { contextBridge, ipcRenderer } from "electron";
 
 import * as IpcChannels from "./ipc/channels.ts";
+
+const pendingDeepLinks: DesktopDeepLink[] = [];
+const deepLinkListeners = new Set<(link: DesktopDeepLink) => void>();
+
+ipcRenderer.on(
+  IpcChannels.DEEP_LINK_CHANNEL,
+  (_event: Electron.IpcRendererEvent, link: unknown) => {
+    if (typeof link !== "object" || link === null) return;
+    const deepLink = link as DesktopDeepLink;
+    if (deepLinkListeners.size === 0) {
+      pendingDeepLinks.push(deepLink);
+      return;
+    }
+    for (const listener of deepLinkListeners) {
+      listener(deepLink);
+    }
+  },
+);
 
 function unwrapEnsureSshEnvironmentResult(result: unknown) {
   if (
@@ -105,6 +123,15 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     ipcRenderer.on(IpcChannels.MENU_ACTION_CHANNEL, wrappedListener);
     return () => {
       ipcRenderer.removeListener(IpcChannels.MENU_ACTION_CHANNEL, wrappedListener);
+    };
+  },
+  onDeepLink: (listener) => {
+    deepLinkListeners.add(listener);
+    for (const link of pendingDeepLinks.splice(0)) {
+      listener(link);
+    }
+    return () => {
+      deepLinkListeners.delete(listener);
     };
   },
   getUpdateState: () => ipcRenderer.invoke(IpcChannels.UPDATE_GET_STATE_CHANNEL),

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -72,6 +72,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     createMainIfBackendReady: Effect.void,
     handleBackendReady: Effect.void,
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
+    dispatchDeepLink: () => Effect.void,
     syncAppearance: Effect.void,
   } satisfies DesktopWindow.DesktopWindowShape);
 

--- a/t3code/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopWindow.test.ts
@@ -63,6 +63,7 @@ function makeFakeBrowserWindow() {
     window: window as unknown as Electron.BrowserWindow,
     loadURL: window.loadURL,
     openDevTools: webContents.openDevTools,
+    send: webContents.send,
   };
 }
 
@@ -174,6 +175,32 @@ describe("DesktopWindow", () => {
         assert.equal(yield* Ref.get(createCount), 1);
         assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["http://127.0.0.1:5733/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("queues deep links until the backend window is ready", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.dispatchDeepLink({ type: "settings" });
+
+        assert.equal(yield* Ref.get(createCount), 0);
+        assert.deepEqual(fakeWindow.send.mock.calls, []);
+
+        yield* desktopWindow.handleBackendReady;
+
+        assert.equal(yield* Ref.get(createCount), 1);
+        assert.deepEqual(fakeWindow.send.mock.calls, [["desktop:deep-link", { type: "settings" }]]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/t3code/apps/desktop/src/window/DesktopWindow.ts
+++ b/t3code/apps/desktop/src/window/DesktopWindow.ts
@@ -7,6 +7,7 @@ import * as Ref from "effect/Ref";
 
 import type * as Electron from "electron";
 
+import type { DesktopDeepLink } from "@t3tools/contracts";
 import * as DesktopAssets from "../app/DesktopAssets.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
@@ -58,6 +59,7 @@ export interface DesktopWindowShape {
   readonly createMainIfBackendReady: Effect.Effect<void, DesktopWindowError>;
   readonly handleBackendReady: Effect.Effect<void, DesktopWindowError>;
   readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
+  readonly dispatchDeepLink: (link: DesktopDeepLink) => Effect.Effect<void, DesktopWindowError>;
   readonly syncAppearance: Effect.Effect<void>;
 }
 
@@ -155,6 +157,7 @@ const make = Effect.gen(function* () {
   const state = yield* DesktopState.DesktopState;
   const context = yield* Effect.context<DesktopWindowRuntimeServices>();
   const runPromise = Effect.runPromiseWith(context);
+  const pendingDeepLinks = yield* Ref.make<DesktopDeepLink[]>([]);
 
   const createWindow = Effect.fn("desktop.window.createWindow")(function* (
     backendHttpUrl: URL,
@@ -320,6 +323,44 @@ const make = Effect.gen(function* () {
     yield* createMain;
   }).pipe(Effect.withSpan("desktop.window.createMainIfBackendReady"));
 
+  const dispatchDeepLinkNow = Effect.fn("desktop.window.dispatchDeepLinkNow")(function* (
+    link: DesktopDeepLink,
+  ) {
+    const targetWindow = yield* revealOrCreateMain;
+
+    const send = () => {
+      if (targetWindow.isDestroyed()) return;
+      targetWindow.webContents.send(IpcChannels.DEEP_LINK_CHANNEL, link);
+      void runPromise(electronWindow.reveal(targetWindow));
+    };
+
+    if (targetWindow.webContents.isLoadingMainFrame()) {
+      targetWindow.webContents.once("did-finish-load", send);
+      return;
+    }
+
+    send();
+  });
+
+  const dispatchDeepLink = Effect.fn("desktop.window.dispatchDeepLink")(function* (
+    link: DesktopDeepLink,
+  ) {
+    const backendReady = yield* Ref.get(state.backendReady);
+    if (!backendReady) {
+      yield* Ref.update(pendingDeepLinks, (links) => [...links, link]);
+      return;
+    }
+
+    yield* dispatchDeepLinkNow(link);
+  });
+
+  const flushPendingDeepLinks = Effect.gen(function* () {
+    const links = yield* Ref.getAndSet(pendingDeepLinks, []);
+    for (const link of links) {
+      yield* dispatchDeepLinkNow(link);
+    }
+  }).pipe(Effect.withSpan("desktop.window.flushPendingDeepLinks"));
+
   return DesktopWindow.of({
     createMain,
     ensureMain,
@@ -337,6 +378,7 @@ const make = Effect.gen(function* () {
       yield* Ref.set(state.backendReady, true);
       yield* logWindowInfo("backend ready", { source: "http" });
       yield* createMainIfBackendReady;
+      yield* flushPendingDeepLinks;
     }).pipe(Effect.withSpan("desktop.window.handleBackendReady")),
     dispatchMenuAction: Effect.fn("desktop.window.dispatchMenuAction")(function* (action) {
       yield* Effect.annotateCurrentSpan({ action });
@@ -356,6 +398,7 @@ const make = Effect.gen(function* () {
 
       send();
     }),
+    dispatchDeepLink,
     syncAppearance: Effect.gen(function* () {
       const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
       yield* electronWindow.syncAllAppearance((window) =>

--- a/t3code/apps/web/src/routes/__root.tsx
+++ b/t3code/apps/web/src/routes/__root.tsx
@@ -1,5 +1,11 @@
-import { type ServerLifecycleWelcomePayload } from "@t3tools/contracts";
-import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime";
+import {
+  DEFAULT_MODEL,
+  type DesktopDeepLink,
+  type EnvironmentId,
+  ProviderInstanceId,
+  type ServerLifecycleWelcomePayload,
+} from "@t3tools/contracts";
+import { scopedProjectKey, scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime";
 import {
   Outlet,
   createRootRouteWithContext,
@@ -29,7 +35,12 @@ import {
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { readLocalApi } from "../localApi";
+import { readEnvironmentApi } from "../environmentApi";
 import { useSettings } from "../hooks/useSettings";
+import { useNewThreadHandler } from "../hooks/useHandleNewThread";
+import { findProjectByPath, inferProjectTitleFromPath } from "../lib/projectPaths";
+import { getLatestThreadForProject } from "../lib/threadSort";
+import { newCommandId, newProjectId } from "../lib/utils";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -43,7 +54,11 @@ import {
   useServerConfigUpdatedSubscription,
   useServerWelcomeSubscription,
 } from "../rpc/serverState";
-import { useStore } from "../store";
+import {
+  selectProjectsAcrossEnvironments,
+  selectThreadsAcrossEnvironments,
+  useStore,
+} from "../store";
 import { useUiStateStore } from "../uiStateStore";
 import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import {
@@ -62,6 +77,7 @@ import {
   updatePrimaryEnvironmentDescriptor,
 } from "../environments/primary";
 import { hasHostedPairingRequest, isHostedStaticApp } from "../hostedPairing";
+import { buildThreadRouteParams } from "../threadRoutes";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -137,6 +153,7 @@ function RootRouteView() {
         <EnvironmentConnectionManagerBootstrap />
         <SshPasswordPromptDialog />
         <HostedStaticEnvironmentBootstrap />
+        <DesktopDeepLinkRouter />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
         {primaryEnvironmentAuthenticated ? <WebSocketConnectionCoordinator /> : null}
@@ -149,6 +166,130 @@ function RootRouteView() {
       </AnchoredToastProvider>
     </ToastProvider>
   );
+}
+
+function getDeepLinkEnvironmentId(): EnvironmentId | null {
+  return (
+    useStore.getState().activeEnvironmentId ?? getPrimaryKnownEnvironment()?.environmentId ?? null
+  );
+}
+
+function DesktopDeepLinkRouter() {
+  const navigate = useNavigate();
+  const { handleNewThread } = useNewThreadHandler();
+  const settings = useSettings();
+
+  const showDeepLinkError = useEffectEvent((description: string) => {
+    toastManager.add(
+      stackedThreadToast({
+        type: "error",
+        title: "Unable to open deep link",
+        description,
+      }),
+    );
+  });
+
+  const openProject = useEffectEvent(async (path: string) => {
+    const environmentId = getDeepLinkEnvironmentId();
+    if (!environmentId) {
+      throw new Error("No active environment is available.");
+    }
+
+    await ensureEnvironmentConnectionBootstrapped(environmentId);
+    const projects = selectProjectsAcrossEnvironments(useStore.getState());
+    const threads = selectThreadsAcrossEnvironments(useStore.getState());
+    const existing = findProjectByPath(
+      projects.filter((project) => project.environmentId === environmentId),
+      path,
+    );
+
+    if (existing) {
+      const latestThread = getLatestThreadForProject(
+        threads.filter((thread) => thread.environmentId === existing.environmentId),
+        existing.id,
+        settings.sidebarThreadSortOrder,
+      );
+      if (latestThread) {
+        await navigate({
+          to: "/$environmentId/$threadId",
+          params: buildThreadRouteParams(
+            scopeThreadRef(latestThread.environmentId, latestThread.id),
+          ),
+        });
+        return;
+      }
+
+      await handleNewThread(scopeProjectRef(existing.environmentId, existing.id), {
+        envMode: settings.defaultThreadEnvMode,
+      });
+      return;
+    }
+
+    const api = readEnvironmentApi(environmentId);
+    if (!api) {
+      throw new Error("The active environment is not connected.");
+    }
+
+    const projectId = newProjectId();
+    await api.orchestration.dispatchCommand({
+      type: "project.create",
+      commandId: newCommandId(),
+      projectId,
+      title: inferProjectTitleFromPath(path),
+      workspaceRoot: path,
+      createWorkspaceRootIfMissing: true,
+      defaultModelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: DEFAULT_MODEL,
+      },
+      createdAt: new Date().toISOString(),
+    });
+    await handleNewThread(scopeProjectRef(environmentId, projectId), {
+      envMode: settings.defaultThreadEnvMode,
+    });
+  });
+
+  const openThread = useEffectEvent(async (id: string) => {
+    const threads = selectThreadsAcrossEnvironments(useStore.getState());
+    const thread = threads.find((candidate) => candidate.id === id);
+    if (!thread) {
+      throw new Error(`Thread ${id} was not found.`);
+    }
+
+    await navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(scopeThreadRef(thread.environmentId, thread.id)),
+    });
+  });
+
+  const handleDeepLink = useEffectEvent((link: DesktopDeepLink) => {
+    if (link.type === "error") {
+      showDeepLinkError(link.message);
+      return;
+    }
+
+    const task =
+      link.type === "settings"
+        ? navigate({ to: "/settings/general" })
+        : link.type === "chatThread"
+          ? openThread(link.id)
+          : openProject(link.path);
+
+    void Promise.resolve(task).catch((error) => {
+      showDeepLinkError(error instanceof Error ? error.message : "An unexpected error occurred.");
+    });
+  });
+
+  useEffect(() => {
+    const onDeepLink = window.desktopBridge?.onDeepLink;
+    if (typeof onDeepLink !== "function") {
+      return;
+    }
+
+    return onDeepLink(handleDeepLink);
+  }, []);
+
+  return null;
 }
 
 function HostedStaticEnvironmentBootstrap() {

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -369,6 +369,23 @@ export const PickFolderOptionsSchema = Schema.Struct({
   initialPath: Schema.optionalKey(Schema.NullOr(Schema.String)),
 });
 
+export type DesktopDeepLink =
+  | {
+      type: "openProject";
+      path: string;
+    }
+  | {
+      type: "chatThread";
+      id: string;
+    }
+  | {
+      type: "settings";
+    }
+  | {
+      type: "error";
+      message: string;
+    };
+
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
   getLocalEnvironmentBootstrap: () => DesktopEnvironmentBootstrap | null;
@@ -415,6 +432,7 @@ export interface DesktopBridge {
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
   onMenuAction: (listener: (action: string) => void) => () => void;
+  onDeepLink?: (listener: (link: DesktopDeepLink) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;


### PR DESCRIPTION
/claim #864

## Summary
- Register and parse t3code:// deep links in the Electron desktop app, including open/project, chat/thread, settings, invalid URL handling, and single-instance forwarding.
- Queue deep-link IPC until the backend window and preload/web listener are ready, then route project, thread, and settings links in the web app.
- Reject non-absolute project paths and paths containing traversal segments before dispatching to the renderer.

## Validation
- bun fmt
- bun lint (exits 0; reports existing warnings outside this change)
- bun typecheck
- bun --filter @t3tools/desktop test -- src/electron/ElectronProtocol.test.ts src/window/DesktopWindow.test.ts

Note: skipped the requested .contributor.json provenance file because it would expose conversation/system context.