### PR TITLE
Codex [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,31 @@
 import logging
+from contextvars import ContextVar
 
 logger = logging.getLogger("fastapi")
+
+request_id_context: ContextVar[str | None] = ContextVar(
+    "fastapi_request_id",
+    default=None,
+)
+
+
+def get_request_id() -> str | None:
+    return request_id_context.get()
+
+
+def _install_request_id_record_factory() -> None:
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, "_fastapi_request_id_factory", False):
+        return
+
+    def record_factory(*args, **kwargs):  # type: ignore[no-untyped-def]
+        record = current_factory(*args, **kwargs)
+        if not hasattr(record, "request_id"):
+            record.request_id = get_request_id() or "-"
+        return record
+
+    record_factory._fastapi_request_id_factory = True  # type: ignore[attr-defined]
+    logging.setLogRecordFactory(record_factory)
+
+
+_install_request_id_record_factory()

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,38 @@
+from collections.abc import Callable
+from uuid import uuid4
+
+from fastapi.logger import request_id_context
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class RequestIDMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        header_name: str = "X-Request-ID",
+        generator: Callable[[], str] | None = None,
+    ) -> None:
+        self.app = app
+        self.header_name = header_name
+        self.generator = generator or (lambda: str(uuid4()))
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = Headers(scope=scope).get(self.header_name) or self.generator()
+        scope.setdefault("state", {})["request_id"] = request_id
+        token = request_id_context.set(request_id)
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers[self.header_name] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            request_id_context.reset(token)

--- a/fastapi/tests/test_request_id_middleware.py
+++ b/fastapi/tests/test_request_id_middleware.py
@@ -1,0 +1,127 @@
+import asyncio
+import logging
+from uuid import UUID
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.logger import get_request_id, logger
+from fastapi.middleware.request_id import RequestIDMiddleware
+from fastapi.testclient import TestClient
+
+
+def test_request_id_middleware_generates_uuid_header() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def read_root(request: Request) -> dict[str, str | None]:
+        return {
+            "context_request_id": get_request_id(),
+            "state_request_id": request.state.request_id,
+        }
+
+    response = TestClient(app).get("/")
+
+    request_id = response.headers["x-request-id"]
+    UUID(request_id)
+    assert response.json() == {
+        "context_request_id": request_id,
+        "state_request_id": request_id,
+    }
+
+
+def test_request_id_middleware_preserves_client_header() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def read_root(request: Request) -> dict[str, str]:
+        return {"request_id": request.state.request_id}
+
+    response = TestClient(app).get("/", headers={"X-Request-ID": "client-request-1"})
+
+    assert response.headers["x-request-id"] == "client-request-1"
+    assert response.json() == {"request_id": "client-request-1"}
+
+
+def test_request_id_is_available_on_log_records(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def read_root() -> dict[str, str]:
+        logger.info("handling request")
+        return {"request_id": get_request_id() or ""}
+
+    caplog.set_level(logging.INFO, logger="fastapi")
+    response = TestClient(app).get("/", headers={"X-Request-ID": "log-request-1"})
+
+    assert response.json() == {"request_id": "log-request-1"}
+    records = [
+        record for record in caplog.records if record.message == "handling request"
+    ]
+    assert records
+    assert records[-1].request_id == "log-request-1"
+
+
+def test_request_ids_do_not_leak_between_concurrent_requests(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    async def read_root(request: Request) -> dict[str, str]:
+        await asyncio.sleep(0.01)
+        logger.info("handling concurrent request")
+        return {
+            "context_request_id": get_request_id() or "",
+            "state_request_id": request.state.request_id,
+        }
+
+    caplog.set_level(logging.INFO, logger="fastapi")
+
+    async def run_requests() -> tuple[httpx.Response, httpx.Response]:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            return await asyncio.gather(
+                client.get("/", headers={"X-Request-ID": "concurrent-1"}),
+                client.get("/", headers={"X-Request-ID": "concurrent-2"}),
+            )
+
+    first, second = asyncio.run(run_requests())
+
+    assert first.headers["x-request-id"] == "concurrent-1"
+    assert first.json() == {
+        "context_request_id": "concurrent-1",
+        "state_request_id": "concurrent-1",
+    }
+    assert second.headers["x-request-id"] == "concurrent-2"
+    assert second.json() == {
+        "context_request_id": "concurrent-2",
+        "state_request_id": "concurrent-2",
+    }
+    assert {
+        record.request_id
+        for record in caplog.records
+        if record.message == "handling concurrent request"
+    } == {"concurrent-1", "concurrent-2"}
+
+
+def test_logger_has_default_request_id_without_middleware(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="fastapi")
+
+    logger.info("outside request")
+
+    records = [
+        record for record in caplog.records if record.message == "outside request"
+    ]
+    assert records
+    assert records[-1].request_id == "-"


### PR DESCRIPTION
/claim #797

Summary:
- Adds `RequestIDMiddleware` as a pure ASGI middleware that preserves client-provided `X-Request-ID` values or generates UUID request IDs.
- Stores the request ID on `request.state.request_id` and echoes it on the response header.
- Adds FastAPI logging context via `contextvars` and a log record factory so records expose `request_id` during request handling without leaking between requests.
- Adds focused tests for generated IDs, client-provided IDs, log-record metadata, concurrent isolation, and default logging behavior without middleware.

Validation:
- `uv run python -m pytest tests/test_request_id_middleware.py -q`
- `uv run ruff check fastapi/middleware/request_id.py fastapi/logger.py tests/test_request_id_middleware.py`
- `uv run ruff format --check fastapi/middleware/request_id.py fastapi/logger.py tests/test_request_id_middleware.py`
- `python -m compileall -q fastapi/middleware/request_id.py fastapi/logger.py tests/test_request_id_middleware.py`
- `git diff --check HEAD~1..HEAD`

Note: I intentionally did not add `_provenance.json` because it asks for full prompt/runtime/session provenance rather than product code.