### PR TITLE
[OpenAI Codex] [ T3 Code ] Add branch protection status display and force-push prevention

### DIFF
--- a/t3code/apps/server/src/git/GitManager.test.ts
+++ b/t3code/apps/server/src/git/GitManager.test.ts
@@ -605,6 +605,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
             detail: `Unexpected repository create: ${input.repository}`,
           }),
         ),
+      getBranchProtection: () => Effect.succeed(null),
       checkoutPullRequest: (input) =>
         execute({
           cwd: input.cwd,

--- a/t3code/apps/server/src/git/GitManager.ts
+++ b/t3code/apps/server/src/git/GitManager.ts
@@ -95,6 +95,7 @@ const MAX_PROGRESS_TEXT_LENGTH = 500;
 const SHORT_SHA_LENGTH = 7;
 const TOAST_DESCRIPTION_MAX = 72;
 const STATUS_RESULT_CACHE_TTL = Duration.seconds(1);
+const BRANCH_PROTECTION_CACHE_TTL = Duration.minutes(5);
 const STATUS_RESULT_CACHE_CAPACITY = 2_048;
 type StripProgressContext<T> = T extends any ? Omit<T, "actionId" | "cwd" | "action"> : never;
 type GitActionProgressPayload = StripProgressContext<GitActionProgressEvent>;
@@ -739,6 +740,27 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     normalizeStatusCacheKey(cwd).pipe(
       Effect.flatMap((cacheKey) => Cache.invalidate(localStatusResultCache, cacheKey)),
     );
+
+  function branchProtectionCacheKey(cwd: string, branch: string): string {
+    return `${encodeURIComponent(cwd)}\n${encodeURIComponent(branch)}`;
+  }
+
+  const readBranchProtection = Effect.fn("readBranchProtection")(function* (cacheKey: string) {
+    const [encodedCwd, encodedBranch] = cacheKey.split("\n", 2);
+    const cwd = decodeURIComponent(encodedCwd ?? "");
+    const branch = decodeURIComponent(encodedBranch ?? "");
+    const provider = yield* sourceControlProvider(cwd);
+    return yield* provider
+      .getBranchProtection({ cwd, branch })
+      .pipe(Effect.catch(() => Effect.succeed(null)));
+  });
+  const branchProtectionCache = yield* Cache.makeWith(readBranchProtection, {
+    capacity: STATUS_RESULT_CACHE_CAPACITY,
+    timeToLive: (exit) => (Exit.isSuccess(exit) ? BRANCH_PROTECTION_CACHE_TTL : Duration.zero),
+  });
+  const getCachedBranchProtection = (cwd: string, branch: string) =>
+    Cache.get(branchProtectionCache, branchProtectionCacheKey(cwd, branch));
+
   const readRemoteStatus = Effect.fn("readRemoteStatus")(function* (cwd: string) {
     const details = yield* gitCore
       .statusDetails(cwd)
@@ -763,6 +785,12 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
             Effect.catch(() => Effect.succeed(null)),
           )
         : null;
+    const branchProtection =
+      details.branch !== null
+        ? yield* getCachedBranchProtection(cwd, details.branch).pipe(
+            Effect.catch(() => Effect.succeed(null)),
+          )
+        : null;
 
     return {
       hasUpstream: details.hasUpstream,
@@ -770,6 +798,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
       behindCount: details.behindCount,
       aheadOfDefaultCount: details.aheadOfDefaultCount,
       pr,
+      ...(branchProtection !== null ? { branchProtection } : {}),
     } satisfies VcsStatusRemoteResult;
   });
   const remoteStatusResultCache = yield* Cache.makeWith(readRemoteStatus, {

--- a/t3code/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -131,6 +131,7 @@ export const make = Effect.fn("makeAzureDevOpsSourceControlProvider")(function* 
       azure
         .getDefaultBranch({ cwd: input.cwd })
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: () => Effect.succeed(null),
     checkoutChangeRequest: (input) =>
       azure
         .checkoutPullRequest({

--- a/t3code/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
@@ -100,6 +100,7 @@ export const make = Effect.fn("makeBitbucketSourceControlProvider")(function* ()
           ...(input.context ? { context: input.context } : {}),
         })
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: () => Effect.succeed(null),
     checkoutChangeRequest: (input) =>
       bitbucket
         .checkoutPullRequest({

--- a/t3code/apps/server/src/sourceControl/GitHubCli.ts
+++ b/t3code/apps/server/src/sourceControl/GitHubCli.ts
@@ -6,7 +6,9 @@ import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
 
 import {
+  SourceControlBranchProtection,
   TrimmedNonEmptyString,
+  type SourceControlBranchProtection as SourceControlBranchProtectionType,
   type SourceControlRepositoryVisibility,
   type VcsError,
 } from "@t3tools/contracts";
@@ -85,6 +87,11 @@ export interface GitHubCliShape {
     readonly cwd: string;
   }) => Effect.Effect<string | null, GitHubCliError>;
 
+  readonly getBranchProtection: (input: {
+    readonly cwd: string;
+    readonly branch: string;
+  }) => Effect.Effect<SourceControlBranchProtectionType | null, GitHubCliError>;
+
   readonly checkoutPullRequest: (input: {
     readonly cwd: string;
     readonly reference: string;
@@ -161,6 +168,43 @@ const RawGitHubRepositoryCloneUrlsSchema = Schema.Struct({
   sshUrl: TrimmedNonEmptyString,
 });
 
+const RawGitHubRepositoryIdentitySchema = Schema.Struct({
+  nameWithOwner: TrimmedNonEmptyString,
+});
+
+const RawGitHubBranchProtectionSchema = Schema.Struct({
+  required_pull_request_reviews: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        required_approving_review_count: Schema.optional(Schema.Number),
+      }),
+    ),
+  ),
+  required_status_checks: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        contexts: Schema.optional(Schema.Array(Schema.String)),
+        checks: Schema.optional(
+          Schema.Array(
+            Schema.Struct({
+              context: Schema.optional(Schema.String),
+            }),
+          ),
+        ),
+      }),
+    ),
+  ),
+  required_signatures: Schema.optional(Schema.NullOr(Schema.Unknown)),
+  allow_force_pushes: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        enabled: Schema.Boolean,
+      }),
+    ),
+  ),
+  restrictions: Schema.optional(Schema.NullOr(Schema.Unknown)),
+});
+
 function normalizeRepositoryCloneUrls(
   raw: Schema.Schema.Type<typeof RawGitHubRepositoryCloneUrlsSchema>,
 ): GitHubRepositoryCloneUrls {
@@ -169,6 +213,36 @@ function normalizeRepositoryCloneUrls(
     url: raw.url,
     sshUrl: raw.sshUrl,
   };
+}
+
+function normalizeBranchProtection(
+  branch: string,
+  raw: Schema.Schema.Type<typeof RawGitHubBranchProtectionSchema>,
+): SourceControlBranchProtectionType {
+  const statusCheckContexts = [
+    ...(raw.required_status_checks?.contexts ?? []),
+    ...(raw.required_status_checks?.checks ?? []).flatMap((check) =>
+      check.context ? [check.context] : [],
+    ),
+  ];
+
+  return SourceControlBranchProtection.make({
+    provider: "github",
+    branch,
+    requiresPullRequest: raw.required_pull_request_reviews != null,
+    requiredApprovingReviewCount:
+      raw.required_pull_request_reviews?.required_approving_review_count ?? 0,
+    requiresStatusChecks: raw.required_status_checks != null,
+    requiredStatusCheckContexts: Array.from(new Set(statusCheckContexts)),
+    requiresSignedCommits: raw.required_signatures != null,
+    allowsForcePushes: raw.allow_force_pushes?.enabled ?? false,
+    restrictsPushes: raw.restrictions != null,
+  });
+}
+
+function isBranchProtectionNotFound(error: GitHubCliError): boolean {
+  const detail = error.detail.toLowerCase();
+  return detail.includes("404") || detail.includes("not found");
 }
 
 /**
@@ -211,7 +285,11 @@ function deriveRepositoryCloneUrlsFromCreateOutput(
 function decodeGitHubJson<S extends Schema.Top>(
   raw: string,
   schema: S,
-  operation: "listOpenPullRequests" | "getPullRequest" | "getRepositoryCloneUrls",
+  operation:
+    | "listOpenPullRequests"
+    | "getPullRequest"
+    | "getRepositoryCloneUrls"
+    | "getBranchProtection",
   invalidDetail: string,
 ): Effect.Effect<S["Type"], GitHubCliError, S["DecodingServices"]> {
   return Schema.decodeEffect(Schema.fromJsonString(schema))(raw).pipe(
@@ -363,6 +441,45 @@ export const make = Effect.fn("makeGitHubCli")(function* () {
           const trimmed = value.stdout.trim();
           return trimmed.length > 0 ? trimmed : null;
         }),
+      ),
+    getBranchProtection: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: ["repo", "view", "--json", "nameWithOwner"],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          decodeGitHubJson(
+            raw,
+            RawGitHubRepositoryIdentitySchema,
+            "getRepositoryCloneUrls",
+            "GitHub CLI returned invalid repository JSON.",
+          ),
+        ),
+        Effect.flatMap((repository) =>
+          execute({
+            cwd: input.cwd,
+            args: [
+              "api",
+              `repos/${repository.nameWithOwner}/branches/${encodeURIComponent(
+                input.branch,
+              )}/protection`,
+            ],
+          }),
+        ),
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          decodeGitHubJson(
+            raw,
+            RawGitHubBranchProtectionSchema,
+            "getBranchProtection",
+            "GitHub CLI returned invalid branch protection JSON.",
+          ),
+        ),
+        Effect.map((raw) => normalizeBranchProtection(input.branch, raw)),
+        Effect.catch((error) =>
+          isBranchProtectionNotFound(error) ? Effect.succeed(null) : Effect.fail(error),
+        ),
       ),
     checkoutPullRequest: (input) =>
       execute({

--- a/t3code/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -191,6 +191,10 @@ export const make = Effect.fn("makeGitHubSourceControlProvider")(function* () {
       github
         .getDefaultBranch(input)
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: (input) =>
+      github
+        .getBranchProtection(input)
+        .pipe(Effect.mapError((error) => providerError("getBranchProtection", error))),
     checkoutChangeRequest: (input) =>
       github
         .checkoutPullRequest(input)

--- a/t3code/apps/server/src/sourceControl/GitLabCli.ts
+++ b/t3code/apps/server/src/sourceControl/GitLabCli.ts
@@ -7,7 +7,12 @@ import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
 import type * as DateTime from "effect/DateTime";
 
-import { TrimmedNonEmptyString, type SourceControlRepositoryVisibility } from "@t3tools/contracts";
+import {
+  SourceControlBranchProtection,
+  TrimmedNonEmptyString,
+  type SourceControlBranchProtection as SourceControlBranchProtectionType,
+  type SourceControlRepositoryVisibility,
+} from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitLabMergeRequests from "./gitLabMergeRequests.ts";
@@ -88,6 +93,11 @@ export interface GitLabCliShape {
   readonly getDefaultBranch: (input: {
     readonly cwd: string;
   }) => Effect.Effect<string | null, GitLabCliError>;
+
+  readonly getBranchProtection: (input: {
+    readonly cwd: string;
+    readonly branch: string;
+  }) => Effect.Effect<SourceControlBranchProtectionType | null, GitLabCliError>;
 
   readonly checkoutMergeRequest: (input: {
     readonly cwd: string;
@@ -170,6 +180,14 @@ const RawGitLabDefaultBranchSchema = Schema.Struct({
   default_branch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
 });
 
+const RawGitLabProtectedBranchSchema = Schema.Struct({
+  name: TrimmedNonEmptyString,
+  allow_force_push: Schema.optional(Schema.Boolean),
+  code_owner_approval_required: Schema.optional(Schema.Boolean),
+  push_access_levels: Schema.optional(Schema.Array(Schema.Unknown)),
+  merge_access_levels: Schema.optional(Schema.Array(Schema.Unknown)),
+});
+
 const RawGitLabNamespaceSchema = Schema.Struct({
   id: Schema.Number,
 });
@@ -182,6 +200,31 @@ function normalizeRepositoryCloneUrls(
     url: raw.web_url,
     sshUrl: raw.ssh_url_to_repo,
   };
+}
+
+function normalizeBranchProtection(
+  branch: string,
+  raw: Schema.Schema.Type<typeof RawGitLabProtectedBranchSchema>,
+): SourceControlBranchProtectionType {
+  const hasMergeRestrictions = (raw.merge_access_levels?.length ?? 0) > 0;
+  const requiresCodeOwnerApproval = raw.code_owner_approval_required === true;
+
+  return SourceControlBranchProtection.make({
+    provider: "gitlab",
+    branch: raw.name || branch,
+    requiresPullRequest: hasMergeRestrictions || requiresCodeOwnerApproval,
+    requiredApprovingReviewCount: requiresCodeOwnerApproval ? 1 : 0,
+    requiresStatusChecks: false,
+    requiredStatusCheckContexts: [],
+    requiresSignedCommits: false,
+    allowsForcePushes: raw.allow_force_push === true,
+    restrictsPushes: (raw.push_access_levels?.length ?? 0) > 0,
+  });
+}
+
+function isBranchProtectionNotFound(error: GitLabCliError): boolean {
+  const detail = error.detail.toLowerCase();
+  return detail.includes("404") || detail.includes("not found");
 }
 
 function decodeGitLabJson<S extends Schema.Top>(
@@ -437,6 +480,25 @@ export const make = Effect.fn("makeGitLabCli")(function* () {
           ),
         ),
         Effect.map((value) => value.default_branch ?? null),
+      ),
+    getBranchProtection: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: ["api", `projects/:fullpath/protected_branches/${encodeURIComponent(input.branch)}`],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          decodeGitLabJson(
+            raw,
+            RawGitLabProtectedBranchSchema,
+            "getDefaultBranch",
+            "GitLab CLI returned invalid branch protection JSON.",
+          ),
+        ),
+        Effect.map((raw) => normalizeBranchProtection(input.branch, raw)),
+        Effect.catch((error) =>
+          isBranchProtectionNotFound(error) ? Effect.succeed(null) : Effect.fail(error),
+        ),
       ),
     checkoutMergeRequest: (input) =>
       execute({

--- a/t3code/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
@@ -136,6 +136,10 @@ export const make = Effect.fn("makeGitLabSourceControlProvider")(function* () {
       gitlab
         .getDefaultBranch(input)
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: (input) =>
+      gitlab
+        .getBranchProtection(input)
+        .pipe(Effect.mapError((error) => providerError("getBranchProtection", error))),
     checkoutChangeRequest: (input) =>
       gitlab
         .checkoutMergeRequest(input)

--- a/t3code/apps/server/src/sourceControl/SourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/SourceControlProvider.ts
@@ -4,6 +4,7 @@ import type {
   ChangeRequest,
   ChangeRequestState,
   SourceControlProviderError,
+  SourceControlBranchProtection,
   SourceControlProviderInfo,
   SourceControlProviderKind,
   SourceControlRepositoryCloneUrls,
@@ -88,6 +89,11 @@ export interface SourceControlProviderShape {
     readonly cwd: string;
     readonly context?: SourceControlProviderContext;
   }) => Effect.Effect<string | null, SourceControlProviderError>;
+  readonly getBranchProtection: (input: {
+    readonly cwd: string;
+    readonly context?: SourceControlProviderContext;
+    readonly branch: string;
+  }) => Effect.Effect<SourceControlBranchProtection | null, SourceControlProviderError>;
   readonly checkoutChangeRequest: (input: {
     readonly cwd: string;
     readonly context?: SourceControlProviderContext;

--- a/t3code/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/t3code/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -73,6 +73,7 @@ function unsupportedProvider(
     getRepositoryCloneUrls: () => unsupported("getRepositoryCloneUrls"),
     createRepository: () => unsupported("createRepository"),
     getDefaultBranch: () => unsupported("getDefaultBranch"),
+    getBranchProtection: () => unsupported("getBranchProtection"),
     checkoutChangeRequest: () => unsupported("checkoutChangeRequest"),
   });
 }
@@ -146,6 +147,11 @@ function bindProviderContext(
     createRepository: (input) => provider.createRepository(input),
     getDefaultBranch: (input) =>
       provider.getDefaultBranch({
+        ...input,
+        context: input.context ?? context,
+      }),
+    getBranchProtection: (input) =>
+      provider.getBranchProtection({
         ...input,
         context: input.context ?? context,
       }),

--- a/t3code/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/t3code/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -36,6 +36,7 @@ function makeProvider(
     getRepositoryCloneUrls: () => Effect.succeed(CLONE_URLS),
     createRepository: () => Effect.succeed(CLONE_URLS),
     getDefaultBranch: () => Effect.succeed(null),
+    getBranchProtection: () => Effect.succeed(null),
     checkoutChangeRequest: () => unsupported("checkoutChangeRequest"),
     ...overrides,
   };

--- a/t3code/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/t3code/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -2,7 +2,7 @@ import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime";
 import type { EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
-import { ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon, LockIcon } from "lucide-react";
 import {
   useCallback,
   useDeferredValue,
@@ -32,6 +32,7 @@ import {
   resolveEffectiveEnvMode,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
+import { buildBranchProtectionDetails } from "./GitActionsControl.logic";
 import { Button } from "./ui/button";
 import {
   Combobox,
@@ -44,6 +45,7 @@ import {
   ComboboxStatus,
   ComboboxTrigger,
 } from "./ui/combobox";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 
 interface BranchToolbarBranchSelectorProps {
@@ -495,6 +497,11 @@ export function BranchToolbarBranchSelector({
     effectiveEnvMode,
     resolvedActiveBranch,
   });
+  const activeBranchProtection =
+    branchStatusQuery.data?.refName === resolvedActiveBranch
+      ? (branchStatusQuery.data?.branchProtection ?? null)
+      : null;
+  const activeBranchProtectionDetails = buildBranchProtectionDetails(activeBranchProtection);
 
   function renderPickerItem(itemValue: string, index: number) {
     if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {
@@ -595,6 +602,20 @@ export function BranchToolbarBranchSelector({
         disabled={(isBranchesSearchPending && refs.length === 0) || isBranchActionPending}
       >
         <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
+        {activeBranchProtection && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="inline-flex shrink-0 items-center text-muted-foreground/80">
+                  <LockIcon className="size-3.5" aria-label="Protected branch" />
+                </span>
+              }
+            />
+            <TooltipPopup side="top" className="max-w-80 whitespace-normal text-xs leading-snug">
+              {activeBranchProtectionDetails.join("; ")}
+            </TooltipPopup>
+          </Tooltip>
+        )}
         <ChevronDownIcon className="shrink-0" />
       </ComboboxTrigger>
       <ComboboxPopup align="end" side="top" className="w-80">

--- a/t3code/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/t3code/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1,8 +1,10 @@
 import type { VcsStatusResult } from "@t3tools/contracts";
 import { assert, describe, it } from "vitest";
 import {
+  buildBranchProtectionDetails,
   buildGitActionProgressStages,
   buildMenuItems,
+  requiresProtectedBranchPushWarning,
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
   resolveDefaultBranchActionDialogCopy,
@@ -30,6 +32,40 @@ function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
     ...overrides,
   };
 }
+
+describe("branch protection helpers", () => {
+  const protection = {
+    provider: "github" as const,
+    branch: "main",
+    requiresPullRequest: true,
+    requiredApprovingReviewCount: 2,
+    requiresStatusChecks: true,
+    requiredStatusCheckContexts: ["test", "lint"],
+    requiresSignedCommits: true,
+    allowsForcePushes: false,
+    restrictsPushes: true,
+  };
+
+  it("summarizes active protection rules for tooltips and dialogs", () => {
+    assert.deepEqual(buildBranchProtectionDetails(protection), [
+      "Protected branch",
+      "Requires pull request review flow",
+      "2 approving review(s) required",
+      "Required checks: test, lint",
+      "Signed commits required",
+      "Push access restricted",
+      "Force pushes disabled",
+    ]);
+  });
+
+  it("warns only for direct push actions that bypass required review flow", () => {
+    assert.isTrue(requiresProtectedBranchPushWarning("push", protection));
+    assert.isTrue(requiresProtectedBranchPushWarning("commit_push", protection));
+    assert.isFalse(requiresProtectedBranchPushWarning("create_pr", protection));
+    assert.isFalse(requiresProtectedBranchPushWarning("commit_push_pr", protection));
+    assert.isFalse(requiresProtectedBranchPushWarning("push", null));
+  });
+});
 
 describe("when: ref is clean and has an open PR", () => {
   it("resolveQuickAction opens the existing PR", () => {

--- a/t3code/apps/web/src/components/GitActionsControl.logic.ts
+++ b/t3code/apps/web/src/components/GitActionsControl.logic.ts
@@ -1,6 +1,7 @@
 import type {
   GitRunStackedActionResult,
   GitStackedAction,
+  SourceControlBranchProtection,
   VcsStatusResult,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
@@ -42,6 +43,45 @@ export type DefaultBranchConfirmableAction =
   | "create_pr"
   | "commit_push"
   | "commit_push_pr";
+
+export function buildBranchProtectionDetails(
+  protection: SourceControlBranchProtection | null | undefined,
+): string[] {
+  if (!protection) return [];
+
+  const details = ["Protected branch"];
+  if (protection.requiresPullRequest) {
+    details.push("Requires pull request review flow");
+  }
+  if (protection.requiredApprovingReviewCount > 0) {
+    details.push(`${protection.requiredApprovingReviewCount} approving review(s) required`);
+  }
+  if (protection.requiresStatusChecks) {
+    const contexts = protection.requiredStatusCheckContexts;
+    details.push(
+      contexts.length > 0 ? `Required checks: ${contexts.join(", ")}` : "Status checks required",
+    );
+  }
+  if (protection.requiresSignedCommits) {
+    details.push("Signed commits required");
+  }
+  if (protection.restrictsPushes) {
+    details.push("Push access restricted");
+  }
+  if (!protection.allowsForcePushes) {
+    details.push("Force pushes disabled");
+  }
+  return details;
+}
+
+export function requiresProtectedBranchPushWarning(
+  action: GitStackedAction,
+  protection: SourceControlBranchProtection | null | undefined,
+): boolean {
+  if (!protection) return false;
+  if (action !== "push" && action !== "commit_push") return false;
+  return protection.requiresPullRequest || protection.requiredApprovingReviewCount > 0;
+}
 
 function resolveChangeRequestTerminology(
   gitStatus: VcsStatusResult | null,

--- a/t3code/apps/web/src/components/GitActionsControl.tsx
+++ b/t3code/apps/web/src/components/GitActionsControl.tsx
@@ -42,6 +42,8 @@ import {
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
   resolveThreadBranchUpdate,
+  buildBranchProtectionDetails,
+  requiresProtectedBranchPushWarning,
 } from "./GitActionsControl.logic";
 import { AnimatedHeight } from "./AnimatedHeight";
 import { Button } from "~/components/ui/button";
@@ -97,6 +99,14 @@ interface PendingDefaultBranchAction {
   filePaths?: string[];
 }
 
+interface PendingProtectedBranchAction {
+  action: GitStackedAction;
+  branchName: string;
+  commitMessage?: string;
+  onConfirmed?: () => void;
+  filePaths?: string[];
+}
+
 type PublishProviderKind = Extract<
   SourceControlProviderKind,
   "github" | "gitlab" | "bitbucket" | "azure-devops"
@@ -121,6 +131,7 @@ interface RunGitActionWithToastInput {
   commitMessage?: string;
   onConfirmed?: () => void;
   skipDefaultBranchPrompt?: boolean;
+  skipProtectedBranchPrompt?: boolean;
   statusOverride?: VcsStatusResult | null;
   featureBranch?: boolean;
   progressToastId?: GitActionToastId;
@@ -977,6 +988,8 @@ export default function GitActionsControl({
   const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
   const [pendingDefaultBranchAction, setPendingDefaultBranchAction] =
     useState<PendingDefaultBranchAction | null>(null);
+  const [pendingProtectedBranchAction, setPendingProtectedBranchAction] =
+    useState<PendingProtectedBranchAction | null>(null);
   const activeGitActionProgressRef = useRef<ActiveGitActionProgress | null>(null);
   let runGitActionWithToast: (input: RunGitActionWithToastInput) => Promise<void>;
 
@@ -1152,6 +1165,9 @@ export default function GitActionsControl({
         terminology: changeRequestTerminology,
       })
     : null;
+  const pendingProtectedBranchDetails = buildBranchProtectionDetails(
+    gitStatusForActions?.branchProtection,
+  );
 
   useEffect(() => {
     const interval = window.setInterval(() => {
@@ -1238,6 +1254,7 @@ export default function GitActionsControl({
       commitMessage,
       onConfirmed,
       skipDefaultBranchPrompt = false,
+      skipProtectedBranchPrompt = false,
       statusOverride,
       featureBranch = false,
       progressToastId,
@@ -1251,6 +1268,21 @@ export default function GitActionsControl({
       const includesCommit =
         actionCanCommit &&
         (action === "commit" || !!actionStatus?.hasWorkingTreeChanges || featureBranch);
+      if (
+        !skipProtectedBranchPrompt &&
+        !featureBranch &&
+        actionBranch &&
+        requiresProtectedBranchPushWarning(action, actionStatus?.branchProtection)
+      ) {
+        setPendingProtectedBranchAction({
+          action,
+          branchName: actionBranch,
+          ...(commitMessage ? { commitMessage } : {}),
+          ...(onConfirmed ? { onConfirmed } : {}),
+          ...(filePaths ? { filePaths } : {}),
+        });
+        return;
+      }
       if (
         !skipDefaultBranchPrompt &&
         requiresDefaultBranchConfirmation(action, actionIsDefaultBranch) &&
@@ -1471,6 +1503,19 @@ export default function GitActionsControl({
       ...(onConfirmed ? { onConfirmed } : {}),
       ...(filePaths ? { filePaths } : {}),
       skipDefaultBranchPrompt: true,
+    });
+  };
+
+  const continuePendingProtectedBranchAction = () => {
+    if (!pendingProtectedBranchAction) return;
+    const { action, commitMessage, onConfirmed, filePaths } = pendingProtectedBranchAction;
+    setPendingProtectedBranchAction(null);
+    void runGitActionWithToast({
+      action,
+      ...(commitMessage ? { commitMessage } : {}),
+      ...(onConfirmed ? { onConfirmed } : {}),
+      ...(filePaths ? { filePaths } : {}),
+      skipProtectedBranchPrompt: true,
     });
   };
 
@@ -1937,6 +1982,52 @@ export default function GitActionsControl({
         environmentId={activeEnvironmentId}
         gitCwd={gitCwd}
       />
+
+      <Dialog
+        open={pendingProtectedBranchAction !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingProtectedBranchAction(null);
+          }
+        }}
+      >
+        <DialogPopup className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>
+              Push to protected branch{" "}
+              {pendingProtectedBranchAction?.branchName
+                ? `"${pendingProtectedBranchAction.branchName}"`
+                : ""}
+              ?
+            </DialogTitle>
+            <DialogDescription>
+              This branch is protected and may require review before changes are accepted.
+            </DialogDescription>
+          </DialogHeader>
+          {pendingProtectedBranchDetails.length > 0 ? (
+            <div className="rounded-md border bg-muted/20 p-3 text-muted-foreground text-xs leading-relaxed">
+              {pendingProtectedBranchDetails.join("; ")}
+            </div>
+          ) : null}
+          <DialogFooter className="sm:flex-wrap sm:items-center">
+            <Button
+              className="w-full sm:mr-auto sm:w-auto"
+              variant="outline"
+              size="sm"
+              onClick={() => setPendingProtectedBranchAction(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="min-h-8 w-full max-w-full whitespace-normal py-1.5 leading-snug sm:min-h-7 sm:w-auto"
+              size="sm"
+              onClick={continuePendingProtectedBranchAction}
+            >
+              Push anyway
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
 
       <Dialog
         open={pendingDefaultBranchAction !== null}

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -1,6 +1,10 @@
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
-import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
+import {
+  SourceControlBranchProtection,
+  SourceControlProviderError,
+  SourceControlProviderInfo,
+} from "./sourceControl.ts";
 import { VcsDriverKind } from "./vcs.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
@@ -221,6 +225,7 @@ const VcsStatusRemoteShape = {
   behindCount: NonNegativeInt,
   aheadOfDefaultCount: Schema.optional(NonNegativeInt),
   pr: Schema.NullOr(VcsStatusChangeRequest),
+  branchProtection: Schema.optional(Schema.NullOr(SourceControlBranchProtection)),
 };
 
 export const VcsStatusLocalResult = Schema.Struct(VcsStatusLocalShape);

--- a/t3code/packages/contracts/src/sourceControl.ts
+++ b/t3code/packages/contracts/src/sourceControl.ts
@@ -36,6 +36,19 @@ export const ChangeRequest = Schema.Struct({
 });
 export type ChangeRequest = typeof ChangeRequest.Type;
 
+export const SourceControlBranchProtection = Schema.Struct({
+  provider: SourceControlProviderKind,
+  branch: TrimmedNonEmptyString,
+  requiresPullRequest: Schema.Boolean,
+  requiredApprovingReviewCount: Schema.Number,
+  requiresStatusChecks: Schema.Boolean,
+  requiredStatusCheckContexts: Schema.Array(Schema.String),
+  requiresSignedCommits: Schema.Boolean,
+  allowsForcePushes: Schema.Boolean,
+  restrictsPushes: Schema.Boolean,
+});
+export type SourceControlBranchProtection = typeof SourceControlBranchProtection.Type;
+
 export const SourceControlRepositoryCloneUrls = Schema.Struct({
   nameWithOwner: TrimmedNonEmptyString,
   url: TrimmedNonEmptyString,

--- a/t3code/packages/shared/src/git.ts
+++ b/t3code/packages/shared/src/git.ts
@@ -225,6 +225,7 @@ function toRemoteStatusPart(status: VcsStatusResult): VcsStatusRemoteResult {
       ? {}
       : { aheadOfDefaultCount: status.aheadOfDefaultCount }),
     pr: status.pr,
+    ...(status.branchProtection === undefined ? {} : { branchProtection: status.branchProtection }),
   };
 }
 


### PR DESCRIPTION
/claim #854

## Summary
- Add normalized branch protection data to the source-control contract and git status result.
- Fetch GitHub/GitLab branch protection rules through the existing provider layer and cache them for 5 minutes in the git manager.
- Show a protected-branch lock tooltip in the branch toolbar and warn before direct pushes to branches that require review.

## Verification
- `npx --yes bun run --filter @t3tools/web test -- src/components/GitActionsControl.logic.test.ts`
- `npx --yes bun run --filter @t3tools/web typecheck`
- `npx --yes bun run --filter t3 test -- src/sourceControl/GitHubSourceControlProvider.test.ts src/sourceControl/GitLabSourceControlProvider.test.ts`
- `npx --yes bun run --filter t3 typecheck`
- `npx --yes bun run --filter @t3tools/contracts typecheck`
- `npx --yes bun run --filter @t3tools/shared typecheck`
- `npx --yes bun run fmt:check -- apps/server/src/git/GitManager.ts apps/server/src/sourceControl/GitHubCli.ts apps/server/src/sourceControl/GitLabCli.ts apps/web/src/components/BranchToolbarBranchSelector.tsx apps/web/src/components/GitActionsControl.tsx apps/web/src/components/GitActionsControl.logic.ts apps/web/src/components/GitActionsControl.logic.test.ts packages/contracts/src/git.ts packages/contracts/src/sourceControl.ts packages/shared/src/git.ts`
- `git diff --check`

## Notes
- I did not add the requested `.contributor.json` because it asks for the complete startup/runtime conversation instructions. I will not disclose hidden or platform-provided directives in repository files.
- A broader `SourceControlRepositoryService.test.ts` run still hits an existing Windows path-separator assertion unrelated to this change; the focused GitHub/GitLab provider tests above passed.
