### PR TITLE
Codex [ T3 Code ] Add Tailscale peer diagnostics with latency graph

### DIFF
--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -88,6 +88,7 @@ import {
   type SessionCredentialChange,
 } from "./auth/Services/SessionCredentialService.ts";
 import { respondToAuthError } from "./auth/http.ts";
+import { diagnosePeer } from "@t3tools/tailscale";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 const isWorkspacePathOutsideRootError = Schema.is(WorkspacePathOutsideRootError);
 
@@ -919,6 +920,10 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
               "rpc.aggregate": "server",
             },
           ),
+        [WS_METHODS.serverDiagnoseTailscalePeer]: (input) =>
+          observeRpcEffect(WS_METHODS.serverDiagnoseTailscalePeer, diagnosePeer(input), {
+            "rpc.aggregate": "server",
+          }),
         [WS_METHODS.serverSignalProcess]: (input) =>
           observeRpcEffect(WS_METHODS.serverSignalProcess, processDiagnostics.signal(input), {
             "rpc.aggregate": "server",

--- a/t3code/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/t3code/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1,6 +1,7 @@
 import {
   ChevronDownIcon,
   ChevronsLeftRightEllipsisIcon,
+  LineChartIcon,
   PlusIcon,
   QrCodeIcon,
   RefreshCwIcon,
@@ -16,6 +17,7 @@ import {
   type DesktopSshEnvironmentTarget,
   type DesktopServerExposureState,
   type EnvironmentId,
+  type PeerDiagnosticsResult,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 
@@ -112,6 +114,52 @@ function formatAccessTimestamp(value: string): string {
     return value;
   }
   return accessTimestampFormatter.format(parsed);
+}
+
+function formatDiagnosticsLatency(value: number | null): string {
+  return value === null ? "Unavailable" : `${Number(value.toFixed(1))} ms`;
+}
+
+function formatDiagnosticsValue(value: string | boolean | null | undefined): string {
+  if (value === null || value === undefined || value === "") {
+    return "Unavailable";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Online" : "Offline";
+  }
+  return value;
+}
+
+function TailscaleLatencyGraph({ diagnostics }: { diagnostics: PeerDiagnosticsResult }) {
+  const maxLatency = Math.max(1, ...diagnostics.samples.map((sample) => sample.latencyMs ?? 0));
+
+  return (
+    <div className="flex h-16 items-end gap-1" aria-label="Tailscale latency samples">
+      {diagnostics.samples.map((sample) => {
+        const heightPercent =
+          sample.latencyMs === null ? 10 : Math.max(10, (sample.latencyMs / maxLatency) * 100);
+        return (
+          <Tooltip key={sample.sequence}>
+            <TooltipTrigger
+              render={
+                <div
+                  className={cn(
+                    "w-4 rounded-t-sm bg-primary/70",
+                    sample.connectionType === "relayed" && "bg-warning/80",
+                    sample.latencyMs === null && "bg-muted-foreground/30",
+                  )}
+                  style={{ height: `${heightPercent}%` }}
+                />
+              }
+            />
+            <TooltipPopup side="top">
+              Sample {sample.sequence}: {formatDiagnosticsLatency(sample.latencyMs)}
+            </TooltipPopup>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
 }
 
 type ConnectionStatusDotProps = {
@@ -1498,6 +1546,12 @@ export function ConnectionsSettings() {
   const [tailscaleServePortInput, setTailscaleServePortInput] = useState(
     String(DEFAULT_TAILSCALE_SERVE_PORT),
   );
+  const [tailscaleDiagnosticsPeer, setTailscaleDiagnosticsPeer] = useState("");
+  const [tailscaleDiagnostics, setTailscaleDiagnostics] = useState<PeerDiagnosticsResult | null>(
+    null,
+  );
+  const [tailscaleDiagnosticsError, setTailscaleDiagnosticsError] = useState<string | null>(null);
+  const [isRunningTailscaleDiagnostics, setIsRunningTailscaleDiagnostics] = useState(false);
   const [pendingDesktopServerExposureMode, setPendingDesktopServerExposureMode] = useState<
     DesktopServerExposureState["mode"] | null
   >(null);
@@ -1640,6 +1694,40 @@ export function ConnectionsSettings() {
   const handleStartTailscaleServeDisable = useCallback((_endpoint: AdvertisedEndpoint) => {
     setDisableTailscaleServeDialogOpen(true);
   }, []);
+
+  const handleRunTailscaleDiagnostics = useCallback(async () => {
+    const peer = tailscaleDiagnosticsPeer.trim();
+    if (!peer) {
+      setTailscaleDiagnosticsError("Enter a peer name or Tailscale IP.");
+      setTailscaleDiagnostics(null);
+      return;
+    }
+
+    setIsRunningTailscaleDiagnostics(true);
+    setTailscaleDiagnosticsError(null);
+    try {
+      const diagnostics =
+        await getPrimaryEnvironmentConnection().client.server.diagnoseTailscalePeer({ peer });
+      setTailscaleDiagnostics(diagnostics);
+      if (diagnostics.error) {
+        setTailscaleDiagnosticsError(diagnostics.error);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to run Tailscale diagnostics.";
+      setTailscaleDiagnostics(null);
+      setTailscaleDiagnosticsError(message);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not run Tailscale diagnostics",
+          description: message,
+        }),
+      );
+    } finally {
+      setIsRunningTailscaleDiagnostics(false);
+    }
+  }, [tailscaleDiagnosticsPeer]);
 
   const handleRevokeDesktopPairingLink = useCallback(async (id: string) => {
     setRevokingDesktopPairingLinkId(id);
@@ -2356,6 +2444,102 @@ export function ConnectionsSettings() {
       }
     />
   );
+  const renderTailscaleDiagnosticsPanel = () => (
+    <div className="border-t border-border/60 px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <label className="min-w-0 flex-1">
+          <span className="text-sm font-medium text-foreground">Peer diagnostics</span>
+          <Input
+            className="mt-2"
+            value={tailscaleDiagnosticsPeer}
+            onChange={(event) => setTailscaleDiagnosticsPeer(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                void handleRunTailscaleDiagnostics();
+              }
+            }}
+            placeholder="runner.tail.ts.net or 100.x.y.z"
+            disabled={isRunningTailscaleDiagnostics}
+          />
+        </label>
+        <Button
+          className="shrink-0 gap-2"
+          variant="outline"
+          onClick={() => void handleRunTailscaleDiagnostics()}
+          disabled={isRunningTailscaleDiagnostics || tailscaleDiagnosticsPeer.trim().length === 0}
+        >
+          {isRunningTailscaleDiagnostics ? (
+            <Spinner className="size-3.5" />
+          ) : (
+            <LineChartIcon className="size-3.5" />
+          )}
+          Run
+        </Button>
+      </div>
+      {tailscaleDiagnosticsError ? (
+        <p className="mt-3 text-xs text-destructive">{tailscaleDiagnosticsError}</p>
+      ) : null}
+      {tailscaleDiagnostics ? (
+        <div className="mt-4 space-y-4">
+          <div className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <p className="text-xs text-muted-foreground">Connection</p>
+              <p className="font-medium capitalize text-foreground">
+                {tailscaleDiagnostics.connectionType}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Latency</p>
+              <p className="font-medium text-foreground">
+                {formatDiagnosticsLatency(tailscaleDiagnostics.latencyMs)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Peer IP</p>
+              <p className="truncate font-medium text-foreground">
+                {formatDiagnosticsValue(tailscaleDiagnostics.peerIp)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Last seen</p>
+              <p className="truncate font-medium text-foreground">
+                {tailscaleDiagnostics.lastSeen
+                  ? formatAccessTimestamp(tailscaleDiagnostics.lastSeen)
+                  : "Unavailable"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Relay</p>
+              <p className="truncate font-medium text-foreground">
+                {formatDiagnosticsValue(tailscaleDiagnostics.relayServer)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Region</p>
+              <p className="truncate font-medium text-foreground">
+                {formatDiagnosticsValue(tailscaleDiagnostics.relayRegion)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Status</p>
+              <p className="font-medium text-foreground">
+                {formatDiagnosticsValue(tailscaleDiagnostics.online)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Checked</p>
+              <p className="truncate font-medium text-foreground">
+                {formatAccessTimestamp(tailscaleDiagnostics.checkedAt)}
+              </p>
+            </div>
+          </div>
+          {tailscaleDiagnostics.samples.length > 0 ? (
+            <TailscaleLatencyGraph diagnostics={tailscaleDiagnostics} />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
   const renderAuthorizedClients = (presentation: AccessSectionPresentation) => (
     <>
       {desktopAccessManagementError ? (
@@ -2463,6 +2647,7 @@ export function ConnectionsSettings() {
                 {renderNetworkAccessRow()}
                 {renderEndpointRows("endpoint-rail")}
                 {renderTailscaleRow()}
+                {renderTailscaleDiagnosticsPanel()}
               </>
             ) : (
               renderDisabledNetworkAccessRow()

--- a/t3code/apps/web/src/localApi.ts
+++ b/t3code/apps/web/src/localApi.ts
@@ -159,6 +159,10 @@ function createBrowserLocalApi(rpcClient?: WsRpcClient): LocalApi {
         rpcClient
           ? rpcClient.server.getProcessResourceHistory(input)
           : Promise.reject(unavailableLocalBackendError()),
+      diagnoseTailscalePeer: (input) =>
+        rpcClient
+          ? rpcClient.server.diagnoseTailscalePeer(input)
+          : Promise.reject(unavailableLocalBackendError()),
       signalProcess: (input) =>
         rpcClient
           ? rpcClient.server.signalProcess(input)

--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -138,6 +138,7 @@ export interface WsRpcClient {
     readonly getProcessResourceHistory: RpcUnaryMethod<
       typeof WS_METHODS.serverGetProcessResourceHistory
     >;
+    readonly diagnoseTailscalePeer: RpcUnaryMethod<typeof WS_METHODS.serverDiagnoseTailscalePeer>;
     readonly signalProcess: RpcUnaryMethod<typeof WS_METHODS.serverSignalProcess>;
     readonly subscribeConfig: RpcStreamMethod<typeof WS_METHODS.subscribeServerConfig>;
     readonly subscribeLifecycle: RpcStreamMethod<typeof WS_METHODS.subscribeServerLifecycle>;
@@ -272,6 +273,12 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
       getProcessResourceHistory: (input) =>
         transport.request((client) =>
           client[WS_METHODS.serverGetProcessResourceHistory](input).pipe(
+            Effect.withTracerEnabled(false),
+          ),
+        ),
+      diagnoseTailscalePeer: (input) =>
+        transport.request((client) =>
+          client[WS_METHODS.serverDiagnoseTailscalePeer](input).pipe(
             Effect.withTracerEnabled(false),
           ),
         ),

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -28,6 +28,8 @@ import type {
 import type { ProviderInstanceId } from "./providerInstance.ts";
 import type {
   ServerConfig,
+  PeerDiagnosticsInput,
+  PeerDiagnosticsResult,
   ServerProcessDiagnosticsResult,
   ServerProcessResourceHistoryInput,
   ServerProcessResourceHistoryResult,
@@ -480,6 +482,7 @@ export interface LocalApi {
     getProcessResourceHistory: (
       input: ServerProcessResourceHistoryInput,
     ) => Promise<ServerProcessResourceHistoryResult>;
+    diagnoseTailscalePeer: (input: PeerDiagnosticsInput) => Promise<PeerDiagnosticsResult>;
     signalProcess: (input: ServerSignalProcessInput) => Promise<ServerSignalProcessResult>;
   };
 }

--- a/t3code/packages/contracts/src/rpc.ts
+++ b/t3code/packages/contracts/src/rpc.ts
@@ -81,6 +81,8 @@ import {
   ServerProcessDiagnosticsResult,
   ServerProcessResourceHistoryInput,
   ServerProcessResourceHistoryResult,
+  PeerDiagnosticsInput,
+  PeerDiagnosticsResult,
   ServerSignalProcessInput,
   ServerSignalProcessResult,
   ServerUpsertKeybindingInput,
@@ -148,6 +150,7 @@ export const WS_METHODS = {
   serverGetTraceDiagnostics: "server.getTraceDiagnostics",
   serverGetProcessDiagnostics: "server.getProcessDiagnostics",
   serverGetProcessResourceHistory: "server.getProcessResourceHistory",
+  serverDiagnoseTailscalePeer: "server.diagnoseTailscalePeer",
   serverSignalProcess: "server.signalProcess",
 
   // Source control methods
@@ -238,6 +241,11 @@ export const WsServerGetProcessResourceHistoryRpc = Rpc.make(
 export const WsServerSignalProcessRpc = Rpc.make(WS_METHODS.serverSignalProcess, {
   payload: ServerSignalProcessInput,
   success: ServerSignalProcessResult,
+});
+
+export const WsServerDiagnoseTailscalePeerRpc = Rpc.make(WS_METHODS.serverDiagnoseTailscalePeer, {
+  payload: PeerDiagnosticsInput,
+  success: PeerDiagnosticsResult,
 });
 
 export const WsSourceControlLookupRepositoryRpc = Rpc.make(
@@ -484,6 +492,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerGetTraceDiagnosticsRpc,
   WsServerGetProcessDiagnosticsRpc,
   WsServerGetProcessResourceHistoryRpc,
+  WsServerDiagnoseTailscalePeerRpc,
   WsServerSignalProcessRpc,
   WsSourceControlLookupRepositoryRpc,
   WsSourceControlCloneRepositoryRpc,

--- a/t3code/packages/contracts/src/server.ts
+++ b/t3code/packages/contracts/src/server.ts
@@ -394,6 +394,40 @@ export const ServerSignalProcessResult = Schema.Struct({
 });
 export type ServerSignalProcessResult = typeof ServerSignalProcessResult.Type;
 
+export const PeerDiagnosticsConnectionType = Schema.Literals(["direct", "relayed", "unknown"]);
+export type PeerDiagnosticsConnectionType = typeof PeerDiagnosticsConnectionType.Type;
+
+export const PeerDiagnosticsInput = Schema.Struct({
+  peer: TrimmedNonEmptyString,
+});
+export type PeerDiagnosticsInput = typeof PeerDiagnosticsInput.Type;
+
+export const PeerDiagnosticsPingSample = Schema.Struct({
+  sequence: PositiveInt,
+  latencyMs: Schema.NullOr(Schema.Number),
+  connectionType: PeerDiagnosticsConnectionType,
+  peerIp: Schema.NullOr(TrimmedNonEmptyString),
+  relayServer: Schema.NullOr(TrimmedNonEmptyString),
+  relayRegion: Schema.NullOr(TrimmedNonEmptyString),
+  raw: TrimmedNonEmptyString,
+});
+export type PeerDiagnosticsPingSample = typeof PeerDiagnosticsPingSample.Type;
+
+export const PeerDiagnosticsResult = Schema.Struct({
+  peer: TrimmedNonEmptyString,
+  checkedAt: IsoDateTime,
+  connectionType: PeerDiagnosticsConnectionType,
+  latencyMs: Schema.NullOr(Schema.Number),
+  peerIp: Schema.NullOr(TrimmedNonEmptyString),
+  relayServer: Schema.NullOr(TrimmedNonEmptyString),
+  relayRegion: Schema.NullOr(TrimmedNonEmptyString),
+  lastSeen: Schema.NullOr(TrimmedNonEmptyString),
+  online: Schema.NullOr(Schema.Boolean),
+  samples: Schema.Array(PeerDiagnosticsPingSample),
+  error: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type PeerDiagnosticsResult = typeof PeerDiagnosticsResult.Type;
+
 export const ServerConfig = Schema.Struct({
   environment: ExecutionEnvironmentDescriptor,
   auth: ServerAuthDescriptor,

--- a/t3code/packages/tailscale/src/tailscale.test.ts
+++ b/t3code/packages/tailscale/src/tailscale.test.ts
@@ -7,17 +7,32 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   buildTailscaleHttpsBaseUrl,
+  diagnosePeer,
   disableTailscaleServe,
   ensureTailscaleServe,
   isTailscaleIpv4Address,
   parseTailscaleMagicDnsName,
+  parseTailscalePingOutput,
   parseTailscaleStatus,
+  parseTailscaleStatusPeer,
   readTailscaleStatus,
 } from "./tailscale.ts";
 
 const encoder = new TextEncoder();
 const tailscaleStatusJson = `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.100.100.100","fd7a:115c:a1e0::1","192.168.1.20"]}}`;
 const tailscaleStatusWithSingleIpJson = `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.90.1.2"]}}`;
+const tailscalePeerStatusJson = JSON.stringify({
+  Peer: {
+    "node:123": {
+      DNSName: "runner.tail.ts.net.",
+      HostName: "runner",
+      TailscaleIPs: ["100.90.1.44"],
+      LastSeen: "2026-05-15T21:10:00Z",
+      Online: true,
+      Relay: "derp-nyc",
+    },
+  },
+});
 
 function mockHandle(result: { stdout?: string; stderr?: string; code?: number }) {
   return ChildProcessSpawner.makeHandle({
@@ -81,6 +96,53 @@ describe("tailscale", () => {
     }),
   );
 
+  it.effect("parses direct and relayed tailscale ping samples", () =>
+    Effect.sync(() => {
+      const samples = parseTailscalePingOutput(
+        [
+          "pong from runner (100.90.1.44) via 192.168.1.20:41641 in 11.2ms",
+          "pong from runner (100.90.1.44) via DERP(nyc) in 83ms",
+        ].join("\n"),
+      );
+
+      assert.deepEqual(samples, [
+        {
+          sequence: 1,
+          latencyMs: 11.2,
+          connectionType: "direct",
+          peerIp: "100.90.1.44",
+          relayServer: null,
+          relayRegion: null,
+          raw: "pong from runner (100.90.1.44) via 192.168.1.20:41641 in 11.2ms",
+        },
+        {
+          sequence: 2,
+          latencyMs: 83,
+          connectionType: "relayed",
+          peerIp: "100.90.1.44",
+          relayServer: "nyc",
+          relayRegion: "nyc",
+          raw: "pong from runner (100.90.1.44) via DERP(nyc) in 83ms",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("parses peer status facts", () =>
+    Effect.gen(function* () {
+      const peer = yield* parseTailscaleStatusPeer(tailscalePeerStatusJson, {
+        peer: "runner.tail.ts.net",
+        peerIp: null,
+      });
+      assert.deepEqual(peer, {
+        lastSeen: "2026-05-15T21:10:00Z",
+        online: true,
+        relayServer: "nyc",
+        relayRegion: "nyc",
+      });
+    }),
+  );
+
   it.effect("builds clean HTTPS base URLs", () =>
     Effect.sync(() => {
       assert.equal(
@@ -109,6 +171,63 @@ describe("tailscale", () => {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.90.1.2"],
       });
+    });
+  });
+
+  it.effect("diagnoses a peer through mocked tailscale ping and status", () => {
+    const commands: {
+      readonly command: string;
+      readonly args: ReadonlyArray<string>;
+    }[] = [];
+    const layer = mockSpawnerLayer((command, args) => {
+      commands.push({ command, args });
+      if (args[0] === "ping") {
+        return {
+          stdout: [
+            "pong from runner (100.90.1.44) via 192.168.1.20:41641 in 12ms",
+            "pong from runner (100.90.1.44) via DERP(nyc) in 81ms",
+          ].join("\n"),
+        };
+      }
+      return { stdout: tailscalePeerStatusJson };
+    });
+
+    return Effect.gen(function* () {
+      const diagnostics = yield* diagnosePeer({ peer: "runner" }).pipe(Effect.provide(layer));
+      assert.deepEqual(commands, [
+        {
+          command: "tailscale",
+          args: ["ping", "--c=10", "--timeout=15s", "runner"],
+        },
+        {
+          command: "tailscale",
+          args: ["status", "--json"],
+        },
+      ]);
+      assert.equal(diagnostics.peer, "runner");
+      assert.equal(diagnostics.connectionType, "relayed");
+      assert.equal(diagnostics.latencyMs, 81);
+      assert.equal(diagnostics.peerIp, "100.90.1.44");
+      assert.equal(diagnostics.relayServer, "nyc");
+      assert.equal(diagnostics.relayRegion, "nyc");
+      assert.equal(diagnostics.lastSeen, "2026-05-15T21:10:00Z");
+      assert.equal(diagnostics.online, true);
+      assert.equal(diagnostics.samples.length, 2);
+      assert.equal(diagnostics.error, null);
+    });
+  });
+
+  it.effect("returns a graceful diagnostic error when tailscale ping fails", () => {
+    const layer = mockSpawnerLayer(() => ({
+      stderr: "peer not found",
+      code: 1,
+    }));
+
+    return Effect.gen(function* () {
+      const diagnostics = yield* diagnosePeer({ peer: "missing" }).pipe(Effect.provide(layer));
+      assert.equal(diagnostics.connectionType, "unknown");
+      assert.equal(diagnostics.error?.includes("peer not found"), true);
+      assert.deepEqual(diagnostics.samples, []);
     });
   });
 

--- a/t3code/packages/tailscale/src/tailscale.ts
+++ b/t3code/packages/tailscale/src/tailscale.ts
@@ -1,4 +1,5 @@
 import * as Data from "effect/Data";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
@@ -10,6 +11,8 @@ export const DEFAULT_TAILSCALE_SERVE_PORT = 443;
 export const TAILSCALE_STATUS_TIMEOUT_MS = 1_500;
 export const TAILSCALE_SERVE_TIMEOUT_MS = 10_000;
 export const TAILSCALE_PROBE_TIMEOUT_MS = 2_500;
+export const TAILSCALE_DIAGNOSTICS_TIMEOUT_MS = 15_000;
+const TAILSCALE_DIAGNOSTICS_PING_COUNT = 10;
 
 export class TailscaleCommandError extends Data.TaggedError("TailscaleCommandError")<{
   readonly command: readonly string[];
@@ -31,16 +34,51 @@ const TailscaleStatusSelf = Schema.Struct({
   TailscaleIPs: Schema.optional(Schema.Unknown),
 });
 
+const TailscaleStatusPeer = Schema.Struct({
+  DNSName: Schema.optional(Schema.Unknown),
+  HostName: Schema.optional(Schema.Unknown),
+  TailscaleIPs: Schema.optional(Schema.Unknown),
+  LastSeen: Schema.optional(Schema.Unknown),
+  Online: Schema.optional(Schema.Unknown),
+  Relay: Schema.optional(Schema.Unknown),
+});
+
 const TailscaleStatusJson = Schema.Struct({
   Self: Schema.optional(TailscaleStatusSelf),
+  Peer: Schema.optional(Schema.Record(Schema.String, TailscaleStatusPeer)),
 });
 
 export type TailscaleStatusSelf = typeof TailscaleStatusSelf.Type;
+export type TailscaleStatusPeer = typeof TailscaleStatusPeer.Type;
 export type TailscaleStatusJson = typeof TailscaleStatusJson.Type;
 
 export interface TailscaleStatus {
   readonly magicDnsName: string | null;
   readonly tailnetIpv4Addresses: readonly string[];
+}
+
+export interface TailscalePingSample {
+  readonly sequence: number;
+  readonly latencyMs: number | null;
+  readonly connectionType: "direct" | "relayed" | "unknown";
+  readonly peerIp: string | null;
+  readonly relayServer: string | null;
+  readonly relayRegion: string | null;
+  readonly raw: string;
+}
+
+export interface PeerDiagnostics {
+  readonly peer: string;
+  readonly checkedAt: string;
+  readonly connectionType: "direct" | "relayed" | "unknown";
+  readonly latencyMs: number | null;
+  readonly peerIp: string | null;
+  readonly relayServer: string | null;
+  readonly relayRegion: string | null;
+  readonly lastSeen: string | null;
+  readonly online: boolean | null;
+  readonly samples: readonly TailscalePingSample[];
+  readonly error: string | null;
 }
 
 const collectStdout = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
@@ -125,6 +163,131 @@ export const parseTailscaleStatus = (
     }),
   );
 
+function normalizeRelayValue(value: string | null): {
+  readonly relayServer: string | null;
+  readonly relayRegion: string | null;
+} {
+  if (!value) {
+    return { relayServer: null, relayRegion: null };
+  }
+
+  const normalized = value
+    .trim()
+    .replace(/^DERP\((.*)\)$/iu, "$1")
+    .replace(/^derp-/iu, "");
+  if (!normalized) {
+    return { relayServer: value, relayRegion: null };
+  }
+
+  const parts = normalized.split("-");
+  return {
+    relayServer: normalized,
+    relayRegion: parts.at(-1) ?? normalized,
+  };
+}
+
+function normalizeStatusTimestamp(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readStatusIps(peer: TailscaleStatusPeer | undefined): readonly string[] {
+  const rawIps = peer?.TailscaleIPs;
+  return Array.isArray(rawIps) ? rawIps.filter((ip): ip is string => typeof ip === "string") : [];
+}
+
+function findPeerStatus(
+  status: TailscaleStatusJson,
+  peer: string,
+  peerIp: string | null,
+): TailscaleStatusPeer | undefined {
+  const normalizedPeer = peer.trim().replace(/\.$/u, "").toLowerCase();
+  const normalizedIp = peerIp?.trim();
+  const peers = status.Peer ? Object.values(status.Peer) : [];
+
+  return peers.find((entry) => {
+    const names = [entry.DNSName, entry.HostName]
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim().replace(/\.$/u, "").toLowerCase());
+    const ips = readStatusIps(entry);
+
+    return (
+      names.includes(normalizedPeer) ||
+      ips.includes(peer) ||
+      (normalizedIp !== undefined && ips.includes(normalizedIp))
+    );
+  });
+}
+
+export function parseTailscalePingOutput(rawOutput: string): readonly TailscalePingSample[] {
+  const samples: TailscalePingSample[] = [];
+  const lines = rawOutput
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  for (const line of lines) {
+    const match =
+      /pong from .+? \((?<peerIp>[^)]+)\) via (?<via>.+?) in (?<latency>[0-9.]+)ms/iu.exec(line);
+    if (!match?.groups) {
+      continue;
+    }
+
+    const via = match.groups.via?.trim();
+    const latency = match.groups.latency;
+    const peerIp = match.groups.peerIp;
+    if (!via || !latency || !peerIp) {
+      continue;
+    }
+    const isRelay = /^DERP\(/iu.test(via) || /^derp-/iu.test(via);
+    const relay = isRelay ? normalizeRelayValue(via) : { relayServer: null, relayRegion: null };
+    samples.push({
+      sequence: samples.length + 1,
+      latencyMs: Number(latency),
+      connectionType: isRelay ? "relayed" : "direct",
+      peerIp,
+      relayServer: relay.relayServer,
+      relayRegion: relay.relayRegion,
+      raw: line,
+    });
+  }
+
+  return samples;
+}
+
+export const parseTailscaleStatusPeer = (
+  rawStatusJson: string,
+  input: { readonly peer: string; readonly peerIp: string | null },
+): Effect.Effect<
+  {
+    readonly lastSeen: string | null;
+    readonly online: boolean | null;
+    readonly relayServer: string | null;
+    readonly relayRegion: string | null;
+  },
+  TailscaleStatusParseError
+> =>
+  decodeTailscaleStatusJson(rawStatusJson).pipe(
+    Effect.mapError((cause) => new TailscaleStatusParseError({ cause })),
+    Effect.map((status) => {
+      const peerStatus = findPeerStatus(status, input.peer, input.peerIp);
+      const relay = normalizeRelayValue(
+        typeof peerStatus?.Relay === "string" ? peerStatus.Relay : null,
+      );
+
+      return {
+        lastSeen: normalizeStatusTimestamp(peerStatus?.LastSeen),
+        online: typeof peerStatus?.Online === "boolean" ? peerStatus.Online : null,
+        relayServer: relay.relayServer,
+        relayRegion: relay.relayRegion,
+      };
+    }),
+  );
+
 export const readTailscaleStatus: Effect.Effect<
   TailscaleStatus,
   TailscaleCommandError | TailscaleStatusParseError,
@@ -185,6 +348,171 @@ export const readTailscaleStatus: Effect.Effect<
     }),
   ),
 );
+
+const runTailscaleOutput = (
+  args: readonly string[],
+  input: {
+    readonly spawnMessage: string;
+    readonly runMessage: string;
+    readonly exitMessage: (exitCode: number) => string;
+  },
+): Effect.Effect<string, TailscaleCommandError, ChildProcessSpawner.ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const child = yield* spawner
+      .spawn(
+        ChildProcess.make("tailscale", args, {
+          shell: process.platform === "win32",
+        }),
+      )
+      .pipe(
+        Effect.mapError((cause) =>
+          tailscaleCommandError(
+            args,
+            cause instanceof Error ? cause.message : input.spawnMessage,
+            null,
+          ),
+        ),
+      );
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectStdout(child.stdout),
+        collectStderr(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ],
+      { concurrency: "unbounded" },
+    ).pipe(
+      Effect.mapError((cause) =>
+        tailscaleCommandError(
+          args,
+          cause instanceof Error ? cause.message : input.runMessage,
+          null,
+        ),
+      ),
+    );
+    if (exitCode !== 0) {
+      return yield* tailscaleCommandError(args, input.exitMessage(exitCode), exitCode, stderr);
+    }
+    return stdout;
+  }).pipe(Effect.scoped);
+
+function formatDiagnosticsError(error: unknown): string {
+  if (error instanceof TailscaleCommandError) {
+    const detail = error.stderr.trim();
+    return detail ? `${error.message} ${detail}` : error.message;
+  }
+  if (error instanceof TailscaleStatusParseError) {
+    return "Tailscale status output could not be parsed.";
+  }
+  return error instanceof Error ? error.message : "Tailscale diagnostics failed.";
+}
+
+function summarizeDiagnostics(
+  peer: string,
+  pingOutput: string,
+  statusOutput: string | null,
+): Effect.Effect<PeerDiagnostics, TailscaleStatusParseError> {
+  const samples = parseTailscalePingOutput(pingOutput).slice(-TAILSCALE_DIAGNOSTICS_PING_COUNT);
+  const latestSample = samples.at(-1);
+  const peerIp = latestSample?.peerIp ?? null;
+
+  return (
+    statusOutput
+      ? parseTailscaleStatusPeer(statusOutput, { peer, peerIp })
+      : Effect.succeed({
+          lastSeen: null,
+          online: null,
+          relayServer: null,
+          relayRegion: null,
+        })
+  ).pipe(
+    Effect.flatMap((statusPeer) =>
+      DateTime.now.pipe(
+        Effect.map((now) => {
+          const relayServer = latestSample?.relayServer ?? statusPeer.relayServer;
+          const relayRegion = latestSample?.relayRegion ?? statusPeer.relayRegion;
+          return {
+            peer,
+            checkedAt: DateTime.formatIso(now),
+            connectionType: latestSample?.connectionType ?? "unknown",
+            latencyMs: latestSample?.latencyMs ?? null,
+            peerIp,
+            relayServer,
+            relayRegion,
+            lastSeen: statusPeer.lastSeen,
+            online: statusPeer.online,
+            samples,
+            error:
+              samples.length > 0 ? null : "No successful tailscale ping samples were returned.",
+          };
+        }),
+      ),
+    ),
+  );
+}
+
+export const diagnosePeer = (input: {
+  readonly peer: string;
+}): Effect.Effect<PeerDiagnostics, never, ChildProcessSpawner.ChildProcessSpawner> => {
+  const peer = input.peer.trim();
+  const emptyResult = (error: string, checkedAt: string): PeerDiagnostics => ({
+    peer,
+    checkedAt,
+    connectionType: "unknown",
+    latencyMs: null,
+    peerIp: null,
+    relayServer: null,
+    relayRegion: null,
+    lastSeen: null,
+    online: null,
+    samples: [],
+    error,
+  });
+
+  if (!peer) {
+    return DateTime.now.pipe(
+      Effect.map((now) =>
+        emptyResult("A peer name or Tailscale IP is required.", DateTime.formatIso(now)),
+      ),
+    );
+  }
+
+  return Effect.gen(function* () {
+    const pingOutput = yield* runTailscaleOutput(["ping", "--c=10", "--timeout=15s", peer], {
+      spawnMessage: "Failed to spawn tailscale ping.",
+      runMessage: "Failed to run tailscale ping.",
+      exitMessage: (exitCode) => `Tailscale ping exited with code ${exitCode}.`,
+    });
+    const statusOutput = yield* runTailscaleOutput(["status", "--json"], {
+      spawnMessage: "Failed to spawn tailscale status.",
+      runMessage: "Failed to run tailscale status.",
+      exitMessage: (exitCode) => `Tailscale status exited with code ${exitCode}.`,
+    }).pipe(Effect.catch(() => Effect.succeed(null)));
+
+    return yield* summarizeDiagnostics(peer, pingOutput, statusOutput);
+  }).pipe(
+    Effect.timeoutOption(TAILSCALE_DIAGNOSTICS_TIMEOUT_MS),
+    Effect.flatMap((result) =>
+      Option.match(result, {
+        onNone: () =>
+          DateTime.now.pipe(
+            Effect.map((now) =>
+              emptyResult(
+                "Tailscale diagnostics timed out after 15 seconds.",
+                DateTime.formatIso(now),
+              ),
+            ),
+          ),
+        onSome: Effect.succeed,
+      }),
+    ),
+    Effect.catch((error) =>
+      DateTime.now.pipe(
+        Effect.map((now) => emptyResult(formatDiagnosticsError(error), DateTime.formatIso(now))),
+      ),
+    ),
+  );
+};
 
 export function buildTailscaleHttpsBaseUrl(input: {
   readonly magicDnsName: string;


### PR DESCRIPTION
﻿/claim #844

## Summary
- Add Tailscale peer diagnostics in `@t3tools/tailscale` using `tailscale ping --c=10 --timeout=15s` plus `tailscale status --json`.
- Parse direct vs DERP-relayed connections, peer IP, latency samples, relay server/region, status, and last-seen timestamps into structured diagnostics.
- Add a websocket RPC endpoint, web client method, and Connections settings diagnostics panel with the last 10 latency samples.
- Handle missing Tailscale, unknown peers, timeouts, and parse gaps by returning a structured diagnostics result with an error message.

## Verification
- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run --filter @t3tools/tailscale test`
- `npx --yes bun run --filter @t3tools/tailscale typecheck`
- `npx --yes bun run --filter @t3tools/contracts typecheck`
- `npx --yes bun run --filter t3 typecheck`
- `npx --yes bun run --filter @t3tools/web typecheck`
- `git diff --check` (passes; local CRLF warnings only)

## Metadata note
I did not add `.generation_meta.json` because it requests hidden/runtime instructions and session context. That information is not appropriate to include in a repository.
