### PR TITLE
Codex [ Crypto ] Bind bridge signatures to chain and nonce

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,10 +4,21 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    string public constant NAME = "CrossChainBridge";
+    string public constant VERSION = "1";
+
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "BridgeTransfer(address sender,address recipient,uint256 amount,uint256 nonce,uint256 chainId,address bridge)"
+    );
+
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
+    bytes32 public immutable DOMAIN_SEPARATOR;
 
+    mapping(address => uint256) public nonces;
     mapping(bytes32 => bool) public processedTransfers;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
@@ -16,42 +27,70 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes(NAME)),
+            keccak256(bytes(VERSION)),
+            block.chainid,
+            address(this)
+        ));
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
-        bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        uint256 transferNonce = nonces[msg.sender]++;
+        require(bridgeToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+        emit TransferInitiated(msg.sender, amount, targetChain, transferNonce);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
+        address sender,
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(transferNonce == nonces[sender], "Invalid nonce");
+
+        bytes32 structHash = hashTransfer(sender, recipient, amount, transferNonce);
+        bytes32 transferHash = toTypedDataHash(structHash);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
-        bridgeToken.transfer(recipient, amount);
+        nonces[sender] = transferNonce + 1;
+        require(bridgeToken.transfer(recipient, amount), "Transfer failed");
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
-    function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
+    function getNonce(address sender) external view returns (uint256) {
+        return nonces[sender];
+    }
+
+    function hashTransfer(
+        address sender,
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        return keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            sender,
+            recipient,
+            amount,
+            transferNonce,
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function toTypedDataHash(bytes32 structHash) public view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+    }
+
+    function verifySignature(bytes32 digest, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
         bytes32 r;
@@ -65,13 +104,11 @@ contract CrossChainBridge {
         }
 
         if (v < 27) v += 27;
+        if (v != 27 && v != 28) return false;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(digest, v, r, s);
+        if (recovered == address(0)) return false;
 
-        // BUG: Missing require(recovered != address(0))
         return recovered == validator;
     }
 

--- a/solidity/test/CrossChainBridge.test.js
+++ b/solidity/test/CrossChainBridge.test.js
@@ -1,0 +1,305 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ganache = require("ganache");
+const solc = require("solc");
+const { ethers } = require("ethers");
+
+const bridgePath = path.join(__dirname, "..", "contracts", "CrossChainBridge.sol");
+
+const ierc20Source = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+`;
+
+const mockSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name = "Mock Token";
+    string public symbol = "MOCK";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+`;
+
+const transferTypes = {
+    BridgeTransfer: [
+        { name: "sender", type: "address" },
+        { name: "recipient", type: "address" },
+        { name: "amount", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+        { name: "chainId", type: "uint256" },
+        { name: "bridge", type: "address" },
+    ],
+};
+
+function compileContracts() {
+    const input = {
+        language: "Solidity",
+        sources: {
+            "solidity/contracts/CrossChainBridge.sol": {
+                content: fs.readFileSync(bridgePath, "utf8"),
+            },
+            "@openzeppelin/contracts/token/ERC20/IERC20.sol": {
+                content: ierc20Source,
+            },
+            "solidity/test/BridgeMocks.sol": {
+                content: mockSource,
+            },
+        },
+        settings: {
+            evmVersion: "shanghai",
+            outputSelection: {
+                "*": {
+                    "*": ["abi", "evm.bytecode.object"],
+                },
+            },
+        },
+    };
+
+    const output = JSON.parse(solc.compile(JSON.stringify(input)));
+    const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+    assert.deepEqual(errors, []);
+    return output.contracts;
+}
+
+function artifact(contracts, source, name) {
+    const contract = contracts[source][name];
+    return {
+        abi: contract.abi,
+        bytecode: `0x${contract.evm.bytecode.object}`,
+    };
+}
+
+async function deploy(factory, ...args) {
+    const contract = await factory.deploy(...args);
+    await contract.waitForDeployment();
+    return contract;
+}
+
+async function send(transaction) {
+    const response = await transaction;
+    return response.wait();
+}
+
+async function setup({ chainId = 31_337, validator = ethers.Wallet.createRandom() } = {}) {
+    const provider = new ethers.BrowserProvider(
+        ganache.provider({ chain: { chainId }, logging: { quiet: true }, wallet: { totalAccounts: 3 } }),
+    );
+    const owner = await provider.getSigner(0);
+    const recipient = await provider.getSigner(1);
+    const contracts = compileContracts();
+
+    const tokenFactory = new ethers.ContractFactory(
+        artifact(contracts, "solidity/test/BridgeMocks.sol", "MockERC20").abi,
+        artifact(contracts, "solidity/test/BridgeMocks.sol", "MockERC20").bytecode,
+        owner,
+    );
+    const token = await deploy(tokenFactory);
+
+    const bridgeFactory = new ethers.ContractFactory(
+        artifact(contracts, "solidity/contracts/CrossChainBridge.sol", "CrossChainBridge").abi,
+        artifact(contracts, "solidity/contracts/CrossChainBridge.sol", "CrossChainBridge").bytecode,
+        owner,
+    );
+    const bridge = await deploy(bridgeFactory, await token.getAddress(), validator.address);
+    await send(token.mint(await bridge.getAddress(), 1_000_000n));
+
+    return { provider, owner, recipient, validator, token, bridge };
+}
+
+async function transferValue(provider, bridge, sender, recipient, amount, nonce) {
+    const network = await provider.getNetwork();
+    return {
+        sender,
+        recipient,
+        amount,
+        nonce,
+        chainId: network.chainId,
+        bridge: await bridge.getAddress(),
+    };
+}
+
+async function transferDomain(provider, bridge) {
+    const network = await provider.getNetwork();
+    return {
+        name: "CrossChainBridge",
+        version: "1",
+        chainId: network.chainId,
+        verifyingContract: await bridge.getAddress(),
+    };
+}
+
+async function signTransfer({ provider, bridge, validator, sender, recipient, amount, nonce }) {
+    return validator.signTypedData(
+        await transferDomain(provider, bridge),
+        transferTypes,
+        await transferValue(provider, bridge, sender, recipient, amount, nonce),
+    );
+}
+
+describe("CrossChainBridge", () => {
+    it("constructs the EIP-712 domain separator from name, version, chain ID, and bridge address", async () => {
+        const { provider, bridge } = await setup();
+
+        assert.equal(
+            await bridge.DOMAIN_SEPARATOR(),
+            ethers.TypedDataEncoder.hashDomain(await transferDomain(provider, bridge)),
+        );
+    });
+
+    it("verifies and processes an EIP-712 bridge transfer", async () => {
+        const { provider, owner, recipient, validator, token, bridge } = await setup();
+        const senderAddress = await owner.getAddress();
+        const recipientAddress = await recipient.getAddress();
+        const signature = await signTransfer({
+            provider,
+            bridge,
+            validator,
+            sender: senderAddress,
+            recipient: recipientAddress,
+            amount: 500n,
+            nonce: 0n,
+        });
+        const digest = await bridge.toTypedDataHash(
+            await bridge.hashTransfer(senderAddress, recipientAddress, 500n, 0n),
+        );
+
+        assert.equal(await bridge.verifySignature(digest, signature), true);
+        await send(bridge.processTransfer(senderAddress, recipientAddress, 500n, 0n, signature));
+
+        assert.equal(await token.balanceOf(recipientAddress), 500n);
+        assert.equal(await bridge.getNonce(senderAddress), 1n);
+    });
+
+    it("rejects same-chain replay with the same nonce and signature", async () => {
+        const { provider, owner, recipient, validator, token, bridge } = await setup();
+        const senderAddress = await owner.getAddress();
+        const recipientAddress = await recipient.getAddress();
+        const signature = await signTransfer({
+            provider,
+            bridge,
+            validator,
+            sender: senderAddress,
+            recipient: recipientAddress,
+            amount: 250n,
+            nonce: 0n,
+        });
+
+        await send(bridge.processTransfer(senderAddress, recipientAddress, 250n, 0n, signature));
+        await assert.rejects(send(bridge.processTransfer(senderAddress, recipientAddress, 250n, 0n, signature)));
+
+        assert.equal(await token.balanceOf(recipientAddress), 250n);
+        assert.equal(await bridge.getNonce(senderAddress), 1n);
+    });
+
+    it("rejects replay against a replacement bridge contract on the same chain", async () => {
+        const { provider, owner, recipient, validator, token, bridge } = await setup();
+        const senderAddress = await owner.getAddress();
+        const recipientAddress = await recipient.getAddress();
+        const signature = await signTransfer({
+            provider,
+            bridge,
+            validator,
+            sender: senderAddress,
+            recipient: recipientAddress,
+            amount: 100n,
+            nonce: 0n,
+        });
+
+        const contracts = compileContracts();
+        const bridgeFactory = new ethers.ContractFactory(
+            artifact(contracts, "solidity/contracts/CrossChainBridge.sol", "CrossChainBridge").abi,
+            artifact(contracts, "solidity/contracts/CrossChainBridge.sol", "CrossChainBridge").bytecode,
+            owner,
+        );
+        const replacementBridge = await deploy(bridgeFactory, await token.getAddress(), validator.address);
+        await send(token.mint(await replacementBridge.getAddress(), 1_000n));
+
+        await assert.rejects(send(replacementBridge.processTransfer(senderAddress, recipientAddress, 100n, 0n, signature)));
+    });
+
+    it("rejects replay on a different chain ID", async () => {
+        const validator = ethers.Wallet.createRandom();
+        const source = await setup({ chainId: 31_337, validator });
+        const destination = await setup({ chainId: 31_338, validator });
+        const senderAddress = await source.owner.getAddress();
+        const recipientAddress = await destination.recipient.getAddress();
+        const signature = await signTransfer({
+            provider: source.provider,
+            bridge: source.bridge,
+            validator,
+            sender: senderAddress,
+            recipient: recipientAddress,
+            amount: 100n,
+            nonce: 0n,
+        });
+
+        await assert.rejects(send(destination.bridge.processTransfer(senderAddress, recipientAddress, 100n, 0n, signature)));
+    });
+
+    it("rejects zero-address ecrecover results as invalid signatures", async () => {
+        const { owner, recipient, bridge } = await setup();
+        const senderAddress = await owner.getAddress();
+        const recipientAddress = await recipient.getAddress();
+        const digest = await bridge.toTypedDataHash(
+            await bridge.hashTransfer(senderAddress, recipientAddress, 100n, 0n),
+        );
+        const zeroSignature = `0x${"00".repeat(65)}`;
+
+        assert.equal(await bridge.verifySignature(digest, zeroSignature), false);
+        await assert.rejects(send(bridge.processTransfer(senderAddress, recipientAddress, 100n, 0n, zeroSignature)));
+    });
+
+    it("exposes and increments sender nonces when transfers are initiated", async () => {
+        const { owner, token, bridge } = await setup();
+        const ownerAddress = await owner.getAddress();
+
+        await send(token.mint(ownerAddress, 1_000n));
+        await send(token.approve(await bridge.getAddress(), 1_000n));
+        await send(bridge.initiateTransfer(100n, 2n));
+
+        assert.equal(await bridge.getNonce(ownerAddress), 1n);
+        assert.equal(await bridge.nonces(ownerAddress), 1n);
+    });
+});


### PR DESCRIPTION
/claim #920

## Summary
- Replaced the bridge's ad hoc personal-message signature flow with EIP-712 typed data verification.
- Bound signed transfers to source sender, recipient, amount, sender nonce, `block.chainid`, and `address(this)`; the EIP-712 domain also includes name, version, chain ID, and verifying contract.
- Added per-sender nonce storage and `getNonce(address)` for frontend queries.
- Reject zero-address `ecrecover` results and invalid `v` values before accepting a validator signature.
- Added a transient Solidity test harness covering EIP-712 verification, same-chain replay, cross-chain replay, replacement-contract replay, invalid signature handling, and nonce queries.

## Validation
- `npx --yes --package=solc@0.8.30 --package=ganache@7.9.2 --package=ethers@6.15.0 powershell -NoProfile -Command '$bin = $env:PATH.Split([IO.Path]::PathSeparator)[0]; $env:NODE_PATH = Split-Path $bin -Parent; node --test solidity/test/CrossChainBridge.test.js'`
- `git diff --check`

## Notes
- I did not add `contributor_meta.json` because it requests full prompt/runtime/session initialization text rather than repository functionality.
- I kept this PR scoped to the single bridge replay issue.