### PR TITLE
Codex [ FastAPI ] Add BackgroundTasks error handling and retries

### DIFF
--- a/fastapi/fastapi/background.py
+++ b/fastapi/fastapi/background.py
@@ -213,10 +213,7 @@ class BackgroundTasks(StarletteBackgroundTasks):
         passed_through_on_error = False
 
         if on_error is not _UNSET:
-            if (
-                _accepts_keyword(func, "on_error")
-                and (max_retries is _UNSET or not callable(on_error))
-            ):
+            if _accepts_keyword(func, "on_error"):
                 task_kwargs["on_error"] = on_error
                 passed_through_on_error = True
             else:

--- a/fastapi/fastapi/background.py
+++ b/fastapi/fastapi/background.py
@@ -1,11 +1,138 @@
-from collections.abc import Callable
-from typing import Annotated, Any
+import inspect
+from collections.abc import Callable, Sequence
+from typing import Annotated, Any, Literal, TypedDict, cast
 
 from annotated_doc import Doc
+from fastapi.logger import logger
+from starlette._utils import is_async_callable
+from starlette.background import BackgroundTask as StarletteBackgroundTask
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
-from typing_extensions import ParamSpec
+from starlette.concurrency import run_in_threadpool
 
-P = ParamSpec("P")
+
+class BackgroundTaskInfo(TypedDict):
+    name: str
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+    retry_count: int
+    max_retries: int
+
+
+class BackgroundTaskResult(TypedDict):
+    task_name: str
+    status: Literal["success", "failed"]
+    exception: str | None
+    retry_count: int
+
+
+ErrorCallback = Callable[[Exception, BackgroundTaskInfo], Any]
+
+
+class _UnsetType:
+    pass
+
+
+_UNSET = _UnsetType()
+
+
+def _task_name(func: Callable[..., Any]) -> str:
+    return getattr(func, "__name__", func.__class__.__name__)
+
+
+def _accepts_keyword(func: Callable[..., Any], name: str) -> bool:
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+
+    for parameter in signature.parameters.values():
+        if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if parameter.name == name and parameter.kind in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            return True
+    return False
+
+
+class BackgroundTask(StarletteBackgroundTask):
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        task_results: list[BackgroundTaskResult],
+        on_error: ErrorCallback | None = None,
+        max_retries: int = 0,
+    ) -> None:
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+        self.task_results = task_results
+        self.on_error = on_error
+        self.max_retries = max_retries
+        self.is_async = is_async_callable(func)
+        self.name = _task_name(func)
+
+    async def __call__(self) -> None:
+        retry_count = 0
+
+        while True:
+            try:
+                if self.is_async:
+                    await self._func(*self._args, **self._kwargs)
+                else:
+                    await run_in_threadpool(self._func, *self._args, **self._kwargs)
+            except Exception as exc:
+                logger.exception(
+                    "Background task %s failed on attempt %s of %s",
+                    self.name,
+                    retry_count + 1,
+                    self.max_retries + 1,
+                )
+                await self._call_error_callback(exc, retry_count)
+
+                if retry_count < self.max_retries:
+                    retry_count += 1
+                    continue
+
+                self.task_results.append(
+                    {
+                        "task_name": self.name,
+                        "status": "failed",
+                        "exception": str(exc),
+                        "retry_count": retry_count,
+                    }
+                )
+                if self.on_error is None and self.max_retries == 0:
+                    raise
+                return
+            else:
+                self.task_results.append(
+                    {
+                        "task_name": self.name,
+                        "status": "success",
+                        "exception": None,
+                        "retry_count": retry_count,
+                    }
+                )
+                return
+
+    async def _call_error_callback(self, exc: Exception, retry_count: int) -> None:
+        if self.on_error is None:
+            return
+
+        task_info: BackgroundTaskInfo = {
+            "name": self.name,
+            "args": self._args,
+            "kwargs": self._kwargs,
+            "retry_count": retry_count,
+            "max_retries": self.max_retries,
+        }
+        result = self.on_error(exc, task_info)
+        if inspect.isawaitable(result):
+            await result
 
 
 class BackgroundTasks(StarletteBackgroundTasks):
@@ -37,10 +164,14 @@ class BackgroundTasks(StarletteBackgroundTasks):
     ```
     """
 
-    def add_task(
+    def __init__(self, tasks: Sequence[StarletteBackgroundTask] | None = None):
+        super().__init__(tasks)
+        self.task_results: list[BackgroundTaskResult] = []
+
+    def add_task(  # type: ignore[override]
         self,
         func: Annotated[
-            Callable[P, Any],
+            Callable[..., Any],
             Doc(
                 """
                 The function to call after the response is sent.
@@ -49,8 +180,26 @@ class BackgroundTasks(StarletteBackgroundTasks):
                 """
             ),
         ],
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Any,
+        on_error: Annotated[
+            ErrorCallback | _UnsetType,
+            Doc(
+                """
+                Optional callback called with the exception and background task
+                info whenever an attempt fails.
+                """
+            ),
+        ] = _UNSET,
+        max_retries: Annotated[
+            int | _UnsetType,
+            Doc(
+                """
+                Maximum number of times to retry the task after the first failed
+                attempt.
+                """
+            ),
+        ] = _UNSET,
+        **kwargs: Any,
     ) -> None:
         """
         Add a function to be called in the background after the response is sent.
@@ -58,4 +207,39 @@ class BackgroundTasks(StarletteBackgroundTasks):
         Read more about it in the
         [FastAPI docs for Background Tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/).
         """
-        return super().add_task(func, *args, **kwargs)
+        task_kwargs = dict(kwargs)
+        task_on_error: ErrorCallback | None = None
+        task_max_retries = 0
+        passed_through_on_error = False
+
+        if on_error is not _UNSET:
+            if (
+                _accepts_keyword(func, "on_error")
+                and (max_retries is _UNSET or not callable(on_error))
+            ):
+                task_kwargs["on_error"] = on_error
+                passed_through_on_error = True
+            else:
+                task_on_error = cast(ErrorCallback, on_error)
+
+        if max_retries is not _UNSET:
+            if (on_error is _UNSET or passed_through_on_error) and _accepts_keyword(
+                func, "max_retries"
+            ):
+                task_kwargs["max_retries"] = max_retries
+            else:
+                task_max_retries = cast(int, max_retries)
+
+        if task_max_retries < 0:
+            raise ValueError("max_retries must be greater than or equal to 0")
+
+        self.tasks.append(
+            BackgroundTask(
+                func,
+                args,
+                task_kwargs,
+                self.task_results,
+                on_error=task_on_error,
+                max_retries=task_max_retries,
+            )
+        )

--- a/fastapi/tests/test_background_tasks_retries.py
+++ b/fastapi/tests/test_background_tasks_retries.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -135,6 +136,32 @@ async def test_background_task_preserves_existing_keyword_arguments() -> None:
     assert tasks.task_results == [
         {
             "task_name": "task_with_reserved_names",
+            "status": "success",
+            "exception": None,
+            "retry_count": 0,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_background_task_preserves_callable_on_error_keyword() -> None:
+    calls: list[str] = []
+    tasks = BackgroundTasks()
+
+    def callback() -> None:
+        calls.append("callback")
+
+    def task_with_on_error(on_error: Callable[[], None]) -> None:
+        on_error()
+
+    tasks.add_task(task_with_on_error, on_error=callback)
+
+    await tasks()
+
+    assert calls == ["callback"]
+    assert tasks.task_results == [
+        {
+            "task_name": "task_with_on_error",
             "status": "success",
             "exception": None,
             "retry_count": 0,

--- a/fastapi/tests/test_background_tasks_retries.py
+++ b/fastapi/tests/test_background_tasks_retries.py
@@ -1,0 +1,152 @@
+import logging
+from typing import Any
+
+import pytest
+from fastapi import BackgroundTasks
+
+
+@pytest.mark.anyio
+async def test_background_task_records_success_result() -> None:
+    calls: list[str] = []
+    tasks = BackgroundTasks()
+
+    def write_message(message: str) -> None:
+        calls.append(message)
+
+    tasks.add_task(write_message, "done")
+
+    await tasks()
+
+    assert calls == ["done"]
+    assert tasks.task_results == [
+        {
+            "task_name": "write_message",
+            "status": "success",
+            "exception": None,
+            "retry_count": 0,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_background_task_retries_until_success() -> None:
+    calls: list[int] = []
+    tasks = BackgroundTasks()
+
+    def flaky_task() -> None:
+        calls.append(1)
+        if len(calls) < 3:
+            raise RuntimeError("not yet")
+
+    tasks.add_task(flaky_task, max_retries=3)
+
+    await tasks()
+
+    assert len(calls) == 3
+    assert tasks.task_results == [
+        {
+            "task_name": "flaky_task",
+            "status": "success",
+            "exception": None,
+            "retry_count": 2,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_background_task_logs_and_calls_error_callback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    calls: list[int] = []
+    callback_errors: list[tuple[str, str, int]] = []
+    tasks = BackgroundTasks()
+
+    def failing_task() -> None:
+        calls.append(1)
+        raise RuntimeError("boom")
+
+    async def on_error(exc: Exception, task_info: dict[str, Any]) -> None:
+        callback_errors.append(
+            (str(exc), str(task_info["name"]), int(task_info["retry_count"]))
+        )
+
+    caplog.set_level(logging.ERROR, logger="fastapi")
+    tasks.add_task(failing_task, on_error=on_error, max_retries=2)
+
+    await tasks()
+
+    assert len(calls) == 3
+    assert callback_errors == [
+        ("boom", "failing_task", 0),
+        ("boom", "failing_task", 1),
+        ("boom", "failing_task", 2),
+    ]
+    assert tasks.task_results == [
+        {
+            "task_name": "failing_task",
+            "status": "failed",
+            "exception": "boom",
+            "retry_count": 2,
+        }
+    ]
+    assert "Background task failing_task failed on attempt 1 of 3" in caplog.text
+    assert "Background task failing_task failed on attempt 3 of 3" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_background_task_default_failure_still_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tasks = BackgroundTasks()
+
+    def failing_task() -> None:
+        raise RuntimeError("default failure")
+
+    caplog.set_level(logging.ERROR, logger="fastapi")
+    tasks.add_task(failing_task)
+
+    with pytest.raises(RuntimeError, match="default failure"):
+        await tasks()
+
+    assert tasks.task_results == [
+        {
+            "task_name": "failing_task",
+            "status": "failed",
+            "exception": "default failure",
+            "retry_count": 0,
+        }
+    ]
+    assert "Background task failing_task failed on attempt 1 of 1" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_background_task_preserves_existing_keyword_arguments() -> None:
+    calls: list[tuple[str, int]] = []
+    tasks = BackgroundTasks()
+
+    def task_with_reserved_names(on_error: str, max_retries: int) -> None:
+        calls.append((on_error, max_retries))
+
+    tasks.add_task(task_with_reserved_names, on_error="value", max_retries=5)
+
+    await tasks()
+
+    assert calls == [("value", 5)]
+    assert tasks.task_results == [
+        {
+            "task_name": "task_with_reserved_names",
+            "status": "success",
+            "exception": None,
+            "retry_count": 0,
+        }
+    ]
+
+
+def test_background_task_rejects_negative_retries() -> None:
+    tasks = BackgroundTasks()
+
+    def task() -> None:
+        pass
+
+    with pytest.raises(ValueError, match="max_retries"):
+        tasks.add_task(task, max_retries=-1)


### PR DESCRIPTION
/claim #760

Summary:
- Added a FastAPI BackgroundTask wrapper that logs failed attempts, records per-task outcomes, and preserves default exception propagation when no retry or error callback is configured.
- Added optional `on_error` callback support with exception plus task info, including the original task name and retry counters.
- Added `max_retries` support and focused tests for success, retry, failure, callback, logging, default behavior, and existing keyword-argument compatibility.

Validation:
- `uv run pytest tests/test_background_tasks_retries.py tests/test_dependency_contextmanager.py tests/test_response_dependency.py tests/test_tutorial/test_background_tasks -q`
- `uv run ruff check fastapi/background.py tests/test_background_tasks_retries.py`
- `uv run mypy fastapi/background.py`
