### PR TITLE
Codex [ Crypto ] Snapshot multisig confirmations

### DIFF
--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -13,9 +13,18 @@ contract MultiSigWallet {
         bool executed;
     }
 
+    struct Confirmation {
+        bool confirmed;
+        uint256 confirmedAtBlock;
+        uint256 revokedAtBlock;
+    }
+
     mapping(uint256 => Transaction) public transactions;
-    mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => Confirmation)) public confirmations;
+    mapping(uint256 => uint256) public lastConfirmationChangeBlock;
     mapping(address => bool) public isOwner;
+
+    uint256 private executionLock = 1;
 
     event Submitted(uint256 indexed txId);
     event Confirmed(uint256 indexed txId, address indexed owner);
@@ -27,18 +36,29 @@ contract MultiSigWallet {
         _;
     }
 
+    modifier nonReentrantExecution() {
+        require(executionLock == 1, "Reentrant execution");
+        executionLock = 2;
+        _;
+        executionLock = 1;
+    }
+
     constructor(address[] memory _owners, uint256 _required) {
         require(_owners.length > 0, "No owners");
         require(_required > 0 && _required <= _owners.length, "Invalid required");
         for (uint256 i = 0; i < _owners.length; i++) {
+            require(_owners[i] != address(0), "Invalid owner");
+            require(!isOwner[_owners[i]], "Duplicate owner");
             isOwner[_owners[i]] = true;
         }
         owners = _owners;
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid target");
+        require(data.length == 0 || to.code.length > 0, "Target not contract");
+
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
@@ -52,36 +72,67 @@ contract MultiSigWallet {
 
     function confirmTransaction(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(!confirmations[txId][msg.sender], "Already confirmed");
-        confirmations[txId][msg.sender] = true;
+        Confirmation storage confirmation = confirmations[txId][msg.sender];
+        require(!confirmation.confirmed, "Already confirmed");
+        confirmation.confirmed = true;
+        confirmation.confirmedAtBlock = block.number;
+        confirmation.revokedAtBlock = 0;
+        lastConfirmationChangeBlock[txId] = block.number;
         emit Confirmed(txId, msg.sender);
     }
 
     function revokeConfirmation(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(confirmations[txId][msg.sender], "Not confirmed");
-        confirmations[txId][msg.sender] = false;
+        Confirmation storage confirmation = confirmations[txId][msg.sender];
+        require(confirmation.confirmed, "Not confirmed");
+        confirmation.confirmed = false;
+        confirmation.revokedAtBlock = block.number;
+        lastConfirmationChangeBlock[txId] = block.number;
         emit Revoked(txId, msg.sender);
     }
 
     function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
         for (uint256 i = 0; i < owners.length; i++) {
-            if (confirmations[txId][owners[i]]) count++;
+            if (confirmations[txId][owners[i]].confirmed) count++;
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
+        for (uint256 i = 0; i < owners.length; i++) {
+            if (isConfirmedAtBlock(txId, owners[i], blockNumber)) count++;
+        }
+    }
+
+    function isConfirmedAtBlock(
+        uint256 txId,
+        address owner,
+        uint256 blockNumber
+    ) public view returns (bool) {
+        Confirmation storage confirmation = confirmations[txId][owner];
+        return confirmation.confirmedAtBlock != 0
+            && confirmation.confirmedAtBlock <= blockNumber
+            && (confirmation.revokedAtBlock == 0 || confirmation.revokedAtBlock > blockNumber);
+    }
+
+    function executeTransaction(uint256 txId) external onlyOwner nonReentrantExecution {
         require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
+        uint256 confirmationBlock = block.number;
+        uint256 changeBlockBeforeExecution = lastConfirmationChangeBlock[txId];
+        require(getConfirmationCountAtBlock(txId, confirmationBlock) >= required, "Not enough confirmations");
 
         Transaction storage txn = transactions[txId];
-        txn.executed = true;
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
         require(success, "Execution failed");
 
+        if (
+            lastConfirmationChangeBlock[txId] == confirmationBlock
+                && lastConfirmationChangeBlock[txId] != changeBlockBeforeExecution
+        ) {
+            require(getConfirmationCountAtBlock(txId, confirmationBlock) >= required, "Confirmations revoked");
+        }
+
+        txn.executed = true;
         emit Executed(txId);
     }
 

--- a/solidity/test/MultiSigWallet.test.js
+++ b/solidity/test/MultiSigWallet.test.js
@@ -1,0 +1,230 @@
+const assert = require("node:assert/strict");
+const { beforeEach, describe, it } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ganache = require("ganache");
+const solc = require("solc");
+const { ethers } = require("ethers");
+
+const walletPath = path.join(__dirname, "..", "contracts", "MultiSigWallet.sol");
+const zeroAddress = "0x0000000000000000000000000000000000000000";
+
+const helperSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IMultiSigWallet {
+    function confirmTransaction(uint256 txId) external;
+    function revokeConfirmation(uint256 txId) external;
+}
+
+contract RevokingOwner {
+    address public wallet;
+    uint256 public txId;
+
+    function configure(address _wallet, uint256 _txId) external {
+        wallet = _wallet;
+        txId = _txId;
+    }
+
+    function confirm() external {
+        IMultiSigWallet(wallet).confirmTransaction(txId);
+    }
+
+    function triggerRevoke() external payable {
+        IMultiSigWallet(wallet).revokeConfirmation(txId);
+    }
+}
+
+contract NoopTarget {
+    uint256 public calls;
+
+    function ping() external payable {
+        calls++;
+    }
+}
+`;
+
+function compileContracts() {
+    const input = {
+        language: "Solidity",
+        sources: {
+            "solidity/contracts/MultiSigWallet.sol": {
+                content: fs.readFileSync(walletPath, "utf8"),
+            },
+            "solidity/test/MultiSigHelpers.sol": {
+                content: helperSource,
+            },
+        },
+        settings: {
+            evmVersion: "shanghai",
+            outputSelection: {
+                "*": {
+                    "*": ["abi", "evm.bytecode.object"],
+                },
+            },
+        },
+    };
+
+    const output = JSON.parse(solc.compile(JSON.stringify(input)));
+    const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+    assert.deepEqual(errors, []);
+    return output.contracts;
+}
+
+function artifact(contracts, source, name) {
+    const contract = contracts[source][name];
+    return {
+        abi: contract.abi,
+        bytecode: `0x${contract.evm.bytecode.object}`,
+    };
+}
+
+async function deploy(factory, ...args) {
+    const contract = await factory.deploy(...args);
+    await contract.waitForDeployment();
+    return contract;
+}
+
+async function send(transaction) {
+    const response = await transaction;
+    return response.wait();
+}
+
+async function submit(wallet, signer, to, value = 0n, data = "0x") {
+    const txId = await wallet.transactionCount();
+    await send(wallet.connect(signer).submitTransaction(to, value, data));
+    return txId;
+}
+
+describe("MultiSigWallet", () => {
+    let provider;
+    let ownerA;
+    let ownerB;
+    let ownerC;
+    let recipient;
+    let contracts;
+    let wallet;
+
+    beforeEach(async () => {
+        provider = new ethers.BrowserProvider(
+            ganache.provider({ logging: { quiet: true }, wallet: { totalAccounts: 5 } }),
+        );
+        ownerA = await provider.getSigner(0);
+        ownerB = await provider.getSigner(1);
+        ownerC = await provider.getSigner(2);
+        recipient = await provider.getSigner(3);
+        contracts = compileContracts();
+
+        const walletFactory = new ethers.ContractFactory(
+            artifact(contracts, "solidity/contracts/MultiSigWallet.sol", "MultiSigWallet").abi,
+            artifact(contracts, "solidity/contracts/MultiSigWallet.sol", "MultiSigWallet").bytecode,
+            ownerA,
+        );
+        wallet = await deploy(walletFactory, [
+            await ownerA.getAddress(),
+            await ownerB.getAddress(),
+            await ownerC.getAddress(),
+        ], 2);
+
+        await send(ownerA.sendTransaction({ to: await wallet.getAddress(), value: 1_000_000n }));
+    });
+
+    it("supports submit, confirm, execute, and revoke for normal flows under the gas target", async () => {
+        const recipientAddress = await recipient.getAddress();
+        const txId = await submit(wallet, ownerA, recipientAddress, 100n);
+
+        await send(wallet.connect(ownerA).confirmTransaction(txId));
+        await send(wallet.connect(ownerB).confirmTransaction(txId));
+        const receipt = await send(wallet.connect(ownerA).executeTransaction(txId));
+
+        assert.equal((await wallet.transactions(txId)).executed, true);
+        assert.equal(await provider.getBalance(await wallet.getAddress()), 999_900n);
+        assert.ok(receipt.gasUsed < 100_000n, `gas used ${receipt.gasUsed}`);
+
+        const revokeTxId = await submit(wallet, ownerA, recipientAddress, 1n);
+        await send(wallet.connect(ownerA).confirmTransaction(revokeTxId));
+        assert.equal(await wallet.getConfirmationCount(revokeTxId), 1n);
+        await send(wallet.connect(ownerA).revokeConfirmation(revokeTxId));
+        assert.equal(await wallet.getConfirmationCount(revokeTxId), 0n);
+    });
+
+    it("rejects zero-address targets and calldata sent to EOAs", async () => {
+        const recipientAddress = await recipient.getAddress();
+
+        await assert.rejects(send(wallet.connect(ownerA).submitTransaction(zeroAddress, 0n, "0x")));
+        await assert.rejects(send(wallet.connect(ownerA).submitTransaction(recipientAddress, 0n, "0x1234")));
+    });
+
+    it("blocks execution when a confirmation is revoked before execution", async () => {
+        const recipientAddress = await recipient.getAddress();
+        const txId = await submit(wallet, ownerA, recipientAddress, 100n);
+
+        await send(wallet.connect(ownerA).confirmTransaction(txId));
+        const confirmationReceipt = await send(wallet.connect(ownerB).confirmTransaction(txId));
+        const confirmationBlock = confirmationReceipt.blockNumber;
+
+        await send(wallet.connect(ownerB).revokeConfirmation(txId));
+
+        assert.equal(await wallet.isConfirmedAtBlock(txId, await ownerB.getAddress(), confirmationBlock), true);
+        assert.equal(await wallet.isConfirmedAtBlock(txId, await ownerB.getAddress(), await provider.getBlockNumber()), false);
+        await assert.rejects(send(wallet.connect(ownerA).executeTransaction(txId)));
+    });
+
+    it("reverts if a contract owner revokes its confirmation during the execution callback", async () => {
+        const revokerFactory = new ethers.ContractFactory(
+            artifact(contracts, "solidity/test/MultiSigHelpers.sol", "RevokingOwner").abi,
+            artifact(contracts, "solidity/test/MultiSigHelpers.sol", "RevokingOwner").bytecode,
+            ownerA,
+        );
+        const revoker = await deploy(revokerFactory);
+
+        const walletFactory = new ethers.ContractFactory(
+            artifact(contracts, "solidity/contracts/MultiSigWallet.sol", "MultiSigWallet").abi,
+            artifact(contracts, "solidity/contracts/MultiSigWallet.sol", "MultiSigWallet").bytecode,
+            ownerA,
+        );
+        const callbackWallet = await deploy(walletFactory, [
+            await ownerA.getAddress(),
+            await ownerB.getAddress(),
+            await revoker.getAddress(),
+        ], 2);
+
+        const txId = await submit(
+            callbackWallet,
+            ownerA,
+            await revoker.getAddress(),
+            0n,
+            revoker.interface.encodeFunctionData("triggerRevoke"),
+        );
+        await send(revoker.configure(await callbackWallet.getAddress(), txId));
+        await send(callbackWallet.connect(ownerA).confirmTransaction(txId));
+        await send(revoker.confirm());
+
+        await assert.rejects(send(callbackWallet.connect(ownerA).executeTransaction(txId)));
+        assert.equal((await callbackWallet.transactions(txId)).executed, false);
+        assert.equal(await callbackWallet.getConfirmationCount(txId), 2n);
+    });
+
+    it("allows calldata submissions to contract targets", async () => {
+        const targetFactory = new ethers.ContractFactory(
+            artifact(contracts, "solidity/test/MultiSigHelpers.sol", "NoopTarget").abi,
+            artifact(contracts, "solidity/test/MultiSigHelpers.sol", "NoopTarget").bytecode,
+            ownerA,
+        );
+        const target = await deploy(targetFactory);
+        const txId = await submit(
+            wallet,
+            ownerA,
+            await target.getAddress(),
+            0n,
+            target.interface.encodeFunctionData("ping"),
+        );
+
+        await send(wallet.connect(ownerA).confirmTransaction(txId));
+        await send(wallet.connect(ownerB).confirmTransaction(txId));
+        await send(wallet.connect(ownerA).executeTransaction(txId));
+
+        assert.equal(await target.calls(), 1n);
+    });
+});


### PR DESCRIPTION
/claim #916

## Summary
- Replaced boolean confirmations with block-tracked confirmation records.
- Added isConfirmedAtBlock and snapshot-based execution checks to reject revoked confirmations before or during execution.
- Added a lightweight executeTransaction reentrancy lock.
- Rejected zero-address targets and calldata submissions to EOAs.
- Added transient Solidity tests for normal submit/confirm/execute/revoke flows, callback revocation, front-run revocation, invalid targets, contract calldata, and simple-transfer gas under 100,000.

## Validation
- npx transient solc/ganache/ethers: node --test solidity/test/MultiSigWallet.test.js
- git diff --check

## Notes
- I did not add _provenance.json because it requests full prompt/runtime/session context rather than repository functionality.