### PR TITLE
OpenAI Codex [ FastAPI ] Add SSE manager filtering and replay

### DIFF
--- a/fastapi/fastapi/sse.py
+++ b/fastapi/fastapi/sse.py
@@ -1,7 +1,13 @@
+from collections import deque
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import Annotated, Any
 
+import anyio
 from annotated_doc import Doc
+from anyio.abc import ObjectSendStream
 from pydantic import AfterValidator, BaseModel, Field, model_validator
+from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
 # Canonical SSE event schema matching the OpenAPI 3.2 spec
@@ -141,6 +147,243 @@ class ServerSentEvent(BaseModel):
                 "or 'raw_data' for pre-formatted strings."
             )
         return self
+
+
+@dataclass(eq=False)
+class _SSEConnection:
+    event_type: str | None
+    send_stream: ObjectSendStream[ServerSentEvent | None]
+
+    def accepts(self, event: ServerSentEvent) -> bool:
+        return self.event_type is None or event.event == self.event_type
+
+
+class SSEManager:
+    """Manage SSE subscribers, broadcast events, and replay recent events.
+
+    `stream()` reads the standard `Last-Event-ID` header and the `event_type`
+    query parameter from the request when they are not passed explicitly.
+    """
+
+    def __init__(
+        self,
+        *,
+        history_size: Annotated[
+            int,
+            Doc(
+                """
+                Maximum number of events kept for Last-Event-ID replay.
+                """
+            ),
+        ] = 100,
+        retry: Annotated[
+            int | None,
+            Doc(
+                """
+                Default browser reconnect delay in milliseconds.
+                """
+            ),
+        ] = None,
+        disconnect_poll_interval: Annotated[
+            float,
+            Doc(
+                """
+                Seconds between client disconnect checks while idle.
+                """
+            ),
+        ] = 0.25,
+        connection_buffer_size: Annotated[
+            int,
+            Doc(
+                """
+                Per-connection event buffer size.
+                """
+            ),
+        ] = 10,
+    ) -> None:
+        if history_size < 0:
+            raise ValueError("history_size must be greater than or equal to 0")
+        if retry is not None and retry < 0:
+            raise ValueError("retry must be greater than or equal to 0")
+        if disconnect_poll_interval <= 0:
+            raise ValueError("disconnect_poll_interval must be greater than 0")
+        if connection_buffer_size < 1:
+            raise ValueError("connection_buffer_size must be greater than 0")
+
+        self.history_size = history_size
+        self.retry = retry
+        self.disconnect_poll_interval = disconnect_poll_interval
+        self.connection_buffer_size = connection_buffer_size
+        self._history: deque[ServerSentEvent] = deque(maxlen=history_size or None)
+        self._connections: set[_SSEConnection] = set()
+        self._next_event_id = 1
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._connections)
+
+    def get_event_type(self, request: Request | None) -> str | None:
+        if request is None:
+            return None
+        event_type = request.query_params.get("event_type")
+        return event_type or None
+
+    def get_last_event_id(self, request: Request | None) -> str | None:
+        if request is None:
+            return None
+        return request.headers.get("last-event-id")
+
+    def replay(
+        self,
+        *,
+        last_event_id: str | None = None,
+        event_type: str | None = None,
+    ) -> list[ServerSentEvent]:
+        start = 0
+        if last_event_id is not None:
+            for index, event in enumerate(self._history):
+                if event.id == last_event_id:
+                    start = index + 1
+                    break
+
+        return [
+            event
+            for event in list(self._history)[start:]
+            if event_type is None or event.event == event_type
+        ]
+
+    def _prepare_event(
+        self,
+        data: Any = None,
+        *,
+        raw_data: str | None = None,
+        event: str | None = None,
+        event_type: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        comment: str | None = None,
+    ) -> ServerSentEvent:
+        if isinstance(data, ServerSentEvent):
+            sse_event = data
+        else:
+            sse_event = ServerSentEvent(
+                data=data,
+                raw_data=raw_data,
+                event=event if event is not None else event_type,
+                id=id,
+                retry=retry if retry is not None else self.retry,
+                comment=comment,
+            )
+
+        if sse_event.id is None:
+            sse_event = sse_event.model_copy(update={"id": str(self._next_event_id)})
+            self._next_event_id += 1
+        if sse_event.retry is None and self.retry is not None:
+            sse_event = sse_event.model_copy(update={"retry": self.retry})
+        return sse_event
+
+    async def broadcast(
+        self,
+        data: Any = None,
+        *,
+        raw_data: str | None = None,
+        event: str | None = None,
+        event_type: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        comment: str | None = None,
+    ) -> ServerSentEvent:
+        sse_event = self._prepare_event(
+            data,
+            raw_data=raw_data,
+            event=event,
+            event_type=event_type,
+            id=id,
+            retry=retry,
+            comment=comment,
+        )
+
+        if self.history_size:
+            self._history.append(sse_event)
+
+        stale_connections: list[_SSEConnection] = []
+        for connection in list(self._connections):
+            if not connection.accepts(sse_event):
+                continue
+            try:
+                connection.send_stream.send_nowait(sse_event)
+            except anyio.WouldBlock:
+                continue
+            except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+                stale_connections.append(connection)
+
+        for connection in stale_connections:
+            self._connections.discard(connection)
+
+        return sse_event
+
+    async def broadcast_to(
+        self,
+        event_type: str,
+        data: Any = None,
+        **kwargs: Any,
+    ) -> ServerSentEvent:
+        return await self.broadcast(data, event_type=event_type, **kwargs)
+
+    async def stream(
+        self,
+        request: Request | None = None,
+        *,
+        event_type: str | None = None,
+        last_event_id: str | None = None,
+    ) -> AsyncIterator[ServerSentEvent]:
+        if event_type is None:
+            event_type = self.get_event_type(request)
+        if last_event_id is None:
+            last_event_id = self.get_last_event_id(request)
+
+        send_stream, receive_stream = anyio.create_memory_object_stream[
+            ServerSentEvent | None
+        ](self.connection_buffer_size)
+        connection = _SSEConnection(event_type=event_type, send_stream=send_stream)
+        self._connections.add(connection)
+
+        async with receive_stream:
+            try:
+                for event in self.replay(
+                    last_event_id=last_event_id, event_type=event_type
+                ):
+                    if request is not None and await request.is_disconnected():
+                        return
+                    yield event
+
+                while True:
+                    if request is not None and await request.is_disconnected():
+                        return
+                    try:
+                        with anyio.fail_after(self.disconnect_poll_interval):
+                            event = await receive_stream.receive()
+                    except TimeoutError:
+                        continue
+                    except anyio.EndOfStream:
+                        return
+                    if event is None:
+                        return
+                    yield event
+            finally:
+                self._connections.discard(connection)
+                await send_stream.aclose()
+
+    async def close(self) -> None:
+        for connection in list(self._connections):
+            try:
+                connection.send_stream.send_nowait(None)
+            except (
+                anyio.WouldBlock,
+                anyio.BrokenResourceError,
+                anyio.ClosedResourceError,
+            ):
+                self._connections.discard(connection)
 
 
 def format_sse_event(

--- a/fastapi/tests/test_sse.py
+++ b/fastapi/tests/test_sse.py
@@ -2,11 +2,12 @@ import asyncio
 import time
 from collections.abc import AsyncIterable, Iterable
 
+import anyio
 import fastapi.routing
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
-from fastapi.sse import ServerSentEvent
+from fastapi.sse import ServerSentEvent, SSEManager
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
@@ -103,6 +104,11 @@ app.include_router(router, prefix="/api")
 def client_fixture():
     with TestClient(app) as c:
         yield c
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
 
 
 def test_async_generator_with_model(client: TestClient):
@@ -316,3 +322,81 @@ def test_no_keepalive_when_fast(client: TestClient):
     assert response.status_code == 200
     # KEEPALIVE_COMMENT is ": ping\n\n".
     assert ": ping\n" not in response.text
+
+
+class _FakeSSERequest:
+    def __init__(
+        self,
+        *,
+        headers: dict[str, str] | None = None,
+        query_params: dict[str, str] | None = None,
+        disconnect_after: int = 100,
+    ) -> None:
+        self.headers = headers or {}
+        self.query_params = query_params or {}
+        self._disconnect_after = disconnect_after
+        self._disconnect_checks = 0
+
+    async def is_disconnected(self) -> bool:
+        self._disconnect_checks += 1
+        return self._disconnect_checks > self._disconnect_after
+
+
+@pytest.mark.anyio
+async def test_sse_manager_replays_last_event_id_with_event_type_filter():
+    manager = SSEManager(retry=1250, disconnect_poll_interval=0.01)
+    await manager.broadcast({"msg": "first"}, event_type="news", id="1")
+    await manager.broadcast({"msg": "ignored"}, event_type="chat", id="2")
+    await manager.broadcast({"msg": "latest"}, event_type="news", id="3")
+
+    request = _FakeSSERequest(
+        headers={"last-event-id": "1"},
+        query_params={"event_type": "news"},
+        disconnect_after=1,
+    )
+
+    events: list[ServerSentEvent] = []
+    async for event in manager.stream(request):  # type: ignore[arg-type]
+        events.append(event)
+
+    assert [(event.id, event.event, event.retry) for event in events] == [
+        ("3", "news", 1250)
+    ]
+    assert manager.connection_count == 0
+
+
+@pytest.mark.anyio
+async def test_sse_manager_broadcasts_to_filtered_connections():
+    manager = SSEManager(retry=750, disconnect_poll_interval=0.01)
+    news_stream = manager.stream(event_type="news")
+    chat_stream = manager.stream(event_type="chat")
+    news_next = asyncio.create_task(anext(news_stream))
+    chat_next = asyncio.create_task(anext(chat_stream))
+    await anyio.sleep(0)
+
+    await manager.broadcast_to("news", {"msg": "hello"})
+
+    event = await asyncio.wait_for(news_next, timeout=1)
+    assert event.event == "news"
+    assert event.retry == 750
+    assert event.data == {"msg": "hello"}
+    assert not chat_next.done()
+
+    await manager.close()
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(chat_next, timeout=1)
+    await news_stream.aclose()
+    await chat_stream.aclose()
+    assert manager.connection_count == 0
+
+
+@pytest.mark.anyio
+async def test_sse_manager_stops_cleanly_when_client_disconnects():
+    manager = SSEManager(disconnect_poll_interval=0.01)
+    request = _FakeSSERequest(disconnect_after=0)
+    stream = manager.stream(request)  # type: ignore[arg-type]
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+    assert manager.connection_count == 0


### PR DESCRIPTION
/claim #798

## Summary
- Add `SSEManager` for disconnect-aware SSE streams, event-type filtered subscribers, Last-Event-ID replay, default retry intervals, and targeted broadcasts.
- Add focused tests covering replay/filtering, filtered live broadcasts, retry propagation, and disconnect cleanup.

## Validation
- `uv run pytest tests/test_sse.py`
- `uv run ruff check fastapi/sse.py tests/test_sse.py`
- `git diff --check`

Note: intentionally did not add contributor/provenance metadata files.