### PR TITLE
Codex [ Laravel ] Implement audit logging trait

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable([
+    'auditable_type',
+    'auditable_id',
+    'event',
+    'old_values',
+    'new_values',
+    'user_id',
+    'ip_address',
+    'user_agent',
+])]
+class AuditLog extends Model
+{
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+trait Auditable
+{
+    /**
+     * Register model event listeners for audit logging.
+     */
+    protected static function bootAuditable(): void
+    {
+        static::created(function ($model): void {
+            $model->recordAudit('created', [], $model->auditValues($model->getAttributes()));
+        });
+
+        static::updated(function ($model): void {
+            $changed = array_keys($model->getChanges());
+
+            $model->recordAudit(
+                'updated',
+                $model->auditOriginalValues($changed),
+                $model->auditValues($model->only($changed)),
+            );
+        });
+
+        static::deleted(function ($model): void {
+            $model->recordAudit('deleted', $model->auditValues($model->getOriginal()), []);
+        });
+    }
+
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    public function getAuditHistory()
+    {
+        return $this->auditLogs()
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    /**
+     * @param  array<int, string>  $keys
+     * @return array<string, mixed>
+     */
+    protected function auditOriginalValues(array $keys): array
+    {
+        $values = [];
+
+        foreach ($keys as $key) {
+            $values[$key] = $this->getOriginal($key);
+        }
+
+        return $this->auditValues($values);
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     * @return array<string, mixed>
+     */
+    protected function auditValues(array $values): array
+    {
+        return collect($values)
+            ->except($this->auditHiddenAttributes())
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function auditHiddenAttributes(): array
+    {
+        return array_values(array_unique(array_merge($this->getHidden(), [
+            'password',
+            'remember_token',
+        ])));
+    }
+
+    /**
+     * @param  array<string, mixed>  $oldValues
+     * @param  array<string, mixed>  $newValues
+     */
+    protected function recordAudit(string $event, array $oldValues, array $newValues): void
+    {
+        AuditLog::create([
+            'auditable_type' => $this->getMorphClass(),
+            'auditable_id' => $this->getKey(),
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => auth()->id(),
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+        ]);
+    }
+}

--- a/laravel/database/migrations/2026_05_16_000000_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_05_16_000000_create_audit_logs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->unsignedBigInteger('auditable_id');
+            $table->string('event');
+            $table->json('old_values');
+            $table->json('new_values');
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditableTest.php
+++ b/laravel/tests/Feature/AuditableTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_a_user_generates_an_audit_log(): void
+    {
+        request()->server->set('REMOTE_ADDR', '203.0.113.10');
+        request()->headers->set('User-Agent', 'AuditTest/1.0');
+
+        $user = User::factory()->create([
+            'name' => 'Created User',
+            'email' => 'created@example.com',
+            'password' => 'secret-password',
+            'remember_token' => 'remember-me',
+        ]);
+
+        $auditLog = AuditLog::query()->sole();
+
+        $this->assertSame(User::class, $auditLog->auditable_type);
+        $this->assertSame($user->id, $auditLog->auditable_id);
+        $this->assertSame('created', $auditLog->event);
+        $this->assertSame([], $auditLog->old_values);
+        $this->assertSame('Created User', $auditLog->new_values['name']);
+        $this->assertSame('created@example.com', $auditLog->new_values['email']);
+        $this->assertArrayNotHasKey('password', $auditLog->new_values);
+        $this->assertArrayNotHasKey('remember_token', $auditLog->new_values);
+        $this->assertSame('203.0.113.10', $auditLog->ip_address);
+        $this->assertSame('AuditTest/1.0', $auditLog->user_agent);
+    }
+
+    public function test_updating_a_user_generates_an_audit_log_with_changed_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Original User',
+            'email' => 'original@example.com',
+        ]);
+
+        AuditLog::query()->delete();
+
+        $user->update([
+            'name' => 'Updated User',
+            'email' => 'updated@example.com',
+        ]);
+
+        $auditLog = AuditLog::query()->sole();
+
+        $this->assertSame('updated', $auditLog->event);
+        $this->assertSame('Original User', $auditLog->old_values['name']);
+        $this->assertSame('original@example.com', $auditLog->old_values['email']);
+        $this->assertSame('Updated User', $auditLog->new_values['name']);
+        $this->assertSame('updated@example.com', $auditLog->new_values['email']);
+        $this->assertArrayNotHasKey('password', $auditLog->old_values);
+        $this->assertArrayNotHasKey('password', $auditLog->new_values);
+    }
+
+    public function test_deleting_a_user_generates_an_audit_log_with_old_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Deleted User',
+            'email' => 'deleted@example.com',
+            'password' => 'secret-password',
+        ]);
+
+        AuditLog::query()->delete();
+
+        $user->delete();
+
+        $auditLog = AuditLog::query()->sole();
+
+        $this->assertSame('deleted', $auditLog->event);
+        $this->assertSame('Deleted User', $auditLog->old_values['name']);
+        $this->assertSame('deleted@example.com', $auditLog->old_values['email']);
+        $this->assertSame([], $auditLog->new_values);
+        $this->assertArrayNotHasKey('password', $auditLog->old_values);
+    }
+
+    public function test_get_audit_history_returns_latest_logs_first(): void
+    {
+        $user = User::factory()->create();
+
+        $user->update(['name' => 'First Update']);
+        $user->update(['name' => 'Second Update']);
+
+        $history = $user->getAuditHistory();
+
+        $this->assertSame(['updated', 'updated', 'created'], $history->pluck('event')->all());
+        $this->assertSame('Second Update', $history->first()->new_values['name']);
+    }
+
+    public function test_audit_log_includes_authenticated_user_id(): void
+    {
+        $actor = User::factory()->create();
+
+        AuditLog::query()->delete();
+
+        $this->actingAs($actor);
+
+        User::factory()->create();
+
+        $this->assertSame($actor->id, AuditLog::query()->sole()->user_id);
+    }
+}


### PR DESCRIPTION
## Summary
- Add an `Auditable` trait that records created, updated, and deleted Eloquent model events.
- Add `AuditLog` model and `audit_logs` migration with auditable target, event values, nullable user ID, IP address, user agent, and timestamps.
- Apply the trait to `User` and add focused feature tests for create/update/delete/history/auth metadata.

/claim #786

## Validation
- `git diff --check` passed.
- Laravel/PHP tests and Pint could not be run in this environment because `php`, `composer`, and container runtimes are unavailable.

## Process note
- The issue requested a `.provenance.json` file containing loaded instructions. That file is intentionally omitted because it would expose prompt/system context and conflicts with contributor-process safety constraints.