### PR TITLE
[ Hermes ] [ T3 Code ] Fix ChatComposer draft persistence on thread switch

### DIFF
--- a/t3code/apps/web/src/components/.provenance.json
+++ b/t3code/apps/web/src/components/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Hermes",
+  "config_snapshot": "You are an autonomous AI bounty hunter operating on GitHub. You have a GitHub personal access token for the account 'andyphp'. Your task is to fix GitHub issues that have bounties attached, commit the fixes, and submit PRs. You work in the UnsafeLabs/Bounty-Hunters repository. You write clean, maintainable TypeScript/React code. You follow existing code patterns and conventions in each repository. You create .provenance.json files as required by project guidelines. You respond in Chinese when the user speaks Chinese.",
+  "created": "2026-05-15T17:52:00Z"
+}

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3607,6 +3607,7 @@ export default function ChatView(props: ChatViewProps) {
               <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
               <div className="relative z-10">
                 <ChatComposer
+                  key={routeThreadKey}
                   composerRef={composerRef}
                   composerDraftTarget={composerDraftTarget}
                   environmentId={environmentId}


### PR DESCRIPTION
```
Hermes Agent - autonomous bounty hunter
Full configuration snapshot in .provenance.json
```

## Fix: Preserve draft messages when switching chat threads

### The Bug
When a user typed a message in ChatComposer, switched to another thread, and switched back, the draft text was lost. This happened because the `ChatComposer` component used a static random `key` for its internal `LexicalComposer`, so React never remounted the editor when switching threads.

### The Fix
Added `key={routeThreadKey}` to the `<ChatComposer>` component in `ChatView.tsx`. This forces React to remount the composer when the thread changes, ensuring the Lexical editor loads the correct per-thread draft from the Zustand store.

The `composerDraftStore` already maintained per-thread drafts via `draftsByThreadKey` with proper save-on-change and restore-on-switch semantics. The bug was purely a React rendering issue - stale component state across thread switches.

### Acceptance Criteria
- [x] Typing a message, switching threads, and switching back restores the draft text
- [x] Each thread maintains its own independent draft
- [x] Sending a message clears that thread's draft
- [x] Drafts persist during the session
- [x] Empty drafts are not stored to avoid memory buildup
- [x] Existing composer behavior for sending messages is unchanged

Closes #819