### PR TITLE
Agent [ T3 Code ] Implement global search overlay

### DIFF
--- a/t3code/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
+++ b/t3code/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
@@ -74,6 +74,22 @@ const searchWorkspaceEntries = (input: { cwd: string; query: string; limit: numb
     return yield* workspaceEntries.search(input);
   });
 
+const globalSearchWorkspace = (input: {
+  cwd: string;
+  query: string;
+  limit: number;
+  regex?: boolean;
+  caseSensitive?: boolean;
+}) =>
+  Effect.gen(function* () {
+    const workspaceEntries = yield* WorkspaceEntries;
+    return yield* workspaceEntries.globalSearch({
+      regex: false,
+      caseSensitive: false,
+      ...input,
+    });
+  });
+
 const appendSeparator = (input: string) =>
   input.endsWith("/") || input.endsWith("\\")
     ? input
@@ -309,6 +325,50 @@ it.layer(TestLayer)("WorkspaceEntriesLive", (it) => {
         yield* Fiber.join(search);
 
         expect(peakReads).toBeLessThanOrEqual(32);
+      }),
+    );
+  });
+
+  describe("globalSearch", () => {
+    it.effect("searches tracked file contents", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-global-files-", git: true });
+        yield* writeTextFile(cwd, "src/bridge.ts", "const bridgeNonce = 1;\n");
+        yield* git(cwd, ["add", "src/bridge.ts"]);
+
+        const result = yield* globalSearchWorkspace({ cwd, query: "bridgeNonce", limit: 10 });
+
+        expect(result.fileMatches).toEqual([
+          {
+            path: "src/bridge.ts",
+            lineNumber: 1,
+            preview: "const bridgeNonce = 1;",
+          },
+        ]);
+        expect(result.filesTruncated).toBe(false);
+      }),
+    );
+
+    it.effect("searches Git commit subjects", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-global-git-", git: true });
+        yield* writeTextFile(cwd, "README.md", "readme\n");
+        yield* git(cwd, ["add", "README.md"]);
+        yield* git(cwd, ["commit", "-m", "Add bridge nonce guard"], {
+          GIT_AUTHOR_NAME: "Test User",
+          GIT_AUTHOR_EMAIL: "test@example.com",
+          GIT_COMMITTER_NAME: "Test User",
+          GIT_COMMITTER_EMAIL: "test@example.com",
+        });
+
+        const result = yield* globalSearchWorkspace({ cwd, query: "nonce", limit: 10 });
+
+        expect(result.gitMatches).toHaveLength(1);
+        expect(result.gitMatches[0]).toMatchObject({
+          subject: "Add bridge nonce guard",
+          author: "Test User",
+        });
+        expect(result.gitTruncated).toBe(false);
       }),
     );
   });

--- a/t3code/apps/server/src/workspace/Layers/WorkspaceEntries.ts
+++ b/t3code/apps/server/src/workspace/Layers/WorkspaceEntries.ts
@@ -1,7 +1,9 @@
 // @effect-diagnostics nodeBuiltinImport:off
+import { execFile } from "node:child_process";
 import * as OS from "node:os";
 import fsPromises from "node:fs/promises";
 import type { Dirent } from "node:fs";
+import { promisify } from "node:util";
 
 import * as Cache from "effect/Cache";
 import * as DateTime from "effect/DateTime";
@@ -11,7 +13,12 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 
-import { type FilesystemBrowseInput, type ProjectEntry } from "@t3tools/contracts";
+import {
+  type FilesystemBrowseInput,
+  type ProjectEntry,
+  type ProjectGlobalSearchInput,
+  type ProjectGlobalSearchResult,
+} from "@t3tools/contracts";
 import { isExplicitRelativePath, isWindowsAbsolutePath } from "@t3tools/shared/path";
 import {
   insertRankedSearchResult,
@@ -33,6 +40,10 @@ const WORKSPACE_CACHE_TTL_MS = 15_000;
 const WORKSPACE_CACHE_MAX_KEYS = 4;
 const WORKSPACE_INDEX_MAX_ENTRIES = 25_000;
 const WORKSPACE_SCAN_READDIR_CONCURRENCY = 32;
+const GLOBAL_SEARCH_GIT_LOG_LIMIT = 500;
+const GLOBAL_SEARCH_GIT_MAX_BUFFER = 8 * 1024 * 1024;
+const GLOBAL_SEARCH_PREVIEW_MAX_LENGTH = 1_000;
+const execFileAsync = promisify(execFile);
 const IGNORED_DIRECTORY_NAMES = new Set([
   ".git",
   ".convex",
@@ -57,6 +68,12 @@ interface SearchableWorkspaceEntry extends ProjectEntry {
 }
 
 type RankedWorkspaceEntry = RankedSearchResult<SearchableWorkspaceEntry>;
+
+interface GitProcessError extends Error {
+  readonly code?: number | string;
+  readonly stdout?: string;
+  readonly stderr?: string;
+}
 
 function toPosixPath(input: string): string {
   return input.replaceAll("\\", "/");
@@ -136,6 +153,114 @@ function isPathInIgnoredDirectory(relativePath: string): boolean {
   const firstSegment = relativePath.split("/")[0];
   if (!firstSegment) return false;
   return IGNORED_DIRECTORY_NAMES.has(firstSegment);
+}
+
+function normalizePreview(input: string): string {
+  return input.replace(/\s+/g, " ").trim().slice(0, GLOBAL_SEARCH_PREVIEW_MAX_LENGTH);
+}
+
+function buildGlobalSearchMatcher(input: ProjectGlobalSearchInput): (value: string) => boolean {
+  if (input.regex) {
+    const matcher = new RegExp(input.query, input.caseSensitive ? "" : "i");
+    return (value) => matcher.test(value);
+  }
+
+  if (input.caseSensitive) {
+    return (value) => value.includes(input.query);
+  }
+
+  const normalizedQuery = input.query.toLowerCase();
+  return (value) => value.toLowerCase().includes(normalizedQuery);
+}
+
+async function runGitForGlobalSearch(
+  cwd: string,
+  args: ReadonlyArray<string>,
+  options?: { readonly allowNoMatches?: boolean; readonly allowNotRepository?: boolean },
+): Promise<string> {
+  try {
+    const result = await execFileAsync("git", args, {
+      cwd,
+      maxBuffer: GLOBAL_SEARCH_GIT_MAX_BUFFER,
+    });
+    return result.stdout;
+  } catch (cause) {
+    const error = cause as GitProcessError;
+    if (options?.allowNoMatches && error.code === 1) {
+      return error.stdout ?? "";
+    }
+    if (
+      options?.allowNotRepository &&
+      (error.code === 128 || error.stderr?.includes("not a git repository"))
+    ) {
+      return "";
+    }
+    throw cause;
+  }
+}
+
+function parseGitGrepOutput(
+  stdout: string,
+  limit: number,
+): ProjectGlobalSearchResult["fileMatches"] {
+  const matches: Array<ProjectGlobalSearchResult["fileMatches"][number]> = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.length === 0) {
+      continue;
+    }
+
+    const firstSeparator = line.indexOf(":");
+    const secondSeparator = firstSeparator === -1 ? -1 : line.indexOf(":", firstSeparator + 1);
+    if (firstSeparator === -1 || secondSeparator === -1) {
+      continue;
+    }
+
+    const lineNumber = Number.parseInt(line.slice(firstSeparator + 1, secondSeparator), 10);
+    if (!Number.isSafeInteger(lineNumber) || lineNumber <= 0) {
+      continue;
+    }
+
+    matches.push({
+      path: line.slice(0, firstSeparator),
+      lineNumber,
+      preview: normalizePreview(line.slice(secondSeparator + 1)),
+    });
+    if (matches.length >= limit) {
+      break;
+    }
+  }
+  return matches;
+}
+
+function parseGitLogOutput(
+  stdout: string,
+  matcher: (value: string) => boolean,
+  limit: number,
+): ProjectGlobalSearchResult["gitMatches"] {
+  const matches: Array<ProjectGlobalSearchResult["gitMatches"][number]> = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.length === 0) {
+      continue;
+    }
+
+    const [sha, author, committedAt, ...subjectParts] = line.split("\u001f");
+    const subject = subjectParts.join("\u001f");
+    if (!sha || !author || !committedAt || !subject || !matcher(subject)) {
+      continue;
+    }
+
+    matches.push({
+      sha,
+      shortSha: sha.slice(0, 8),
+      subject,
+      author,
+      committedAt,
+    });
+    if (matches.length >= limit) {
+      break;
+    }
+  }
+  return matches;
 }
 
 function directoryAncestorsOf(relativePath: string): string[] {
@@ -510,8 +635,78 @@ export const makeWorkspaceEntries = Effect.gen(function* () {
     },
   );
 
+  const globalSearch: WorkspaceEntriesShape["globalSearch"] = Effect.fn(
+    "WorkspaceEntries.globalSearch",
+  )(function* (input) {
+    const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
+    const limit = Math.max(0, Math.floor(input.limit));
+    const matcher = yield* Effect.try({
+      try: () => buildGlobalSearchMatcher(input),
+      catch: (cause) =>
+        new WorkspaceEntriesError({
+          cwd: input.cwd,
+          operation: "workspaceEntries.globalSearch.compileMatcher",
+          detail: cause instanceof Error ? cause.message : String(cause),
+          cause,
+        }),
+    });
+
+    return yield* Effect.tryPromise({
+      try: async (): Promise<ProjectGlobalSearchResult> => {
+        const grepArgs = [
+          "grep",
+          "-n",
+          "-I",
+          "--full-name",
+          input.caseSensitive ? undefined : "-i",
+          input.regex ? "-E" : "-F",
+          "-e",
+          input.query,
+          "--",
+          ".",
+        ].filter((arg): arg is string => arg !== undefined);
+        const [grepOutput, gitLogOutput] = await Promise.all([
+          runGitForGlobalSearch(normalizedCwd, grepArgs, {
+            allowNoMatches: true,
+            allowNotRepository: true,
+          }),
+          runGitForGlobalSearch(
+            normalizedCwd,
+            [
+              "log",
+              "--all",
+              `--max-count=${GLOBAL_SEARCH_GIT_LOG_LIMIT}`,
+              "--format=%H%x1f%an%x1f%aI%x1f%s",
+            ],
+            {
+              allowNotRepository: true,
+            },
+          ),
+        ]);
+
+        const fileMatches = parseGitGrepOutput(grepOutput, limit);
+        const gitMatches = parseGitLogOutput(gitLogOutput, matcher, limit);
+        return {
+          fileMatches,
+          gitMatches,
+          filesTruncated:
+            fileMatches.length >= limit && grepOutput.split(/\r?\n/).filter(Boolean).length > limit,
+          gitTruncated: gitMatches.length >= limit,
+        };
+      },
+      catch: (cause) =>
+        new WorkspaceEntriesError({
+          cwd: input.cwd,
+          operation: "workspaceEntries.globalSearch",
+          detail: cause instanceof Error ? cause.message : String(cause),
+          cause,
+        }),
+    });
+  });
+
   return {
     browse,
+    globalSearch,
     invalidate,
     search,
   } satisfies WorkspaceEntriesShape;

--- a/t3code/apps/server/src/workspace/Services/WorkspaceEntries.ts
+++ b/t3code/apps/server/src/workspace/Services/WorkspaceEntries.ts
@@ -13,6 +13,8 @@ import type * as Effect from "effect/Effect";
 import type {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
+  ProjectGlobalSearchInput,
+  ProjectGlobalSearchResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
 } from "@t3tools/contracts";
@@ -57,6 +59,13 @@ export interface WorkspaceEntriesShape {
   readonly search: (
     input: ProjectSearchEntriesInput,
   ) => Effect.Effect<ProjectSearchEntriesResult, WorkspaceEntriesError>;
+
+  /**
+   * Search project file contents and Git commit subjects for global search.
+   */
+  readonly globalSearch: (
+    input: ProjectGlobalSearchInput,
+  ) => Effect.Effect<ProjectGlobalSearchResult, WorkspaceEntriesError>;
 
   /**
    * Drop any cached workspace entries for the given workspace root.

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -25,6 +25,7 @@ import {
   OrchestrationGetTurnDiffError,
   ORCHESTRATION_WS_METHODS,
   ProjectSearchEntriesError,
+  ProjectGlobalSearchError,
   ProjectWriteFileError,
   OrchestrationReplayEventsError,
   FilesystemBrowseError,
@@ -957,6 +958,20 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
                 (cause) =>
                   new ProjectSearchEntriesError({
                     message: `Failed to search workspace entries: ${cause.detail}`,
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.projectsGlobalSearch]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.projectsGlobalSearch,
+            workspaceEntries.globalSearch(input).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProjectGlobalSearchError({
+                    message: `Failed to search project: ${cause.detail}`,
                     cause,
                   }),
               ),

--- a/t3code/apps/web/src/components/GlobalSearch.logic.test.ts
+++ b/t3code/apps/web/src/components/GlobalSearch.logic.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  EnvironmentId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+import type { Project, Thread } from "../types";
+import {
+  buildGlobalSearchMatcher,
+  createSnippet,
+  highlightSearchText,
+  searchChatMessages,
+} from "./GlobalSearch.logic";
+
+const ENVIRONMENT_ID = EnvironmentId.make("environment-local");
+const PROJECT_ID = ProjectId.make("project-1");
+const THREAD_ID = ThreadId.make("thread-1");
+
+const project: Project = {
+  id: PROJECT_ID,
+  environmentId: ENVIRONMENT_ID,
+  name: "Money Maker",
+  cwd: "/repo",
+  repositoryIdentity: null,
+  defaultModelSelection: null,
+  scripts: [],
+};
+
+function makeThread(messages: Thread["messages"]): Thread {
+  return {
+    id: THREAD_ID,
+    environmentId: ENVIRONMENT_ID,
+    codexThreadId: null,
+    projectId: PROJECT_ID,
+    title: "Search thread",
+    modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    session: null,
+    messages,
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    archivedAt: null,
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    turnDiffSummaries: [],
+    activities: [],
+  };
+}
+
+describe("buildGlobalSearchMatcher", () => {
+  it("matches plain text case-insensitively by default", () => {
+    const result = buildGlobalSearchMatcher("wallet", { regex: false, caseSensitive: false });
+
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") return;
+    expect(result.matcher.matches("Wallet migration")).toBe(true);
+    expect(result.matcher.ranges("Wallet migration")).toEqual([{ start: 0, end: 6 }]);
+  });
+
+  it("honors case-sensitive plain text matching", () => {
+    const result = buildGlobalSearchMatcher("Wallet", { regex: false, caseSensitive: true });
+
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") return;
+    expect(result.matcher.matches("wallet migration")).toBe(false);
+    expect(result.matcher.matches("Wallet migration")).toBe(true);
+  });
+
+  it("returns an invalid result for malformed regex queries", () => {
+    const result = buildGlobalSearchMatcher("[", { regex: true, caseSensitive: false });
+
+    expect(result.status).toBe("invalid");
+    if (result.status !== "invalid") return;
+    expect(result.message).toContain("regular expression");
+  });
+});
+
+describe("highlightSearchText", () => {
+  it("splits matching segments for rendering", () => {
+    const result = buildGlobalSearchMatcher("bar", { regex: false, caseSensitive: false });
+
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") return;
+    expect(highlightSearchText("foo bar baz", result.matcher)).toEqual([
+      { text: "foo ", match: false },
+      { text: "bar", match: true },
+      { text: " baz", match: false },
+    ]);
+  });
+});
+
+describe("searchChatMessages", () => {
+  it("returns matching chat messages with project and thread context", () => {
+    const matcherResult = buildGlobalSearchMatcher("bridge", {
+      regex: false,
+      caseSensitive: false,
+    });
+    expect(matcherResult.status).toBe("valid");
+    if (matcherResult.status !== "valid") return;
+
+    const thread = makeThread([
+      {
+        id: MessageId.make("message-1"),
+        role: "user",
+        text: "Please inspect the bridge nonce handling.",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        streaming: false,
+      },
+      {
+        id: MessageId.make("message-2"),
+        role: "assistant",
+        text: "No match here.",
+        createdAt: "2026-03-01T00:00:01.000Z",
+        streaming: false,
+      },
+    ]);
+
+    expect(
+      searchChatMessages({
+        projects: [project],
+        threads: [thread],
+        matcher: matcherResult.matcher,
+      }),
+    ).toMatchObject([
+      {
+        threadTitle: "Search thread",
+        projectName: "Money Maker",
+        role: "user",
+        snippet: "Please inspect the bridge nonce handling.",
+      },
+    ]);
+  });
+});
+
+describe("createSnippet", () => {
+  it("centers snippets around the first match", () => {
+    const snippet = createSnippet("start ".repeat(20) + "needle" + " end".repeat(20), [
+      { start: 120, end: 126 },
+    ]);
+
+    expect(snippet).toContain("needle");
+    expect(snippet.startsWith("...")).toBe(true);
+    expect(snippet.endsWith("...")).toBe(true);
+  });
+});

--- a/t3code/apps/web/src/components/GlobalSearch.logic.ts
+++ b/t3code/apps/web/src/components/GlobalSearch.logic.ts
@@ -1,0 +1,193 @@
+import type { EnvironmentId, MessageId, ProjectId, ThreadId } from "@t3tools/contracts";
+import type { Project, Thread } from "../types";
+
+const SNIPPET_RADIUS = 56;
+const MAX_CHAT_RESULTS = 80;
+
+export interface GlobalSearchOptions {
+  readonly regex: boolean;
+  readonly caseSensitive: boolean;
+}
+
+export interface MatchRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+export interface HighlightSegment {
+  readonly text: string;
+  readonly match: boolean;
+}
+
+export interface GlobalSearchMatcher {
+  readonly matches: (value: string) => boolean;
+  readonly ranges: (value: string) => MatchRange[];
+}
+
+export type GlobalSearchMatcherResult =
+  | {
+      readonly status: "valid";
+      readonly matcher: GlobalSearchMatcher;
+    }
+  | {
+      readonly status: "invalid";
+      readonly message: string;
+    };
+
+export interface ChatSearchResult {
+  readonly id: string;
+  readonly environmentId: EnvironmentId;
+  readonly projectId: ProjectId;
+  readonly threadId: ThreadId;
+  readonly messageId: MessageId;
+  readonly threadTitle: string;
+  readonly projectName: string;
+  readonly role: Thread["messages"][number]["role"];
+  readonly snippet: string;
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeCase(input: string, caseSensitive: boolean): string {
+  return caseSensitive ? input : input.toLowerCase();
+}
+
+function collectRegExpRanges(value: string, pattern: RegExp): MatchRange[] {
+  const ranges: MatchRange[] = [];
+  const globalPattern = new RegExp(
+    pattern.source,
+    pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+  );
+  let match: RegExpExecArray | null;
+  while ((match = globalPattern.exec(value)) !== null) {
+    const text = match[0] ?? "";
+    if (text.length === 0) {
+      globalPattern.lastIndex += 1;
+      continue;
+    }
+    ranges.push({ start: match.index, end: match.index + text.length });
+  }
+  return ranges;
+}
+
+export function buildGlobalSearchMatcher(
+  query: string,
+  options: GlobalSearchOptions,
+): GlobalSearchMatcherResult {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery.length === 0) {
+    return {
+      status: "valid",
+      matcher: {
+        matches: () => false,
+        ranges: () => [],
+      },
+    };
+  }
+
+  if (options.regex) {
+    try {
+      const pattern = new RegExp(trimmedQuery, options.caseSensitive ? "" : "i");
+      return {
+        status: "valid",
+        matcher: {
+          matches: (value) => pattern.test(value),
+          ranges: (value) => collectRegExpRanges(value, pattern),
+        },
+      };
+    } catch (error) {
+      return {
+        status: "invalid",
+        message: error instanceof Error ? error.message : "Invalid regular expression.",
+      };
+    }
+  }
+
+  const normalizedQuery = normalizeCase(trimmedQuery, options.caseSensitive);
+  const literalPattern = new RegExp(escapeRegExp(trimmedQuery), options.caseSensitive ? "g" : "gi");
+  return {
+    status: "valid",
+    matcher: {
+      matches: (value) => normalizeCase(value, options.caseSensitive).includes(normalizedQuery),
+      ranges: (value) => collectRegExpRanges(value, literalPattern),
+    },
+  };
+}
+
+export function createSnippet(value: string, ranges: ReadonlyArray<MatchRange>): string {
+  const firstMatch = ranges[0];
+  if (!firstMatch) {
+    return value.trim().slice(0, SNIPPET_RADIUS * 2);
+  }
+
+  const start = Math.max(0, firstMatch.start - SNIPPET_RADIUS);
+  const end = Math.min(value.length, firstMatch.end + SNIPPET_RADIUS);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < value.length ? "..." : "";
+  return `${prefix}${value.slice(start, end).trim()}${suffix}`;
+}
+
+export function highlightSearchText(
+  value: string,
+  matcher: GlobalSearchMatcher,
+): HighlightSegment[] {
+  const ranges = matcher.ranges(value);
+  if (ranges.length === 0) {
+    return [{ text: value, match: false }];
+  }
+
+  const segments: HighlightSegment[] = [];
+  let cursor = 0;
+  for (const range of ranges) {
+    if (range.start > cursor) {
+      segments.push({ text: value.slice(cursor, range.start), match: false });
+    }
+    segments.push({ text: value.slice(range.start, range.end), match: true });
+    cursor = range.end;
+  }
+  if (cursor < value.length) {
+    segments.push({ text: value.slice(cursor), match: false });
+  }
+  return segments.filter((segment) => segment.text.length > 0);
+}
+
+export function searchChatMessages(input: {
+  readonly projects: ReadonlyArray<Project>;
+  readonly threads: ReadonlyArray<Thread>;
+  readonly matcher: GlobalSearchMatcher;
+  readonly limit?: number;
+}): ChatSearchResult[] {
+  const limit = input.limit ?? MAX_CHAT_RESULTS;
+  const projectNameByScopedId = new Map(
+    input.projects.map((project) => [`${project.environmentId}:${project.id}`, project.name]),
+  );
+  const results: ChatSearchResult[] = [];
+
+  for (const thread of input.threads) {
+    const projectName = projectNameByScopedId.get(`${thread.environmentId}:${thread.projectId}`);
+    for (const message of thread.messages) {
+      if (!input.matcher.matches(message.text)) {
+        continue;
+      }
+
+      results.push({
+        id: `${thread.environmentId}:${thread.id}:${message.id}`,
+        environmentId: thread.environmentId,
+        projectId: thread.projectId,
+        threadId: thread.id,
+        messageId: message.id,
+        threadTitle: thread.title,
+        projectName: projectName ?? thread.projectId,
+        role: message.role,
+        snippet: createSnippet(message.text, input.matcher.ranges(message.text)),
+      });
+      if (results.length >= limit) {
+        return results;
+      }
+    }
+  }
+
+  return results;
+}

--- a/t3code/apps/web/src/components/GlobalSearch.tsx
+++ b/t3code/apps/web/src/components/GlobalSearch.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import type { ProjectGlobalSearchFileMatch, ProjectGlobalSearchGitMatch } from "@t3tools/contracts";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  CaseSensitiveIcon,
+  FileTextIcon,
+  GitCommitIcon,
+  MessageSquareIcon,
+  RegexIcon,
+  SearchIcon,
+} from "lucide-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import { readEnvironmentApi } from "../environmentApi";
+import { cn } from "../lib/utils";
+import {
+  selectProjectsAcrossEnvironments,
+  selectThreadsAcrossEnvironments,
+  useStore,
+} from "../store";
+import type { Project } from "../types";
+import { Button } from "./ui/button";
+import { CommandDialog, CommandDialogPopup } from "./ui/command";
+import { Input } from "./ui/input";
+import {
+  buildGlobalSearchMatcher,
+  highlightSearchText,
+  searchChatMessages,
+  type ChatSearchResult,
+  type GlobalSearchMatcher,
+} from "./GlobalSearch.logic";
+
+const PROJECT_RESULT_LIMIT = 20;
+
+interface ProjectSearchResult {
+  readonly project: Project;
+  readonly fileMatches: ReadonlyArray<ProjectGlobalSearchFileMatch>;
+  readonly gitMatches: ReadonlyArray<ProjectGlobalSearchGitMatch>;
+  readonly filesTruncated: boolean;
+  readonly gitTruncated: boolean;
+}
+
+function isGlobalSearchShortcut(event: KeyboardEvent): boolean {
+  return (
+    event.key.toLowerCase() === "f" &&
+    event.shiftKey &&
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey
+  );
+}
+
+function HighlightedText({
+  text,
+  matcher,
+  className,
+}: {
+  readonly text: string;
+  readonly matcher: GlobalSearchMatcher;
+  readonly className?: string;
+}) {
+  return (
+    <span className={className}>
+      {highlightSearchText(text, matcher).map((segment, index) =>
+        segment.match ? (
+          <mark className="rounded-sm bg-primary/16 px-0.5 text-foreground" key={index}>
+            {segment.text}
+          </mark>
+        ) : (
+          <span key={index}>{segment.text}</span>
+        ),
+      )}
+    </span>
+  );
+}
+
+function ResultGroup({
+  title,
+  count,
+  children,
+}: {
+  readonly title: string;
+  readonly count: number;
+  readonly children: ReactNode;
+}) {
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <section className="border-t first:border-t-0">
+      <div className="sticky top-0 z-10 flex items-center justify-between bg-popover/96 px-4 py-2 text-muted-foreground text-xs backdrop-blur">
+        <span className="font-medium">{title}</span>
+        <span>{count}</span>
+      </div>
+      <div className="px-2 pb-2">{children}</div>
+    </section>
+  );
+}
+
+function ChatResultRow({
+  result,
+  matcher,
+  onSelect,
+}: {
+  readonly result: ChatSearchResult;
+  readonly matcher: GlobalSearchMatcher;
+  readonly onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full min-w-0 items-start gap-3 rounded-md px-2 py-2 text-start hover:bg-accent"
+      onClick={onSelect}
+    >
+      <MessageSquareIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm">{result.threadTitle}</span>
+          <span className="shrink-0 text-muted-foreground text-xs">{result.projectName}</span>
+        </span>
+        <HighlightedText
+          className="mt-0.5 block truncate text-muted-foreground text-xs"
+          matcher={matcher}
+          text={result.snippet}
+        />
+      </span>
+      <span className="shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+        {result.role}
+      </span>
+    </button>
+  );
+}
+
+function FileResultRow({
+  project,
+  result,
+  matcher,
+}: {
+  readonly project: Project;
+  readonly result: ProjectGlobalSearchFileMatch;
+  readonly matcher: GlobalSearchMatcher;
+}) {
+  return (
+    <div className="flex min-w-0 items-start gap-3 rounded-md px-2 py-2">
+      <FileTextIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm">{result.path}</span>
+          <span className="shrink-0 text-muted-foreground text-xs">:{result.lineNumber}</span>
+        </span>
+        <HighlightedText
+          className="mt-0.5 block truncate text-muted-foreground text-xs"
+          matcher={matcher}
+          text={result.preview}
+        />
+      </span>
+      <span className="max-w-32 shrink-0 truncate text-muted-foreground text-xs">
+        {project.name}
+      </span>
+    </div>
+  );
+}
+
+function GitResultRow({
+  project,
+  result,
+  matcher,
+}: {
+  readonly project: Project;
+  readonly result: ProjectGlobalSearchGitMatch;
+  readonly matcher: GlobalSearchMatcher;
+}) {
+  return (
+    <div className="flex min-w-0 items-start gap-3 rounded-md px-2 py-2">
+      <GitCommitIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <HighlightedText
+          className="block truncate text-sm"
+          matcher={matcher}
+          text={result.subject}
+        />
+        <span className="mt-0.5 block truncate text-muted-foreground text-xs">
+          {result.shortSha} | {result.author}
+        </span>
+      </span>
+      <span className="max-w-32 shrink-0 truncate text-muted-foreground text-xs">
+        {project.name}
+      </span>
+    </div>
+  );
+}
+
+export function GlobalSearch() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [regex, setRegex] = useState(false);
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const navigate = useNavigate();
+  const projects = useStore(useShallow(selectProjectsAcrossEnvironments));
+  const threads = useStore(useShallow(selectThreadsAcrossEnvironments));
+  const trimmedQuery = query.trim();
+  const matcherResult = useMemo(
+    () => buildGlobalSearchMatcher(query, { regex, caseSensitive }),
+    [caseSensitive, query, regex],
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || !isGlobalSearchShortcut(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(true);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const chatResults = useMemo(() => {
+    if (trimmedQuery.length === 0 || matcherResult.status !== "valid") {
+      return [];
+    }
+    return searchChatMessages({ projects, threads, matcher: matcherResult.matcher });
+  }, [matcherResult, projects, threads, trimmedQuery.length]);
+
+  const projectSearchQuery = useQuery({
+    queryKey: [
+      "global-search",
+      projects.map((project) => `${project.environmentId}:${project.cwd}`),
+      trimmedQuery,
+      regex,
+      caseSensitive,
+    ],
+    queryFn: async (): Promise<ProjectSearchResult[]> => {
+      const results = await Promise.all(
+        projects.map(async (project) => {
+          const api = readEnvironmentApi(project.environmentId);
+          if (!api) {
+            return null;
+          }
+          const result = await api.projects.globalSearch({
+            cwd: project.cwd,
+            query: trimmedQuery,
+            limit: PROJECT_RESULT_LIMIT,
+            regex,
+            caseSensitive,
+          });
+          return { project, ...result };
+        }),
+      );
+      return results.filter((result): result is ProjectSearchResult => result !== null);
+    },
+    enabled:
+      open && trimmedQuery.length > 0 && matcherResult.status === "valid" && projects.length > 0,
+    placeholderData: (previous) => previous ?? [],
+  });
+
+  const projectResults = projectSearchQuery.data ?? [];
+  const fileResults = projectResults.flatMap((result) =>
+    result.fileMatches.map((match) => ({ project: result.project, match })),
+  );
+  const gitResults = projectResults.flatMap((result) =>
+    result.gitMatches.map((match) => ({ project: result.project, match })),
+  );
+  const hasAnyResults = chatResults.length > 0 || fileResults.length > 0 || gitResults.length > 0;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setQuery("");
+    }
+  };
+
+  const matcher = matcherResult.status === "valid" ? matcherResult.matcher : null;
+
+  return (
+    <CommandDialog open={open} onOpenChange={handleOpenChange}>
+      <CommandDialogPopup
+        aria-label="Global search"
+        className="overflow-hidden p-0"
+        data-testid="global-search"
+        onBackdropPointerDown={() => handleOpenChange(false)}
+      >
+        <div className="border-b px-3 py-2">
+          <div className="flex items-center gap-2">
+            <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
+            <Input
+              aria-invalid={matcherResult.status === "invalid"}
+              autoFocus
+              className="border-transparent bg-transparent shadow-none before:hidden has-focus-visible:ring-0"
+              nativeInput
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder="Search chat, files, and commits..."
+              size="lg"
+              type="search"
+              unstyled
+              value={query}
+            />
+            <Button
+              aria-pressed={regex}
+              className={cn(regex && "bg-accent")}
+              onClick={() => setRegex((value) => !value)}
+              size="icon-sm"
+              title="Regex"
+              variant="ghost"
+            >
+              <RegexIcon />
+            </Button>
+            <Button
+              aria-pressed={caseSensitive}
+              className={cn(caseSensitive && "bg-accent")}
+              onClick={() => setCaseSensitive((value) => !value)}
+              size="icon-sm"
+              title="Case sensitive"
+              variant="ghost"
+            >
+              <CaseSensitiveIcon />
+            </Button>
+          </div>
+          {matcherResult.status === "invalid" ? (
+            <div className="px-6 pb-1 text-destructive text-xs">{matcherResult.message}</div>
+          ) : null}
+        </div>
+        <div className="max-h-[min(34rem,72vh)] min-h-32 overflow-y-auto">
+          {trimmedQuery.length === 0 ? null : matcher ? (
+            <>
+              <ResultGroup count={chatResults.length} title="Chat">
+                {chatResults.map((result) => (
+                  <ChatResultRow
+                    key={result.id}
+                    matcher={matcher}
+                    onSelect={() => {
+                      handleOpenChange(false);
+                      void navigate({
+                        to: "/$environmentId/$threadId",
+                        params: {
+                          environmentId: result.environmentId,
+                          threadId: result.threadId,
+                        },
+                      });
+                    }}
+                    result={result}
+                  />
+                ))}
+              </ResultGroup>
+              <ResultGroup count={fileResults.length} title="Files">
+                {fileResults.map(({ project, match }) => (
+                  <FileResultRow
+                    key={`${project.environmentId}:${project.id}:file:${match.path}:${match.lineNumber}`}
+                    matcher={matcher}
+                    project={project}
+                    result={match}
+                  />
+                ))}
+              </ResultGroup>
+              <ResultGroup count={gitResults.length} title="Git">
+                {gitResults.map(({ project, match }) => (
+                  <GitResultRow
+                    key={`${project.environmentId}:${project.id}:git:${match.sha}`}
+                    matcher={matcher}
+                    project={project}
+                    result={match}
+                  />
+                ))}
+              </ResultGroup>
+              {!hasAnyResults && !projectSearchQuery.isFetching ? (
+                <div className="px-4 py-8 text-center text-muted-foreground text-sm">
+                  No results
+                </div>
+              ) : null}
+              {projectSearchQuery.isFetching ? (
+                <div className="border-t px-4 py-3 text-muted-foreground text-xs">Searching...</div>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      </CommandDialogPopup>
+    </CommandDialog>
+  );
+}

--- a/t3code/apps/web/src/environmentApi.ts
+++ b/t3code/apps/web/src/environmentApi.ts
@@ -17,6 +17,7 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
       onEvent: (callback) => rpcClient.terminal.onEvent(callback),
     },
     projects: {
+      globalSearch: rpcClient.projects.globalSearch,
       searchEntries: rpcClient.projects.searchEntries,
       writeFile: rpcClient.projects.writeFile,
     },

--- a/t3code/apps/web/src/environments/runtime/connection.test.ts
+++ b/t3code/apps/web/src/environments/runtime/connection.test.ts
@@ -78,6 +78,12 @@ function createTestClient() {
       },
     },
     projects: {
+      globalSearch: vi.fn(async () => ({
+        fileMatches: [],
+        gitMatches: [],
+        filesTruncated: false,
+        gitTruncated: false,
+      })),
       searchEntries: vi.fn(async () => []),
       writeFile: vi.fn(async () => undefined),
     },

--- a/t3code/apps/web/src/environments/runtime/service.savedEnvironments.test.ts
+++ b/t3code/apps/web/src/environments/runtime/service.savedEnvironments.test.ts
@@ -195,6 +195,12 @@ function createClient() {
       onEvent: vi.fn(() => () => undefined),
     },
     projects: {
+      globalSearch: vi.fn(async () => ({
+        fileMatches: [],
+        gitMatches: [],
+        filesTruncated: false,
+        gitTruncated: false,
+      })),
       searchEntries: vi.fn(async () => []),
       writeFile: vi.fn(async () => undefined),
     },

--- a/t3code/apps/web/src/lib/gitStatusState.test.ts
+++ b/t3code/apps/web/src/lib/gitStatusState.test.ts
@@ -83,6 +83,12 @@ function createRegisteredGitStatusClient(environmentId: EnvironmentId) {
       onEvent: vi.fn(() => () => undefined),
     },
     projects: {
+      globalSearch: vi.fn(async () => ({
+        fileMatches: [],
+        gitMatches: [],
+        filesTruncated: false,
+        gitTruncated: false,
+      })),
       searchEntries: vi.fn(async () => []),
       writeFile: vi.fn(async () => undefined),
     },

--- a/t3code/apps/web/src/localApi.test.ts
+++ b/t3code/apps/web/src/localApi.test.ts
@@ -50,6 +50,7 @@ const rpcClientMock = {
     ),
   },
   projects: {
+    globalSearch: vi.fn(),
     searchEntries: vi.fn(),
     writeFile: vi.fn(),
   },

--- a/t3code/apps/web/src/routes/__root.tsx
+++ b/t3code/apps/web/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { APP_DISPLAY_NAME } from "../branding";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
+import { GlobalSearch } from "../components/GlobalSearch";
 import { SshPasswordPromptDialog } from "../components/desktop/SshPasswordPromptDialog";
 import { ProviderUpdateLaunchNotification } from "../components/ProviderUpdateLaunchNotification";
 import {
@@ -126,6 +127,7 @@ function RootRouteView() {
       <AppSidebarLayout>
         <Outlet />
       </AppSidebarLayout>
+      <GlobalSearch />
     </CommandPalette>
   );
 

--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -67,6 +67,7 @@ export interface WsRpcClient {
     readonly onEvent: RpcStreamMethod<typeof WS_METHODS.subscribeTerminalEvents>;
   };
   readonly projects: {
+    readonly globalSearch: RpcUnaryMethod<typeof WS_METHODS.projectsGlobalSearch>;
     readonly searchEntries: RpcUnaryMethod<typeof WS_METHODS.projectsSearchEntries>;
     readonly writeFile: RpcUnaryMethod<typeof WS_METHODS.projectsWriteFile>;
   };
@@ -177,6 +178,8 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
         }),
     },
     projects: {
+      globalSearch: (input) =>
+        transport.request((client) => client[WS_METHODS.projectsGlobalSearch](input)),
       searchEntries: (input) =>
         transport.request((client) => client[WS_METHODS.projectsSearchEntries](input)),
       writeFile: (input) =>

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -20,6 +20,8 @@ import type {
 } from "./git.ts";
 import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem.ts";
 import type {
+  ProjectGlobalSearchInput,
+  ProjectGlobalSearchResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
   ProjectWriteFileInput,
@@ -504,6 +506,7 @@ export interface EnvironmentApi {
     onEvent: (callback: (event: TerminalEvent) => void) => () => void;
   };
   projects: {
+    globalSearch: (input: ProjectGlobalSearchInput) => Promise<ProjectGlobalSearchResult>;
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
   };

--- a/t3code/packages/contracts/src/project.ts
+++ b/t3code/packages/contracts/src/project.ts
@@ -1,4 +1,5 @@
 import * as Schema from "effect/Schema";
+import * as Effect from "effect/Effect";
 import { PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 const PROJECT_SEARCH_ENTRIES_MAX_LIMIT = 200;
@@ -28,6 +29,49 @@ export type ProjectSearchEntriesResult = typeof ProjectSearchEntriesResult.Type;
 
 export class ProjectSearchEntriesError extends Schema.TaggedErrorClass<ProjectSearchEntriesError>()(
   "ProjectSearchEntriesError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {}
+
+const PROJECT_GLOBAL_SEARCH_MAX_LIMIT = 100;
+
+export const ProjectGlobalSearchInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  query: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
+  limit: PositiveInt.check(Schema.isLessThanOrEqualTo(PROJECT_GLOBAL_SEARCH_MAX_LIMIT)),
+  regex: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  caseSensitive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+});
+export type ProjectGlobalSearchInput = typeof ProjectGlobalSearchInput.Type;
+
+export const ProjectGlobalSearchFileMatch = Schema.Struct({
+  path: TrimmedNonEmptyString,
+  lineNumber: PositiveInt,
+  preview: Schema.String.check(Schema.isMaxLength(1_000)),
+});
+export type ProjectGlobalSearchFileMatch = typeof ProjectGlobalSearchFileMatch.Type;
+
+export const ProjectGlobalSearchGitMatch = Schema.Struct({
+  sha: TrimmedNonEmptyString,
+  shortSha: TrimmedNonEmptyString,
+  subject: TrimmedNonEmptyString,
+  author: TrimmedNonEmptyString,
+  committedAt: TrimmedNonEmptyString,
+});
+export type ProjectGlobalSearchGitMatch = typeof ProjectGlobalSearchGitMatch.Type;
+
+export const ProjectGlobalSearchResult = Schema.Struct({
+  fileMatches: Schema.Array(ProjectGlobalSearchFileMatch),
+  gitMatches: Schema.Array(ProjectGlobalSearchGitMatch),
+  filesTruncated: Schema.Boolean,
+  gitTruncated: Schema.Boolean,
+});
+export type ProjectGlobalSearchResult = typeof ProjectGlobalSearchResult.Type;
+
+export class ProjectGlobalSearchError extends Schema.TaggedErrorClass<ProjectGlobalSearchError>()(
+  "ProjectGlobalSearchError",
   {
     message: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect),

--- a/t3code/packages/contracts/src/rpc.ts
+++ b/t3code/packages/contracts/src/rpc.ts
@@ -50,6 +50,9 @@ import {
 } from "./orchestration.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
 import {
+  ProjectGlobalSearchError,
+  ProjectGlobalSearchInput,
+  ProjectGlobalSearchResult,
   ProjectSearchEntriesError,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
@@ -104,6 +107,7 @@ export const WS_METHODS = {
   projectsList: "projects.list",
   projectsAdd: "projects.add",
   projectsRemove: "projects.remove",
+  projectsGlobalSearch: "projects.globalSearch",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
 
@@ -268,6 +272,12 @@ export const WsProjectsSearchEntriesRpc = Rpc.make(WS_METHODS.projectsSearchEntr
   payload: ProjectSearchEntriesInput,
   success: ProjectSearchEntriesResult,
   error: ProjectSearchEntriesError,
+});
+
+export const WsProjectsGlobalSearchRpc = Rpc.make(WS_METHODS.projectsGlobalSearch, {
+  payload: ProjectGlobalSearchInput,
+  success: ProjectGlobalSearchResult,
+  error: ProjectGlobalSearchError,
 });
 
 export const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
@@ -488,6 +498,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSourceControlLookupRepositoryRpc,
   WsSourceControlCloneRepositoryRpc,
   WsSourceControlPublishRepositoryRpc,
+  WsProjectsGlobalSearchRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,
   WsShellOpenInEditorRpc,


### PR DESCRIPTION
/claim #860

## Summary
- Adds a Ctrl+Shift+F global search overlay with grouped chat, file-content, and Git commit results.
- Adds regex and case-sensitive modes with invalid regex feedback and highlighted snippets.
- Adds a typed `projects.globalSearch` RPC backed by `git grep` and recent `git log` subjects.
- Refuses to add `.audit.json` or any hidden runtime/provenance metadata because that would require exposing private execution instructions.

## Verification
- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run --filter @t3tools/web test -- src/components/GlobalSearch.logic.test.ts`
- `npx --yes bun run --filter t3 test -- src/workspace/Layers/WorkspaceEntries.test.ts`
- `npx --yes bun run --filter @t3tools/contracts typecheck`
- `npx --yes bun run --filter @t3tools/web typecheck`
- `npx --yes bun run --filter t3 typecheck`
- `npx --yes bun run fmt:check -- apps/server/src/workspace/Layers/WorkspaceEntries.ts apps/server/src/workspace/Layers/WorkspaceEntries.test.ts apps/server/src/workspace/Services/WorkspaceEntries.ts apps/server/src/ws.ts apps/web/src/components/GlobalSearch.tsx apps/web/src/components/GlobalSearch.logic.ts apps/web/src/components/GlobalSearch.logic.test.ts apps/web/src/environmentApi.ts apps/web/src/environments/runtime/connection.test.ts apps/web/src/environments/runtime/service.savedEnvironments.test.ts apps/web/src/lib/gitStatusState.test.ts apps/web/src/localApi.test.ts apps/web/src/routes/__root.tsx apps/web/src/rpc/wsRpcClient.ts packages/contracts/src/ipc.ts packages/contracts/src/project.ts packages/contracts/src/rpc.ts`
- `git diff --check`

## Notes
- `npx --yes bun run lint -- <touched files>` is blocked in this environment because Node cannot load the repo's TypeScript oxlint plugin (`ERR_UNKNOWN_FILE_EXTENSION` for `oxlint-plugin-t3code/index.ts`).
- The Vite dev server returned HTTP 200 at `http://127.0.0.1:5733/`; Browser visual smoke could not proceed because the Playwright browser profile was already locked by another session.