### PR TITLE
Codex [ FastAPI ] Add concurrent task runner with semaphore limiting and timeout

### DIFF
--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,9 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable, Iterable
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from inspect import iscoroutine
+from typing import Any, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +14,113 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+_MISSING = object()
+
+
+class ConcurrencyError(Exception):
+    """Raised when run_concurrently collects one or more failures."""
+
+    def __init__(
+        self,
+        errors: Iterable[BaseException],
+        results: list[Any] | None = None,
+    ) -> None:
+        self.errors = list(errors)
+        self.failures = self.errors
+        self.exceptions = self.errors
+        self.results = [] if results is None else results
+        self.partial_results = self.results
+        super().__init__(f"{len(self.errors)} task(s) failed during concurrent execution")
+
+
+def _normalize_awaitables(
+    awaitables: Iterable[Awaitable[_T]] | Awaitable[_T] | None,
+    additional_awaitables: tuple[Awaitable[_T], ...],
+) -> list[Awaitable[_T]]:
+    if awaitables is None:
+        return list(additional_awaitables)
+    if additional_awaitables:
+        return [cast(Awaitable[_T], awaitables), *additional_awaitables]
+    if isinstance(awaitables, Awaitable):
+        return [awaitables]
+    return list(awaitables)
+
+
+def _close_unstarted_awaitables(
+    awaitables: list[Awaitable[_T]], started: list[bool]
+) -> None:
+    for awaitable, did_start in zip(awaitables, started, strict=True):
+        if not did_start and iscoroutine(awaitable):
+            awaitable.close()
+
+
+async def run_concurrently(
+    awaitables: Iterable[Awaitable[_T]] | Awaitable[_T] | None = None,
+    *additional_awaitables: Awaitable[_T],
+    max_concurrency: int = 5,
+    timeout: float | None = None,
+) -> list[_T]:
+    """Run awaitables concurrently with a bounded concurrency limit.
+
+    Results are returned in the same order as the input awaitables. When any
+    awaitable fails, all awaitables are allowed to finish and the collected
+    exceptions are raised together as ``ConcurrencyError``.
+    """
+    pending_awaitables = _normalize_awaitables(awaitables, additional_awaitables)
+    if max_concurrency < 1:
+        _close_unstarted_awaitables(
+            pending_awaitables,
+            [False] * len(pending_awaitables),
+        )
+        raise ValueError("max_concurrency must be greater than 0")
+
+    if not pending_awaitables:
+        return []
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    started = [False] * len(pending_awaitables)
+    results: list[Any] = [_MISSING] * len(pending_awaitables)
+    errors: list[tuple[int, BaseException]] = []
+
+    async def run_one(index: int) -> None:
+        try:
+            async with semaphore:
+                awaitable = pending_awaitables[index]
+                started[index] = True
+                results[index] = await awaitable
+        except Exception as exc:
+            errors.append((index, exc))
+
+    tasks = [
+        asyncio.create_task(run_one(index)) for index in range(len(pending_awaitables))
+    ]
+
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=timeout)
+    except TimeoutError as exc:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        _close_unstarted_awaitables(pending_awaitables, started)
+        errors.append((len(pending_awaitables), exc))
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        _close_unstarted_awaitables(pending_awaitables, started)
+        raise
+
+    if errors:
+        errors.sort(key=lambda error: error[0])
+        partial_results = [
+            None if result is _MISSING else result for result in results
+        ]
+        raise ConcurrencyError(
+            (error for _, error in errors),
+            results=partial_results,
+        )
+
+    return cast(list[_T], results)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,159 @@
+import asyncio
+from collections.abc import Awaitable
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+def run(coro: Awaitable[object]) -> object:
+    return asyncio.run(coro)
+
+
+def test_run_concurrently_returns_empty_list_for_empty_input():
+    assert run(run_concurrently([])) == []
+
+
+def test_run_concurrently_preserves_input_order():
+    async def value_after_delay(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    result = run(
+        run_concurrently(
+            [
+                value_after_delay(1, 0.03),
+                value_after_delay(2, 0.01),
+                value_after_delay(3, 0.02),
+            ],
+            max_concurrency=3,
+        )
+    )
+
+    assert result == [1, 2, 3]
+
+
+def test_run_concurrently_limits_active_tasks():
+    running = 0
+    max_seen = 0
+
+    async def track_running() -> int:
+        nonlocal max_seen, running
+        running += 1
+        max_seen = max(max_seen, running)
+        await asyncio.sleep(0.01)
+        running -= 1
+        return running
+
+    result = run(
+        run_concurrently(
+            [track_running() for _ in range(10)],
+            max_concurrency=3,
+        )
+    )
+
+    assert len(result) == 10
+    assert max_seen == 3
+
+
+def test_run_concurrently_max_concurrency_one_is_sequential():
+    running = 0
+    max_seen = 0
+
+    async def track_running() -> str:
+        nonlocal max_seen, running
+        running += 1
+        max_seen = max(max_seen, running)
+        await asyncio.sleep(0)
+        running -= 1
+        return "done"
+
+    assert run(
+        run_concurrently(
+            [track_running() for _ in range(5)],
+            max_concurrency=1,
+        )
+    ) == ["done"] * 5
+    assert max_seen == 1
+
+
+def test_run_concurrently_allows_concurrency_above_task_count():
+    started = 0
+
+    async def wait_for_all_tasks() -> int:
+        nonlocal started
+        started += 1
+        while started < 4:
+            await asyncio.sleep(0)
+        return started
+
+    result = run(
+        run_concurrently(
+            [wait_for_all_tasks() for _ in range(4)],
+            max_concurrency=10,
+        )
+    )
+
+    assert result == [4, 4, 4, 4]
+
+
+def test_run_concurrently_collects_all_failures_with_partial_results():
+    async def succeed(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    async def fail(message: str) -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError(message)
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        run(
+            run_concurrently(
+                [
+                    succeed(1),
+                    fail("first"),
+                    succeed(3),
+                    fail("second"),
+                ],
+                max_concurrency=4,
+            )
+        )
+
+    error = exc_info.value
+    assert [str(exc) for exc in error.errors] == ["first", "second"]
+    assert error.failures == error.errors
+    assert error.results == [1, None, 3, None]
+
+
+def test_run_concurrently_timeout_cancels_remaining_tasks():
+    cancelled = []
+
+    async def complete() -> str:
+        await asyncio.sleep(0.01)
+        return "complete"
+
+    async def never_complete(index: int) -> str:
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled.append(index)
+            raise
+        return "never"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        run(
+            run_concurrently(
+                [complete(), never_complete(1), never_complete(2)],
+                max_concurrency=3,
+                timeout=0.05,
+            )
+        )
+
+    error = exc_info.value
+    assert error.results == ["complete", None, None]
+    assert any(isinstance(exc, TimeoutError) for exc in error.errors)
+    assert sorted(cancelled) == [1, 2]
+
+
+def test_run_concurrently_rejects_non_positive_concurrency():
+    with pytest.raises(ValueError, match="max_concurrency"):
+        run(run_concurrently([], max_concurrency=0))


### PR DESCRIPTION
/claim #803

## Summary
- Added `ConcurrencyError` and `run_concurrently` to `fastapi.concurrency` for ordered async execution with `asyncio.Semaphore` concurrency limiting.
- Preserves input order, supports list input and varargs, collects failures with partial results, and raises timeout failures after cancelling remaining tasks.
- Added focused tests for ordering, concurrency limits, sequential execution, all-at-once execution, failure collection, timeout cancellation, and invalid concurrency.

## Validation
- `uv run pytest tests/test_concurrency.py`
- `uv run ruff check fastapi/concurrency.py tests/test_concurrency.py`
- `python -m compileall fastapi/concurrency.py tests/test_concurrency.py`
- `git diff --check`