### PR TITLE
Codex [ Laravel ] Add failed job monitoring and summary command

### DIFF
--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+
+class LogFailedJob
+{
+    public function handle(JobFailed $event): void
+    {
+        $payload = $event->job->payload();
+
+        Log::error('Queue job failed', [
+            'connection' => $event->connectionName,
+            'queue' => $event->job->getQueue(),
+            'job' => $payload['displayName'] ?? $payload['job'] ?? null,
+            'payload' => $payload,
+            'exception_class' => $event->exception::class,
+            'exception_message' => $event->exception->getMessage(),
+            'exception_trace' => $event->exception->getTraceAsString(),
+        ]);
+    }
+}

--- a/laravel/app/Listeners/contributor_meta.json
+++ b/laravel/app/Listeners/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+    "name": "Codex",
+    "session_init": "AI-assisted implementation. Full private system/developer initialization text is not included because it contains confidential operating instructions; the implementation is scoped to the public bounty requirements in UnsafeLabs/Bounty-Hunters#789.",
+    "ts": "2026-05-15T17:50:00-06:00"
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, LogFailedJob::class);
     }
 }

--- a/laravel/config/queue.php
+++ b/laravel/config/queue.php
@@ -41,6 +41,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'max_tries' => (int) env('DB_QUEUE_MAX_TRIES', 3),
             'after_commit' => false,
         ],
 

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,32 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('queue:failed-summary', function () {
+    $failedJobs = DB::table(config('queue.failed.table', 'failed_jobs'))
+        ->select('exception')
+        ->get();
+
+    if ($failedJobs->isEmpty()) {
+        $this->info('No failed jobs found.');
+
+        return 0;
+    }
+
+    $summary = $failedJobs
+        ->map(fn (object $job): string => strtok($job->exception, ':') ?: 'Unknown exception')
+        ->countBy()
+        ->sortKeys()
+        ->map(fn (int $count, string $exception): array => [$exception, $count])
+        ->values()
+        ->all();
+
+    $this->table(['Exception', 'Count'], $summary);
+
+    return 0;
+})->purpose('Show failed queue jobs grouped by exception class');

--- a/laravel/tests/Feature/FailedJobMonitoringTest.php
+++ b/laravel/tests/Feature/FailedJobMonitoringTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Listeners\LogFailedJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Jobs\Job;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class FailedJobMonitoringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_failed_job_listener_logs_job_metadata(): void
+    {
+        Log::spy();
+
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('payload')->once()->andReturn([
+            'displayName' => 'App\\Jobs\\ImportCustomers',
+            'uuid' => 'job-uuid',
+        ]);
+        $job->shouldReceive('getQueue')->once()->andReturn('imports');
+
+        $exception = new RuntimeException('Import failed');
+        $event = new JobFailed('database', $job, $exception);
+
+        $this->assertNotEmpty(app('events')->getListeners(JobFailed::class));
+
+        (new LogFailedJob)->handle($event);
+
+        Log::shouldHaveReceived('error')->once()->with('Queue job failed', Mockery::on(function (array $context) use ($exception) {
+            return $context['connection'] === 'database'
+                && $context['queue'] === 'imports'
+                && $context['job'] === 'App\\Jobs\\ImportCustomers'
+                && $context['payload']['uuid'] === 'job-uuid'
+                && $context['exception_class'] === RuntimeException::class
+                && $context['exception_message'] === 'Import failed'
+                && $context['exception_trace'] === $exception->getTraceAsString();
+        }));
+    }
+
+    public function test_failed_summary_command_groups_failed_jobs_by_exception_class(): void
+    {
+        Config::set('queue.failed.table', 'failed_jobs');
+
+        DB::table('failed_jobs')->insert([
+            [
+                'uuid' => 'failed-1',
+                'connection' => 'database',
+                'queue' => 'default',
+                'payload' => '{}',
+                'exception' => 'RuntimeException: First failure',
+            ],
+            [
+                'uuid' => 'failed-2',
+                'connection' => 'database',
+                'queue' => 'default',
+                'payload' => '{}',
+                'exception' => 'RuntimeException: Second failure',
+            ],
+            [
+                'uuid' => 'failed-3',
+                'connection' => 'database',
+                'queue' => 'default',
+                'payload' => '{}',
+                'exception' => 'InvalidArgumentException: Bad input',
+            ],
+        ]);
+
+        $this->artisan('queue:failed-summary')
+            ->expectsTable(['Exception', 'Count'], [
+                ['InvalidArgumentException', 1],
+                ['RuntimeException', 2],
+            ])
+            ->assertSuccessful();
+    }
+
+    public function test_database_queue_config_sets_retry_after_and_max_tries(): void
+    {
+        $this->assertSame(90, config('queue.connections.database.retry_after'));
+        $this->assertSame(3, config('queue.connections.database.max_tries'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LogFailedJob` to log failed queue job metadata, payload, queue, and full exception details.
- Register the listener for Laravel `JobFailed` events in `AppServiceProvider`.
- Add `queue:failed-summary` to group failed jobs by exception class, and set database queue `max_tries` alongside the existing 90 second `retry_after`.
- Add focused feature tests for listener metadata, event listener registration, summary output, and queue config defaults.

## Recent bounty opportunity
This claims the same-day Algora bounty in #789. The issue was created and funded on 2026-05-15, so this is a recent bounty candidate.

## Independent value / related work
I found no open PR in `UnsafeLabs/Bounty-Hunters` for #789. There is one linked fork-only PR in the issue comments, but this PR adds the upstream pull request plus the listener registration, summary command, queue config, and tests together.

## Files changed
- `laravel/app/Listeners/LogFailedJob.php`
- `laravel/app/Providers/AppServiceProvider.php`
- `laravel/routes/console.php`
- `laravel/config/queue.php`
- `laravel/tests/Feature/FailedJobMonitoringTest.php`
- `laravel/app/Listeners/contributor_meta.json`

## Validation
- `php artisan test --filter=FailedJobMonitoringTest`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test`
- `./vendor/bin/pint --test app/Providers/AppServiceProvider.php app/Listeners/LogFailedJob.php routes/console.php config/queue.php tests/Feature/FailedJobMonitoringTest.php`
- `git diff --check`

## Notes
- Work was AI-assisted. `contributor_meta.json` is included, but private system/developer initialization text is not copied verbatim because it contains confidential operating instructions.

/claim #789