### PR TITLE
Codex [ T3 Code ] Add system tray icon with context menu and status indicator

### DIFF
--- a/t3code/apps/desktop/src/app/DesktopApp.ts
+++ b/t3code/apps/desktop/src/app/DesktopApp.ts
@@ -21,6 +21,7 @@ import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
+import * as DesktopTray from "../window/DesktopTray.ts";
 
 const DEFAULT_DESKTOP_BACKEND_PORT = 3773;
 const MAX_TCP_PORT = 65_535;
@@ -190,6 +191,7 @@ const startup = Effect.gen(function* () {
   const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
   const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
+  const tray = yield* DesktopTray.DesktopTray;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
@@ -214,6 +216,7 @@ const startup = Effect.gen(function* () {
   yield* logStartupInfo("app ready");
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
+  yield* tray.configure;
   yield* electronProtocol.registerDesktopFileProtocol;
   yield* updates.configure;
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));

--- a/t3code/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/t3code/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -38,6 +38,7 @@ import {
   getLocalEnvironmentBootstrap,
   openExternal,
   pickFolder,
+  setTrayState,
   setTheme,
   showContextMenu,
 } from "./methods/window.ts";
@@ -73,6 +74,7 @@ export const installDesktopIpcHandlers = Effect.gen(function* () {
   yield* ipc.handle(pickFolder);
   yield* ipc.handle(confirm);
   yield* ipc.handle(setTheme);
+  yield* ipc.handle(setTrayState);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
 

--- a/t3code/apps/desktop/src/ipc/channels.ts
+++ b/t3code/apps/desktop/src/ipc/channels.ts
@@ -4,6 +4,7 @@ export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
+export const SET_TRAY_STATE_CHANNEL = "desktop:set-tray-state";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 export const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";

--- a/t3code/apps/desktop/src/ipc/methods/window.ts
+++ b/t3code/apps/desktop/src/ipc/methods/window.ts
@@ -2,6 +2,7 @@ import {
   ContextMenuItemSchema,
   DesktopAppBrandingSchema,
   DesktopEnvironmentBootstrapSchema,
+  DesktopTrayStateSchema,
   DesktopThemeSchema,
   PickFolderOptionsSchema,
 } from "@t3tools/contracts";
@@ -16,6 +17,7 @@ import * as ElectronMenu from "../../electron/ElectronMenu.ts";
 import * as ElectronShell from "../../electron/ElectronShell.ts";
 import * as ElectronTheme from "../../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
+import * as DesktopTray from "../../window/DesktopTray.ts";
 import * as IpcChannels from "../channels.ts";
 import { makeIpcMethod, makeSyncIpcMethod } from "../DesktopIpc.ts";
 
@@ -100,6 +102,16 @@ export const setTheme = makeIpcMethod({
   handler: Effect.fn("desktop.ipc.window.setTheme")(function* (theme) {
     const electronTheme = yield* ElectronTheme.ElectronTheme;
     yield* electronTheme.setSource(theme);
+  }),
+});
+
+export const setTrayState = makeIpcMethod({
+  channel: IpcChannels.SET_TRAY_STATE_CHANNEL,
+  payload: DesktopTrayStateSchema,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.setTrayState")(function* (state) {
+    const tray = yield* DesktopTray.DesktopTray;
+    yield* tray.updateState(state);
   }),
 });
 

--- a/t3code/apps/desktop/src/main.ts
+++ b/t3code/apps/desktop/src/main.ts
@@ -43,6 +43,7 @@ import * as DesktopSshPasswordPrompts from "./ssh/DesktopSshPasswordPrompts.ts";
 import * as DesktopSshRemoteApi from "./ssh/DesktopSshRemoteApi.ts";
 import * as DesktopState from "./app/DesktopState.ts";
 import * as DesktopUpdates from "./updates/DesktopUpdates.ts";
+import * as DesktopTray from "./window/DesktopTray.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
 
 const desktopEnvironmentLayer = Layer.unwrap(
@@ -136,6 +137,7 @@ const desktopBackendLayer = DesktopBackendManager.layer.pipe(
 const desktopApplicationLayer = Layer.mergeAll(
   DesktopLifecycle.layer,
   DesktopApplicationMenu.layer,
+  DesktopTray.layer,
   DesktopShellEnvironment.layer,
   desktopSshLayer,
 ).pipe(Layer.provideMerge(DesktopUpdates.layer), Layer.provideMerge(desktopBackendLayer));

--- a/t3code/apps/desktop/src/preload.ts
+++ b/t3code/apps/desktop/src/preload.ts
@@ -90,6 +90,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   pickFolder: (options) => ipcRenderer.invoke(IpcChannels.PICK_FOLDER_CHANNEL, options),
   confirm: (message) => ipcRenderer.invoke(IpcChannels.CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(IpcChannels.SET_THEME_CHANNEL, theme),
+  setTrayState: (state) => ipcRenderer.invoke(IpcChannels.SET_TRAY_STATE_CHANNEL, state),
   showContextMenu: (items, position) =>
     ipcRenderer.invoke(IpcChannels.CONTEXT_MENU_CHANNEL, {
       items,

--- a/t3code/apps/desktop/src/window/DesktopTray.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopTray.test.ts
@@ -1,0 +1,106 @@
+import {
+  DESKTOP_TRAY_NEW_CHAT_ACTION,
+  encodeDesktopTrayOpenProjectAction,
+  type DesktopTrayState,
+} from "@t3tools/contracts";
+import { assert, describe, it } from "@effect/vitest";
+
+import {
+  buildDesktopTrayMenuTemplate,
+  makeTrayTooltip,
+  normalizeTrayState,
+} from "./DesktopTray.ts";
+
+const trayState: DesktopTrayState = {
+  connectionStatus: "connected",
+  activeProject: {
+    id: "project-active",
+    environmentId: "environment-local",
+    name: "money-maker",
+    cwd: "/repo/money-maker",
+  },
+  recentProjects: [
+    {
+      id: "project-one",
+      environmentId: "environment-local",
+      name: "one",
+      cwd: "/repo/one",
+    },
+  ],
+};
+
+describe("DesktopTray", () => {
+  it("normalizes recent projects to five unique entries", () => {
+    const normalized = normalizeTrayState({
+      ...trayState,
+      recentProjects: [
+        { id: "one", environmentId: "env", name: " one ", cwd: "/repo/one" },
+        { id: "one", environmentId: "env", name: "duplicate", cwd: "/repo/one-copy" },
+        { id: "two", environmentId: "env", name: "two", cwd: "/repo/two" },
+        { id: "three", environmentId: "env", name: "three", cwd: "/repo/three" },
+        { id: "four", environmentId: "env", name: "four", cwd: "/repo/four" },
+        { id: "five", environmentId: "env", name: "five", cwd: "/repo/five" },
+        { id: "six", environmentId: "env", name: "six", cwd: "/repo/six" },
+      ],
+    });
+
+    assert.deepEqual(
+      normalized.recentProjects.map((project) => project.id),
+      ["one", "two", "three", "four", "five"],
+    );
+    assert.equal(normalized.recentProjects[0]?.name, "one");
+  });
+
+  it("builds tooltip text from app name, connection status, and active project", () => {
+    assert.equal(makeTrayTooltip("T3 Code", trayState), "T3 Code\nConnected - money-maker");
+    assert.equal(
+      makeTrayTooltip("T3 Code", { ...trayState, connectionStatus: "reconnecting" }),
+      "T3 Code\nReconnecting - money-maker",
+    );
+  });
+
+  it("routes menu actions through the shared tray action strings", () => {
+    const dispatchedActions: string[] = [];
+    const template = buildDesktopTrayMenuTemplate({
+      state: trayState,
+      windowVisible: false,
+      onToggleWindow: () => dispatchedActions.push("toggle"),
+      onDispatchMenuAction: (action) => dispatchedActions.push(action),
+      onQuit: () => dispatchedActions.push("quit"),
+    });
+
+    template[0]?.click?.({} as never, {} as never, {} as never);
+    template[1]?.click?.({} as never, {} as never, {} as never);
+    const recentSubmenu = template.find((item) => item.label === "Open Recent Project")?.submenu;
+    if (!Array.isArray(recentSubmenu)) {
+      throw new Error("Expected recent-project submenu to be an array.");
+    }
+    recentSubmenu[0]?.click?.({} as never, {} as never, {} as never);
+
+    assert.deepEqual(dispatchedActions, [
+      "toggle",
+      DESKTOP_TRAY_NEW_CHAT_ACTION,
+      encodeDesktopTrayOpenProjectAction(trayState.recentProjects[0]!),
+    ]);
+  });
+
+  it("uses the current visibility for the show or hide menu label", () => {
+    const hiddenTemplate = buildDesktopTrayMenuTemplate({
+      state: trayState,
+      windowVisible: false,
+      onToggleWindow: () => {},
+      onDispatchMenuAction: () => {},
+      onQuit: () => {},
+    });
+    const visibleTemplate = buildDesktopTrayMenuTemplate({
+      state: trayState,
+      windowVisible: true,
+      onToggleWindow: () => {},
+      onDispatchMenuAction: () => {},
+      onQuit: () => {},
+    });
+
+    assert.equal(hiddenTemplate[0]?.label, "Show Window");
+    assert.equal(visibleTemplate[0]?.label, "Hide Window");
+  });
+});

--- a/t3code/apps/desktop/src/window/DesktopTray.ts
+++ b/t3code/apps/desktop/src/window/DesktopTray.ts
@@ -1,0 +1,253 @@
+import {
+  DESKTOP_TRAY_NEW_CHAT_ACTION,
+  type DesktopTrayConnectionStatus,
+  type DesktopTrayProject,
+  type DesktopTrayState,
+  encodeDesktopTrayOpenProjectAction,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Scope from "effect/Scope";
+
+import * as Electron from "electron";
+
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopObservability from "../app/DesktopObservability.ts";
+import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronWindow from "../electron/ElectronWindow.ts";
+import * as DesktopWindow from "./DesktopWindow.ts";
+
+const MAX_RECENT_PROJECTS = 5;
+
+const STATUS_LABEL: Record<DesktopTrayConnectionStatus, string> = {
+  connected: "Connected",
+  reconnecting: "Reconnecting",
+  disconnected: "Disconnected",
+};
+
+const STATUS_COLOR: Record<DesktopTrayConnectionStatus, string> = {
+  connected: "#22c55e",
+  reconnecting: "#eab308",
+  disconnected: "#ef4444",
+};
+
+export interface DesktopTrayShape {
+  readonly configure: Effect.Effect<void, never, Scope.Scope>;
+  readonly updateState: (state: DesktopTrayState) => Effect.Effect<void>;
+}
+
+export class DesktopTray extends Context.Service<DesktopTray, DesktopTrayShape>()(
+  "t3/desktop/Tray",
+) {}
+
+type DesktopTrayRuntimeServices =
+  | DesktopState.DesktopState
+  | DesktopWindow.DesktopWindow
+  | ElectronApp.ElectronApp
+  | ElectronWindow.ElectronWindow;
+
+export interface DesktopTrayMenuInput {
+  readonly state: DesktopTrayState;
+  readonly windowVisible: boolean;
+  readonly onToggleWindow: () => void;
+  readonly onDispatchMenuAction: (action: string) => void;
+  readonly onQuit: () => void;
+}
+
+const initialTrayState: DesktopTrayState = {
+  connectionStatus: "disconnected",
+  activeProject: null,
+  recentProjects: [],
+};
+
+function normalizeProject(project: DesktopTrayProject): DesktopTrayProject {
+  return {
+    id: project.id,
+    environmentId: project.environmentId,
+    name: project.name.trim() || project.cwd,
+    cwd: project.cwd,
+  };
+}
+
+export function normalizeTrayState(state: DesktopTrayState): DesktopTrayState {
+  const seen = new Set<string>();
+  const recentProjects: DesktopTrayProject[] = [];
+  for (const project of state.recentProjects) {
+    const normalized = normalizeProject(project);
+    const key = `${normalized.environmentId}:${normalized.id}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    recentProjects.push(normalized);
+    if (recentProjects.length >= MAX_RECENT_PROJECTS) {
+      break;
+    }
+  }
+
+  return {
+    connectionStatus: state.connectionStatus,
+    activeProject: state.activeProject ? normalizeProject(state.activeProject) : null,
+    recentProjects,
+  };
+}
+
+export function makeTrayTooltip(appName: string, state: DesktopTrayState): string {
+  const activeProject = state.activeProject?.name ?? "No active project";
+  return `${appName}\n${STATUS_LABEL[state.connectionStatus]} - ${activeProject}`;
+}
+
+function makeStatusImage(status: DesktopTrayConnectionStatus): Electron.NativeImage {
+  const color = STATUS_COLOR[status];
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#111827"/><path d="M9 10h14v3H9zM9 15h14v3H9zM9 20h9v3H9z" fill="#f9fafb"/><circle cx="24" cy="24" r="6" fill="${color}" stroke="#111827" stroke-width="2"/></svg>`;
+  return Electron.nativeImage.createFromDataURL(
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`,
+  );
+}
+
+export function buildDesktopTrayMenuTemplate({
+  state,
+  windowVisible,
+  onToggleWindow,
+  onDispatchMenuAction,
+  onQuit,
+}: DesktopTrayMenuInput): Electron.MenuItemConstructorOptions[] {
+  const recentProjects = state.recentProjects.slice(0, MAX_RECENT_PROJECTS);
+  return [
+    {
+      label: windowVisible ? "Hide Window" : "Show Window",
+      click: onToggleWindow,
+    },
+    {
+      label: "New Chat",
+      click: () => onDispatchMenuAction(DESKTOP_TRAY_NEW_CHAT_ACTION),
+    },
+    {
+      label: "Open Recent Project",
+      enabled: recentProjects.length > 0,
+      submenu:
+        recentProjects.length > 0
+          ? recentProjects.map((project) => ({
+              label: project.name,
+              toolTip: project.cwd,
+              click: () => onDispatchMenuAction(encodeDesktopTrayOpenProjectAction(project)),
+            }))
+          : [{ label: "No recent projects", enabled: false }],
+    },
+    { type: "separator" },
+    {
+      label: "Quit",
+      click: onQuit,
+    },
+  ];
+}
+
+function isWindowVisible(window: Electron.BrowserWindow): boolean {
+  return !window.isDestroyed() && window.isVisible();
+}
+
+const { logError: logTrayError } = DesktopObservability.makeComponentLogger("desktop-tray");
+
+const make = Effect.gen(function* () {
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const app = yield* ElectronApp.ElectronApp;
+  const electronWindow = yield* ElectronWindow.ElectronWindow;
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const trayStateRef = yield* Ref.make(initialTrayState);
+  const trayRef = yield* Ref.make<Option.Option<Electron.Tray>>(Option.none());
+  const context = yield* Effect.context<DesktopTrayRuntimeServices>();
+  const runPromise = Effect.runPromiseWith(context);
+  const appName = yield* app.name;
+
+  const runTrayEffect = <E>(effect: Effect.Effect<void, E, DesktopTrayRuntimeServices>) => {
+    void runPromise(
+      effect.pipe(
+        Effect.catchCause((cause) =>
+          logTrayError("desktop tray action failed", { cause: Cause.pretty(cause) }),
+        ),
+      ),
+    );
+  };
+
+  const toggleWindow = Effect.gen(function* () {
+    const currentWindow = yield* electronWindow.currentMainOrFirst;
+    if (Option.isSome(currentWindow) && isWindowVisible(currentWindow.value)) {
+      currentWindow.value.hide();
+      return;
+    }
+    yield* desktopWindow.revealOrCreateMain;
+  }).pipe(Effect.withSpan("desktop.tray.toggleWindow"));
+
+  const showWindow = desktopWindow.revealOrCreateMain.pipe(
+    Effect.asVoid,
+    Effect.withSpan("desktop.tray.showWindow"),
+  );
+
+  const quit = Effect.gen(function* () {
+    const state = yield* DesktopState.DesktopState;
+    yield* Ref.set(state.quitting, true);
+    yield* app.quit;
+  }).pipe(Effect.withSpan("desktop.tray.quit"));
+
+  const syncTray = Effect.gen(function* () {
+    const tray = yield* Ref.get(trayRef);
+    if (Option.isNone(tray) || tray.value.isDestroyed()) {
+      return;
+    }
+
+    const state = yield* Ref.get(trayStateRef);
+    const currentWindow = yield* electronWindow.currentMainOrFirst;
+    const windowVisible = Option.isSome(currentWindow) && isWindowVisible(currentWindow.value);
+    tray.value.setImage(makeStatusImage(state.connectionStatus));
+    tray.value.setToolTip(makeTrayTooltip(appName, state));
+    tray.value.setContextMenu(
+      Electron.Menu.buildFromTemplate(
+        buildDesktopTrayMenuTemplate({
+          state,
+          windowVisible,
+          onToggleWindow: () => runTrayEffect(toggleWindow),
+          onDispatchMenuAction: (action) => runTrayEffect(desktopWindow.dispatchMenuAction(action)),
+          onQuit: () => runTrayEffect(quit),
+        }),
+      ),
+    );
+  }).pipe(Effect.withSpan("desktop.tray.sync"));
+
+  const configure = Effect.acquireRelease(
+    Effect.sync(() => new Electron.Tray(makeStatusImage(initialTrayState.connectionStatus))).pipe(
+      Effect.tap((tray) => Ref.set(trayRef, Option.some(tray))),
+      Effect.tap((tray) =>
+        Effect.sync(() => {
+          tray.on("click", () => {
+            runTrayEffect(environment.platform === "darwin" ? toggleWindow : showWindow);
+          });
+          tray.on("right-click", () => {
+            tray.popUpContextMenu();
+          });
+        }),
+      ),
+      Effect.tap(() => syncTray),
+    ),
+    (tray) =>
+      Effect.sync(() => {
+        if (!tray.isDestroyed()) {
+          tray.destroy();
+        }
+      }).pipe(Effect.andThen(Ref.set(trayRef, Option.none()))),
+  ).pipe(Effect.asVoid, Effect.withSpan("desktop.tray.configure"));
+
+  return DesktopTray.of({
+    configure,
+    updateState: Effect.fn("desktop.tray.updateState")(function* (state) {
+      yield* Ref.set(trayStateRef, normalizeTrayState(state));
+      yield* syncTray;
+    }),
+  });
+});
+
+export const layer = Layer.effect(DesktopTray, make);

--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,18 +1,85 @@
+import {
+  DESKTOP_TRAY_NEW_CHAT_ACTION,
+  decodeDesktopTrayOpenProjectAction,
+  type DesktopTrayConnectionStatus,
+} from "@t3tools/contracts";
+import { scopeProjectRef } from "@t3tools/client-runtime";
 import { useEffect, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import ThreadSidebar from "./Sidebar";
 import { Sidebar, SidebarProvider, SidebarRail } from "./ui/sidebar";
+import { useCommandPaletteStore } from "../commandPaletteStore";
+import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
   clearShortcutModifierState,
   syncShortcutModifierStateFromKeyboardEvent,
 } from "../shortcutModifierState";
+import { selectEnvironmentState, selectProjectsAcrossEnvironments, useStore } from "../store";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
 const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
+    useHandleNewThread();
+  const openAddProject = useCommandPaletteStore((state) => state.openAddProject);
+  const projects = useStore(selectProjectsAcrossEnvironments);
+  const connectionStatus = useStore((state): DesktopTrayConnectionStatus => {
+    if (!state.activeEnvironmentId) {
+      return "disconnected";
+    }
+    return selectEnvironmentState(state, state.activeEnvironmentId).bootstrapComplete
+      ? "connected"
+      : "reconnecting";
+  });
+
+  useEffect(() => {
+    const setTrayState = window.desktopBridge?.setTrayState;
+    if (typeof setTrayState !== "function") {
+      return;
+    }
+
+    const activeProject =
+      projects.find((project) =>
+        activeThread
+          ? project.environmentId === activeThread.environmentId &&
+            project.id === activeThread.projectId
+          : activeDraftThread
+            ? project.environmentId === activeDraftThread.environmentId &&
+              project.id === activeDraftThread.projectId
+            : false,
+      ) ?? null;
+
+    void setTrayState({
+      connectionStatus,
+      activeProject: activeProject
+        ? {
+            environmentId: activeProject.environmentId,
+            id: activeProject.id,
+            name: activeProject.name,
+            cwd: activeProject.cwd,
+          }
+        : null,
+      recentProjects: [...projects]
+        .sort((left, right) => {
+          const leftTime = Date.parse(left.updatedAt ?? left.createdAt ?? "");
+          const rightTime = Date.parse(right.updatedAt ?? right.createdAt ?? "");
+          return (
+            (Number.isFinite(rightTime) ? rightTime : 0) -
+            (Number.isFinite(leftTime) ? leftTime : 0)
+          );
+        })
+        .slice(0, 5)
+        .map((project) => ({
+          environmentId: project.environmentId,
+          id: project.id,
+          name: project.name,
+          cwd: project.cwd,
+        })),
+    }).catch(() => undefined);
+  }, [activeDraftThread, activeThread, connectionStatus, projects]);
 
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
@@ -45,13 +112,36 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
     const unsubscribe = onMenuAction((action) => {
       if (action === "open-settings") {
         void navigate({ to: "/settings" });
+        return;
+      }
+      if (action === DESKTOP_TRAY_NEW_CHAT_ACTION) {
+        if (defaultProjectRef) {
+          void handleNewThread(defaultProjectRef);
+        } else {
+          void navigate({ to: "/" });
+        }
+        return;
+      }
+      const projectAction = decodeDesktopTrayOpenProjectAction(action);
+      if (projectAction) {
+        const project = projects.find(
+          (candidate) =>
+            candidate.environmentId === projectAction.environmentId &&
+            candidate.id === projectAction.projectId,
+        );
+        if (project) {
+          void handleNewThread(scopeProjectRef(project.environmentId, project.id));
+        } else {
+          void navigate({ to: "/" });
+          openAddProject();
+        }
       }
     });
 
     return () => {
       unsubscribe?.();
     };
-  }, [navigate]);
+  }, [defaultProjectRef, handleNewThread, navigate, openAddProject, projects]);
 
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen>

--- a/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -447,6 +447,7 @@ const createDesktopBridgeStub = (overrides?: {
     pickFolder: vi.fn().mockResolvedValue(null),
     confirm: vi.fn().mockResolvedValue(false),
     setTheme: vi.fn().mockResolvedValue(undefined),
+    setTrayState: vi.fn().mockResolvedValue(undefined),
     showContextMenu: vi.fn().mockResolvedValue(null),
     openExternal: vi.fn().mockResolvedValue(true),
     onMenuAction: () => () => {},

--- a/t3code/apps/web/src/localApi.test.ts
+++ b/t3code/apps/web/src/localApi.test.ts
@@ -223,6 +223,7 @@ function makeDesktopBridge(overrides: Partial<DesktopBridge> = {}): DesktopBridg
     pickFolder: async () => null,
     confirm: async () => true,
     setTheme: async () => undefined,
+    setTrayState: async () => undefined,
     showContextMenu: async () => null,
     openExternal: async () => true,
     onMenuAction: () => () => undefined,

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -216,6 +216,78 @@ export const DesktopUpdateCheckResultSchema = Schema.Struct({
   state: DesktopUpdateStateSchema,
 });
 
+export type DesktopTrayConnectionStatus = "connected" | "reconnecting" | "disconnected";
+
+export const DesktopTrayConnectionStatusSchema = Schema.Literals([
+  "connected",
+  "reconnecting",
+  "disconnected",
+]);
+
+export interface DesktopTrayProject {
+  id: string;
+  environmentId: string;
+  name: string;
+  cwd: string;
+}
+
+export const DesktopTrayProjectSchema = Schema.Struct({
+  id: Schema.String,
+  environmentId: Schema.String,
+  name: Schema.String,
+  cwd: Schema.String,
+});
+
+export interface DesktopTrayState {
+  connectionStatus: DesktopTrayConnectionStatus;
+  activeProject: DesktopTrayProject | null;
+  recentProjects: readonly DesktopTrayProject[];
+}
+
+export const DesktopTrayStateSchema = Schema.Struct({
+  connectionStatus: DesktopTrayConnectionStatusSchema,
+  activeProject: Schema.NullOr(DesktopTrayProjectSchema),
+  recentProjects: Schema.Array(DesktopTrayProjectSchema),
+});
+
+export const DESKTOP_TRAY_NEW_CHAT_ACTION = "new-chat";
+export const DESKTOP_TRAY_OPEN_PROJECT_ACTION_PREFIX = "open-project:";
+
+export function encodeDesktopTrayOpenProjectAction(
+  project: Pick<DesktopTrayProject, "environmentId" | "id">,
+): string {
+  return `${DESKTOP_TRAY_OPEN_PROJECT_ACTION_PREFIX}${JSON.stringify({
+    environmentId: project.environmentId,
+    projectId: project.id,
+  })}`;
+}
+
+export function decodeDesktopTrayOpenProjectAction(
+  action: string,
+): { environmentId: string; projectId: string } | null {
+  if (!action.startsWith(DESKTOP_TRAY_OPEN_PROJECT_ACTION_PREFIX)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(action.slice(DESKTOP_TRAY_OPEN_PROJECT_ACTION_PREFIX.length));
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof parsed.environmentId !== "string" ||
+      typeof parsed.projectId !== "string"
+    ) {
+      return null;
+    }
+    return {
+      environmentId: parsed.environmentId,
+      projectId: parsed.projectId,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export interface DesktopEnvironmentBootstrap {
   label: string;
   httpBaseUrl: string | null;
@@ -415,6 +487,7 @@ export interface DesktopBridge {
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
   onMenuAction: (listener: (action: string) => void) => () => void;
+  setTrayState: (state: DesktopTrayState) => Promise<void>;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;


### PR DESCRIPTION
/claim #859

## Summary
- Adds a desktop `DesktopTray` service wired into Electron startup with system tray creation, platform-specific click handling, Show/Hide, New Chat, Open Recent Project, and Quit actions.
- Adds a shared tray-state IPC contract plus preload bridge so the renderer publishes active project, recent projects, and connection status for tooltip/menu/icon updates.
- Routes tray menu actions through the existing desktop menu-action bridge and handles New Chat / recent project selection in `AppSidebarLayout`.
- Adds focused desktop tray unit coverage for state normalization, tooltip text, menu labels, and action dispatch strings.

## Verification
- `npx --yes bun run --filter @t3tools/desktop test -- src/window/DesktopTray.test.ts`
- `npx --yes bun run --filter @t3tools/desktop typecheck`
- `npx --yes bun run --filter @t3tools/web typecheck`
- `npx --yes bun run --filter @t3tools/contracts typecheck`
- `npx --yes bun run fmt:check -- apps/desktop/src/window/DesktopTray.ts apps/desktop/src/window/DesktopTray.test.ts apps/desktop/src/app/DesktopApp.ts apps/desktop/src/main.ts apps/desktop/src/ipc/channels.ts apps/desktop/src/ipc/DesktopIpcHandlers.ts apps/desktop/src/ipc/methods/window.ts apps/desktop/src/preload.ts apps/web/src/components/AppSidebarLayout.tsx packages/contracts/src/ipc.ts apps/web/src/components/settings/SettingsPanels.browser.tsx apps/web/src/localApi.test.ts`
- `git diff --check HEAD~1..HEAD`

`npx --yes bun run lint -- <touched files>` is blocked by the repository's TypeScript oxlint plugin failing to load under the available Node runtime: `ERR_UNKNOWN_FILE_EXTENSION` for `oxlint-plugin-t3code/index.ts`.

I did not add `_contributor.json` because it asks for hidden runtime instructions rather than product code.