### PR TITLE
Codex [ FastAPI ] Add HTTPBasic brute force protection

### DIFF
--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,10 @@
 import binascii
+import hashlib
+import secrets
+import time
 from base64 import b64decode
+from collections.abc import Callable
+from math import ceil
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +15,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -217,6 +222,196 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    """
+    HTTP Basic authentication with in-memory brute-force protection.
+
+    This class preserves `HTTPBasic` parsing behavior and adds optional credential
+    validation plus per-client failure tracking. The in-memory store is process-local;
+    use an external shared store for distributed deployments.
+    """
+
+    _HASH_SCHEME = "pbkdf2_sha256"
+    _DEFAULT_HASH_ITERATIONS = 260_000
+
+    def __init__(
+        self,
+        *,
+        max_attempts: Annotated[
+            int,
+            Doc(
+                """
+                Number of failed authentication attempts allowed per client within
+                `window_seconds` before requests are temporarily rejected.
+                """
+            ),
+        ] = 5,
+        window_seconds: Annotated[
+            int,
+            Doc(
+                """
+                Time window, in seconds, used to count failed authentication attempts.
+                """
+            ),
+        ] = 60,
+        credentials_validator: Annotated[
+            Callable[[HTTPBasicCredentials], bool] | None,
+            Doc(
+                """
+                Optional callable used to validate parsed HTTP Basic credentials.
+
+                Return `True` to accept credentials and reset failed attempts for the
+                client, or `False` to reject them and record a failed attempt.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        realm: Annotated[
+            str | None,
+            Doc(
+                """
+                HTTP Basic authentication realm.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, authentication errors are raised automatically.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            scheme_name=scheme_name,
+            realm=realm,
+            description=description,
+            auto_error=auto_error,
+        )
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be greater than or equal to 1")
+        if window_seconds < 1:
+            raise ValueError("window_seconds must be greater than or equal to 1")
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self.credentials_validator = credentials_validator
+        self._failed_attempts: dict[str, list[float]] = {}
+
+    @staticmethod
+    def hash_password(
+        password: str,
+        *,
+        salt: bytes | None = None,
+        iterations: int = _DEFAULT_HASH_ITERATIONS,
+    ) -> str:
+        salt = salt or secrets.token_bytes(16)
+        digest = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, iterations)
+        return (
+            f"{HTTPBasicWithProtection._HASH_SCHEME}"
+            f"${iterations}${salt.hex()}${digest.hex()}"
+        )
+
+    @staticmethod
+    def verify_password(password: str, expected_password: str) -> bool:
+        try:
+            scheme, iterations, salt, digest = expected_password.split("$", 3)
+        except ValueError:
+            return secrets.compare_digest(
+                password.encode(),
+                expected_password.encode(),
+            )
+        if scheme != HTTPBasicWithProtection._HASH_SCHEME:
+            return False
+        try:
+            iteration_count = int(iterations)
+            salt_bytes = bytes.fromhex(salt)
+            expected_digest = bytes.fromhex(digest)
+        except ValueError:
+            return False
+        actual_digest = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode(),
+            salt_bytes,
+            iteration_count,
+        )
+        return secrets.compare_digest(actual_digest, expected_digest)
+
+    def _client_key(self, request: Request) -> str:
+        if request.client is None:
+            return "unknown"
+        return request.client.host
+
+    def _active_failures(self, client_key: str, now: float) -> list[float]:
+        failures = [
+            failed_at
+            for failed_at in self._failed_attempts.get(client_key, [])
+            if now - failed_at < self.window_seconds
+        ]
+        if failures:
+            self._failed_attempts[client_key] = failures
+        else:
+            self._failed_attempts.pop(client_key, None)
+        return failures
+
+    def _retry_after(self, failures: list[float], now: float) -> int:
+        if not failures:
+            return self.window_seconds
+        return max(1, ceil(self.window_seconds - (now - failures[0])))
+
+    def _raise_locked_out(self, retry_after: int) -> None:
+        raise HTTPException(
+            status_code=HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many authentication attempts",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    def _record_failure(self, client_key: str, now: float) -> None:
+        failures = self._active_failures(client_key, now)
+        failures.append(now)
+        self._failed_attempts[client_key] = failures
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        client_key = self._client_key(request)
+        now = time.monotonic()
+        failures = self._active_failures(client_key, now)
+        if len(failures) >= self.max_attempts:
+            self._raise_locked_out(self._retry_after(failures, now))
+
+        try:
+            credentials = await super().__call__(request)
+        except HTTPException:
+            self._record_failure(client_key, now)
+            raise
+
+        if credentials is None or self.credentials_validator is None:
+            return credentials
+
+        if self.credentials_validator(credentials):
+            self._failed_attempts.pop(client_key, None)
+            return credentials
+
+        self._record_failure(client_key, now)
+        raise self.make_not_authenticated_error()
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_security_http_basic_protection.py
+++ b/fastapi/tests/test_security_http_basic_protection.py
@@ -1,0 +1,143 @@
+from base64 import b64encode
+
+import fastapi.security.http as http_security
+import pytest
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+
+def basic_auth(username: str, password: str) -> dict[str, str]:
+    token = b64encode(f"{username}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def build_client(
+    *,
+    max_attempts: int = 2,
+    window_seconds: int = 60,
+    client_addr: tuple[str, int] = ("testclient", 50000),
+) -> TestClient:
+    return TestClient(
+        build_app(max_attempts=max_attempts, window_seconds=window_seconds),
+        client=client_addr,
+    )
+
+
+def build_app(
+    *,
+    max_attempts: int = 2,
+    window_seconds: int = 60,
+) -> FastAPI:
+    password_hash = HTTPBasicWithProtection.hash_password(
+        "secret",
+        salt=b"fixed-test-salt",
+        iterations=1,
+    )
+
+    def validate(credentials: HTTPBasicCredentials) -> bool:
+        return (
+            credentials.username == "alice"
+            and HTTPBasicWithProtection.verify_password(
+                credentials.password,
+                password_hash,
+            )
+        )
+
+    security = HTTPBasicWithProtection(
+        max_attempts=max_attempts,
+        window_seconds=window_seconds,
+        credentials_validator=validate,
+    )
+    app = FastAPI()
+
+    @app.get("/users/me")
+    def read_current_user(
+        credentials: HTTPBasicCredentials = Security(security),
+    ) -> dict[str, str]:
+        return {"username": credentials.username}
+
+    return app
+
+
+def test_http_basic_with_protection_tracks_failures_and_locks_out() -> None:
+    client = build_client(max_attempts=2, window_seconds=30)
+
+    first = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    second = client.get("/users/me", headers=basic_auth("alice", "wrong-again"))
+    locked = client.get("/users/me", headers=basic_auth("alice", "secret"))
+
+    assert first.status_code == 401
+    assert second.status_code == 401
+    assert locked.status_code == 429
+    assert locked.json() == {"detail": "Too many authentication attempts"}
+    assert locked.headers["retry-after"].isdigit()
+
+
+def test_http_basic_with_protection_resets_failures_on_success() -> None:
+    client = build_client(max_attempts=2, window_seconds=30)
+
+    failed = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    successful = client.get("/users/me", headers=basic_auth("alice", "secret"))
+    failed_after_reset = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+
+    assert failed.status_code == 401
+    assert successful.status_code == 200
+    assert successful.json() == {"username": "alice"}
+    assert failed_after_reset.status_code == 401
+
+
+def test_http_basic_with_protection_tracks_failures_per_ip() -> None:
+    app = build_app(max_attempts=1, window_seconds=30)
+    locked_client = TestClient(app, client=("192.0.2.1", 50000))
+    other_client = TestClient(app, client=("192.0.2.2", 50000))
+
+    failed = locked_client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    locked = locked_client.get("/users/me", headers=basic_auth("alice", "secret"))
+    other_success = other_client.get("/users/me", headers=basic_auth("alice", "secret"))
+
+    assert failed.status_code == 401
+    assert locked.status_code == 429
+    assert other_success.status_code == 200
+
+
+def test_http_basic_with_protection_expires_failure_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 100.0
+    monkeypatch.setattr(http_security.time, "monotonic", lambda: now)
+    client = build_client(max_attempts=2, window_seconds=1)
+
+    assert (
+        client.get("/users/me", headers=basic_auth("alice", "wrong")).status_code == 401
+    )
+    assert (
+        client.get("/users/me", headers=basic_auth("alice", "wrong")).status_code == 401
+    )
+
+    now = 101.1
+
+    response = client.get("/users/me", headers=basic_auth("alice", "secret"))
+
+    assert response.status_code == 200
+
+
+def test_http_basic_with_protection_password_hash_verification() -> None:
+    password_hash = HTTPBasicWithProtection.hash_password(
+        "secret",
+        salt=b"fixed-test-salt",
+        iterations=1,
+    )
+
+    assert HTTPBasicWithProtection.verify_password("secret", password_hash)
+    assert not HTTPBasicWithProtection.verify_password("wrong", password_hash)
+    assert HTTPBasicWithProtection.verify_password("plain", "plain")
+    assert not HTTPBasicWithProtection.verify_password("plain", "different")
+
+
+def test_http_basic_with_protection_validates_constructor_bounds() -> None:
+    with pytest.raises(ValueError, match="max_attempts"):
+        HTTPBasicWithProtection(max_attempts=0)
+
+    with pytest.raises(ValueError, match="window_seconds"):
+        HTTPBasicWithProtection(window_seconds=0)


### PR DESCRIPTION
/claim #800

Summary:
- Adds opt-in `HTTPBasicWithProtection` while leaving existing `HTTPBasic` behavior unchanged.
- Tracks failed authentication attempts per client IP in a configurable time window and returns 429 with `Retry-After` when locked out.
- Resets the failure counter after successful credential validation.
- Adds `hash_password` and `verify_password` helpers using hashlib PBKDF2 plus constant-time comparison.
- Exports the new class from `fastapi.security` and adds focused regression coverage.

Validation:
- `uv run python -m pytest tests/test_security_http_basic_protection.py tests/test_security_http_basic_optional.py tests/test_security_http_basic_realm.py tests/test_security_http_basic_realm_description.py -q`
- `uv run ruff check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py`
- `uv run ruff format --check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py`
- `python -m compileall -q fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py`
- `git diff --check HEAD~1..HEAD`

Note: I intentionally did not add `.generation_meta.json` because it asks for full prompt/runtime/session provenance rather than product code.