### PR TITLE
Codex [ T3 Code ] Complete visual keybinding editor

### DIFF
--- a/t3code/apps/web/src/components/settings/KeybindingsEditor.tsx
+++ b/t3code/apps/web/src/components/settings/KeybindingsEditor.tsx
@@ -1,0 +1,5 @@
+import { KeybindingsSettingsPanel } from "./KeybindingsSettings";
+
+export function KeybindingsEditor() {
+  return <KeybindingsSettingsPanel />;
+}

--- a/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -8,6 +8,7 @@ import {
   commandLabel,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  nextKeybindingSort,
   parseWhenExpressionDraft,
   shortcutToKeybindingInput,
   unknownWhenVariables,
@@ -44,9 +45,72 @@ describe("KeybindingsSettings.logic", () => {
         when: "!terminalFocus",
         defaultKey: "mod+j",
         defaultWhen: "",
-        source: "Custom",
+        source: "User",
       }),
     ]);
+  });
+
+  it("sorts rows by visible keybinding table columns", () => {
+    const keybindings = [
+      {
+        command: "terminal.toggle",
+        shortcut: {
+          key: "j",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+      },
+      {
+        command: "script.setup-db.run",
+        shortcut: {
+          key: "r",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+      },
+      {
+        command: "chat.newLocal",
+        shortcut: {
+          key: "n",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+      },
+    ] satisfies ResolvedKeybindingsConfig;
+
+    expect(
+      buildKeybindingRows(keybindings, "", { key: "key", direction: "desc" }).map((row) => row.key),
+    ).toEqual(["mod+r", "mod+n", "mod+j"]);
+    expect(
+      buildKeybindingRows(keybindings, "", { key: "source", direction: "asc" }).map(
+        (row) => row.source,
+      ),
+    ).toEqual(["Default", "Project", "User"]);
+    expect(
+      buildKeybindingRows(keybindings, "", { key: "command", direction: "asc" }).map(
+        (row) => row.command,
+      ),
+    ).toEqual(["chat.newLocal", "script.setup-db.run", "terminal.toggle"]);
+  });
+
+  it("toggles keybinding sort direction for repeated column selections", () => {
+    expect(nextKeybindingSort({ key: "command", direction: "asc" }, "key")).toEqual({
+      key: "key",
+      direction: "asc",
+    });
+    expect(nextKeybindingSort({ key: "key", direction: "asc" }, "key")).toEqual({
+      key: "key",
+      direction: "desc",
+    });
   });
 
   it("captures platform-specific mod shortcuts", () => {

--- a/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -12,7 +12,14 @@ import {
 
 import { isMacPlatform } from "../../lib/utils";
 
-export type KeybindingSource = "Default" | "Custom" | "Project";
+export type KeybindingSource = "Default" | "User" | "Project";
+export type KeybindingSortKey = "command" | "key" | "source" | "when";
+export type KeybindingSortDirection = "asc" | "desc";
+
+export interface KeybindingSort {
+  readonly key: KeybindingSortKey;
+  readonly direction: KeybindingSortDirection;
+}
 
 export interface KeybindingRow {
   readonly id: string;
@@ -28,6 +35,11 @@ export interface KeybindingRow {
 
 export type WhenVariableOption = string;
 export type KeybindingCommandOption = KeybindingCommand;
+
+export const DEFAULT_KEYBINDING_SORT: KeybindingSort = {
+  key: "command",
+  direction: "asc",
+};
 
 const CORE_WHEN_VARIABLES = ["terminalFocus", "terminalOpen", "true", "false"] as const;
 
@@ -103,7 +115,7 @@ function sourceForBinding(binding: ResolvedKeybindingRule): KeybindingSource {
       whenAstToExpression(entry.whenAst) === bindingWhen,
   );
 
-  return isDefault ? "Default" : "Custom";
+  return isDefault ? "Default" : "User";
 }
 
 function defaultBindingForBinding(
@@ -154,6 +166,7 @@ export function keybindingConflictLabels(
 export function buildKeybindingRows(
   keybindings: ResolvedKeybindingsConfig,
   query: string,
+  sort: KeybindingSort = DEFAULT_KEYBINDING_SORT,
 ): ReadonlyArray<KeybindingRow> {
   const normalizedQuery = query.trim().toLowerCase();
   const rows = keybindings.map((binding, index) => {
@@ -184,11 +197,7 @@ export function buildKeybindingRows(
       : row;
   });
 
-  rowsWithConflicts.sort((left, right) => {
-    const commandCompare = left.command.localeCompare(right.command);
-    if (commandCompare !== 0) return commandCompare;
-    return left.key.localeCompare(right.key);
-  });
+  rowsWithConflicts.sort((left, right) => compareKeybindingRows(left, right, sort));
 
   if (normalizedQuery.length === 0) {
     return rowsWithConflicts;
@@ -202,6 +211,51 @@ export function buildKeybindingRows(
       row.source.toLowerCase().includes(normalizedQuery)
     );
   });
+}
+
+function keybindingSortValue(row: KeybindingRow, key: KeybindingSortKey): string {
+  switch (key) {
+    case "command":
+      return commandLabel(row.command);
+    case "key":
+      return row.key;
+    case "source":
+      return row.source;
+    case "when":
+      return row.when || "Always";
+  }
+}
+
+export function compareKeybindingRows(
+  left: KeybindingRow,
+  right: KeybindingRow,
+  sort: KeybindingSort,
+): number {
+  const direction = sort.direction === "asc" ? 1 : -1;
+  const primary =
+    keybindingSortValue(left, sort.key).localeCompare(keybindingSortValue(right, sort.key)) *
+    direction;
+  if (primary !== 0) return primary;
+
+  const commandCompare = commandLabel(left.command).localeCompare(commandLabel(right.command));
+  if (commandCompare !== 0) return commandCompare;
+  const keyCompare = left.key.localeCompare(right.key);
+  if (keyCompare !== 0) return keyCompare;
+  return left.when.localeCompare(right.when);
+}
+
+export function nextKeybindingSort(
+  current: KeybindingSort,
+  key: KeybindingSortKey,
+): KeybindingSort {
+  if (current.key !== key) {
+    return { key, direction: "asc" };
+  }
+
+  return {
+    key,
+    direction: current.direction === "asc" ? "desc" : "asc",
+  };
 }
 
 function collectWhenIdentifiersFromNode(

--- a/t3code/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/t3code/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -55,8 +55,12 @@ import {
   parseWhenExpressionDraft,
   type KeybindingCommandOption,
   type KeybindingRow,
+  type KeybindingSort,
+  type KeybindingSortKey,
   type WhenVariableOption,
+  DEFAULT_KEYBINDING_SORT,
   unknownWhenVariables,
+  nextKeybindingSort,
   whenAstToExpression,
 } from "./KeybindingsSettings.logic";
 import { SettingsPageContainer, SettingsSection } from "./settingsLayout";
@@ -748,6 +752,40 @@ function rowKeybindingTarget(row: KeybindingRow): ServerRemoveKeybindingInput {
   };
 }
 
+function KeybindingSortableColumnHeader({
+  label,
+  sortKey,
+  sort,
+  onSortChange,
+}: {
+  label: string;
+  sortKey: KeybindingSortKey;
+  sort: KeybindingSort;
+  onSortChange: (key: KeybindingSortKey) => void;
+}) {
+  const isActive = sort.key === sortKey;
+  const ariaSort = isActive ? (sort.direction === "asc" ? "ascending" : "descending") : "none";
+
+  return (
+    <div role="columnheader" aria-sort={ariaSort}>
+      <button
+        type="button"
+        className="inline-flex max-w-full items-center gap-1 rounded-sm text-left outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/24"
+        onClick={() => onSortChange(sortKey)}
+      >
+        <span className="truncate">{label}</span>
+        <ChevronDownIcon
+          className={cn(
+            "size-3 shrink-0 transition-transform",
+            isActive ? "opacity-100" : "opacity-35",
+            isActive && sort.direction === "asc" && "rotate-180",
+          )}
+        />
+      </button>
+    </div>
+  );
+}
+
 function KeybindingTableRow({
   row,
   allRows,
@@ -770,7 +808,7 @@ function KeybindingTableRow({
   const whenDraftExpression = whenAstToExpression(whenDraft);
   const isDirty = keyDraft !== row.key || whenDraftExpression !== row.when;
   const displayShortcut = formatShortcutLabel(row.binding.shortcut);
-  const canReset = row.source === "Custom" && row.defaultKey !== null;
+  const canReset = row.source === "User" && row.defaultKey !== null;
   const canRemove = row.source !== "Default";
   const hasRowActions = canReset || canRemove;
   const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
@@ -802,7 +840,7 @@ function KeybindingTableRow({
   };
 
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(210px,0.8fr)_96px_minmax(190px,0.9fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
         <div className="flex min-w-0 items-center gap-1.5">
           <div className="truncate text-[13px] font-medium text-foreground" title={row.command}>
@@ -849,6 +887,14 @@ function KeybindingTableRow({
             {isSaving ? "Saving" : "Save"}
           </Button>
         ) : null}
+      </div>
+      <div className="pr-4">
+        <span
+          data-keybinding-source
+          className="inline-flex h-6 items-center rounded-md border border-border/70 bg-background px-2 text-[11px] font-medium text-muted-foreground"
+        >
+          {row.source}
+        </span>
       </div>
       <div className="pr-4">
         <Popover>
@@ -963,7 +1009,7 @@ function NewKeybindingTableRow({
   };
 
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(210px,0.8fr)_96px_minmax(190px,0.9fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
         <Select
           value={commandDraft}
@@ -1010,6 +1056,14 @@ function NewKeybindingTableRow({
         >
           {isSaving ? "Saving" : "Save"}
         </Button>
+      </div>
+      <div className="pr-4">
+        <span
+          data-keybinding-source
+          className="inline-flex h-6 items-center rounded-md border border-border/70 bg-background px-2 text-[11px] font-medium text-muted-foreground"
+        >
+          User
+        </span>
       </div>
       <div className="pr-4">
         <Popover>
@@ -1066,9 +1120,16 @@ export function KeybindingsSettingsPanel() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [savingCommand, setSavingCommand] = useState<KeybindingCommand | null>(null);
   const [isAddingBinding, setIsAddingBinding] = useState(false);
-  const rows = useMemo(() => buildKeybindingRows(keybindings, query), [keybindings, query]);
+  const [sort, setSort] = useState<KeybindingSort>(DEFAULT_KEYBINDING_SORT);
+  const rows = useMemo(
+    () => buildKeybindingRows(keybindings, query, sort),
+    [keybindings, query, sort],
+  );
   const commandOptions = useMemo(() => buildKeybindingCommandOptions(keybindings), [keybindings]);
   const whenVariables = useMemo(() => buildWhenVariableOptions(), []);
+  const updateSort = useCallback((key: KeybindingSortKey) => {
+    setSort((current) => nextKeybindingSort(current, key));
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -1240,13 +1301,37 @@ export function KeybindingsSettingsPanel() {
           hideScrollbars
           className="w-full max-w-full rounded-none"
         >
-          <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
-            <div>Command</div>
-            <div>Keybinding</div>
-            <div>When</div>
-            <div>Status</div>
+          <div
+            role="row"
+            className="grid min-w-[820px] grid-cols-[minmax(190px,1.1fr)_minmax(210px,0.8fr)_96px_minmax(190px,0.9fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground"
+          >
+            <KeybindingSortableColumnHeader
+              label="Command"
+              sortKey="command"
+              sort={sort}
+              onSortChange={updateSort}
+            />
+            <KeybindingSortableColumnHeader
+              label="Shortcut"
+              sortKey="key"
+              sort={sort}
+              onSortChange={updateSort}
+            />
+            <KeybindingSortableColumnHeader
+              label="Source"
+              sortKey="source"
+              sort={sort}
+              onSortChange={updateSort}
+            />
+            <KeybindingSortableColumnHeader
+              label="When"
+              sortKey="when"
+              sort={sort}
+              onSortChange={updateSort}
+            />
+            <div role="columnheader">Actions</div>
           </div>
-          <div className="min-w-[680px] divide-y divide-border/60">
+          <div className="min-w-[820px] divide-y divide-border/60">
             {isAddingBinding ? (
               <NewKeybindingTableRow
                 commandOptions={commandOptions}

--- a/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -38,6 +38,7 @@ import { useUiStateStore } from "../../uiStateStore";
 import { ConnectionsSettings } from "./ConnectionsSettings";
 import { DiagnosticsSettingsPanel } from "./DiagnosticsSettings";
 import { GeneralSettingsPanel, ProviderSettingsPanel } from "./SettingsPanels";
+import { KeybindingsSettingsPanel } from "./KeybindingsSettings";
 import { SourceControlSettingsPanel } from "./SourceControlSettings";
 
 function renderWithTestRouter(children: ReactNode) {
@@ -1175,6 +1176,84 @@ describe("GeneralSettingsPanel observability", () => {
       provider: ProviderDriverKind.make("codex"),
       instanceId: ProviderInstanceId.make("codex"),
     });
+  });
+
+  it("sorts keybindings by the source column", async () => {
+    setServerConfigSnapshot({
+      ...createBaseServerConfig(),
+      keybindings: [
+        {
+          command: "terminal.toggle",
+          shortcut: {
+            key: "j",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: false,
+          },
+          whenAst: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+        },
+        {
+          command: "script.setup-db.run",
+          shortcut: {
+            key: "r",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: false,
+          },
+        },
+        {
+          command: "chat.newLocal",
+          shortcut: {
+            key: "n",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: true,
+          },
+          whenAst: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+        },
+      ],
+    });
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <KeybindingsSettingsPanel />
+      </AppAtomRegistryProvider>,
+    );
+
+    const sourceHeader = page.getByRole("button", { name: "Source" });
+    await sourceHeader.click();
+
+    await expect
+      .element(page.getByRole("columnheader", { name: "Source" }))
+      .toHaveAttribute("aria-sort", "ascending");
+    expect(
+      Array.from(document.querySelectorAll<HTMLElement>("[data-keybinding-source]")).map(
+        (element) => element.textContent,
+      ),
+    ).toEqual(["Default", "Project", "User"]);
+
+    await sourceHeader.click();
+
+    await expect
+      .element(page.getByRole("columnheader", { name: "Source" }))
+      .toHaveAttribute("aria-sort", "descending");
+    expect(
+      Array.from(document.querySelectorAll<HTMLElement>("[data-keybinding-source]")).map(
+        (element) => element.textContent,
+      ),
+    ).toEqual(["User", "Project", "Default"]);
   });
 
   it("keeps long provider update commands inside the fixed-width popover", async () => {

--- a/t3code/apps/web/src/routes/settings.keybindings.tsx
+++ b/t3code/apps/web/src/routes/settings.keybindings.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { KeybindingsSettingsPanel } from "../components/settings/KeybindingsSettings";
+import { KeybindingsEditor } from "../components/settings/KeybindingsEditor";
 
 export const Route = createFileRoute("/settings/keybindings")({
-  component: KeybindingsSettingsPanel,
+  component: KeybindingsEditor,
 });


### PR DESCRIPTION
/claim #843

Summary:
- Added a KeybindingsEditor route component that uses the existing settings panel implementation.
- Added sortable keyboard-accessible table headers for Command, Shortcut, Source, and When with aria-sort state.
- Split Source into an explicit Default/User/Project column, kept reset/remove behavior aligned with user-defined overrides, and preserved recording/conflict/save flows.
- Added focused logic and Chromium browser coverage for visible-column sorting.

Verification:
- npx --yes bun run --filter @t3tools/web test -- src/components/settings/KeybindingsSettings.logic.test.ts
- npx --yes bun run --filter @t3tools/web test:browser -- src/components/settings/SettingsPanels.browser.tsx
- npx --yes bun run --filter @t3tools/web typecheck
- npx --yes bun run fmt:check -- apps/web/src/components/settings/KeybindingsSettings.tsx apps/web/src/components/settings/KeybindingsSettings.logic.ts apps/web/src/components/settings/KeybindingsSettings.logic.test.ts apps/web/src/components/settings/KeybindingsEditor.tsx apps/web/src/components/settings/SettingsPanels.browser.tsx apps/web/src/routes/settings.keybindings.tsx
- git diff --check
- HTTP smoke: http://127.0.0.1:5743/settings/keybindings returned 200

Notes:
- I did not add contributor_meta.json because it asks for hidden session/runtime initialization text rather than product code.
- Touched-file lint is still blocked locally by the repository oxlint TypeScript plugin loader failing with ERR_UNKNOWN_FILE_EXTENSION for oxlint-plugin-t3code/index.ts.
- The in-app browser smoke was blocked by the shared Playwright profile lock, so I relied on the Vitest Chromium browser test and HTTP smoke.