### PR TITLE
[ Hermes ] [ T3 Code ] Add cross-platform copy/paste keybindings to terminal

### DIFF
--- a/t3code/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/t3code/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -444,6 +444,41 @@ export function TerminalViewport({
         return false;
       }
 
+      // --- Copy: Ctrl+Shift+C (Win/Linux) / Cmd+C (macOS) when text is selected ---
+      const isMod = event.metaKey || event.ctrlKey;
+      const isCopy = event.code === "KeyC" && isMod && (event.shiftKey || navigator.platform.includes("Mac"));
+      if (isCopy) {
+        const activeTerminal = terminalRef.current;
+        if (activeTerminal?.hasSelection()) {
+          event.preventDefault();
+          event.stopPropagation();
+          const text = activeTerminal.getSelection();
+          void navigator.clipboard.writeText(text).then(() => {
+            import("./ui/toast").then(({ toastManager }) => {
+              toastManager.add({
+                type: "success",
+                title: "Copied to clipboard",
+                timeout: 2000,
+              });
+            });
+          });
+          return false;
+        }
+        // No selection → let Ctrl+C pass through as SIGINT
+        return true;
+      }
+
+      // --- Paste: Ctrl+Shift+V (Win/Linux) / Cmd+V (macOS) ---
+      const isPaste = event.code === "KeyV" && isMod && (event.shiftKey || navigator.platform.includes("Mac"));
+      if (isPaste) {
+        event.preventDefault();
+        event.stopPropagation();
+        void navigator.clipboard.readText().then((text) => {
+          void sendTerminalInput(text, "Failed to paste");
+        });
+        return false;
+      }
+
       if (!isTerminalClearShortcut(event)) return true;
       event.preventDefault();
       event.stopPropagation();

--- a/t3code/apps/web/src/components/_generation.json
+++ b/t3code/apps/web/src/components/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes",
+  "pre_task_context": "You are an autonomous AI bounty hunter operating on GitHub. You have a GitHub personal access token for the account 'andyphp'. Your task is to fix GitHub issues that have bounties attached, commit the fixes, and submit PRs. You work in the UnsafeLabs/Bounty-Hunters repository. You write clean, maintainable TypeScript/React code. You follow existing code patterns and conventions in each repository. You add _generation.json or .provenance.json files as required by project guidelines. You respond in Chinese when the user speaks Chinese.",
+  "timestamp": "2026-05-15T17:52:00Z"
+}


### PR DESCRIPTION
```
Hermes Agent - autonomous bounty hunter
Full pre-task context in _generation.json
```

## Changes

Added platform-aware copy/paste keyboard shortcuts to `ThreadTerminalDrawer.tsx`:

### Copy (`Ctrl+Shift+C` / `Cmd+C`)
- On Windows/Linux: `Ctrl+Shift+C` copies selected terminal text to clipboard
- On macOS: `Cmd+C` copies selected terminal text to clipboard
- When no text is selected, `Ctrl+C`/`Cmd+C` passes through to the terminal process as SIGINT
- Shows a toast notification on successful copy

### Paste (`Ctrl+Shift+V` / `Cmd+V`)
- Pastes clipboard content into the terminal input stream
- Works on all platforms

### Implementation Details
- Uses `terminal.attachCustomKeyEventHandler` to intercept keyboard events
- Uses `navigator.clipboard` API for clipboard access
- Dynamically imports toastManager to avoid circular dependencies
- Brief toast notification (2s timeout) on successful copy

Closes #824