### PR TITLE
Codex [ Laravel ] Add cache health checks

### DIFF
--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status {--force : Bypass the cached health-check result}';
+
+    protected $description = 'Display the active cache store health status';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $status = $healthCheck->check((bool) $this->option('force'));
+        $available = $status['available'] ? 'available' : 'unavailable';
+
+        $this->line('Driver: '.$status['driver']);
+        $this->line('Availability: '.$available);
+        $this->line('Latency: '.$status['latency_ms'].' ms');
+
+        return $status['available'] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Support\Str;
+use Throwable;
+
+class CacheHealthCheck
+{
+    private static ?array $cachedStatus = null;
+
+    private static ?string $cachedSignature = null;
+
+    private static ?float $cachedAt = null;
+
+    public function __construct(
+        private readonly CacheFactory $cache,
+        private readonly ConfigRepository $config,
+    ) {
+        //
+    }
+
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float}
+     */
+    public function check(bool $force = false): array
+    {
+        $enabled = (bool) $this->config->get('cache.health_check_enabled', true);
+        $interval = max(0, (int) $this->config->get('cache.health_check_interval', 300));
+        $store = (string) $this->config->get('cache.default', '');
+        $driver = (string) $this->config->get("cache.stores.{$store}.driver", 'unknown');
+        $signature = implode('|', [$enabled ? '1' : '0', $interval, $store, $driver]);
+
+        if (! $force && $interval > 0 && static::$cachedStatus !== null && static::$cachedSignature === $signature && static::$cachedAt !== null) {
+            if ((microtime(true) - static::$cachedAt) < $interval) {
+                return static::$cachedStatus;
+            }
+        }
+
+        if (! $enabled) {
+            return $this->remember([
+                'available' => true,
+                'driver' => $driver,
+                'latency_ms' => 0.0,
+            ], $signature);
+        }
+
+        return $this->remember($this->probeStore($store, $driver), $signature);
+    }
+
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float}
+     */
+    private function probeStore(string $store, string $driver): array
+    {
+        $startedAt = microtime(true);
+        $cache = null;
+
+        try {
+            $cache = $this->cache->store($store !== '' ? $store : null);
+            $key = 'cache_health_check:'.(string) Str::uuid();
+            $value = (string) Str::uuid();
+
+            $written = $cache->put($key, $value, 10);
+            $available = $written !== false && $cache->get($key) === $value;
+
+            return [
+                'available' => $available,
+                'driver' => $driver,
+                'latency_ms' => $this->elapsedMilliseconds($startedAt),
+            ];
+        } catch (Throwable) {
+            return [
+                'available' => false,
+                'driver' => $driver,
+                'latency_ms' => $this->elapsedMilliseconds($startedAt),
+            ];
+        } finally {
+            if ($cache instanceof CacheRepository && isset($key)) {
+                try {
+                    $cache->forget($key);
+                } catch (Throwable) {
+                    //
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array{available: bool, driver: string, latency_ms: float}  $status
+     * @return array{available: bool, driver: string, latency_ms: float}
+     */
+    private function remember(array $status, string $signature): array
+    {
+        static::$cachedStatus = $status;
+        static::$cachedSignature = $signature;
+        static::$cachedAt = microtime(true);
+
+        return $status;
+    }
+
+    private function elapsedMilliseconds(float $startedAt): float
+    {
+        return round((microtime(true) - $startedAt) * 1000, 2);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\CacheStatusCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -10,6 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        CacheStatusCommand::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -19,6 +19,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Health Checks
+    |--------------------------------------------------------------------------
+    |
+    | These values control cache store availability checks used by the
+    | cache:status command and /health/cache endpoint. Results are cached
+    | briefly per process to avoid repeatedly probing the active store.
+    |
+    */
+
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => (int) env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Stores
     |--------------------------------------------------------------------------
     |

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    $status = $healthCheck->check();
+
+    return response()->json($status, $status['available'] ? 200 : 503);
 });

--- a/laravel/tests/Feature/CacheHealthTest.php
+++ b/laravel/tests/Feature/CacheHealthTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class CacheHealthTest extends TestCase
+{
+    public function test_health_endpoint_returns_ok_for_available_cache_store(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertOk()
+            ->assertJson([
+                'available' => true,
+                'driver' => 'array',
+            ])
+            ->assertJsonStructure([
+                'available',
+                'driver',
+                'latency_ms',
+            ]);
+    }
+
+    public function test_health_endpoint_returns_service_unavailable_for_unavailable_cache_store(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertStatus(503)
+            ->assertJson([
+                'available' => false,
+                'driver' => 'unknown',
+            ]);
+    }
+
+    public function test_cache_status_command_outputs_health_details(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $this->artisan('cache:status --force')
+            ->expectsOutputToContain('Driver: array')
+            ->expectsOutputToContain('Availability: available')
+            ->expectsOutputToContain('Latency:')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_cache_status_command_fails_when_cache_store_is_unavailable(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $this->artisan('cache:status --force')
+            ->expectsOutputToContain('Availability: unavailable')
+            ->assertExitCode(Command::FAILURE);
+    }
+}

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Mockery;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    public function test_reports_available_active_cache_store(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $status = $this->app->make(CacheHealthCheck::class)->check(force: true);
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('array', $status['driver']);
+        $this->assertGreaterThanOrEqual(0, $status['latency_ms']);
+    }
+
+    public function test_reports_unavailable_when_active_cache_store_is_not_configured(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $status = $this->app->make(CacheHealthCheck::class)->check(force: true);
+
+        $this->assertFalse($status['available']);
+        $this->assertSame('unknown', $status['driver']);
+        $this->assertGreaterThanOrEqual(0, $status['latency_ms']);
+    }
+
+    public function test_respects_disabled_health_check_config(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_enabled' => false,
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $status = $this->app->make(CacheHealthCheck::class)->check(force: true);
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('unknown', $status['driver']);
+        $this->assertSame(0.0, $status['latency_ms']);
+    }
+
+    public function test_reuses_cached_status_within_configured_interval(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 300,
+        ]);
+
+        $writtenValue = null;
+        $repository = Mockery::mock(CacheRepository::class);
+        $repository->shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function (string $key, string $value, int $seconds) use (&$writtenValue): bool {
+                $writtenValue = $value;
+
+                return $seconds === 10;
+            });
+        $repository->shouldReceive('get')
+            ->once()
+            ->andReturnUsing(fn (string $key): ?string => $writtenValue);
+        $repository->shouldReceive('forget')
+            ->once()
+            ->andReturn(true);
+
+        $cache = Mockery::mock(CacheFactory::class);
+        $cache->shouldReceive('store')
+            ->once()
+            ->with('array')
+            ->andReturn($repository);
+
+        $healthCheck = new CacheHealthCheck($cache, $this->app['config']);
+
+        $first = $healthCheck->check(force: true);
+        $second = $healthCheck->check();
+
+        $this->assertSame($first, $second);
+        $this->assertTrue($second['available']);
+        $this->assertSame('array', $second['driver']);
+    }
+}


### PR DESCRIPTION
## Issue
/claim #747
Closes #747

## Summary
Adds a Laravel cache health-check service with per-process interval caching, registers `cache:status`, exposes `GET /health/cache`, and adds focused service, command, and endpoint tests.

## Acceptance criteria
- [x] CacheHealthCheck service reports cache store availability with `available`, `driver`, and `latency_ms`
- [x] `cache:status` outputs driver name, availability, and latency
- [x] `/health/cache` returns JSON with 200 when healthy and 503 when unavailable
- [x] `health_check_enabled` and `health_check_interval` config values are respected
- [x] Tests cover the service, command, and endpoint

## Validation
- [x] `git diff --cached --check` before commit
- [ ] PHP/Laravel tests not run locally: this workspace has no `php`, `composer`, or `docker` executable available

## Process note
No `_provenance.json`, metadata, contributor, audit, prompt, boot-context, or system-context files are included per operator instructions.