### PR TITLE
Codex [ T3 Code ] Standardize error types with Effect.Data.TaggedEnum

### DIFF
--- a/t3code/apps/server/src/auth/Layers/ServerAuth.ts
+++ b/t3code/apps/server/src/auth/Layers/ServerAuth.ts
@@ -39,14 +39,14 @@ const WEBSOCKET_TOKEN_QUERY_PARAM = "wsToken";
 
 export function toBootstrapExchangeAuthError(cause: BootstrapCredentialError): AuthError {
   if (cause.status === 500) {
-    return new AuthError({
+    return AuthError({
       message: "Failed to validate bootstrap credential.",
       status: 500,
       cause,
     });
   }
 
-  return new AuthError({
+  return AuthError({
     message: "Invalid bootstrap credential.",
     status: 401,
     cause,
@@ -85,13 +85,12 @@ export const makeServerAuth = Effect.gen(function* () {
         role: session.role,
         ...(session.expiresAt ? { expiresAt: session.expiresAt } : {}),
       })),
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Unauthorized request.",
-            status: 401,
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Unauthorized request.",
+          status: 401,
+          cause,
+        }),
       ),
     );
 
@@ -101,7 +100,7 @@ export const makeServerAuth = Effect.gen(function* () {
     const credential = cookieToken ?? bearerToken;
     if (!credential) {
       return Effect.fail(
-        new AuthError({
+        AuthError({
           message: "Authentication required.",
           status: 401,
         }),
@@ -148,12 +147,11 @@ export const makeServerAuth = Effect.gen(function* () {
             },
           })
           .pipe(
-            Effect.mapError(
-              (cause) =>
-                new AuthError({
-                  message: "Failed to issue authenticated session.",
-                  cause,
-                }),
+            Effect.mapError((cause) =>
+              AuthError({
+                message: "Failed to issue authenticated session.",
+                cause,
+              }),
             ),
           ),
       ),
@@ -187,12 +185,11 @@ export const makeServerAuth = Effect.gen(function* () {
               },
             })
             .pipe(
-              Effect.mapError(
-                (cause) =>
-                  new AuthError({
-                    message: "Failed to issue authenticated session.",
-                    cause,
-                  }),
+              Effect.mapError((cause) =>
+                AuthError({
+                  message: "Failed to issue authenticated session.",
+                  cause,
+                }),
               ),
             ),
         ),
@@ -216,12 +213,11 @@ export const makeServerAuth = Effect.gen(function* () {
         ...(input?.label ? { label: input.label } : {}),
       })
       .pipe(
-        Effect.mapError(
-          (cause) =>
-            new AuthError({
-              message: "Failed to issue pairing credential.",
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          AuthError({
+            message: "Failed to issue pairing credential.",
+            cause,
+          }),
         ),
         Effect.map(
           (issued) =>
@@ -241,34 +237,31 @@ export const makeServerAuth = Effect.gen(function* () {
         excludeSubjects: ["owner-bootstrap"],
       })
       .pipe(
-        Effect.mapError(
-          (cause) =>
-            new AuthError({
-              message: "Failed to load pairing links.",
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          AuthError({
+            message: "Failed to load pairing links.",
+            cause,
+          }),
         ),
       );
 
   const revokePairingLink: ServerAuthShape["revokePairingLink"] = (id) =>
     authControlPlane.revokePairingLink(id).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Failed to revoke pairing link.",
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Failed to revoke pairing link.",
+          cause,
+        }),
       ),
     );
 
   const listClientSessions: ServerAuthShape["listClientSessions"] = (currentSessionId) =>
     authControlPlane.listSessions().pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Failed to load paired clients.",
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Failed to load paired clients.",
+          cause,
+        }),
       ),
       Effect.map((clientSessions) =>
         clientSessions.map(
@@ -286,18 +279,19 @@ export const makeServerAuth = Effect.gen(function* () {
   ) =>
     Effect.gen(function* () {
       if (currentSessionId === targetSessionId) {
-        return yield* new AuthError({
-          message: "Use revoke other clients to keep the current owner session active.",
-          status: 403,
-        });
+        return yield* Effect.fail(
+          AuthError({
+            message: "Use revoke other clients to keep the current owner session active.",
+            status: 403,
+          }),
+        );
       }
       return yield* authControlPlane.revokeSession(targetSessionId).pipe(
-        Effect.mapError(
-          (cause) =>
-            new AuthError({
-              message: "Failed to revoke client session.",
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          AuthError({
+            message: "Failed to revoke client session.",
+            cause,
+          }),
         ),
       );
     });
@@ -306,12 +300,11 @@ export const makeServerAuth = Effect.gen(function* () {
     currentSessionId,
   ) =>
     authControlPlane.revokeOtherSessionsExcept(currentSessionId).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Failed to revoke other client sessions.",
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Failed to revoke other client sessions.",
+          cause,
+        }),
       ),
     );
 
@@ -328,12 +321,11 @@ export const makeServerAuth = Effect.gen(function* () {
 
   const issueWebSocketToken: ServerAuthShape["issueWebSocketToken"] = (session) =>
     sessions.issueWebSocketToken(session.sessionId).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Failed to issue websocket token.",
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Failed to issue websocket token.",
+          cause,
+        }),
       ),
       Effect.map(
         (issued) =>
@@ -358,13 +350,12 @@ export const makeServerAuth = Effect.gen(function* () {
               role: session.role,
               ...(session.expiresAt ? { expiresAt: session.expiresAt } : {}),
             })),
-            Effect.mapError(
-              (cause) =>
-                new AuthError({
-                  message: "Unauthorized request.",
-                  status: 401,
-                  cause,
-                }),
+            Effect.mapError((cause) =>
+              AuthError({
+                message: "Unauthorized request.",
+                status: 401,
+                cause,
+              }),
             ),
           );
         }

--- a/t3code/apps/server/src/auth/Services/ServerAuth.ts
+++ b/t3code/apps/server/src/auth/Services/ServerAuth.ts
@@ -12,12 +12,12 @@ import type {
   ServerAuthSessionMethod,
   AuthWebSocketTokenResult,
 } from "@t3tools/contracts";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 import type * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import type { SessionRole } from "./SessionCredentialService.ts";
+import { AuthError as makeAuthError, type AuthError as ServerAuthError } from "../../errors.ts";
 
 export interface AuthenticatedSession {
   readonly sessionId: AuthSessionId;
@@ -27,11 +27,8 @@ export interface AuthenticatedSession {
   readonly expiresAt?: DateTime.DateTime;
 }
 
-export class AuthError extends Data.TaggedError("AuthError")<{
-  readonly message: string;
-  readonly status?: 400 | 401 | 403 | 500;
-  readonly cause?: unknown;
-}> {}
+export type AuthError = ServerAuthError;
+export const AuthError = makeAuthError;
 
 export interface ServerAuthShape {
   readonly getDescriptor: () => Effect.Effect<ServerAuthDescriptor>;

--- a/t3code/apps/server/src/auth/http.ts
+++ b/t3code/apps/server/src/auth/http.ts
@@ -71,13 +71,12 @@ export const authBootstrapRouteLayer = HttpRouter.add(
     const serverAuth = yield* ServerAuth;
     const sessions = yield* SessionCredentialService;
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthBootstrapInput).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Invalid bootstrap payload.",
-            status: 400,
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Invalid bootstrap payload.",
+          status: 400,
+          cause,
+        }),
       ),
     );
     const result = yield* serverAuth.exchangeBootstrapCredential(
@@ -106,13 +105,12 @@ export const authBearerBootstrapRouteLayer = HttpRouter.add(
     const request = yield* HttpServerRequest.HttpServerRequest;
     const serverAuth = yield* ServerAuth;
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthBootstrapInput).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Invalid bootstrap payload.",
-            status: 400,
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Invalid bootstrap payload.",
+          status: 400,
+          cause,
+        }),
       ),
     );
     const result = yield* serverAuth.exchangeBootstrapCredentialForBearerSession(
@@ -149,30 +147,30 @@ export const authPairingCredentialRouteLayer = HttpRouter.add(
     const request = yield* HttpServerRequest.HttpServerRequest;
     const session = yield* serverAuth.authenticateHttpRequest(request);
     if (session.role !== "owner") {
-      return yield* new AuthError({
-        message: "Only owner sessions can create pairing credentials.",
-        status: 403,
-      });
+      return yield* Effect.fail(
+        AuthError({
+          message: "Only owner sessions can create pairing credentials.",
+          status: 403,
+        }),
+      );
     }
     const headers = yield* HttpServerRequest.schemaHeaders(PairingCredentialRequestHeaders).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Invalid pairing credential request headers.",
-            status: 400,
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Invalid pairing credential request headers.",
+          status: 400,
+          cause,
+        }),
       ),
     );
     const payload = hasRequestBody(headers)
       ? yield* HttpServerRequest.schemaBodyJson(AuthCreatePairingCredentialInput).pipe(
-          Effect.mapError(
-            (cause) =>
-              new AuthError({
-                message: "Invalid pairing credential payload.",
-                status: 400,
-                cause,
-              }),
+          Effect.mapError((cause) =>
+            AuthError({
+              message: "Invalid pairing credential payload.",
+              status: 400,
+              cause,
+            }),
           ),
         )
       : {};
@@ -186,10 +184,12 @@ const authenticateOwnerSession = Effect.gen(function* () {
   const serverAuth = yield* ServerAuth;
   const session = yield* serverAuth.authenticateHttpRequest(request);
   if (session.role !== "owner") {
-    return yield* new AuthError({
-      message: "Only owner sessions can manage network access.",
-      status: 403,
-    });
+    return yield* Effect.fail(
+      AuthError({
+        message: "Only owner sessions can manage network access.",
+        status: 403,
+      }),
+    );
   }
   return { serverAuth, session } as const;
 });
@@ -210,13 +210,12 @@ export const authPairingLinksRevokeRouteLayer = HttpRouter.add(
   Effect.gen(function* () {
     const { serverAuth } = yield* authenticateOwnerSession;
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthRevokePairingLinkInput).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Invalid revoke pairing link payload.",
-            status: 400,
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Invalid revoke pairing link payload.",
+          status: 400,
+          cause,
+        }),
       ),
     );
     const revoked = yield* serverAuth.revokePairingLink(payload.id);
@@ -240,13 +239,12 @@ export const authClientsRevokeRouteLayer = HttpRouter.add(
   Effect.gen(function* () {
     const { serverAuth, session } = yield* authenticateOwnerSession;
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthRevokeClientSessionInput).pipe(
-      Effect.mapError(
-        (cause) =>
-          new AuthError({
-            message: "Invalid revoke client payload.",
-            status: 400,
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AuthError({
+          message: "Invalid revoke client payload.",
+          status: 400,
+          cause,
+        }),
       ),
     );
     const revoked = yield* serverAuth.revokeClientSession(session.sessionId, payload.sessionId);

--- a/t3code/apps/server/src/bootstrap.ts
+++ b/t3code/apps/server/src/bootstrap.ts
@@ -4,7 +4,6 @@ import * as Net from "node:net";
 import * as readline from "node:readline";
 import type { Readable } from "node:stream";
 
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
@@ -12,10 +11,7 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
-class BootstrapError extends Data.TaggedError("BootstrapError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+import { ConfigError, type ConfigError as BootstrapError } from "./errors.ts";
 
 export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function* <A, I>(
   schema: Schema.Codec<A, I>,
@@ -52,7 +48,7 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       }
       resume(
         Effect.fail(
-          new BootstrapError({
+          ConfigError({
             message: "Failed to read bootstrap envelope.",
             cause: error,
           }),
@@ -67,7 +63,7 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       } else {
         resume(
           Effect.fail(
-            new BootstrapError({
+            ConfigError({
               message: "Failed to decode bootstrap envelope.",
               cause: parsed.failure,
             }),
@@ -97,7 +93,7 @@ const isFdReady = (fd: number) =>
   Effect.try({
     try: () => NFS.fstatSync(fd),
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to stat bootstrap fd.",
         cause: error,
       }),
@@ -136,7 +132,7 @@ const makeBootstrapInputStream = (fd: number) =>
       }
     },
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to duplicate bootstrap fd.",
         cause: error,
       }),

--- a/t3code/apps/server/src/errors.test.ts
+++ b/t3code/apps/server/src/errors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import * as Match from "effect/Match";
+
+import {
+  AuthError,
+  ConfigError,
+  DatabaseError,
+  errorToLog,
+  errorToResponse,
+  GitError,
+  NetworkError,
+  type ServerError,
+  ValidationError,
+} from "./errors.ts";
+
+const timestamp = "2026-05-16T00:00:00.000Z";
+
+describe("server errors", () => {
+  it("maps every server error type to the expected HTTP response", () => {
+    const cases: ReadonlyArray<readonly [ServerError, number]> = [
+      [AuthError({ message: "auth failed", timestamp }), 401],
+      [ValidationError({ message: "invalid input", timestamp }), 400],
+      [DatabaseError({ message: "database failed", timestamp }), 500],
+      [NetworkError({ message: "upstream failed", timestamp }), 502],
+      [ConfigError({ message: "config failed", timestamp }), 500],
+      [GitError({ message: "git failed", timestamp }), 422],
+    ];
+
+    for (const [error, status] of cases) {
+      expect(errorToResponse(error)).toEqual({
+        status,
+        body: {
+          error: error.message,
+          tag: error._tag,
+          timestamp,
+        },
+      });
+    }
+  });
+
+  it("preserves cause chains in structured logs", () => {
+    const rootCause = new Error("root cause");
+    const parentCause = new Error("parent cause", { cause: rootCause });
+    const error = DatabaseError({
+      message: "could not write event",
+      cause: parentCause,
+      timestamp,
+    });
+
+    expect(error.cause).toBe(parentCause);
+    expect(errorToLog(error)).toMatchObject({
+      tag: "DatabaseError",
+      message: "could not write event",
+      timestamp,
+      cause: {
+        message: "parent cause",
+        cause: {
+          message: "root cause",
+        },
+      },
+    });
+    expect(errorToLog(error).cause?.stack).toContain("parent cause");
+  });
+
+  it("supports exhaustive Effect Match pattern matching by tag", () => {
+    const toCategory = Match.type<ServerError>().pipe(
+      Match.tag("AuthError", () => "auth"),
+      Match.tag("ValidationError", () => "validation"),
+      Match.tag("DatabaseError", () => "database"),
+      Match.tag("NetworkError", () => "network"),
+      Match.tag("ConfigError", () => "config"),
+      Match.tag("GitError", () => "git"),
+      Match.exhaustive,
+    );
+
+    expect(toCategory(GitError({ message: "merge conflict", timestamp }))).toBe("git");
+  });
+});

--- a/t3code/apps/server/src/errors.ts
+++ b/t3code/apps/server/src/errors.ts
@@ -1,0 +1,177 @@
+import * as Data from "effect/Data";
+import * as DateTime from "effect/DateTime";
+import * as Match from "effect/Match";
+
+type ServerErrorPayload = {
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly timestamp: string;
+};
+
+type AuthErrorPayload = ServerErrorPayload & {
+  readonly status?: 400 | 401 | 403 | 500;
+};
+
+export type ServerError = Data.TaggedEnum<{
+  readonly NetworkError: ServerErrorPayload;
+  readonly DatabaseError: ServerErrorPayload;
+  readonly AuthError: AuthErrorPayload;
+  readonly GitError: ServerErrorPayload;
+  readonly ConfigError: ServerErrorPayload;
+  readonly ValidationError: ServerErrorPayload;
+}>;
+
+export type NetworkError = Extract<ServerError, { readonly _tag: "NetworkError" }>;
+export type DatabaseError = Extract<ServerError, { readonly _tag: "DatabaseError" }>;
+export type AuthError = Extract<ServerError, { readonly _tag: "AuthError" }>;
+export type GitError = Extract<ServerError, { readonly _tag: "GitError" }>;
+export type ConfigError = Extract<ServerError, { readonly _tag: "ConfigError" }>;
+export type ValidationError = Extract<ServerError, { readonly _tag: "ValidationError" }>;
+
+export type ServerErrorInput<T extends ServerError> = Omit<T, "_tag" | "timestamp"> & {
+  readonly timestamp?: string;
+};
+
+export type ServerErrorResponse = {
+  readonly status: 400 | 401 | 422 | 500 | 502;
+  readonly body: {
+    readonly error: string;
+    readonly tag: ServerError["_tag"];
+    readonly timestamp: string;
+  };
+};
+
+export type ServerErrorLogCause = {
+  readonly tag?: string;
+  readonly message: string;
+  readonly stack: string;
+  readonly cause?: ServerErrorLogCause;
+};
+
+export type ServerErrorLog = {
+  readonly tag: ServerError["_tag"];
+  readonly message: string;
+  readonly stack: string;
+  readonly timestamp: string;
+  readonly cause?: ServerErrorLogCause;
+};
+
+const serverError = Data.taggedEnum<ServerError>();
+
+const serverErrorTags = new Set<ServerError["_tag"]>([
+  "NetworkError",
+  "DatabaseError",
+  "AuthError",
+  "GitError",
+  "ConfigError",
+  "ValidationError",
+]);
+
+const withTimestamp = <T extends { readonly timestamp?: string }>(
+  input: T,
+): T & { readonly timestamp: string } => ({
+  ...input,
+  timestamp: input.timestamp ?? DateTime.formatIso(DateTime.nowUnsafe()),
+});
+
+export const NetworkError = (input: ServerErrorInput<NetworkError>): NetworkError =>
+  serverError.NetworkError(withTimestamp(input));
+
+export const DatabaseError = (input: ServerErrorInput<DatabaseError>): DatabaseError =>
+  serverError.DatabaseError(withTimestamp(input));
+
+export const AuthError = (input: ServerErrorInput<AuthError>): AuthError =>
+  serverError.AuthError(withTimestamp(input));
+
+export const GitError = (input: ServerErrorInput<GitError>): GitError =>
+  serverError.GitError(withTimestamp(input));
+
+export const ConfigError = (input: ServerErrorInput<ConfigError>): ConfigError =>
+  serverError.ConfigError(withTimestamp(input));
+
+export const ValidationError = (input: ServerErrorInput<ValidationError>): ValidationError =>
+  serverError.ValidationError(withTimestamp(input));
+
+const responseBody = (error: ServerError): ServerErrorResponse["body"] => ({
+  error: error.message,
+  tag: error._tag,
+  timestamp: error.timestamp,
+});
+
+const toResponse = (
+  status: ServerErrorResponse["status"],
+  error: ServerError,
+): ServerErrorResponse => ({
+  status,
+  body: responseBody(error),
+});
+
+export const errorToResponse = (error: ServerError): ServerErrorResponse =>
+  Match.value(error).pipe(
+    Match.tag("AuthError", (error) => toResponse(401, error)),
+    Match.tag("ValidationError", (error) => toResponse(400, error)),
+    Match.tag("DatabaseError", (error) => toResponse(500, error)),
+    Match.tag("NetworkError", (error) => toResponse(502, error)),
+    Match.tag("ConfigError", (error) => toResponse(500, error)),
+    Match.tag("GitError", (error) => toResponse(422, error)),
+    Match.exhaustive,
+  );
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null;
+
+export const isServerError = (value: unknown): value is ServerError =>
+  isRecord(value) &&
+  typeof value._tag === "string" &&
+  serverErrorTags.has(value._tag as ServerError["_tag"]) &&
+  typeof value.message === "string" &&
+  typeof value.timestamp === "string";
+
+const stringifyCause = (cause: unknown): string => {
+  if (typeof cause === "string") return cause;
+  if (typeof cause === "number" || typeof cause === "boolean" || typeof cause === "bigint") {
+    return cause.toString();
+  }
+  if (cause === undefined) return "undefined";
+  if (cause === null) return "null";
+  if (isRecord(cause) && typeof cause.message === "string") return cause.message;
+  return String(cause);
+};
+
+const stackFromCause = (cause: unknown): string =>
+  isRecord(cause) && typeof cause.stack === "string" ? cause.stack : "";
+
+const tagFromCause = (cause: unknown): string | undefined =>
+  isRecord(cause) && typeof cause._tag === "string" ? cause._tag : undefined;
+
+const nestedCauseFrom = (cause: unknown): unknown =>
+  isRecord(cause) && "cause" in cause ? cause.cause : undefined;
+
+const causeToLog = (cause: unknown): ServerErrorLogCause => {
+  if (isServerError(cause)) {
+    const logged = errorToLog(cause);
+    return {
+      tag: logged.tag,
+      message: logged.message,
+      stack: logged.stack,
+      ...(logged.cause ? { cause: logged.cause } : {}),
+    };
+  }
+
+  const nestedCause = nestedCauseFrom(cause);
+  const tag = tagFromCause(cause);
+  return {
+    ...(tag ? { tag } : {}),
+    message: stringifyCause(cause),
+    stack: stackFromCause(cause),
+    ...(nestedCause !== undefined ? { cause: causeToLog(nestedCause) } : {}),
+  };
+};
+
+export const errorToLog = (error: ServerError): ServerErrorLog => ({
+  tag: error._tag,
+  message: error.message,
+  stack: stackFromCause(error.cause),
+  timestamp: error.timestamp,
+  ...(error.cause !== undefined ? { cause: causeToLog(error.cause) } : {}),
+});

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,6 +1,5 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -33,6 +32,7 @@ import {
   browserApiCorsAllowedMethods,
   browserApiCorsHeaders,
 } from "./httpCors.ts";
+import { ValidationError } from "./errors.ts";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
@@ -81,11 +81,6 @@ export const serverEnvironmentRouteLayer = HttpRouter.add(
   }),
 );
 
-class DecodeOtlpTraceRecordsError extends Data.TaggedError("DecodeOtlpTraceRecordsError")<{
-  readonly cause: unknown;
-  readonly bodyJson: OtlpTracer.TraceData;
-}> {}
-
 export const otlpTracesProxyRouteLayer = HttpRouter.add(
   "POST",
   OTLP_TRACES_PROXY_PATH,
@@ -100,7 +95,11 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),
-      catch: (cause) => new DecodeOtlpTraceRecordsError({ cause, bodyJson }),
+      catch: (cause) =>
+        ValidationError({
+          message: "Failed to decode browser OTLP traces.",
+          cause,
+        }),
     }).pipe(
       Effect.flatMap((records) => browserTraceCollector.record(records)),
       Effect.catch((cause) =>

--- a/t3code/apps/server/src/serverRuntimeStartup.test.ts
+++ b/t3code/apps/server/src/serverRuntimeStartup.test.ts
@@ -64,7 +64,7 @@ it.effect("enqueueCommand fails queued work when readiness fails", () =>
         .pipe(Effect.forkScoped);
 
       yield* commandGate.failCommandReady(
-        new ServerRuntimeStartupError({
+        ServerRuntimeStartupError({
           message: "startup failed",
         }),
       );

--- a/t3code/apps/server/src/serverRuntimeStartup.ts
+++ b/t3code/apps/server/src/serverRuntimeStartup.ts
@@ -7,7 +7,6 @@ import {
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
-import * as Data from "effect/Data";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -39,11 +38,10 @@ import {
   isWildcardHost,
   issueHeadlessServeAccessInfo,
 } from "./startupAccess.ts";
+import { ConfigError, type ConfigError as ServerRuntimeStartupConfigError } from "./errors.ts";
 
-export class ServerRuntimeStartupError extends Data.TaggedError("ServerRuntimeStartupError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export type ServerRuntimeStartupError = ServerRuntimeStartupConfigError;
+export const ServerRuntimeStartupError = ConfigError;
 
 export interface ServerRuntimeStartupShape {
   readonly awaitCommandReady: Effect.Effect<void, ServerRuntimeStartupError>;
@@ -106,7 +104,7 @@ export const makeCommandGate = Effect.gen(function* () {
           return yield* effect;
         }
         if (readinessState !== "pending") {
-          return yield* readinessState;
+          return yield* Effect.fail(readinessState);
         }
 
         const result = yield* Deferred.make<A, E | ServerRuntimeStartupError>();
@@ -402,7 +400,7 @@ export const makeServerRuntimeStartup = Effect.gen(function* () {
     Effect.gen(function* () {
       const startupExit = yield* Effect.exit(startup);
       if (Exit.isFailure(startupExit)) {
-        const error = new ServerRuntimeStartupError({
+        const error = ServerRuntimeStartupError({
           message: "Server runtime startup failed before command readiness.",
           cause: startupExit.cause,
         });


### PR DESCRIPTION
/claim #861

## Summary
- Added centralized T3 server error types in `t3code/apps/server/src/errors.ts` using `Effect.Data.TaggedEnum`.
- Added response/log helpers with exhaustive Effect Match handling and cause-chain logging.
- Migrated auth, bootstrap, runtime startup, and OTLP validation error handling to the centralized constructors.
- Added focused tests for status mapping, cause preservation, and tag pattern matching.

## Validation
- `npx -y bun@1.3.11 run test src/errors.test.ts src/serverRuntimeStartup.test.ts src/bootstrap.test.ts src/http.test.ts`
- `npx -y bun@1.3.11 run typecheck --pretty false` in `t3code/apps/server`
- `npx -y bun@1.3.11 run fmt:check`
- `npx -y -p node@24.13.1 -p bun@1.3.11 bun run lint` (existing warnings only)
- `npx -y -p node@24.13.1 -p bun@1.3.11 bun run typecheck`
- `npx -y -p node@24.13.1 -p bun@1.3.11 bun run test` in `t3code/apps/server`
- `npx -y -p node@24.13.1 -p bun@1.3.11 bun run build` in `t3code/apps/server`
- `git diff --check`