### PR TITLE
Agent [ FastAPI ] Add WebSocket heartbeat wrapper

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -23,3 +23,4 @@ from .responses import Response as Response
 from .routing import APIRouter as APIRouter
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect
+from .websockets import WebSocketWithHeartbeat as WebSocketWithHeartbeat

--- a/fastapi/fastapi/websockets.py
+++ b/fastapi/fastapi/websockets.py
@@ -1,3 +1,171 @@
+import asyncio
+import inspect
+import json
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from typing import Any, cast
+
+from starlette.types import Message
 from starlette.websockets import WebSocket as WebSocket  # noqa
 from starlette.websockets import WebSocketDisconnect as WebSocketDisconnect  # noqa
 from starlette.websockets import WebSocketState as WebSocketState  # noqa
+
+DisconnectCallback = Callable[[int, float], Awaitable[Any] | Any]
+
+
+class WebSocketWithHeartbeat:
+    def __init__(
+        self,
+        websocket: WebSocket,
+        *,
+        ping_interval: float = 30.0,
+        pong_timeout: float = 10.0,
+        on_disconnect: DisconnectCallback | None = None,
+        ping_payload: bytes = b"ping",
+        pong_payload: bytes = b"pong",
+    ) -> None:
+        self.websocket = websocket
+        self.ping_interval = ping_interval
+        self.pong_timeout = pong_timeout
+        self.on_disconnect = on_disconnect
+        self.ping_payload = ping_payload
+        self.pong_payload = pong_payload
+        self._started_at = time.monotonic()
+        self._last_pong_at = self._started_at
+        self._message_count = 0
+        self._closed = False
+        self._disconnect_notified = False
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+    @property
+    def connection_duration(self) -> float:
+        return time.monotonic() - self._started_at
+
+    @property
+    def message_count(self) -> int:
+        return self._message_count
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.websocket, name)
+
+    async def accept(self, *args: Any, **kwargs: Any) -> None:
+        await self.websocket.accept(*args, **kwargs)
+        self.start_heartbeat()
+
+    def start_heartbeat(self) -> None:
+        if self._heartbeat_task is None or self._heartbeat_task.done():
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def stop_heartbeat(self) -> None:
+        task = self._heartbeat_task
+        if task is None or task.done():
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    def record_pong(self) -> None:
+        self._last_pong_at = time.monotonic()
+
+    async def send_ping(self) -> None:
+        await self.websocket.send_bytes(self.ping_payload)
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        if self._closed:
+            return
+
+        self._closed = True
+        await self.websocket.close(code=code, reason=reason)
+        if (
+            self._heartbeat_task is not None
+            and self._heartbeat_task is not asyncio.current_task()
+        ):
+            await self.stop_heartbeat()
+        await self._notify_disconnect(code)
+
+    async def receive(self) -> Message:
+        while True:
+            message = await self.websocket.receive()
+            message_type = message.get("type")
+            if message_type == "websocket.disconnect":
+                self._closed = True
+                await self.stop_heartbeat()
+                await self._notify_disconnect(int(message.get("code", 1000)))
+                return message
+
+            if self._is_pong_message(message):
+                self.record_pong()
+                continue
+
+            if message_type == "websocket.receive":
+                self._message_count += 1
+
+            return message
+
+    async def receive_text(self) -> str:
+        if self.websocket.application_state != WebSocketState.CONNECTED:
+            raise RuntimeError(
+                'WebSocket is not connected. Need to call "accept" first.'
+            )
+        message = await self.receive()
+        self.websocket._raise_on_disconnect(message)
+        return cast(str, message["text"])
+
+    async def receive_bytes(self) -> bytes:
+        if self.websocket.application_state != WebSocketState.CONNECTED:
+            raise RuntimeError(
+                'WebSocket is not connected. Need to call "accept" first.'
+            )
+        message = await self.receive()
+        self.websocket._raise_on_disconnect(message)
+        return cast(bytes, message["bytes"])
+
+    async def receive_json(self, mode: str = "text") -> Any:
+        if mode not in {"text", "binary"}:
+            raise RuntimeError('The "mode" argument should be "text" or "binary".')
+        if self.websocket.application_state != WebSocketState.CONNECTED:
+            raise RuntimeError(
+                'WebSocket is not connected. Need to call "accept" first.'
+            )
+        message = await self.receive()
+        self.websocket._raise_on_disconnect(message)
+
+        if mode == "text":
+            text = message["text"]
+        else:
+            text = message["bytes"].decode("utf-8")
+        return json.loads(text)
+
+    async def _heartbeat_loop(self) -> None:
+        try:
+            while not self._closed:
+                await asyncio.sleep(self.ping_interval)
+                if self._closed:
+                    return
+                ping_sent_at = time.monotonic()
+                await self.send_ping()
+                await asyncio.sleep(self.pong_timeout)
+                if not self._closed and self._last_pong_at < ping_sent_at:
+                    await self.close(code=1001)
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if not self._closed:
+                await self.close(code=1001)
+
+    async def _notify_disconnect(self, code: int) -> None:
+        if self._disconnect_notified or self.on_disconnect is None:
+            return
+
+        self._disconnect_notified = True
+        result = self.on_disconnect(code, self.connection_duration)
+        if inspect.isawaitable(result):
+            await result
+
+    def _is_pong_message(self, message: Message) -> bool:
+        return (
+            message.get("text") == self.pong_payload.decode("utf-8")
+            or message.get("bytes") == self.pong_payload
+        )

--- a/fastapi/tests/test_websocket_heartbeat.py
+++ b/fastapi/tests/test_websocket_heartbeat.py
@@ -1,0 +1,125 @@
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import WebSocket
+from fastapi import WebSocketWithHeartbeat as TopLevelWebSocketWithHeartbeat
+from fastapi.websockets import (
+    WebSocketDisconnect,
+    WebSocketState,
+    WebSocketWithHeartbeat,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class FakeWebSocket:
+    def __init__(self) -> None:
+        self.application_state = WebSocketState.CONNECTED
+        self.accepted = False
+        self.sent_bytes: list[bytes] = []
+        self.close_calls: list[tuple[int, str | None]] = []
+        self.messages: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def accept(self, *args: Any, **kwargs: Any) -> None:
+        self.accepted = True
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent_bytes.append(data)
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.application_state = WebSocketState.DISCONNECTED
+        self.close_calls.append((code, reason))
+
+    async def receive(self) -> dict[str, Any]:
+        return await self.messages.get()
+
+    def _raise_on_disconnect(self, message: dict[str, Any]) -> None:
+        if message["type"] == "websocket.disconnect":
+            raise WebSocketDisconnect(code=message.get("code", 1000))
+
+
+def test_existing_websocket_export_is_unchanged() -> None:
+    assert WebSocket.__name__ == "WebSocket"
+    assert TopLevelWebSocketWithHeartbeat is WebSocketWithHeartbeat
+
+
+@pytest.mark.anyio
+async def test_heartbeat_sends_ping_payload_at_configured_interval() -> None:
+    websocket = FakeWebSocket()
+    heartbeat = WebSocketWithHeartbeat(websocket, ping_interval=0.01, pong_timeout=1.0)
+
+    await heartbeat.accept()
+    await asyncio.sleep(0.03)
+    await heartbeat.close()
+
+    assert websocket.accepted is True
+    assert websocket.sent_bytes
+    assert websocket.sent_bytes[0] == b"ping"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_closes_when_pong_timeout_is_exceeded() -> None:
+    disconnects: list[tuple[int, float]] = []
+    websocket = FakeWebSocket()
+    heartbeat = WebSocketWithHeartbeat(
+        websocket,
+        ping_interval=0.01,
+        pong_timeout=0.01,
+        on_disconnect=lambda code, duration: disconnects.append((code, duration)),
+    )
+
+    await heartbeat.accept()
+    await asyncio.sleep(0.05)
+
+    assert websocket.close_calls == [(1001, None)]
+    assert disconnects
+    assert disconnects[0][0] == 1001
+    assert disconnects[0][1] > 0
+
+
+@pytest.mark.anyio
+async def test_recorded_pong_keeps_connection_open_until_later_timeout() -> None:
+    websocket = FakeWebSocket()
+    heartbeat = WebSocketWithHeartbeat(websocket, ping_interval=0.01, pong_timeout=0.03)
+
+    await heartbeat.accept()
+    await asyncio.sleep(0.015)
+    heartbeat.record_pong()
+    await asyncio.sleep(0.02)
+
+    assert websocket.close_calls == []
+
+    await heartbeat.close()
+
+
+@pytest.mark.anyio
+async def test_receive_filters_pong_and_tracks_application_message_count() -> None:
+    websocket = FakeWebSocket()
+    heartbeat = WebSocketWithHeartbeat(websocket)
+    await websocket.messages.put({"type": "websocket.receive", "bytes": b"pong"})
+    await websocket.messages.put({"type": "websocket.receive", "text": "hello"})
+
+    assert await heartbeat.receive_text() == "hello"
+    assert heartbeat.message_count == 1
+
+
+@pytest.mark.anyio
+async def test_disconnect_callback_receives_close_code_and_duration() -> None:
+    disconnects: list[tuple[int, float]] = []
+    websocket = FakeWebSocket()
+    heartbeat = WebSocketWithHeartbeat(
+        websocket,
+        on_disconnect=lambda code, duration: disconnects.append((code, duration)),
+    )
+    await websocket.messages.put({"type": "websocket.disconnect", "code": 1006})
+
+    message = await heartbeat.receive()
+
+    assert message["type"] == "websocket.disconnect"
+    assert disconnects
+    assert disconnects[0][0] == 1006
+    assert disconnects[0][1] >= 0


### PR DESCRIPTION
/claim #766

## Summary
- Adds `WebSocketWithHeartbeat`, an opt-in FastAPI WebSocket wrapper with configurable ping interval and pong timeout.
- Tracks connection duration and application message count, filters heartbeat pong payloads, and invokes `on_disconnect(code, duration)` once when the wrapper observes or initiates a disconnect.
- Keeps the existing `WebSocket` export unchanged while also exposing the new wrapper at `fastapi.WebSocketWithHeartbeat` and `fastapi.websockets.WebSocketWithHeartbeat`.
- Refuses to add `_contributor.json` because it asks for hidden runtime instructions from this session.

## Verification
- `uv run pytest tests/test_websocket_heartbeat.py`
- `uv run pytest tests/test_ws_router.py tests/test_ws_dependencies.py`
- `uv run ruff check fastapi/__init__.py fastapi/websockets.py tests/test_websocket_heartbeat.py`
- `uv run ruff format --check fastapi/__init__.py fastapi/websockets.py tests/test_websocket_heartbeat.py`
- `uv run mypy fastapi/websockets.py`
- `git diff --check`