### PR TITLE
Codex [ Crypto ] Fix missing slippage protection and deadline in SimpleSwap

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract SimpleSwap {
+    uint256 private constant BASIS_POINTS = 10_000;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
     uint256 public reserveA;
@@ -13,6 +15,7 @@ contract SimpleSwap {
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_fee < BASIS_POINTS, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
@@ -25,10 +28,13 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Deadline expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
@@ -37,14 +43,10 @@ contract SimpleSwap {
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
+        amountOut = _getAmountOut(amountIn, reserveIn, reserveOut);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+
         inputToken.transferFrom(msg.sender, address(this), amountIn);
-
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
         outputToken.transfer(msg.sender, amountOut);
 
         if (isTokenA) {
@@ -59,11 +61,19 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-        return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+        return _getAmountOut(amountIn, reserveIn, reserveOut);
+    }
+
+    function _getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) internal view returns (uint256) {
+        uint256 amountInWithFee = amountIn * (BASIS_POINTS - fee);
+        return (reserveOut * amountInWithFee) / (reserveIn * BASIS_POINTS + amountInWithFee);
     }
 }

--- a/solidity/test/SimpleSwap.test.js
+++ b/solidity/test/SimpleSwap.test.js
@@ -1,0 +1,201 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { after, before, test } = require("node:test");
+const ganache = require("ganache");
+const solc = require("solc");
+const { ethers } = require("ethers");
+
+const contractPath = path.join(__dirname, "..", "contracts", "SimpleSwap.sol");
+const source = fs.readFileSync(contractPath, "utf8");
+const ierc20 = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 value) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+`;
+
+let server;
+let provider;
+let accounts;
+let compiled;
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "contracts/SimpleSwap.sol": { content: source },
+      "@openzeppelin/contracts/token/ERC20/IERC20.sol": { content: ierc20 },
+      "test/MockERC20.sol": {
+        content: `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockERC20 is IERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "insufficient allowance");
+        allowance[from][msg.sender] = allowed - amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+}
+`,
+      },
+    },
+    settings: {
+      evmVersion: "shanghai",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+  return output.contracts;
+}
+
+async function deploy(name, signer, args = []) {
+  const artifact =
+    compiled["contracts/SimpleSwap.sol"]?.[name] ?? compiled["test/MockERC20.sol"][name];
+  const factory = new ethers.ContractFactory(
+    artifact.abi,
+    artifact.evm.bytecode.object,
+    signer,
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function latestTimestamp() {
+  const block = await provider.getBlock("latest");
+  return BigInt(block.timestamp);
+}
+
+async function deploySwap({ liquidity = ethers.parseEther("1000"), traderAmount = ethers.parseEther("100") } = {}) {
+  const [owner, trader] = accounts;
+  const tokenA = await deploy("MockERC20", owner, ["Token A", "TKA"]);
+  const tokenB = await deploy("MockERC20", owner, ["Token B", "TKB"]);
+  const swap = await deploy("SimpleSwap", owner, [
+    await tokenA.getAddress(),
+    await tokenB.getAddress(),
+    30,
+  ]);
+  await tokenA.mint(owner.address, liquidity);
+  await tokenB.mint(owner.address, liquidity);
+  await tokenA.mint(trader.address, traderAmount);
+  await tokenB.mint(trader.address, traderAmount);
+  await tokenA.approve(await swap.getAddress(), liquidity);
+  await tokenB.approve(await swap.getAddress(), liquidity);
+  await swap.addLiquidity(liquidity, liquidity);
+  await tokenA.connect(trader).approve(await swap.getAddress(), traderAmount);
+  await tokenB.connect(trader).approve(await swap.getAddress(), traderAmount);
+
+  return { owner, trader, tokenA, tokenB, swap };
+}
+
+before(async () => {
+  compiled = compileContracts();
+  server = ganache.server({ logging: { quiet: true } });
+  await server.listen(0);
+  provider = new ethers.JsonRpcProvider(`http://127.0.0.1:${server.address().port}`);
+  accounts = await provider.listAccounts();
+});
+
+after(async () => {
+  await provider?.destroy();
+  await server?.close();
+});
+
+test("executes a swap when exact expected output satisfies minAmountOut", async () => {
+  const { trader, tokenA, tokenB, swap } = await deploySwap();
+  const amountIn = ethers.parseEther("10");
+  const expectedOut = await swap.getAmountOut(await tokenA.getAddress(), amountIn);
+  const deadline = (await latestTimestamp()) + 60n;
+  const balanceBefore = await tokenB.balanceOf(trader.address);
+
+  await swap.connect(trader).swap(await tokenA.getAddress(), amountIn, expectedOut, deadline);
+
+  assert.equal(await tokenB.balanceOf(trader.address), balanceBefore + expectedOut);
+});
+
+test("reverts when output is below minAmountOut", async () => {
+  const { trader, tokenA, swap } = await deploySwap();
+  const amountIn = ethers.parseEther("10");
+  const expectedOut = await swap.getAmountOut(await tokenA.getAddress(), amountIn);
+  const deadline = (await latestTimestamp()) + 60n;
+
+  await assert.rejects(
+    swap.connect(trader).swap(await tokenA.getAddress(), amountIn, expectedOut + 1n, deadline),
+  );
+});
+
+test("reverts expired swaps", async () => {
+  const { trader, tokenA, swap } = await deploySwap();
+  const amountIn = ethers.parseEther("10");
+  const expectedOut = await swap.getAmountOut(await tokenA.getAddress(), amountIn);
+  const deadline = (await latestTimestamp()) - 1n;
+
+  await assert.rejects(
+    swap.connect(trader).swap(await tokenA.getAddress(), amountIn, expectedOut, deadline),
+  );
+});
+
+test("uses fee-adjusted input before division", async () => {
+  const liquidity = 10_000n;
+  const { tokenA, swap } = await deploySwap({ liquidity, traderAmount: liquidity });
+  const amountIn = 3333n;
+  const amountInWithFee = amountIn * 9970n;
+  const expectedOut = liquidity * amountInWithFee / (liquidity * 10000n + amountInWithFee);
+
+  assert.equal(await swap.getAmountOut(await tokenA.getAddress(), amountIn), expectedOut);
+});


### PR DESCRIPTION
## Issue
Closes #913

/claim #913

## Summary
Updates swap to require minAmountOut and deadline, rejecting stale or overly-slipped swaps before token transfers. Fee-adjusted input is now calculated in one basis-point fixed-point step before applying the constant-product formula, and getAmountOut shares that calculation.

## Acceptance criteria
- [x] swap function requires minAmountOut and reverts when slippage exceeds it
- [x] deadline parameter prevents stale transactions from executing
- [x] Fee calculation uses proper fixed-point math to avoid zero-fee truncation for small amounts
- [x] Swap with exact expected output succeeds
- [x] Swap with output below minAmountOut reverts with clear error message
- [x] Expired transactions revert with deadline error

## Validation
- [x] node --test solidity/test/SimpleSwap.test.js
- [x] git diff --check

Note: I did not include the requested _meta.json because it asks contributors to paste complete runtime/platform instructions into the repository.