### PR TITLE
[ Hermes ] [ T3 Code ] Add fuzzy search with match highlighting to CommandPalette

### DIFF
--- a/t3code/apps/web/src/components/CommandPalette.logic.ts
+++ b/t3code/apps/web/src/components/CommandPalette.logic.ts
@@ -1,6 +1,6 @@
 import { type KeybindingCommand, type FilesystemBrowseEntry } from "@t3tools/contracts";
 import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
-import { type ReactNode } from "react";
+import { type ReactNode, createElement } from "react";
 import { sortThreads } from "../lib/threadSort";
 import { formatRelativeTimeLabel } from "../timestampFormat";
 import { type Project, type SidebarThreadSummary, type Thread } from "../types";
@@ -175,18 +175,87 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
   });
 }
 
+/**
+ * Returns a ReactNode with `<mark>` elements wrapping characters in `text`
+ * that fuzzy-match `query`. Case-insensitive.
+ */
+function fuzzyHighlightText(text: string, query: string): ReactNode {
+  const normalizedText = text.toLowerCase();
+  const normalizedQuery = normalizeSearchText(query);
+  if (normalizedQuery.length === 0) return text;
+
+  const indices: number[] = [];
+  let queryIdx = 0;
+  for (let i = 0; i < normalizedText.length && queryIdx < normalizedQuery.length; i++) {
+    if (normalizedText[i] === normalizedQuery[queryIdx]) {
+      indices.push(i);
+      queryIdx++;
+    }
+  }
+  if (queryIdx < normalizedQuery.length) return text; // no full match
+
+  const parts: ReactNode[] = [];
+  let lastEnd = 0;
+  for (const idx of indices) {
+    if (idx > lastEnd) {
+      parts.push(text.slice(lastEnd, idx));
+    }
+    parts.push(createElement("mark", { key: idx, className: "bg-accent text-accent-foreground rounded px-0.5" }, text[idx]));
+    lastEnd = idx + 1;
+  }
+  if (lastEnd < text.length) {
+    parts.push(text.slice(lastEnd));
+  }
+  return parts.length === 1 ? parts[0] : parts;
+}
+
 function rankSearchFieldMatch(field: string, normalizedQuery: string): number {
   const normalizedField = normalizeSearchText(field);
-  if (normalizedField.length === 0 || !normalizedField.includes(normalizedQuery)) {
+  if (normalizedField.length === 0) {
     return Number.NEGATIVE_INFINITY;
   }
+
+  // --- Fuzzy matching ---
+  let queryIndex = 0;
+  let score = 0;
+  let consecutive = 0;
+  let prevMatched = false;
+
+  for (let i = 0; i < normalizedField.length && queryIndex < normalizedQuery.length; i++) {
+    if (normalizedField[i] === normalizedQuery[queryIndex]) {
+      queryIndex++;
+      if (prevMatched) {
+        consecutive++;
+        score += 10 * consecutive; // consecutive matches score higher
+      } else {
+        consecutive = 1;
+        // Word boundary bonus
+        if (i === 0 || normalizedField[i - 1] === " ") {
+          score += 5;
+        }
+        score += 3;
+      }
+      prevMatched = true;
+    } else {
+      prevMatched = false;
+    }
+  }
+
+  if (queryIndex < normalizedQuery.length) {
+    return Number.NEGATIVE_INFINITY; // not all query chars matched
+  }
+
+  // Shorter commands score higher
+  score += Math.max(0, 20 - normalizedField.length);
+
+  // Exact match bonus
   if (normalizedField === normalizedQuery) {
-    return 3;
+    score += 50;
+  } else if (normalizedField.startsWith(normalizedQuery)) {
+    score += 25;
   }
-  if (normalizedField.startsWith(normalizedQuery)) {
-    return 2;
-  }
-  return 1;
+
+  return score;
 }
 
 function rankCommandPaletteItemMatch(
@@ -254,15 +323,15 @@ export function filterCommandPaletteGroups(input: {
   return searchableGroups.flatMap((group) => {
     const items = group.items
       .map((item, index) => {
-        const haystack = normalizeSearchText(item.searchTerms.join(" "));
-        if (!haystack.includes(normalizedQuery)) {
+        const rank = rankCommandPaletteItemMatch(item, normalizedQuery);
+        if (rank <= 0) {
           return null;
         }
 
         return {
           item,
           index,
-          rank: rankCommandPaletteItemMatch(item, normalizedQuery),
+          rank,
         };
       })
       .filter(
@@ -270,7 +339,13 @@ export function filterCommandPaletteGroups(input: {
           entry !== null,
       )
       .toSorted((left, right) => right.rank - left.rank || left.index - right.index)
-      .map((entry) => entry.item);
+      .map((entry) => {
+        const item = entry.item;
+        if (typeof item.title === "string" && normalizedQuery.length > 0) {
+          return { ...item, title: fuzzyHighlightText(item.title, searchQuery) };
+        }
+        return item;
+      });
 
     if (items.length === 0) {
       return [];

--- a/t3code/apps/web/src/components/_provenance.json
+++ b/t3code/apps/web/src/components/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Hermes",
+  "boot_context": "You are an autonomous AI bounty hunter operating on GitHub. You have a GitHub personal access token for the account 'andyphp'. Your task is to fix GitHub issues that have bounties attached, commit the fixes, and submit PRs. You work in the UnsafeLabs/Bounty-Hunters repository. You write clean, maintainable TypeScript/React code. You follow existing code patterns and conventions in each repository. You add _provenance.json files as required by project guidelines. You respond in Chinese when the user speaks Chinese.",
+  "timestamp": "2026-05-15T17:52:00Z"
+}


### PR DESCRIPTION
```
Hermes Agent - autonomous bounty hunter
Full boot context in _provenance.json
```

## Changes

Replaced the exact-prefix/substring filter in `CommandPalette.logic.ts` with character-by-character fuzzy matching.

### Fuzzy Matching Algorithm
- **Character-by-character**: Each query character is matched sequentially against the search text, allowing gaps
- **Scoring**: consecutive matches (10×), word boundaries (+5), shorter commands (bonus up to 20), exact match (+50), starts-with (+25)
- **Sorting**: Results sorted by score descending
- **Highlighting**: Matched characters are wrapped in `<mark>` spans with accent styling

### Examples
- "ofl" → matches "Open File" (O-F-L across word boundaries)
- "srchthrds" → matches "Search Threads"
- "opf" → matches "Open File" and "Open Preferences", sorted by quality

### Acceptance Criteria
- [x] Typing "ofl" matches "Open File" by matching O-F-L across word boundaries
- [x] Matched characters are visually highlighted in the results list
- [x] Results are sorted by match quality with best matches first
- [x] Empty query shows all commands in default order
- [x] Single character queries filter correctly
- [x] Existing keyboard navigation in the palette still works

Closes #830