### PR TITLE
Codex [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,73 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed feed, uint256 updatedAt);
 
     constructor(address _primaryFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+    function getLatestPrice() external returns (int256) {
+        (int256 price, uint256 updatedAt, bool stale) = _readPrice(primaryFeed, true);
+        if (!stale) {
+            emit PriceQueried(price, updatedAt);
+            return price;
+        }
 
-        return price;
+        require(address(fallbackFeed) != address(0), "Stale price");
+        emit StalePrice(address(primaryFeed), updatedAt);
+
+        (int256 fallbackPrice, uint256 fallbackUpdatedAt,) = _readPrice(fallbackFeed, false);
+        emit PriceQueried(fallbackPrice, fallbackUpdatedAt);
+        return fallbackPrice;
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+    }
+
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        require(_maxStaleness > 0, "Invalid staleness");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function _readPrice(
+        AggregatorV3Interface feed,
+        bool allowStale
+    ) internal view returns (int256 price, uint256 updatedAt, bool stale) {
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 lastUpdatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(answer > 0, "Invalid price");
+
+        bool isStale = block.timestamp - lastUpdatedAt >= MAX_STALENESS;
+        if (!allowStale) {
+            require(!isStale, "Stale price");
+        }
+
+        return (answer, lastUpdatedAt, isStale);
     }
 }

--- a/solidity/test/PriceOracle.test.js
+++ b/solidity/test/PriceOracle.test.js
@@ -1,0 +1,202 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { after, before, test } = require("node:test");
+const ganache = require("ganache");
+const solc = require("solc");
+const { ethers } = require("ethers");
+
+const contractPath = path.join(__dirname, "..", "contracts", "PriceOracle.sol");
+const source = fs.readFileSync(contractPath, "utf8");
+
+let server;
+let provider;
+let accounts;
+let compiled;
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "contracts/PriceOracle.sol": { content: source },
+      "test/MockAggregator.sol": {
+        content: `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../contracts/PriceOracle.sol";
+
+contract MockAggregator is AggregatorV3Interface {
+    uint80 private roundId;
+    int256 private answer;
+    uint256 private startedAt;
+    uint256 private updatedAt;
+    uint80 private answeredInRound;
+    uint8 private feedDecimals;
+
+    constructor(uint8 decimals_) {
+        feedDecimals = decimals_;
+    }
+
+    function setRoundData(
+        uint80 roundId_,
+        int256 answer_,
+        uint256 updatedAt_,
+        uint80 answeredInRound_
+    ) external {
+        roundId = roundId_;
+        answer = answer_;
+        startedAt = updatedAt_;
+        updatedAt = updatedAt_;
+        answeredInRound = answeredInRound_;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+}
+`,
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(
+    solc.compile(JSON.stringify(input), {
+      import: (importPath) => {
+        if (importPath === "../contracts/PriceOracle.sol") {
+          return { contents: source };
+        }
+        return { error: `Unable to resolve import: ${importPath}` };
+      },
+    }),
+  );
+
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+  return output.contracts;
+}
+
+async function deploy(name, signer, args = []) {
+  const artifact =
+    compiled["contracts/PriceOracle.sol"]?.[name] ?? compiled["test/MockAggregator.sol"][name];
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    artifact.evm.bytecode.object,
+    signer,
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function now() {
+  const block = await provider.getBlock("latest");
+  return BigInt(block.timestamp);
+}
+
+async function deployOracle() {
+  const [owner, other] = accounts;
+  const primary = await deploy("MockAggregator", owner, [8]);
+  const fallback = await deploy("MockAggregator", owner, [8]);
+  const oracle = await deploy("PriceOracle", owner, [await primary.getAddress()]);
+  await oracle.setFallbackFeed(await fallback.getAddress());
+  return { owner, other, primary, fallback, oracle };
+}
+
+async function setRound(feed, roundId, answer, updatedAt, answeredInRound = roundId) {
+  await feed.setRoundData(roundId, answer, updatedAt, answeredInRound);
+}
+
+before(async () => {
+  compiled = compileContracts();
+  server = ganache.server({ logging: { quiet: true } });
+  await server.listen(0);
+  provider = new ethers.JsonRpcProvider(`http://127.0.0.1:${server.address().port}`);
+  accounts = await provider.listAccounts();
+});
+
+after(async () => {
+  await provider?.destroy();
+  await server?.close();
+});
+
+test("returns a valid primary price", async () => {
+  const { primary, oracle } = await deployOracle();
+  const timestamp = await now();
+  await setRound(primary, 7, 2000n * 10n ** 8n, timestamp);
+
+  assert.equal(await oracle.getLatestPrice.staticCall(), 2000n * 10n ** 8n);
+});
+
+test("falls back and emits StalePrice when the primary price is stale", async () => {
+  const { primary, fallback, oracle } = await deployOracle();
+  const timestamp = await now();
+  await setRound(primary, 7, 2000n * 10n ** 8n, timestamp - 7200n);
+  await setRound(fallback, 8, 1995n * 10n ** 8n, timestamp);
+
+  assert.equal(await oracle.getLatestPrice.staticCall(), 1995n * 10n ** 8n);
+  const receipt = await (await oracle.getLatestPrice()).wait();
+  const logs = receipt.logs.map((log) => oracle.interface.parseLog(log));
+  const staleLog = logs.find((log) => log?.name === "StalePrice");
+
+  assert.equal(staleLog.args.feed, await primary.getAddress());
+  assert.equal(staleLog.args.updatedAt, timestamp - 7200n);
+});
+
+test("rejects zero and negative prices", async () => {
+  const { primary, oracle } = await deployOracle();
+  const timestamp = await now();
+
+  await setRound(primary, 7, 0, timestamp);
+  await assert.rejects(oracle.getLatestPrice.staticCall(), /Invalid price/);
+
+  await setRound(primary, 8, -1, timestamp);
+  await assert.rejects(oracle.getLatestPrice.staticCall(), /Invalid price/);
+});
+
+test("rejects incomplete rounds", async () => {
+  const { primary, oracle } = await deployOracle();
+  const timestamp = await now();
+  await setRound(primary, 9, 2000n * 10n ** 8n, timestamp, 8);
+
+  await assert.rejects(oracle.getLatestPrice.staticCall(), /Incomplete round/);
+});
+
+test("reverts when both primary and fallback prices are stale", async () => {
+  const { primary, fallback, oracle } = await deployOracle();
+  const timestamp = await now();
+  await setRound(primary, 7, 2000n * 10n ** 8n, timestamp - 7200n);
+  await setRound(fallback, 8, 1995n * 10n ** 8n, timestamp - 7200n);
+
+  await assert.rejects(oracle.getLatestPrice.staticCall(), /Stale price/);
+});
+
+test("allows only the owner to configure staleness and fallback feed", async () => {
+  const { other, oracle } = await deployOracle();
+  const replacement = await deploy("MockAggregator", other, [8]);
+
+  await oracle.setMaxStaleness(120);
+  assert.equal(await oracle.MAX_STALENESS(), 120n);
+
+  await assert.rejects(oracle.connect(other).setMaxStaleness(60));
+  await assert.rejects(
+    oracle.connect(other).setFallbackFeed(await replacement.getAddress()),
+  );
+});


### PR DESCRIPTION
## Issue
Closes #915

/claim #915

## Summary
Adds Chainlink round completeness and positive-price validation, detects stale primary prices, and falls back to a configured secondary feed only for stale primary data. MAX_STALENESS remains owner-configurable, fallback feed configuration is owner-only, and stale fallback emits StalePrice with the primary feed timestamp.

## Acceptance criteria
- [x] Stale prices older than 1 hour trigger fallback to secondary oracle
- [x] Zero or negative prices revert with clear error
- [x] Incomplete rounds are rejected
- [x] StalePrice event is emitted with the primary oracle's last update timestamp
- [x] If both oracles return stale data, the function reverts instead of returning bad data
- [x] MAX_STALENESS is configurable by the contract owner
- [x] Tests mock Chainlink responses for valid price, stale price, negative/zero price, incomplete round, and both oracles stale

## Validation
- [x] node --test solidity/test/PriceOracle.test.js
- [x] git diff --check

Note: I did not include the requested .generation_meta.json because it asks contributors to paste complete runtime/platform instructions into the repository.