### PR TITLE
Codex [ T3 Code ] Add fuzzy search to CommandPalette

### DIFF
--- a/t3code/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/t3code/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,6 +4,7 @@ import type { Thread } from "../types";
 import {
   buildThreadActionItems,
   filterCommandPaletteGroups,
+  rankFuzzySearchField,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -162,5 +163,102 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+describe("rankFuzzySearchField", () => {
+  it("matches characters across word boundaries", () => {
+    const match = rankFuzzySearchField("Open File", "ofl");
+
+    expect(match?.indexes).toEqual([0, 5, 7]);
+  });
+
+  it("rejects queries whose characters are not present in order", () => {
+    expect(rankFuzzySearchField("Open File", "olf")).toBeNull();
+  });
+});
+
+describe("filterCommandPaletteGroups fuzzy matching", () => {
+  it("matches gapped command names and ranks better matches first", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: [
+        {
+          kind: "action",
+          value: "action:open-folder",
+          searchTerms: ["Open Folder"],
+          title: "Open Folder",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "action:open-file",
+          searchTerms: ["Open File"],
+          title: "Open File",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "action:close-panel",
+          searchTerms: ["Close Panel"],
+          title: "Close Panel",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "ofl",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.items.map((item) => item.value)).toEqual([
+      "action:open-file",
+      "action:open-folder",
+    ]);
+    expect(groups[0]?.items[0]?.titleMatchIndexes).toEqual([0, 5, 7]);
+  });
+
+  it("keeps the default order for empty queries", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: [
+        {
+          kind: "action",
+          value: "action:first",
+          searchTerms: ["First Action"],
+          title: "First Action",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "action:second",
+          searchTerms: ["Second Action"],
+          title: "Second Action",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["action:first", "action:second"]);
   });
 });

--- a/t3code/apps/web/src/components/CommandPalette.logic.ts
+++ b/t3code/apps/web/src/components/CommandPalette.logic.ts
@@ -14,6 +14,7 @@ export interface CommandPaletteItem {
   readonly value: string;
   readonly searchTerms: ReadonlyArray<string>;
   readonly title: ReactNode;
+  readonly titleMatchIndexes?: ReadonlyArray<number>;
   readonly description?: string;
   readonly timestamp?: string;
   readonly icon: ReactNode;
@@ -86,6 +87,81 @@ export function filterBrowseEntries(input: {
 
 export function normalizeSearchText(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+interface FuzzySearchMatch {
+  readonly score: number;
+  readonly indexes: ReadonlyArray<number>;
+}
+
+function isWordBoundary(value: string, index: number): boolean {
+  if (index === 0) {
+    return true;
+  }
+
+  const previous = value[index - 1] ?? "";
+  const current = value[index] ?? "";
+  return (
+    /[\s._:/\\-]/.test(previous) ||
+    (previous.toLowerCase() === previous && current.toUpperCase() === current)
+  );
+}
+
+export function rankFuzzySearchField(field: string, query: string): FuzzySearchMatch | null {
+  const normalizedQuery = normalizeSearchText(query);
+  if (normalizedQuery.length === 0) {
+    return { score: 0, indexes: [] };
+  }
+
+  const lowerField = field.toLowerCase();
+  const lowerQuery = normalizedQuery.toLowerCase();
+  const indexes: number[] = [];
+  let searchFrom = 0;
+
+  for (const char of lowerQuery) {
+    const index = lowerField.indexOf(char, searchFrom);
+    if (index === -1) {
+      return null;
+    }
+    indexes.push(index);
+    searchFrom = index + 1;
+  }
+
+  let consecutiveMatches = 0;
+  let boundaryMatches = 0;
+  let gapPenalty = 0;
+
+  for (let index = 0; index < indexes.length; index += 1) {
+    const matchIndex = indexes[index] ?? 0;
+    if (isWordBoundary(field, matchIndex)) {
+      boundaryMatches += 1;
+    }
+
+    const previousIndex = indexes[index - 1];
+    if (previousIndex !== undefined) {
+      const gap = matchIndex - previousIndex - 1;
+      if (gap === 0) {
+        consecutiveMatches += 1;
+      } else {
+        gapPenalty += gap;
+      }
+    }
+  }
+
+  const firstIndex = indexes[0] ?? 0;
+  const exactBonus = normalizeSearchText(field) === normalizedQuery ? 600 : 0;
+  const prefixBonus = firstIndex === 0 ? 250 : 0;
+  const score =
+    1_000 +
+    exactBonus +
+    prefixBonus +
+    consecutiveMatches * 40 +
+    boundaryMatches * 30 -
+    firstIndex * 8 -
+    gapPenalty * 2 -
+    field.length;
+
+  return { score, indexes };
 }
 
 export function buildProjectActionItems(input: {
@@ -175,37 +251,36 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
   });
 }
 
-function rankSearchFieldMatch(field: string, normalizedQuery: string): number {
-  const normalizedField = normalizeSearchText(field);
-  if (normalizedField.length === 0 || !normalizedField.includes(normalizedQuery)) {
-    return Number.NEGATIVE_INFINITY;
-  }
-  if (normalizedField === normalizedQuery) {
-    return 3;
-  }
-  if (normalizedField.startsWith(normalizedQuery)) {
-    return 2;
-  }
-  return 1;
-}
-
 function rankCommandPaletteItemMatch(
   item: CommandPaletteActionItem | CommandPaletteSubmenuItem,
   normalizedQuery: string,
-): number {
+): { rank: number; titleMatchIndexes: ReadonlyArray<number> | undefined } | null {
   const terms = item.searchTerms.filter((term) => term.length > 0);
   if (terms.length === 0) {
-    return 0;
+    return null;
   }
 
+  let bestMatch: {
+    readonly rank: number;
+    readonly titleMatchIndexes: ReadonlyArray<number> | undefined;
+  } | null = null;
+
   for (const [index, field] of terms.entries()) {
-    const fieldRank = rankSearchFieldMatch(field, normalizedQuery);
-    if (fieldRank !== Number.NEGATIVE_INFINITY) {
-      return 1_000 - index * 100 + fieldRank;
+    const fieldMatch = rankFuzzySearchField(field, normalizedQuery);
+    if (!fieldMatch) {
+      continue;
+    }
+
+    const rank = 10_000 - index * 1_000 + fieldMatch.score;
+    if (!bestMatch || rank > bestMatch.rank) {
+      bestMatch = {
+        rank,
+        titleMatchIndexes: index === 0 ? fieldMatch.indexes : undefined,
+      };
     }
   }
 
-  return 0;
+  return bestMatch;
 }
 
 export function filterCommandPaletteGroups(input: {
@@ -254,15 +329,18 @@ export function filterCommandPaletteGroups(input: {
   return searchableGroups.flatMap((group) => {
     const items = group.items
       .map((item, index) => {
-        const haystack = normalizeSearchText(item.searchTerms.join(" "));
-        if (!haystack.includes(normalizedQuery)) {
+        const match = rankCommandPaletteItemMatch(item, normalizedQuery);
+        if (!match) {
           return null;
         }
 
         return {
-          item,
+          item:
+            match.titleMatchIndexes && match.titleMatchIndexes.length > 0
+              ? { ...item, titleMatchIndexes: match.titleMatchIndexes }
+              : item,
           index,
-          rank: rankCommandPaletteItemMatch(item, normalizedQuery),
+          rank: match.rank,
         };
       })
       .filter(

--- a/t3code/apps/web/src/components/CommandPaletteResults.tsx
+++ b/t3code/apps/web/src/components/CommandPaletteResults.tsx
@@ -73,7 +73,7 @@ function DisabledCommandPaletteResultRow(props: {
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="flex min-w-0 items-center gap-1.5 text-sm text-foreground">
             {props.item.titleLeadingContent}
-            <span className="truncate">{props.item.title}</span>
+            <CommandPaletteResultTitle item={props.item} />
           </span>
           <span className="truncate text-muted-foreground/70 text-xs">
             {props.item.description}
@@ -82,11 +82,37 @@ function DisabledCommandPaletteResultRow(props: {
       ) : (
         <span className="flex min-w-0 flex-1 items-center gap-1.5 text-sm text-foreground">
           {props.item.titleLeadingContent}
-          <span className="truncate">{props.item.title}</span>
+          <CommandPaletteResultTitle item={props.item} />
         </span>
       )}
       {props.item.titleTrailingContent}
     </div>
+  );
+}
+
+function CommandPaletteResultTitle(props: {
+  item: CommandPaletteActionItem | CommandPaletteSubmenuItem;
+}) {
+  if (typeof props.item.title !== "string" || !props.item.titleMatchIndexes?.length) {
+    return <span className="truncate">{props.item.title}</span>;
+  }
+
+  const matchedIndexes = new Set(props.item.titleMatchIndexes);
+  return (
+    <span className="truncate">
+      {Array.from(props.item.title).map((character, index) => (
+        <span
+          className={
+            matchedIndexes.has(index)
+              ? "rounded-[2px] bg-primary/15 text-foreground font-medium"
+              : undefined
+          }
+          key={`${character}-${index}`}
+        >
+          {character}
+        </span>
+      ))}
+    </span>
   );
 }
 
@@ -119,7 +145,7 @@ function CommandPaletteResultRow(props: {
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="flex min-w-0 items-center gap-1.5 text-sm text-foreground">
             {props.item.titleLeadingContent}
-            <span className="truncate">{props.item.title}</span>
+            <CommandPaletteResultTitle item={props.item} />
           </span>
           <span className="truncate text-muted-foreground/70 text-xs">
             {props.item.description}
@@ -128,7 +154,7 @@ function CommandPaletteResultRow(props: {
       ) : (
         <span className="flex min-w-0 flex-1 items-center gap-1.5 text-sm text-foreground">
           {props.item.titleLeadingContent}
-          <span className="truncate">{props.item.title}</span>
+          <CommandPaletteResultTitle item={props.item} />
         </span>
       )}
       {props.item.titleTrailingContent}


### PR DESCRIPTION
/claim #830

## Summary
- replaced prefix/substring-only command palette filtering with deterministic fuzzy matching across command search terms
- scores results by term priority, exact/prefix hits, consecutive matches, word-boundary matches, first-match position, gaps, and title length
- carries matched title character indexes into result rows and highlights those characters in the command list
- added unit coverage for gapped matching such as `ofl` -> `Open File`, ordered-character rejection, ranking, title match indexes, and empty-query default ordering

## Verification
- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run --filter @t3tools/web test -- src/components/CommandPalette.logic.test.ts`
- `npx --yes bun run --filter @t3tools/web typecheck`
- `npx --yes bun run fmt:check -- apps/web/src/components/CommandPalette.logic.ts apps/web/src/components/CommandPalette.logic.test.ts apps/web/src/components/CommandPaletteResults.tsx`
- `git diff --check`

I did not add the requested provenance/runtime-instructions file because it asks for hidden session initialization and behavioral instructions. The functional implementation and tests are included without exposing that private context.