### PR TITLE
yi-hialong [ Laravel ] Fix console.php missing scheduled task registration and add log cleanup command

### DIFF
--- a/laravel/routes/_generation.json
+++ b/laravel/routes/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "yi-hialong",
+  "pre_task_context": "Task: Fix console.php missing scheduled task registration and add log cleanup command. Add Artisan logs:clear command with --days option, human-readable size output, and Schedule dailyAt midnight. Include _generation.json per acceptance criteria.",
+  "timestamp": "2026-05-16T02:59:23.464Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -1,8 +1,60 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\Artisan;
+use IlluminateFoundationInspiring;
+use IlluminateSupportFacadesArtisan;
+use IlluminateSupportFacadesSchedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
+})->describe('Display an inspiring quote');
+
+// Helper: convert bytes to human readable format
+function humanReadableSize($bytes) {
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $i = 0;
+    while ($bytes >= 1024 && $i < count($units) - 1) {
+        $bytes /= 1024;
+        $i++;
+    }
+    return round($bytes, 2) . ' ' . $units[$i];
+}
+
+Artisan::command('logs:clear {--days=7 : Number of days to keep logs}', function () {
+    $days = (int) $this->option('days');
+    $logPath = storage_path('logs');
+
+    if (!is_dir($logPath)) {
+        $this->error('Log directory not found: ' . $logPath);
+        return 1;
+    }
+
+    $files = glob($logPath . '/*.log');
+    if ($files === false) {
+        $this->error('Failed to scan log directory');
+        return 1;
+    }
+
+    $cutoffTime = now()->subDays($days)->getTimestamp();
+    $deletedCount = 0;
+    $freedSpace = 0;
+
+    foreach ($files as $file) {
+        if (filemtime($file) < $cutoffTime) {
+            $fileSize = filesize($file);
+            if (unlink($file)) {
+                $deletedCount++;
+                $freedSpace += $fileSize;
+            }
+        }
+    }
+
+    $this->info(sprintf(
+        'Deleted %d file(s), freed %s',
+        $deletedCount,
+        humanReadableSize($freedSpace)
+    ));
+
+    return 0;
+})->describe('Clear log files older than specified days');
+
+Schedule::command('logs:clear')->dailyAt('00:00');

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -1,8 +1,8 @@
 <?php
 
-use IlluminateFoundationInspiring;
-use IlluminateSupportFacadesArtisan;
-use IlluminateSupportFacadesSchedule;
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());


### PR DESCRIPTION
Closes #753

This PR addresses issue #753 by adding a `logs:clear` Artisan command and scheduling it to run daily at midnight.

**Changes:**
- Added `logs:clear` command in `laravel/routes/console.php` with `--days=7` default and `--days` override
- Added `humanReadableSize()` helper for human-readable space output
- Added `Schedule::command('logs:clear')->dailyAt('00:00')` for automated daily cleanup
- Added `_generation.json` per acceptance criteria

All acceptance criteria verified.