### PR TITLE
Codex [ Laravel ] Implement file upload system with checksum dedup and thumbnails

### DIFF
--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File as FileSystem;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class FileController extends Controller
+{
+    public function upload(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'file' => ['required', 'file'],
+        ]);
+
+        /** @var UploadedFile $uploadedFile */
+        $uploadedFile = $validated['file'];
+        $originalName = $uploadedFile->getClientOriginalName();
+        $mimeType = $uploadedFile->getMimeType() ?: 'application/octet-stream';
+        $checksum = hash_file('sha256', $uploadedFile->getRealPath());
+
+        if (File::query()->where('checksum_sha256', $checksum)->exists()) {
+            return response()->json([
+                'message' => 'A file with the same checksum already exists.',
+            ], 409);
+        }
+
+        $datePath = now()->format('Y/m/d');
+        $extension = $uploadedFile->getClientOriginalExtension();
+        $storedName = (string) Str::uuid().($extension !== '' ? ".{$extension}" : '');
+        $relativePath = "uploads/{$datePath}/{$storedName}";
+        $absolutePath = storage_path("app/{$relativePath}");
+
+        FileSystem::ensureDirectoryExists(dirname($absolutePath));
+        $uploadedFile->move(dirname($absolutePath), basename($absolutePath));
+
+        $thumbnailPath = null;
+
+        if ($this->isSupportedImage($absolutePath)) {
+            $thumbnailPath = $this->createThumbnail($absolutePath, $datePath, pathinfo($storedName, PATHINFO_FILENAME));
+        }
+
+        $file = File::query()->create([
+            'original_name' => $originalName,
+            'stored_path' => $relativePath,
+            'mime_type' => $mimeType,
+            'size_bytes' => FileSystem::size($absolutePath),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => optional($request->user())->getAuthIdentifier(),
+            'thumbnail_path' => $thumbnailPath,
+        ]);
+
+        return response()->json([
+            'data' => $file,
+        ], 201);
+    }
+
+    public function download(File $file): BinaryFileResponse|JsonResponse
+    {
+        $absolutePath = storage_path("app/{$file->stored_path}");
+
+        if (! FileSystem::exists($absolutePath)) {
+            return response()->json([
+                'message' => 'File not found on disk.',
+            ], 404);
+        }
+
+        return response()->download(
+            $absolutePath,
+            $file->original_name,
+            ['Content-Type' => $file->mime_type]
+        );
+    }
+
+    public function delete(File $file): Response
+    {
+        FileSystem::delete(storage_path("app/{$file->stored_path}"));
+
+        if ($file->thumbnail_path !== null) {
+            FileSystem::delete(storage_path("app/{$file->thumbnail_path}"));
+        }
+
+        $file->delete();
+
+        return response()->noContent();
+    }
+
+    public function index(): JsonResponse
+    {
+        return response()->json(File::query()->latest()->paginate(20));
+    }
+
+    private function isSupportedImage(string $path): bool
+    {
+        if (! function_exists('imagecreatefromstring')) {
+            return false;
+        }
+
+        $info = @getimagesize($path);
+
+        return is_array($info) && str_starts_with((string) $info['mime'], 'image/');
+    }
+
+    private function createThumbnail(string $sourcePath, string $datePath, string $baseName): ?string
+    {
+        $sourceContents = FileSystem::get($sourcePath);
+        $sourceImage = @imagecreatefromstring($sourceContents);
+
+        if ($sourceImage === false) {
+            return null;
+        }
+
+        $sourceWidth = imagesx($sourceImage);
+        $sourceHeight = imagesy($sourceImage);
+        $thumbnail = imagecreatetruecolor(200, 200);
+
+        imagealphablending($thumbnail, false);
+        imagesavealpha($thumbnail, true);
+
+        $transparent = imagecolorallocatealpha($thumbnail, 0, 0, 0, 127);
+        imagefilledrectangle($thumbnail, 0, 0, 200, 200, $transparent);
+        imagecopyresampled($thumbnail, $sourceImage, 0, 0, 0, 0, 200, 200, $sourceWidth, $sourceHeight);
+
+        $relativePath = "thumbnails/{$datePath}/{$baseName}.png";
+        $absolutePath = storage_path("app/{$relativePath}");
+
+        FileSystem::ensureDirectoryExists(dirname($absolutePath));
+        $created = imagepng($thumbnail, $absolutePath);
+
+        imagedestroy($sourceImage);
+        imagedestroy($thumbnail);
+
+        return $created ? $relativePath : null;
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable([
+    'original_name',
+    'stored_path',
+    'mime_type',
+    'size_bytes',
+    'checksum_sha256',
+    'uploaded_by',
+    'thumbnail_path',
+])]
+class File extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'size_bytes' => 'integer',
+            'uploaded_by' => 'integer',
+        ];
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -3,12 +3,16 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        then: function (): void {
+            Route::middleware('api')->group(base_path('routes/api.php'));
+        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
         //

--- a/laravel/database/migrations/2026_05_16_000000_create_files_table.php
+++ b/laravel/database/migrations/2026_05_16_000000_create_files_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size_bytes');
+            $table->string('checksum_sha256', 64)->unique();
+            $table->foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Http\Controllers\FileController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/files/upload', [FileController::class, 'upload']);
+Route::get('/files/{file}/download', [FileController::class, 'download']);
+Route::delete('/files/{file}', [FileController::class, 'delete']);
+Route::get('/files', [FileController::class, 'index']);

--- a/laravel/tests/Feature/FileUploadTest.php
+++ b/laravel/tests/Feature/FileUploadTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File as FileSystem;
+use Tests\TestCase;
+
+class FileUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        FileSystem::deleteDirectory(storage_path('app/uploads'));
+        FileSystem::deleteDirectory(storage_path('app/thumbnails'));
+    }
+
+    protected function tearDown(): void
+    {
+        FileSystem::deleteDirectory(storage_path('app/uploads'));
+        FileSystem::deleteDirectory(storage_path('app/thumbnails'));
+
+        parent::tearDown();
+    }
+
+    public function test_file_upload_stores_file_and_metadata(): void
+    {
+        $contents = 'quarterly report';
+
+        $response = $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('report.txt', $contents),
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.original_name', 'report.txt')
+            ->assertJsonPath('data.mime_type', 'text/plain')
+            ->assertJsonPath('data.size_bytes', strlen($contents))
+            ->assertJsonPath('data.checksum_sha256', hash('sha256', $contents))
+            ->assertJsonPath('data.thumbnail_path', null);
+
+        $file = File::query()->firstOrFail();
+
+        $this->assertStringStartsWith('uploads/'.now()->format('Y/m/d').'/', $file->stored_path);
+        $this->assertFileExists(storage_path("app/{$file->stored_path}"));
+    }
+
+    public function test_duplicate_checksum_is_rejected(): void
+    {
+        $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('first.txt', 'same file body'),
+        ])->assertCreated();
+
+        $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('second.txt', 'same file body'),
+        ])->assertConflict()
+            ->assertJsonPath('message', 'A file with the same checksum already exists.');
+
+        $this->assertSame(1, File::query()->count());
+    }
+
+    public function test_image_upload_generates_200_by_200_thumbnail(): void
+    {
+        if (! function_exists('imagecreatefromstring')) {
+            $this->markTestSkipped('GD is required for thumbnail generation.');
+        }
+
+        $response = $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->image('photo.jpg', 640, 480),
+        ]);
+
+        $response->assertCreated();
+
+        $file = File::query()->firstOrFail();
+
+        $this->assertNotNull($file->thumbnail_path);
+        $this->assertStringStartsWith('thumbnails/'.now()->format('Y/m/d').'/', $file->thumbnail_path);
+        $this->assertFileExists(storage_path("app/{$file->thumbnail_path}"));
+        $this->assertSame([200, 200], array_slice(getimagesize(storage_path("app/{$file->thumbnail_path}")), 0, 2));
+    }
+
+    public function test_download_streams_file_with_content_type(): void
+    {
+        $contents = 'download me';
+
+        $upload = $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('download.txt', $contents),
+        ]);
+
+        $id = $upload->json('data.id');
+
+        $response = $this->get("/files/{$id}/download");
+
+        $response->assertOk()
+            ->assertHeader('content-type', 'text/plain; charset=UTF-8');
+        $this->assertSame($contents, $response->streamedContent());
+    }
+
+    public function test_delete_removes_file_thumbnail_and_database_record(): void
+    {
+        if (! function_exists('imagecreatefromstring')) {
+            $this->markTestSkipped('GD is required for thumbnail generation.');
+        }
+
+        $upload = $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->image('photo.png', 300, 300),
+        ]);
+
+        $file = File::query()->findOrFail($upload->json('data.id'));
+        $storedPath = storage_path("app/{$file->stored_path}");
+        $thumbnailPath = storage_path("app/{$file->thumbnail_path}");
+
+        $this->assertFileExists($storedPath);
+        $this->assertFileExists($thumbnailPath);
+
+        $this->delete("/files/{$file->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('files', ['id' => $file->id]);
+        $this->assertFileDoesNotExist($storedPath);
+        $this->assertFileDoesNotExist($thumbnailPath);
+    }
+
+    public function test_list_endpoint_paginates_twenty_files_per_page(): void
+    {
+        foreach (range(1, 25) as $index) {
+            $this->post('/files/upload', [
+                'file' => UploadedFile::fake()->createWithContent("file-{$index}.txt", "contents {$index}"),
+            ])->assertCreated();
+        }
+
+        $response = $this->get('/files');
+
+        $response->assertOk()
+            ->assertJsonPath('per_page', 20)
+            ->assertJsonPath('total', 25)
+            ->assertJsonCount(20, 'data');
+    }
+}


### PR DESCRIPTION
## Issue
/claim #790

Closes #790

## Summary
Adds Laravel file upload endpoints for upload, download, delete, and listing with SHA-256 duplicate rejection, date-organized storage under `storage/app/uploads`, and GD-generated 200x200 image thumbnails under `storage/app/thumbnails`.

## Acceptance criteria
- [x] File upload stores file and creates database record with correct metadata
- [x] SHA-256 checksum is computed and stored
- [x] Duplicate files with same checksum are rejected with 409 Conflict
- [x] Image uploads get a 200x200 thumbnail generated automatically
- [x] Non-image uploads have null thumbnail_path
- [x] Download endpoint streams file with correct Content-Type header
- [x] Delete removes both file from disk and database record
- [x] List endpoint supports pagination with 20 items per page

## Validation
- [x] `git diff --check HEAD~1 HEAD`
- [x] Confirmed no provenance, metadata, contributor, audit, prompt, boot-context, or system-context files were created
- [ ] `php artisan test` not run: local environment has no `php`, `composer`, or `docker` binaries available

## Process note
The requested `.generation_meta.json` was intentionally omitted because it requires full startup directives/session context. That is a security and privacy risk, so this PR contains only Laravel package and test changes.

## Demo
A demo video could not be produced in this local environment because PHP/composer/docker are unavailable.