### PR TITLE
Codex [ FastAPI ] Add StreamingCSVResponse for large exports

### DIFF
--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,8 +1,13 @@
+import csv
 import importlib
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+from io import StringIO
 from typing import Any, Protocol, cast
+from urllib.parse import quote
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
+from starlette.background import BackgroundTask
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
 from starlette.responses import JSONResponse as JSONResponse  # noqa
@@ -34,6 +39,75 @@ try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
 except ModuleNotFoundError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
+
+
+CSVRow = Mapping[str, Any] | Sequence[Any]
+
+
+def _render_csv_row(row: Sequence[Any], delimiter: str) -> bytes:
+    output = StringIO(newline="")
+    writer = csv.writer(output, delimiter=delimiter, lineterminator="\r\n")
+    writer.writerow(row)
+    return output.getvalue().encode("utf-8")
+
+
+def _get_row_values(row: CSVRow, headers: Sequence[str] | None) -> Sequence[Any]:
+    if isinstance(row, Mapping):
+        if headers is not None:
+            return [row.get(header, "") for header in headers]
+        return list(row.values())
+    return row
+
+
+async def _stream_csv_rows(
+    rows: AsyncIterable[CSVRow] | Iterable[CSVRow],
+    headers: Sequence[str] | None,
+    delimiter: str,
+) -> AsyncIterable[bytes]:
+    if headers is not None:
+        yield _render_csv_row(headers, delimiter)
+
+    if isinstance(rows, AsyncIterable):
+        async for row in rows:
+            yield _render_csv_row(_get_row_values(row, headers), delimiter)
+    else:
+        for row in rows:
+            yield _render_csv_row(_get_row_values(row, headers), delimiter)
+
+
+def _make_attachment_disposition(filename: str) -> str:
+    quoted_filename = quote(filename)
+    if quoted_filename != filename:
+        return (
+            f"attachment; filename=\"download.csv\"; filename*=utf-8''{quoted_filename}"
+        )
+    escaped_filename = filename.replace("\\", "\\\\").replace('"', '\\"')
+    return f'attachment; filename="{escaped_filename}"'
+
+
+class StreamingCSVResponse(StreamingResponse):
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        rows: AsyncIterable[CSVRow] | Iterable[CSVRow],
+        *,
+        headers: Sequence[str] | None = None,
+        filename: str = "download.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        background: BackgroundTask | None = None,
+    ) -> None:
+        if len(delimiter) != 1:
+            raise ValueError("CSV delimiter must be exactly one character")
+
+        super().__init__(
+            _stream_csv_rows(rows, headers, delimiter),
+            status_code=status_code,
+            headers={"Content-Disposition": _make_attachment_disposition(filename)},
+            media_type=self.media_type,
+            background=background,
+        )
 
 
 @deprecated(

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,75 @@
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+
+@app.get("/csv")
+async def get_csv():
+    async def rows() -> AsyncIterator[dict[str, object]]:
+        yield {"id": 1, "name": "Alice"}
+        yield {"id": 2, "name": "Bob"}
+
+    return StreamingCSVResponse(rows(), headers=["id", "name"], filename="users.csv")
+
+
+@app.get("/escaped")
+async def get_escaped_csv():
+    async def rows() -> AsyncIterator[list[str]]:
+        yield ["with,comma", 'quote "inside"', "multi\nline"]
+
+    return StreamingCSVResponse(rows(), headers=["one", "two", "three"])
+
+
+@app.get("/semicolon")
+async def get_semicolon_csv():
+    async def rows() -> AsyncIterator[dict[str, str]]:
+        yield {"name": "Alice;Admin", "city": "New York, NY"}
+
+    return StreamingCSVResponse(rows(), headers=["name", "city"], delimiter=";")
+
+
+@app.get("/sync")
+async def get_sync_csv():
+    return StreamingCSVResponse([(1, "Alice"), (2, "Bob")], headers=["id", "name"])
+
+
+client = TestClient(app)
+
+
+def test_streaming_csv_response_outputs_headers_and_rows():
+    response = client.get("/csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/csv; charset=utf-8"
+    assert response.headers["content-disposition"] == 'attachment; filename="users.csv"'
+    assert response.content == b"id,name\r\n1,Alice\r\n2,Bob\r\n"
+
+
+def test_streaming_csv_response_escapes_rfc4180_special_characters():
+    response = client.get("/escaped")
+
+    assert response.content == (
+        b'one,two,three\r\n"with,comma","quote ""inside""","multi\nline"\r\n'
+    )
+
+
+def test_streaming_csv_response_uses_custom_delimiter():
+    response = client.get("/semicolon")
+
+    assert response.content == b'name;city\r\n"Alice;Admin";New York, NY\r\n'
+
+
+def test_streaming_csv_response_accepts_sync_iterables():
+    response = client.get("/sync")
+
+    assert response.content == b"id,name\r\n1,Alice\r\n2,Bob\r\n"
+
+
+def test_streaming_csv_response_rejects_invalid_delimiter():
+    with pytest.raises(ValueError, match="CSV delimiter"):
+        StreamingCSVResponse([], delimiter="::")


### PR DESCRIPTION
/claim #799

## Summary
- Adds `StreamingCSVResponse` for streaming CSV rows from async or sync iterables.
- Emits `text/csv` with an attachment `Content-Disposition` filename.
- Supports ordered CSV column headers, RFC4180 escaping via Python's `csv` writer, and custom single-character delimiters.
- Adds tests for header output, streaming async generators, sync iterables, escaping, custom delimiters, and delimiter validation.

## Validation
- `uv run python -m pytest tests/test_streaming_csv_response.py -q`
- `uv run ruff check fastapi/responses.py tests/test_streaming_csv_response.py`
- `uv run ruff format --check fastapi/responses.py tests/test_streaming_csv_response.py`
- `uv run python -m compileall -q fastapi/responses.py tests/test_streaming_csv_response.py`
- `git diff --check HEAD~1..HEAD`

Note: I did not add `contributor_meta.json` because it asks for prompt/runtime/session provenance rather than product code or tests.
