### PR TITLE
Codex [ T3 Code ] Add cross-platform terminal clipboard shortcuts

### DIFF
--- a/t3code/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/t3code/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -33,7 +33,9 @@ import {
   isDiffToggleShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
+  isTerminalCopyShortcut,
   isTerminalNewShortcut,
+  isTerminalPasteShortcut,
   isTerminalSplitShortcut,
   isTerminalToggleShortcut,
   terminalDeleteShortcutData,
@@ -48,6 +50,7 @@ import {
 import { readEnvironmentApi } from "~/environmentApi";
 import { readLocalApi } from "~/localApi";
 import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalStateStore";
+import { toastManager } from "./ui/toast";
 
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
@@ -415,6 +418,41 @@ export function TerminalViewport({
       }
     };
 
+    const copyTerminalSelection = async () => {
+      const activeTerminal = terminalRef.current;
+      if (!activeTerminal) return;
+      const selection = activeTerminal.getSelection();
+      try {
+        await navigator.clipboard.writeText(selection);
+        toastManager.add({
+          type: "success",
+          title: "Terminal selection copied",
+          data: { dismissAfterVisibleMs: 1200 },
+        });
+      } catch (error) {
+        writeSystemMessage(
+          activeTerminal,
+          error instanceof Error ? error.message : "Failed to copy terminal selection",
+        );
+      }
+    };
+
+    const pasteTerminalClipboard = async () => {
+      const activeTerminal = terminalRef.current;
+      if (!activeTerminal) return;
+      try {
+        const text = await navigator.clipboard.readText();
+        if (text.length > 0) {
+          await sendTerminalInput(text, "Failed to paste terminal input");
+        }
+      } catch (error) {
+        writeSystemMessage(
+          activeTerminal,
+          error instanceof Error ? error.message : "Failed to read clipboard",
+        );
+      }
+    };
+
     terminal.attachCustomKeyEventHandler((event) => {
       const currentKeybindings = keybindingsRef.current;
       const options = { context: { terminalFocus: true, terminalOpen: true } };
@@ -425,6 +463,21 @@ export function TerminalViewport({
         isTerminalCloseShortcut(event, currentKeybindings, options) ||
         isDiffToggleShortcut(event, currentKeybindings, options)
       ) {
+        return false;
+      }
+
+      const isCopyShortcut = isTerminalCopyShortcut(event);
+      if (isCopyShortcut && terminal.hasSelection() && terminal.getSelection().length > 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        void copyTerminalSelection();
+        return false;
+      }
+
+      if (isTerminalPasteShortcut(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void pasteTerminalClipboard();
         return false;
       }
 

--- a/t3code/apps/web/src/keybindings.test.ts
+++ b/t3code/apps/web/src/keybindings.test.ts
@@ -16,7 +16,9 @@ import {
   isOpenFavoriteEditorShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
+  isTerminalCopyShortcut,
   isTerminalNewShortcut,
+  isTerminalPasteShortcut,
   isTerminalSplitShortcut,
   isTerminalToggleShortcut,
   resolveShortcutCommand,
@@ -626,6 +628,61 @@ describe("isTerminalClearShortcut", () => {
   it("ignores non-keydown events", () => {
     assert.isFalse(
       isTerminalClearShortcut(event({ type: "keyup", key: "l", ctrlKey: true }), "Linux"),
+    );
+  });
+});
+
+describe("isTerminalCopyShortcut", () => {
+  it("matches Ctrl+Shift+C on non-macOS platforms", () => {
+    assert.isTrue(
+      isTerminalCopyShortcut(event({ key: "c", ctrlKey: true, shiftKey: true }), "Linux"),
+    );
+    assert.isTrue(
+      isTerminalCopyShortcut(event({ key: "C", ctrlKey: true, shiftKey: true }), "Win32"),
+    );
+  });
+
+  it("matches Cmd+C on macOS", () => {
+    assert.isTrue(isTerminalCopyShortcut(event({ key: "c", metaKey: true }), "MacIntel"));
+  });
+
+  it("does not treat plain Ctrl+C as terminal copy on non-macOS", () => {
+    assert.isFalse(isTerminalCopyShortcut(event({ key: "c", ctrlKey: true }), "Linux"));
+  });
+
+  it("ignores non-keydown events", () => {
+    assert.isFalse(
+      isTerminalCopyShortcut(
+        event({ type: "keyup", key: "c", ctrlKey: true, shiftKey: true }),
+        "Linux",
+      ),
+    );
+  });
+});
+
+describe("isTerminalPasteShortcut", () => {
+  it("matches Ctrl+Shift+V on non-macOS platforms", () => {
+    assert.isTrue(
+      isTerminalPasteShortcut(event({ key: "v", ctrlKey: true, shiftKey: true }), "Linux"),
+    );
+    assert.isTrue(
+      isTerminalPasteShortcut(event({ key: "V", ctrlKey: true, shiftKey: true }), "Win32"),
+    );
+  });
+
+  it("matches Cmd+V on macOS", () => {
+    assert.isTrue(isTerminalPasteShortcut(event({ key: "v", metaKey: true }), "MacIntel"));
+  });
+
+  it("ignores modified variants", () => {
+    assert.isFalse(
+      isTerminalPasteShortcut(
+        event({ key: "v", ctrlKey: true, shiftKey: true, altKey: true }),
+        "Linux",
+      ),
+    );
+    assert.isFalse(
+      isTerminalPasteShortcut(event({ key: "v", metaKey: true, shiftKey: true }), "MacIntel"),
     );
   });
 });

--- a/t3code/apps/web/src/keybindings.ts
+++ b/t3code/apps/web/src/keybindings.ts
@@ -427,6 +427,46 @@ export function isTerminalClearShortcut(
   );
 }
 
+export function isTerminalCopyShortcut(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): boolean {
+  if (event.type !== undefined && event.type !== "keydown") {
+    return false;
+  }
+
+  const key = normalizeEventKey(event.key);
+  if (key !== "c") {
+    return false;
+  }
+
+  if (isMacPlatform(platform)) {
+    return event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  }
+
+  return event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+}
+
+export function isTerminalPasteShortcut(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): boolean {
+  if (event.type !== undefined && event.type !== "keydown") {
+    return false;
+  }
+
+  const key = normalizeEventKey(event.key);
+  if (key !== "v") {
+    return false;
+  }
+
+  if (isMacPlatform(platform)) {
+    return event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  }
+
+  return event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+}
+
 export function terminalDeleteShortcutData(
   event: ShortcutEventLike,
   platform = navigator.platform,


### PR DESCRIPTION
/claim #824

Summary:
- Adds platform-aware terminal copy and paste shortcut detection: Ctrl+Shift+C / Ctrl+Shift+V on Windows/Linux, Cmd+C / Cmd+V on macOS.
- Wires xterm's custom key handler so copy only intercepts when the terminal has a non-empty selection; otherwise Ctrl+C continues through to the terminal process.
- Pastes clipboard text through the existing terminal write RPC and shows a short success toast after copying selected terminal text.
- Adds focused unit coverage for the shortcut matching behavior.

Validation:
- npx --yes bun install --frozen-lockfile
- npx --yes bun run --filter @t3tools/web test -- src/keybindings.test.ts
- npx --yes bun run --filter @t3tools/web typecheck
- npx --yes bun run fmt:check -- apps/web/src/keybindings.ts apps/web/src/keybindings.test.ts apps/web/src/components/ThreadTerminalDrawer.tsx
- git diff --check

Note: I did not include the requested `_generation.json` because it asks for hidden runtime/session instructions rather than product code.