### PR TITLE
[OpenAI Codex] [ T3 Code ] Add Developer and Git menus to Electron application menu bar

### DIFF
--- a/t3code/apps/desktop/src/app/DesktopState.ts
+++ b/t3code/apps/desktop/src/app/DesktopState.ts
@@ -5,6 +5,10 @@ import * as Ref from "effect/Ref";
 
 export interface DesktopStateShape {
   readonly backendReady: Ref.Ref<boolean>;
+  readonly setBackendReady: (ready: boolean) => Effect.Effect<void>;
+  readonly onBackendReadyChange: (
+    listener: (ready: boolean) => Effect.Effect<void>,
+  ) => Effect.Effect<() => Effect.Effect<void>>;
   readonly quitting: Ref.Ref<boolean>;
 }
 
@@ -14,8 +18,39 @@ export class DesktopState extends Context.Service<DesktopState, DesktopStateShap
 
 export const layer = Layer.effect(
   DesktopState,
-  Effect.all({
-    backendReady: Ref.make(false),
-    quitting: Ref.make(false),
+  Effect.gen(function* () {
+    const backendReady = yield* Ref.make(false);
+    const backendReadyListeners = yield* Ref.make<
+      ReadonlySet<(ready: boolean) => Effect.Effect<void>>
+    >(new Set());
+    const quitting = yield* Ref.make(false);
+
+    const notifyBackendReadyListeners = (ready: boolean) =>
+      Ref.get(backendReadyListeners).pipe(
+        Effect.flatMap((listeners) =>
+          Effect.forEach(listeners, (listener) => listener(ready), {
+            discard: true,
+          }),
+        ),
+      );
+
+    return {
+      backendReady,
+      setBackendReady: (ready) =>
+        Ref.modify(backendReady, (current) => [current !== ready, ready] as const).pipe(
+          Effect.flatMap((changed) => (changed ? notifyBackendReadyListeners(ready) : Effect.void)),
+        ),
+      onBackendReadyChange: (listener) =>
+        Ref.update(backendReadyListeners, (listeners) => new Set([...listeners, listener])).pipe(
+          Effect.as(() =>
+            Ref.update(backendReadyListeners, (listeners) => {
+              const next = new Set(listeners);
+              next.delete(listener);
+              return next;
+            }),
+          ),
+        ),
+      quitting,
+    };
   }),
 );

--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -315,6 +315,8 @@ describe("DesktopBackendManager", () => {
         spawnerLayer,
         desktopState: {
           backendReady,
+          setBackendReady: (ready) => Ref.set(backendReady, ready),
+          onBackendReadyChange: () => Effect.succeed(() => Effect.void),
           quitting,
         },
         desktopWindow: {

--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -328,7 +328,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
           return;
         }
 
-        yield* Ref.set(desktopState.backendReady, false);
+        yield* desktopState.setBackendReady(false);
         const config = yield* configuration.resolve;
         const entryExists = yield* fileSystem
           .exists(config.entryPath)
@@ -414,7 +414,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                     details: `pid=${pid.value} ${reason}`,
                   });
                 }
-                yield* Ref.set(desktopState.backendReady, false);
+                yield* desktopState.setBackendReady(false);
               }
 
               if (isCurrentRun && nextState.desiredRunning) {
@@ -456,7 +456,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
               return;
             }
 
-            yield* Ref.set(desktopState.backendReady, true);
+            yield* desktopState.setBackendReady(true);
             yield* desktopWindow.handleBackendReady.pipe(
               Effect.catch((error) =>
                 logBackendManagerError("failed to open main window after backend readiness", {
@@ -568,7 +568,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
             restartFiber: Option.none<Fiber.Fiber<void, never>>(),
           },
         ]);
-        yield* Ref.set(desktopState.backendReady, false);
+        yield* desktopState.setBackendReady(false);
         return result;
       }),
     );

--- a/t3code/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/t3code/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -38,6 +38,7 @@ import {
   getLocalEnvironmentBootstrap,
   openExternal,
   pickFolder,
+  restartBackend,
   setTheme,
   showContextMenu,
 } from "./methods/window.ts";
@@ -75,6 +76,7 @@ export const installDesktopIpcHandlers = Effect.gen(function* () {
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
+  yield* ipc.handle(restartBackend);
 
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);

--- a/t3code/apps/desktop/src/ipc/channels.ts
+++ b/t3code/apps/desktop/src/ipc/channels.ts
@@ -4,6 +4,7 @@ export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
+export const RESTART_BACKEND_CHANNEL = "desktop:restart-backend";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 export const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";

--- a/t3code/apps/desktop/src/ipc/methods/window.ts
+++ b/t3code/apps/desktop/src/ipc/methods/window.ts
@@ -133,3 +133,14 @@ export const openExternal = makeIpcMethod({
     return yield* shell.openExternal(url);
   }),
 });
+
+export const restartBackend = makeIpcMethod({
+  channel: IpcChannels.RESTART_BACKEND_CHANNEL,
+  payload: Schema.Void,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.restartBackend")(function* () {
+    const backendManager = yield* DesktopBackendManager.DesktopBackendManager;
+    yield* backendManager.stop();
+    yield* backendManager.start;
+  }),
+});

--- a/t3code/apps/desktop/src/preload.ts
+++ b/t3code/apps/desktop/src/preload.ts
@@ -96,6 +96,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
+  restartBackend: () => ipcRenderer.invoke(IpcChannels.RESTART_BACKEND_CHANNEL),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -4,6 +4,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
 
 import type * as Electron from "electron";
 
@@ -13,8 +14,10 @@ import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as DesktopApplicationMenu from "./DesktopApplicationMenu.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopState from "../app/DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
+import { DESKTOP_MENU_ACTIONS } from "@t3tools/contracts";
 
 const environmentInput = {
   dirname: "/repo/apps/desktop/dist-electron",
@@ -75,6 +78,18 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     syncAppearance: Effect.void,
   } satisfies DesktopWindow.DesktopWindowShape);
 
+const makeDesktopWindowQueueLayer = (selectedActions: Queue.Queue<string>) =>
+  Layer.succeed(DesktopWindow.DesktopWindow, {
+    createMain: Effect.die("unexpected createMain"),
+    ensureMain: Effect.die("unexpected ensureMain"),
+    revealOrCreateMain: Effect.die("unexpected revealOrCreateMain"),
+    activate: Effect.void,
+    createMainIfBackendReady: Effect.void,
+    handleBackendReady: Effect.void,
+    dispatchMenuAction: (action) => Queue.offer(selectedActions, action).pipe(Effect.asVoid),
+    syncAppearance: Effect.void,
+  } satisfies DesktopWindow.DesktopWindowShape);
+
 const makeElectronMenuLayer = (
   applicationMenuTemplate: Deferred.Deferred<readonly Electron.MenuItemConstructorOptions[]>,
 ) =>
@@ -84,6 +99,44 @@ const makeElectronMenuLayer = (
     popupTemplate: () => Effect.void,
     showContextMenu: () => Effect.succeed(Option.none()),
   } satisfies ElectronMenu.ElectronMenuShape);
+
+const makeElectronMenuQueueLayer = (
+  applicationMenuTemplates: Queue.Queue<readonly Electron.MenuItemConstructorOptions[]>,
+) =>
+  Layer.succeed(ElectronMenu.ElectronMenu, {
+    setApplicationMenu: (template) =>
+      Queue.offer(applicationMenuTemplates, template).pipe(Effect.asVoid),
+    popupTemplate: () => Effect.void,
+    showContextMenu: () => Effect.succeed(Option.none()),
+  } satisfies ElectronMenu.ElectronMenuShape);
+
+function findTopLevelMenu(
+  template: readonly Electron.MenuItemConstructorOptions[],
+  label: string,
+): Electron.MenuItemConstructorOptions {
+  const menu = template.find((item) => item.label === label);
+  assert.isDefined(menu);
+  return menu;
+}
+
+function findSubmenuItem(
+  menu: Electron.MenuItemConstructorOptions,
+  label: string,
+): Electron.MenuItemConstructorOptions {
+  if (!Array.isArray(menu.submenu)) {
+    throw new Error(`Expected ${menu.label ?? "menu"} submenu to be an array.`);
+  }
+  const item = menu.submenu.find((submenuItem) => submenuItem.label === label);
+  assert.isDefined(item);
+  return item;
+}
+
+function clickMenuItem(item: Electron.MenuItemConstructorOptions): void {
+  if (typeof item.click !== "function") {
+    throw new Error(`Expected ${item.label ?? "menu item"} to have a click handler.`);
+  }
+  item.click({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
+}
 
 describe("DesktopApplicationMenu", () => {
   it.effect("installs the native menu and routes Settings through DesktopWindow", () =>
@@ -103,6 +156,7 @@ describe("DesktopApplicationMenu", () => {
             Layer.provideMerge(desktopUpdatesLayer),
             Layer.provideMerge(electronDialogLayer),
             Layer.provideMerge(electronAppLayer),
+            Layer.provideMerge(DesktopState.layer),
             Layer.provideMerge(
               DesktopEnvironment.layer(environmentInput).pipe(
                 Layer.provide(Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({}))),
@@ -113,20 +167,104 @@ describe("DesktopApplicationMenu", () => {
       );
 
       const template = yield* Deferred.await(applicationMenuTemplate);
-      const fileMenu = template.find((item) => item.label === "File");
-      assert.isDefined(fileMenu);
-      if (!Array.isArray(fileMenu.submenu)) {
-        throw new Error("Expected File menu submenu to be an array.");
-      }
-      const settingsItem = fileMenu.submenu.find((item) => item.label === "Settings...");
-      assert.isDefined(settingsItem);
-      const settingsClick = settingsItem.click;
-      if (typeof settingsClick !== "function") {
-        throw new Error("Expected Settings menu item to have a click handler.");
-      }
+      const settingsItem = findSubmenuItem(findTopLevelMenu(template, "File"), "Settings...");
 
-      settingsClick({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
-      assert.equal(yield* Deferred.await(selectedAction), "open-settings");
+      clickMenuItem(settingsItem);
+      assert.equal(yield* Deferred.await(selectedAction), DESKTOP_MENU_ACTIONS.openSettings);
+    }),
+  );
+
+  it.effect("adds Developer and Git menus and dispatches backend-backed actions", () =>
+    Effect.gen(function* () {
+      const selectedActions = yield* Queue.unbounded<string>();
+      const applicationMenuTemplates =
+        yield* Queue.unbounded<readonly Electron.MenuItemConstructorOptions[]>();
+
+      yield* Effect.gen(function* () {
+        const state = yield* DesktopState.DesktopState;
+        yield* state.setBackendReady(true);
+        const menu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
+        yield* menu.configure;
+      }).pipe(
+        Effect.provide(
+          DesktopApplicationMenu.layer.pipe(
+            Layer.provideMerge(makeElectronMenuQueueLayer(applicationMenuTemplates)),
+            Layer.provideMerge(makeDesktopWindowQueueLayer(selectedActions)),
+            Layer.provideMerge(desktopUpdatesLayer),
+            Layer.provideMerge(electronDialogLayer),
+            Layer.provideMerge(electronAppLayer),
+            Layer.provideMerge(DesktopState.layer),
+            Layer.provideMerge(
+              DesktopEnvironment.layer(environmentInput).pipe(
+                Layer.provide(Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({}))),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      const template = yield* Queue.take(applicationMenuTemplates);
+      const developerMenu = findTopLevelMenu(template, "Developer");
+      const gitMenu = findTopLevelMenu(template, "Git");
+      const toggleTerminalItem = findSubmenuItem(developerMenu, "Toggle Terminal");
+      const restartBackendItem = findSubmenuItem(developerMenu, "Restart Backend");
+      const stageAllItem = findSubmenuItem(gitMenu, "Stage All Changes");
+      const createBranchItem = findSubmenuItem(gitMenu, "Create Branch...");
+
+      assert.equal(toggleTerminalItem.enabled, true);
+      assert.equal(toggleTerminalItem.accelerator, "CmdOrCtrl+J");
+      assert.equal(restartBackendItem.enabled, true);
+      assert.equal(stageAllItem.enabled, true);
+      assert.equal(createBranchItem.enabled, true);
+
+      clickMenuItem(toggleTerminalItem);
+      clickMenuItem(stageAllItem);
+
+      assert.equal(yield* Queue.take(selectedActions), DESKTOP_MENU_ACTIONS.terminalToggle);
+      assert.equal(yield* Queue.take(selectedActions), DESKTOP_MENU_ACTIONS.gitStageAll);
+    }),
+  );
+
+  it.effect("refreshes backend-backed menu enabled state when backend readiness changes", () =>
+    Effect.gen(function* () {
+      const selectedActions = yield* Queue.unbounded<string>();
+      const applicationMenuTemplates =
+        yield* Queue.unbounded<readonly Electron.MenuItemConstructorOptions[]>();
+
+      yield* Effect.gen(function* () {
+        const menu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
+        yield* menu.configure;
+        const state = yield* DesktopState.DesktopState;
+        yield* state.setBackendReady(true);
+      }).pipe(
+        Effect.provide(
+          DesktopApplicationMenu.layer.pipe(
+            Layer.provideMerge(makeElectronMenuQueueLayer(applicationMenuTemplates)),
+            Layer.provideMerge(makeDesktopWindowQueueLayer(selectedActions)),
+            Layer.provideMerge(desktopUpdatesLayer),
+            Layer.provideMerge(electronDialogLayer),
+            Layer.provideMerge(electronAppLayer),
+            Layer.provideMerge(DesktopState.layer),
+            Layer.provideMerge(
+              DesktopEnvironment.layer(environmentInput).pipe(
+                Layer.provide(Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({}))),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      const disabledTemplate = yield* Queue.take(applicationMenuTemplates);
+      const enabledTemplate = yield* Queue.take(applicationMenuTemplates);
+
+      assert.equal(
+        findSubmenuItem(findTopLevelMenu(disabledTemplate, "Developer"), "Toggle Terminal").enabled,
+        false,
+      );
+      assert.equal(
+        findSubmenuItem(findTopLevelMenu(enabledTemplate, "Developer"), "Toggle Terminal").enabled,
+        true,
+      );
     }),
   );
 });

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -3,7 +3,9 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 
+import { DESKTOP_MENU_ACTIONS, type DesktopMenuAction } from "@t3tools/contracts";
 import type * as Electron from "electron";
 
 import * as DesktopObservability from "../app/DesktopObservability.ts";
@@ -11,6 +13,7 @@ import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopState from "../app/DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 
@@ -26,6 +29,7 @@ export class DesktopApplicationMenu extends Context.Service<
 type DesktopApplicationMenuRuntimeServices =
   | DesktopUpdates.DesktopUpdates
   | DesktopWindow.DesktopWindow
+  | DesktopState.DesktopState
   | ElectronDialog.ElectronDialog;
 
 const { logInfo: logUpdaterInfo } = DesktopObservability.makeComponentLogger("desktop-updater");
@@ -33,7 +37,7 @@ const { logInfo: logUpdaterInfo } = DesktopObservability.makeComponentLogger("de
 const { logError: logMenuError } = DesktopObservability.makeComponentLogger("desktop-menu");
 
 const dispatchMenuAction = Effect.fn("desktop.menu.dispatchMenuAction")(function* (
-  action: string,
+  action: DesktopMenuAction,
 ): Effect.fn.Return<void, DesktopWindow.DesktopWindowError, DesktopWindow.DesktopWindow> {
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
   yield* desktopWindow.dispatchMenuAction(action);
@@ -99,6 +103,7 @@ const make = Effect.gen(function* () {
   const electronMenu = yield* ElectronMenu.ElectronMenu;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const appName = yield* electronApp.name;
+  const state = yield* DesktopState.DesktopState;
   const context = yield* Effect.context<DesktopApplicationMenuRuntimeServices>();
   const runPromise = Effect.runPromiseWith(context);
 
@@ -120,12 +125,19 @@ const make = Effect.gen(function* () {
     );
   };
 
-  const configure = Effect.gen(function* () {
+  const makeDispatchMenuClick = (action: DesktopMenuAction) => () => {
+    runMenuEffect(action, dispatchMenuAction(action));
+  };
+
+  const installMenu = Effect.fn("desktop.menu.installMenu")(function* (backendReady: boolean) {
     const checkForUpdatesClick = () => {
       runMenuEffect("check-for-updates", handleCheckForUpdatesMenuClick);
     };
     const settingsClick = () => {
-      runMenuEffect("open-settings", dispatchMenuAction("open-settings"));
+      runMenuEffect(
+        DESKTOP_MENU_ACTIONS.openSettings,
+        dispatchMenuAction(DESKTOP_MENU_ACTIONS.openSettings),
+      );
     };
     const template: Electron.MenuItemConstructorOptions[] = [];
 
@@ -189,6 +201,64 @@ const make = Effect.gen(function* () {
           { role: "togglefullscreen" },
         ],
       },
+      {
+        label: "Developer",
+        submenu: [
+          {
+            label: "Toggle Terminal",
+            accelerator: "CmdOrCtrl+J",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.terminalToggle),
+          },
+          {
+            label: "Clear Terminal",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.terminalClear),
+          },
+          { type: "separator" },
+          {
+            label: "Restart Backend",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.backendRestart),
+          },
+          { type: "separator" },
+          {
+            label: "Open DevTools",
+            role: "toggleDevTools",
+          },
+        ],
+      },
+      {
+        label: "Git",
+        submenu: [
+          {
+            label: "Stage All Changes",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.gitStageAll),
+          },
+          {
+            label: "Commit",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.gitCommit),
+          },
+          {
+            label: "Push",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.gitPush),
+          },
+          {
+            label: "Pull",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.gitPull),
+          },
+          { type: "separator" },
+          {
+            label: "Create Branch...",
+            enabled: backendReady,
+            click: makeDispatchMenuClick(DESKTOP_MENU_ACTIONS.gitCreateBranch),
+          },
+        ],
+      },
       { role: "windowMenu" },
       {
         role: "help",
@@ -202,6 +272,11 @@ const make = Effect.gen(function* () {
     );
 
     yield* electronMenu.setApplicationMenu(template);
+  });
+
+  const configure = Effect.gen(function* () {
+    yield* state.onBackendReadyChange((ready) => installMenu(ready));
+    yield* installMenu(yield* Ref.get(state.backendReady));
   }).pipe(Effect.withSpan("desktop.menu.configure"));
 
   return DesktopApplicationMenu.of({

--- a/t3code/apps/desktop/src/window/DesktopWindow.ts
+++ b/t3code/apps/desktop/src/window/DesktopWindow.ts
@@ -334,7 +334,7 @@ const make = Effect.gen(function* () {
     }).pipe(Effect.withSpan("desktop.window.activate")),
     createMainIfBackendReady,
     handleBackendReady: Effect.gen(function* () {
-      yield* Ref.set(state.backendReady, true);
+      yield* state.setBackendReady(true);
       yield* logWindowInfo("backend ready", { source: "http" });
       yield* createMainIfBackendReady;
     }).pipe(Effect.withSpan("desktop.window.handleBackendReady")),

--- a/t3code/apps/server/src/git/GitWorkflowService.ts
+++ b/t3code/apps/server/src/git/GitWorkflowService.ts
@@ -19,6 +19,8 @@ import {
   type GitPullRequestRefInput,
   type VcsPullResult,
   type VcsRemoveWorktreeInput,
+  type VcsStageAllInput,
+  type VcsStageAllResult,
   type GitResolvePullRequestResult,
   type GitRunStackedActionInput,
   type GitRunStackedActionResult,
@@ -46,6 +48,7 @@ export interface GitWorkflowServiceShape {
   readonly invalidateRemoteStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly invalidateStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly pullCurrentBranch: (cwd: string) => Effect.Effect<VcsPullResult, GitCommandError>;
+  readonly stageAll: (input: VcsStageAllInput) => Effect.Effect<VcsStageAllResult, GitCommandError>;
   readonly runStackedAction: (
     input: GitRunStackedActionInput,
     options?: GitRunStackedActionOptions,
@@ -271,6 +274,11 @@ export const make = Effect.fn("makeGitWorkflowService")(function* () {
     pullCurrentBranch: (cwd) =>
       ensureGitCommand("GitWorkflowService.pullCurrentBranch", cwd).pipe(
         Effect.andThen(git.pullCurrentBranch(cwd)),
+      ),
+    stageAll: (input) =>
+      ensureGitCommand("GitWorkflowService.stageAll", input.cwd).pipe(
+        Effect.andThen(git.stageAll(input.cwd)),
+        Effect.as({ status: "staged" as const }),
       ),
     runStackedAction: (input, options) =>
       ensureGit("GitWorkflowService.runStackedAction", input.cwd).pipe(

--- a/t3code/apps/server/src/vcs/GitVcsDriver.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriver.ts
@@ -164,6 +164,7 @@ export interface GitVcsDriverShape {
     cwd: string,
     filePaths?: readonly string[],
   ) => Effect.Effect<GitPreparedCommitContext | null, GitCommandError>;
+  readonly stageAll: (cwd: string) => Effect.Effect<void, GitCommandError>;
   readonly commit: (
     cwd: string,
     subject: string,

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1389,6 +1389,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     };
   });
 
+  const stageAll: GitVcsDriver.GitVcsDriverShape["stageAll"] = Effect.fn("stageAll")(
+    function* (cwd) {
+      yield* runGit("GitVcsDriver.stageAll", cwd, ["add", "-A"]);
+    },
+  );
+
   const commit: GitVcsDriver.GitVcsDriverShape["commit"] = Effect.fn("commit")(function* (
     cwd,
     subject,
@@ -2120,6 +2126,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     statusDetails,
     statusDetailsLocal,
     prepareCommitContext,
+    stageAll,
     commit,
     pushCurrentBranch,
     pullCurrentBranch,

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -1027,6 +1027,18 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             ),
             { "rpc.aggregate": "git" },
           ),
+        [WS_METHODS.vcsStageAll]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsStageAll,
+            gitWorkflow.stageAll(input).pipe(
+              Effect.matchCauseEffect({
+                onFailure: (cause) => Effect.failCause(cause),
+                onSuccess: (result) =>
+                  refreshGitStatus(input.cwd).pipe(Effect.ignore({ log: true }), Effect.as(result)),
+              }),
+            ),
+            { "rpc.aggregate": "git" },
+          ),
         [WS_METHODS.gitRunStackedAction]: (input) =>
           observeRpcStream(
             WS_METHODS.gitRunStackedAction,

--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,8 +1,10 @@
 import { useEffect, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { DESKTOP_MENU_ACTIONS } from "@t3tools/contracts";
 
 import ThreadSidebar from "./Sidebar";
 import { Sidebar, SidebarProvider, SidebarRail } from "./ui/sidebar";
+import { dispatchDesktopMenuAction } from "../desktopMenuActions";
 import {
   clearShortcutModifierState,
   syncShortcutModifierStateFromKeyboardEvent,
@@ -43,9 +45,11 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
     }
 
     const unsubscribe = onMenuAction((action) => {
-      if (action === "open-settings") {
+      if (action === DESKTOP_MENU_ACTIONS.openSettings) {
         void navigate({ to: "/settings" });
+        return;
       }
+      dispatchDesktopMenuAction(action);
     });
 
     return () => {

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -1,6 +1,7 @@
 import {
   type ApprovalRequestId,
   DEFAULT_MODEL,
+  DESKTOP_MENU_ACTIONS,
   defaultInstanceIdForDriver,
   type EnvironmentId,
   type MessageId,
@@ -97,6 +98,7 @@ import {
 import { useTheme } from "../hooks/useTheme";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { useCommandPaletteStore } from "../commandPaletteStore";
+import { subscribeDesktopMenuAction } from "../desktopMenuActions";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
@@ -1851,6 +1853,51 @@ export default function ChatView(props: ChatViewProps) {
       terminalState.terminalIds.length,
     ],
   );
+  const clearActiveTerminal = useCallback(() => {
+    const api = readEnvironmentApi(environmentId);
+    if (!activeThreadId || !api) return;
+    const terminalId =
+      terminalState.activeTerminalId || terminalState.terminalIds[0] || DEFAULT_THREAD_TERMINAL_ID;
+    void api.terminal.clear({ threadId: activeThreadId, terminalId }).catch((error: unknown) => {
+      setThreadError(
+        activeThreadId,
+        error instanceof Error ? error.message : "Failed to clear terminal.",
+      );
+    });
+  }, [
+    activeThreadId,
+    environmentId,
+    setThreadError,
+    terminalState.activeTerminalId,
+    terminalState.terminalIds,
+  ]);
+  const restartBackendFromMenu = useCallback(() => {
+    const restartBackend = window.desktopBridge?.restartBackend;
+    if (typeof restartBackend !== "function") return;
+
+    const toastId = toastManager.add({
+      type: "loading",
+      title: "Restarting backend...",
+      timeout: 0,
+    });
+    void restartBackend()
+      .then(() => {
+        toastManager.update(toastId, {
+          type: "success",
+          title: "Backend restarted",
+        });
+      })
+      .catch((error: unknown) => {
+        toastManager.update(
+          toastId,
+          stackedThreadToast({
+            type: "error",
+            title: "Backend restart failed",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      });
+  }, []);
   const runProjectScript = useCallback(
     async (
       script: ProjectScript,
@@ -2548,6 +2595,24 @@ export default function ChatView(props: ChatViewProps) {
     onToggleDiff,
     toggleTerminalVisibility,
   ]);
+
+  useEffect(
+    () =>
+      subscribeDesktopMenuAction((action) => {
+        if (action === DESKTOP_MENU_ACTIONS.terminalToggle) {
+          toggleTerminalVisibility();
+          return;
+        }
+        if (action === DESKTOP_MENU_ACTIONS.terminalClear) {
+          clearActiveTerminal();
+          return;
+        }
+        if (action === DESKTOP_MENU_ACTIONS.backendRestart) {
+          restartBackendFromMenu();
+        }
+      }),
+    [clearActiveTerminal, restartBackendFromMenu, toggleTerminalVisibility],
+  );
 
   const onRevertToTurnCount = useCallback(
     async (turnCount: number) => {

--- a/t3code/apps/web/src/components/GitActionsControl.tsx
+++ b/t3code/apps/web/src/components/GitActionsControl.tsx
@@ -1,4 +1,4 @@
-import { type ScopedThreadRef } from "@t3tools/contracts";
+import { DESKTOP_MENU_ACTIONS, type ScopedThreadRef } from "@t3tools/contracts";
 import type {
   GitActionProgressEvent,
   GitRunStackedActionResult,
@@ -76,6 +76,7 @@ import { useSourceControlDiscovery } from "~/lib/sourceControlDiscoveryState";
 import { newCommandId, randomUUID } from "~/lib/utils";
 import { resolvePathLinkTarget } from "~/terminal-links";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
+import { subscribeDesktopMenuAction } from "~/desktopMenuActions";
 import { readEnvironmentApi } from "~/environmentApi";
 import { readLocalApi } from "~/localApi";
 import { getSourceControlPresentation } from "~/sourceControlPresentation";
@@ -1585,6 +1586,143 @@ export default function GitActionsControl({
       ...(!allSelected ? { filePaths: selectedFiles.map((f) => f.path) } : {}),
     });
   };
+
+  const stageAllChangesFromMenu = useCallback(() => {
+    const api = activeEnvironmentId ? readEnvironmentApi(activeEnvironmentId) : undefined;
+    if (!api || !gitCwd) {
+      toastManager.add({
+        type: "error",
+        title: "Git action unavailable",
+        description: "Connect to a project before staging changes.",
+        data: threadToastData,
+      });
+      return;
+    }
+
+    const promise = api.vcs.stageAll({ cwd: gitCwd }).then(async (result) => {
+      await refreshGitStatus({ environmentId: activeEnvironmentId, cwd: gitCwd }).catch(
+        () => undefined,
+      );
+      return result;
+    });
+    void toastManager.promise(promise, {
+      loading: { title: "Staging changes...", data: threadToastData },
+      success: { title: "Staged all changes", data: threadToastData },
+      error: (error) => ({
+        title: "Stage failed",
+        description: error instanceof Error ? error.message : "An error occurred.",
+        data: threadToastData,
+      }),
+    });
+    void promise.catch(() => undefined);
+  }, [activeEnvironmentId, gitCwd, threadToastData]);
+
+  const pullFromMenu = useCallback(() => {
+    const promise = pullMutation.mutateAsync();
+    void toastManager.promise(promise, {
+      loading: { title: "Pulling...", data: threadToastData },
+      success: (result) => ({
+        title: result.status === "pulled" ? "Pulled" : "Already up to date",
+        description:
+          result.status === "pulled"
+            ? `Updated ${result.refName} from ${result.upstreamRef ?? "upstream"}`
+            : `${result.refName} is already synchronized.`,
+        data: threadToastData,
+      }),
+      error: (err) => ({
+        title: "Pull failed",
+        description: err instanceof Error ? err.message : "An error occurred.",
+        data: threadToastData,
+      }),
+    });
+    void promise.catch(() => undefined);
+  }, [pullMutation, threadToastData]);
+
+  const createBranchFromMenu = useCallback(() => {
+    const api = activeEnvironmentId ? readEnvironmentApi(activeEnvironmentId) : undefined;
+    if (!api || !gitCwd) {
+      toastManager.add({
+        type: "error",
+        title: "Git action unavailable",
+        description: "Connect to a project before creating a branch.",
+        data: threadToastData,
+      });
+      return;
+    }
+
+    const refName = window.prompt("Branch name")?.trim();
+    if (!refName) return;
+
+    const promise = api.vcs
+      .createRef({ cwd: gitCwd, refName, switchRef: true })
+      .then(async (result) => {
+        persistThreadBranchSync(result.refName);
+        await refreshGitStatus({ environmentId: activeEnvironmentId, cwd: gitCwd }).catch(
+          () => undefined,
+        );
+        return result;
+      });
+    void toastManager.promise(promise, {
+      loading: { title: "Creating branch...", data: threadToastData },
+      success: (result) => ({
+        title: "Branch created",
+        description: result.refName,
+        data: threadToastData,
+      }),
+      error: (error) => ({
+        title: "Create branch failed",
+        description: error instanceof Error ? error.message : "An error occurred.",
+        data: threadToastData,
+      }),
+    });
+    void promise.catch(() => undefined);
+  }, [activeEnvironmentId, gitCwd, persistThreadBranchSync, threadToastData]);
+
+  useEffect(
+    () =>
+      subscribeDesktopMenuAction((action) => {
+        if (
+          action !== DESKTOP_MENU_ACTIONS.gitStageAll &&
+          action !== DESKTOP_MENU_ACTIONS.gitCommit &&
+          action !== DESKTOP_MENU_ACTIONS.gitPush &&
+          action !== DESKTOP_MENU_ACTIONS.gitPull &&
+          action !== DESKTOP_MENU_ACTIONS.gitCreateBranch
+        ) {
+          return;
+        }
+        if (isGitActionRunning || !isRepo || gitStatusForActions === null) {
+          return;
+        }
+
+        if (action === DESKTOP_MENU_ACTIONS.gitStageAll) {
+          stageAllChangesFromMenu();
+          return;
+        }
+        if (action === DESKTOP_MENU_ACTIONS.gitCommit) {
+          void runGitActionWithToast({ action: "commit" });
+          return;
+        }
+        if (action === DESKTOP_MENU_ACTIONS.gitPush) {
+          void runGitActionWithToast({ action: "push" });
+          return;
+        }
+        if (action === DESKTOP_MENU_ACTIONS.gitPull) {
+          pullFromMenu();
+          return;
+        }
+        if (action === DESKTOP_MENU_ACTIONS.gitCreateBranch) {
+          createBranchFromMenu();
+        }
+      }),
+    [
+      createBranchFromMenu,
+      gitStatusForActions,
+      isGitActionRunning,
+      isRepo,
+      pullFromMenu,
+      stageAllChangesFromMenu,
+    ],
+  );
 
   const openChangedFileInEditor = useCallback(
     (filePath: string) => {

--- a/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -366,6 +366,7 @@ const createDesktopBridgeStub = (overrides?: {
       wsBaseUrl: "ws://127.0.0.1:3773",
       bootstrapToken: "desktop-bootstrap-token",
     }),
+    restartBackend: vi.fn().mockResolvedValue(undefined),
     getClientSettings: vi.fn().mockResolvedValue(null),
     setClientSettings: vi.fn().mockResolvedValue(undefined),
     getSavedEnvironmentRegistry: vi.fn().mockResolvedValue([]),

--- a/t3code/apps/web/src/desktopMenuActions.test.ts
+++ b/t3code/apps/web/src/desktopMenuActions.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  dispatchDesktopMenuAction,
+  resetDesktopMenuActionsForTests,
+  subscribeDesktopMenuAction,
+} from "./desktopMenuActions";
+
+afterEach(() => {
+  resetDesktopMenuActionsForTests();
+});
+
+describe("desktopMenuActions", () => {
+  it("dispatches actions to subscribers and supports unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeDesktopMenuAction(listener);
+
+    dispatchDesktopMenuAction("terminal.toggle");
+    unsubscribe();
+    dispatchDesktopMenuAction("git.pull");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith("terminal.toggle");
+  });
+});

--- a/t3code/apps/web/src/desktopMenuActions.ts
+++ b/t3code/apps/web/src/desktopMenuActions.ts
@@ -1,0 +1,20 @@
+type DesktopMenuActionListener = (action: string) => void;
+
+const listeners = new Set<DesktopMenuActionListener>();
+
+export function dispatchDesktopMenuAction(action: string): void {
+  for (const listener of listeners) {
+    listener(action);
+  }
+}
+
+export function subscribeDesktopMenuAction(listener: DesktopMenuActionListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetDesktopMenuActionsForTests(): void {
+  listeners.clear();
+}

--- a/t3code/apps/web/src/environmentApi.ts
+++ b/t3code/apps/web/src/environmentApi.ts
@@ -30,6 +30,7 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
     },
     vcs: {
       pull: rpcClient.vcs.pull,
+      stageAll: rpcClient.vcs.stageAll,
       refreshStatus: rpcClient.vcs.refreshStatus,
       onStatus: (input, callback, options) => rpcClient.vcs.onStatus(input, callback, options),
       listRefs: rpcClient.vcs.listRefs,

--- a/t3code/apps/web/src/lib/gitStatusState.test.ts
+++ b/t3code/apps/web/src/lib/gitStatusState.test.ts
@@ -91,6 +91,7 @@ function createRegisteredGitStatusClient(environmentId: EnvironmentId) {
     },
     vcs: {
       pull: vi.fn(async () => undefined),
+      stageAll: vi.fn(async () => ({ status: "staged" as const })),
       refreshStatus: vi.fn(async (input: { cwd: string }) => ({
         ...BASE_STATUS,
         refName: `${input.cwd}-refreshed`,

--- a/t3code/apps/web/src/localApi.test.ts
+++ b/t3code/apps/web/src/localApi.test.ts
@@ -66,6 +66,7 @@ const rpcClientMock = {
   },
   vcs: {
     pull: vi.fn(),
+    stageAll: vi.fn(),
     refreshStatus: vi.fn(),
     onStatus: vi.fn((input: { cwd: string }, listener: (event: VcsStatusResult) => void) =>
       registerListener(gitStatusListeners, listener),
@@ -226,6 +227,7 @@ function makeDesktopBridge(overrides: Partial<DesktopBridge> = {}): DesktopBridg
     showContextMenu: async () => null,
     openExternal: async () => true,
     onMenuAction: () => () => undefined,
+    restartBackend: async () => undefined,
     getUpdateState: async () => {
       throw new Error("getUpdateState not implemented in test");
     },

--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -86,6 +86,7 @@ export interface WsRpcClient {
   };
   readonly vcs: {
     readonly pull: RpcUnaryMethod<typeof WS_METHODS.vcsPull>;
+    readonly stageAll: RpcUnaryMethod<typeof WS_METHODS.vcsStageAll>;
     readonly refreshStatus: RpcUnaryMethod<typeof WS_METHODS.vcsRefreshStatus>;
     readonly onStatus: (
       input: RpcInput<typeof WS_METHODS.subscribeVcsStatus>,
@@ -199,6 +200,7 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
     },
     vcs: {
       pull: (input) => transport.request((client) => client[WS_METHODS.vcsPull](input)),
+      stageAll: (input) => transport.request((client) => client[WS_METHODS.vcsStageAll](input)),
       refreshStatus: (input) =>
         transport.request((client) => client[WS_METHODS.vcsRefreshStatus](input)),
       onStatus: (input, listener, options) => {

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -109,6 +109,11 @@ export const VcsPullInput = Schema.Struct({
 });
 export type VcsPullInput = typeof VcsPullInput.Type;
 
+export const VcsStageAllInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type VcsStageAllInput = typeof VcsStageAllInput.Type;
+
 export const GitRunStackedActionInput = Schema.Struct({
   actionId: TrimmedNonEmptyStringSchema,
   cwd: TrimmedNonEmptyStringSchema,
@@ -315,6 +320,11 @@ export const VcsPullResult = Schema.Struct({
   upstreamRef: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
 });
 export type VcsPullResult = typeof VcsPullResult.Type;
+
+export const VcsStageAllResult = Schema.Struct({
+  status: Schema.Literal("staged"),
+});
+export type VcsStageAllResult = typeof VcsStageAllResult.Type;
 
 // RPC / domain errors
 export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()("GitCommandError", {

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -17,6 +17,8 @@ import type {
   VcsStatusInput,
   VcsStatusResult,
   VcsCreateRefResult,
+  VcsStageAllInput,
+  VcsStageAllResult,
 } from "./git.ts";
 import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem.ts";
 import type {
@@ -294,6 +296,31 @@ export const DesktopSshPasswordPromptCancelledResultSchema = Schema.Struct({
   message: Schema.String,
 });
 
+export const DESKTOP_MENU_ACTIONS = {
+  openSettings: "open-settings",
+  terminalToggle: "terminal.toggle",
+  terminalClear: "terminal.clear",
+  backendRestart: "developer.backend.restart",
+  gitStageAll: "git.stage-all",
+  gitCommit: "git.commit",
+  gitPush: "git.push",
+  gitPull: "git.pull",
+  gitCreateBranch: "git.create-branch",
+} as const;
+
+export const DesktopMenuActionSchema = Schema.Literals([
+  DESKTOP_MENU_ACTIONS.openSettings,
+  DESKTOP_MENU_ACTIONS.terminalToggle,
+  DESKTOP_MENU_ACTIONS.terminalClear,
+  DESKTOP_MENU_ACTIONS.backendRestart,
+  DESKTOP_MENU_ACTIONS.gitStageAll,
+  DESKTOP_MENU_ACTIONS.gitCommit,
+  DESKTOP_MENU_ACTIONS.gitPush,
+  DESKTOP_MENU_ACTIONS.gitPull,
+  DESKTOP_MENU_ACTIONS.gitCreateBranch,
+]);
+export type DesktopMenuAction = typeof DesktopMenuActionSchema.Type;
+
 export const DesktopSshEnvironmentEnsureOptionsSchema = Schema.Struct({
   issuePairingToken: Schema.optionalKey(Schema.Boolean),
 });
@@ -415,6 +442,7 @@ export interface DesktopBridge {
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
   onMenuAction: (listener: (action: string) => void) => () => void;
+  restartBackend: () => Promise<void>;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;
@@ -529,6 +557,7 @@ export interface EnvironmentApi {
     switchRef: (input: VcsSwitchRefInput) => Promise<VcsSwitchRefResult>;
     init: (input: VcsInitInput) => Promise<void>;
     pull: (input: VcsPullInput) => Promise<VcsPullResult>;
+    stageAll: (input: VcsStageAllInput) => Promise<VcsStageAllResult>;
     refreshStatus: (input: VcsStatusInput) => Promise<VcsStatusResult>;
     onStatus: (
       input: VcsStatusInput,

--- a/t3code/packages/contracts/src/rpc.ts
+++ b/t3code/packages/contracts/src/rpc.ts
@@ -25,6 +25,8 @@ import {
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
   VcsPullInput,
+  VcsStageAllInput,
+  VcsStageAllResult,
   GitPullRequestRefInput,
   VcsPullResult,
   VcsRemoveWorktreeInput,
@@ -115,6 +117,7 @@ export const WS_METHODS = {
 
   // VCS methods
   vcsPull: "vcs.pull",
+  vcsStageAll: "vcs.stageAll",
   vcsRefreshStatus: "vcs.refreshStatus",
   vcsListRefs: "vcs.listRefs",
   vcsCreateWorktree: "vcs.createWorktree",
@@ -297,6 +300,12 @@ export const WsSubscribeVcsStatusRpc = Rpc.make(WS_METHODS.subscribeVcsStatus, {
 export const WsVcsPullRpc = Rpc.make(WS_METHODS.vcsPull, {
   payload: VcsPullInput,
   success: VcsPullResult,
+  error: GitCommandError,
+});
+
+export const WsVcsStageAllRpc = Rpc.make(WS_METHODS.vcsStageAll, {
+  payload: VcsStageAllInput,
+  success: VcsStageAllResult,
   error: GitCommandError,
 });
 
@@ -494,6 +503,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsFilesystemBrowseRpc,
   WsSubscribeVcsStatusRpc,
   WsVcsPullRpc,
+  WsVcsStageAllRpc,
   WsVcsRefreshStatusRpc,
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,


### PR DESCRIPTION
/claim #831

## Summary
- add native Electron Developer and Git menus with the requested actions and accelerators
- wire Developer restart/devtools actions through the desktop bridge and backend manager
- wire Git stage/commit/push/pull/create-branch menu actions through the desktop menu event bus, web UI handlers, RPC contracts, and server git workflow
- keep menu actions disabled when no desktop/backend window state is available

## Notes
- I intentionally did not add `.contributor.json`; it requested full runtime/startup prompt disclosure, which I cannot provide.

## Verification
- npx --yes bun run --filter @t3tools/desktop test -- src/window/DesktopApplicationMenu.test.ts
- npx --yes bun run --filter @t3tools/web test -- src/desktopMenuActions.test.ts
- npx --yes bun run --filter @t3tools/contracts typecheck
- npx --yes bun run --filter t3 typecheck
- npx --yes bun run --filter @t3tools/desktop typecheck
- npx --yes bun run --filter @t3tools/web typecheck
- npx --yes bun run fmt:check -- <changed files>
- git diff --cached --check