### PR TITLE
[OpenAI Codex] [ T3 Code ] Add inline commenting to DiffPanelShell

### DIFF
--- a/t3code/apps/web/src/components/DiffPanel.tsx
+++ b/t3code/apps/web/src/components/DiffPanel.tsx
@@ -46,10 +46,13 @@ import ChatMarkdown from "./ChatMarkdown";
 import {
   buildDiffCommentAnnotations,
   buildDiffCommentKey,
+  buildDiffCommentResetKey,
   countPendingDiffComments,
+  readDiffCommentSession,
   type DiffCommentAnnotationMetadata,
   type DiffCommentSide,
   type DiffInlineComment,
+  writeDiffCommentSession,
 } from "./DiffPanelComments.logic";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
@@ -217,7 +220,8 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const patchViewportRef = useRef<HTMLDivElement>(null);
   const turnStripRef = useRef<HTMLDivElement>(null);
   const previousDiffOpenRef = useRef(false);
-  const previousDiffCommentResetKeyRef = useRef<string | null>(null);
+  const currentDiffCommentResetKeyRef = useRef<string | null>(null);
+  const skipNextDiffCommentPersistRef = useRef(false);
   const [canScrollTurnStripLeft, setCanScrollTurnStripLeft] = useState(false);
   const [canScrollTurnStripRight, setCanScrollTurnStripRight] = useState(false);
   const routeThreadRef = useParams({
@@ -359,7 +363,11 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   }, [renderablePatch]);
   const diffCommentResetKey = useMemo(
     () =>
-      `${activeThreadId ?? "no-thread"}:${selectedTurn?.turnId ?? "conversation"}:${selectedPatch ?? ""}`,
+      buildDiffCommentResetKey({
+        threadId: activeThreadId ? String(activeThreadId) : null,
+        turnId: selectedTurn?.turnId ? String(selectedTurn.turnId) : null,
+        patch: selectedPatch,
+      }),
     [activeThreadId, selectedPatch, selectedTurn?.turnId],
   );
   const pendingDiffCommentCount = countPendingDiffComments(diffCommentsByKey);
@@ -378,18 +386,27 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   }, [renderableFiles]);
 
   useEffect(() => {
-    if (previousDiffCommentResetKeyRef.current === null) {
-      previousDiffCommentResetKeyRef.current = diffCommentResetKey;
-      return;
-    }
-    if (previousDiffCommentResetKeyRef.current === diffCommentResetKey) {
+    if (currentDiffCommentResetKeyRef.current === diffCommentResetKey) {
       return;
     }
 
-    previousDiffCommentResetKeyRef.current = diffCommentResetKey;
-    setDiffCommentsByKey({});
+    currentDiffCommentResetKeyRef.current = diffCommentResetKey;
+    skipNextDiffCommentPersistRef.current = true;
+    setDiffCommentsByKey(readDiffCommentSession(diffCommentResetKey));
     setActiveDiffCommentEditor(null);
   }, [diffCommentResetKey]);
+
+  useEffect(() => {
+    if (currentDiffCommentResetKeyRef.current !== diffCommentResetKey) {
+      return;
+    }
+    if (skipNextDiffCommentPersistRef.current) {
+      skipNextDiffCommentPersistRef.current = false;
+      return;
+    }
+
+    writeDiffCommentSession(diffCommentResetKey, diffCommentsByKey);
+  }, [diffCommentResetKey, diffCommentsByKey]);
 
   useEffect(() => {
     if (diffOpen && !previousDiffOpenRef.current) {
@@ -940,6 +957,9 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                           lineDiffType: "none",
                           lineHoverHighlight: "number",
                           onLineNumberClick: ({ annotationSide, lineNumber }) => {
+                            if (lineNumber <= 0) {
+                              return;
+                            }
                             openDiffCommentEditor({
                               filePath,
                               lineNumber,

--- a/t3code/apps/web/src/components/DiffPanel.tsx
+++ b/t3code/apps/web/src/components/DiffPanel.tsx
@@ -1,4 +1,4 @@
-import { parsePatchFiles } from "@pierre/diffs";
+import { parsePatchFiles, type DiffLineAnnotation } from "@pierre/diffs";
 import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
@@ -8,10 +8,14 @@ import {
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  CheckIcon,
   Columns2Icon,
+  MessageSquarePlusIcon,
+  MessagesSquareIcon,
   PilcrowIcon,
   Rows3Icon,
   TextWrapIcon,
+  XIcon,
 } from "lucide-react";
 import {
   type WheelEvent as ReactWheelEvent,
@@ -38,6 +42,15 @@ import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { useSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
+import ChatMarkdown from "./ChatMarkdown";
+import {
+  buildDiffCommentAnnotations,
+  buildDiffCommentKey,
+  countPendingDiffComments,
+  type DiffCommentAnnotationMetadata,
+  type DiffCommentSide,
+  type DiffInlineComment,
+} from "./DiffPanelComments.logic";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
 type DiffRenderMode = "stacked" | "split";
@@ -193,9 +206,18 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const [collapsedDiffFileKeys, setCollapsedDiffFileKeys] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
+  const [diffCommentsByKey, setDiffCommentsByKey] = useState<Record<string, DiffInlineComment>>({});
+  const [activeDiffCommentEditor, setActiveDiffCommentEditor] = useState<{
+    readonly key: string;
+    readonly filePath: string;
+    readonly lineNumber: number;
+    readonly side: DiffCommentSide;
+    readonly draft: string;
+  } | null>(null);
   const patchViewportRef = useRef<HTMLDivElement>(null);
   const turnStripRef = useRef<HTMLDivElement>(null);
   const previousDiffOpenRef = useRef(false);
+  const previousDiffCommentResetKeyRef = useRef<string | null>(null);
   const [canScrollTurnStripLeft, setCanScrollTurnStripLeft] = useState(false);
   const [canScrollTurnStripRight, setCanScrollTurnStripRight] = useState(false);
   const routeThreadRef = useParams({
@@ -335,6 +357,12 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       }),
     );
   }, [renderablePatch]);
+  const diffCommentResetKey = useMemo(
+    () =>
+      `${activeThreadId ?? "no-thread"}:${selectedTurn?.turnId ?? "conversation"}:${selectedPatch ?? ""}`,
+    [activeThreadId, selectedPatch, selectedTurn?.turnId],
+  );
+  const pendingDiffCommentCount = countPendingDiffComments(diffCommentsByKey);
 
   useEffect(() => {
     if (renderableFiles.length === 0) {
@@ -348,6 +376,20 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       return next.size === current.size ? current : next;
     });
   }, [renderableFiles]);
+
+  useEffect(() => {
+    if (previousDiffCommentResetKeyRef.current === null) {
+      previousDiffCommentResetKeyRef.current = diffCommentResetKey;
+      return;
+    }
+    if (previousDiffCommentResetKeyRef.current === diffCommentResetKey) {
+      return;
+    }
+
+    previousDiffCommentResetKeyRef.current = diffCommentResetKey;
+    setDiffCommentsByKey({});
+    setActiveDiffCommentEditor(null);
+  }, [diffCommentResetKey]);
 
   useEffect(() => {
     if (diffOpen && !previousDiffOpenRef.current) {
@@ -389,6 +431,177 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       return next;
     });
   }, []);
+  const openDiffCommentEditor = useCallback(
+    (input: { filePath: string; lineNumber: number; side: DiffCommentSide }) => {
+      const key = buildDiffCommentKey(input);
+      setActiveDiffCommentEditor({
+        ...input,
+        key,
+        draft: diffCommentsByKey[key]?.body ?? "",
+      });
+    },
+    [diffCommentsByKey],
+  );
+  const updateDiffCommentDraft = useCallback((key: string, draft: string) => {
+    setActiveDiffCommentEditor((current) =>
+      current?.key === key ? { ...current, draft } : current,
+    );
+  }, []);
+  const closeDiffCommentEditor = useCallback(() => {
+    setActiveDiffCommentEditor(null);
+  }, []);
+  const saveActiveDiffComment = useCallback(() => {
+    setActiveDiffCommentEditor((current) => {
+      if (!current) return current;
+      const body = current.draft.trim();
+      setDiffCommentsByKey((comments) => {
+        const next = { ...comments };
+        if (body.length === 0) {
+          delete next[current.key];
+          return next;
+        }
+
+        next[current.key] = {
+          key: current.key,
+          filePath: current.filePath,
+          lineNumber: current.lineNumber,
+          side: current.side,
+          body,
+          collapsed: false,
+          createdAt: comments[current.key]?.createdAt ?? new Date().toISOString(),
+        };
+        return next;
+      });
+      return null;
+    });
+  }, []);
+  const toggleDiffCommentCollapsed = useCallback((key: string) => {
+    setDiffCommentsByKey((comments) => {
+      const comment = comments[key];
+      if (!comment) return comments;
+      return {
+        ...comments,
+        [key]: {
+          ...comment,
+          collapsed: !comment.collapsed,
+        },
+      };
+    });
+  }, []);
+  const deleteDiffComment = useCallback((key: string) => {
+    setDiffCommentsByKey((comments) => {
+      if (!(key in comments)) return comments;
+      const next = { ...comments };
+      delete next[key];
+      return next;
+    });
+    setActiveDiffCommentEditor((current) => (current?.key === key ? null : current));
+  }, []);
+  const renderDiffCommentAnnotation = useCallback(
+    (annotation: DiffLineAnnotation<DiffCommentAnnotationMetadata>) => {
+      const metadata = annotation.metadata;
+      if (!metadata) return null;
+
+      if (metadata.kind === "editor") {
+        const { editor } = metadata;
+        return (
+          <div className="mx-9 my-1 rounded-md border border-primary/30 bg-background/95 p-2 shadow-sm">
+            <textarea
+              autoFocus
+              className="min-h-20 w-full resize-y rounded-md border border-border bg-card px-2 py-1.5 text-xs text-foreground outline-hidden transition-colors placeholder:text-muted-foreground/60 focus:border-primary/60"
+              value={editor.draft}
+              placeholder={`Comment on ${editor.filePath}:${editor.lineNumber}`}
+              onChange={(event) => updateDiffCommentDraft(editor.key, event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  closeDiffCommentEditor();
+                }
+                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                  event.preventDefault();
+                  saveActiveDiffComment();
+                }
+              }}
+            />
+            <div className="mt-2 flex items-center justify-end gap-1.5">
+              <button
+                type="button"
+                className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label="Cancel comment"
+                onClick={closeDiffCommentEditor}
+              >
+                <XIcon className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                className="inline-flex size-7 items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Save comment"
+                disabled={editor.draft.trim().length === 0}
+                onClick={saveActiveDiffComment}
+              >
+                <CheckIcon className="size-3.5" />
+              </button>
+            </div>
+          </div>
+        );
+      }
+
+      const { comment } = metadata;
+      return (
+        <div className="mx-9 my-1 rounded-md border border-border/70 bg-card/80 shadow-sm">
+          <div className="flex items-center gap-2 px-2 py-1.5">
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+              aria-expanded={!comment.collapsed}
+              onClick={() => toggleDiffCommentCollapsed(comment.key)}
+            >
+              <MessagesSquareIcon className="size-3.5 shrink-0" />
+              <span className="truncate">
+                {comment.filePath}:{comment.lineNumber}
+              </span>
+            </button>
+            <button
+              type="button"
+              className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              aria-label="Edit comment"
+              onClick={() =>
+                openDiffCommentEditor({
+                  filePath: comment.filePath,
+                  lineNumber: comment.lineNumber,
+                  side: comment.side,
+                })
+              }
+            >
+              <MessageSquarePlusIcon className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+              aria-label="Delete comment"
+              onClick={() => deleteDiffComment(comment.key)}
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </div>
+          {!comment.collapsed ? (
+            <div className="border-t border-border/60 px-2 py-2 text-xs">
+              <ChatMarkdown text={comment.body} cwd={activeCwd} isStreaming={false} />
+            </div>
+          ) : null}
+        </div>
+      );
+    },
+    [
+      activeCwd,
+      closeDiffCommentEditor,
+      deleteDiffComment,
+      openDiffCommentEditor,
+      saveActiveDiffComment,
+      toggleDiffCommentCollapsed,
+      updateDiffCommentDraft,
+    ],
+  );
 
   const selectTurn = (turnId: TurnId) => {
     if (!activeThread) return;
@@ -567,6 +780,17 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+        {pendingDiffCommentCount > 0 ? (
+          <span
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-border/70 bg-card px-2 text-[11px] font-medium text-muted-foreground"
+            aria-label={`${pendingDiffCommentCount} pending diff ${
+              pendingDiffCommentCount === 1 ? "comment" : "comments"
+            }`}
+          >
+            <MessagesSquareIcon className="size-3" />
+            {pendingDiffCommentCount}
+          </span>
+        ) : null}
         <ToggleGroup
           className="shrink-0"
           variant="outline"
@@ -682,6 +906,12 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                     >
                       <FileDiff
                         fileDiff={fileDiff}
+                        lineAnnotations={buildDiffCommentAnnotations({
+                          filePath,
+                          commentsByKey: diffCommentsByKey,
+                          activeEditor: activeDiffCommentEditor,
+                        })}
+                        renderAnnotation={renderDiffCommentAnnotation}
                         renderHeaderPrefix={() => (
                           <button
                             type="button"
@@ -708,6 +938,14 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                           collapsed,
                           diffStyle: diffRenderMode === "split" ? "split" : "unified",
                           lineDiffType: "none",
+                          lineHoverHighlight: "number",
+                          onLineNumberClick: ({ annotationSide, lineNumber }) => {
+                            openDiffCommentEditor({
+                              filePath,
+                              lineNumber,
+                              side: annotationSide,
+                            });
+                          },
                           overflow: diffWordWrap ? "wrap" : "scroll",
                           theme: resolveDiffThemeName(resolvedTheme),
                           themeType: resolvedTheme as DiffThemeType,

--- a/t3code/apps/web/src/components/DiffPanelComments.logic.test.ts
+++ b/t3code/apps/web/src/components/DiffPanelComments.logic.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDiffCommentAnnotations,
+  buildDiffCommentKey,
+  countPendingDiffComments,
+  type DiffInlineComment,
+} from "./DiffPanelComments.logic";
+
+describe("DiffPanelComments logic", () => {
+  it("builds stable keys that distinguish side and line", () => {
+    expect(
+      buildDiffCommentKey({
+        filePath: "src/app.ts",
+        side: "additions",
+        lineNumber: 12,
+      }),
+    ).toBe("src/app.ts:additions:12");
+    expect(
+      buildDiffCommentKey({
+        filePath: "src/app.ts",
+        side: "deletions",
+        lineNumber: 12,
+      }),
+    ).toBe("src/app.ts:deletions:12");
+  });
+
+  it("counts only non-empty pending comments", () => {
+    const commentsByKey: Record<string, DiffInlineComment> = {
+      one: {
+        key: "one",
+        filePath: "src/app.ts",
+        side: "additions",
+        lineNumber: 1,
+        body: "Looks good",
+        collapsed: false,
+        createdAt: "2026-05-16T03:30:00.000Z",
+      },
+      empty: {
+        key: "empty",
+        filePath: "src/app.ts",
+        side: "additions",
+        lineNumber: 2,
+        body: "   ",
+        collapsed: false,
+        createdAt: "2026-05-16T03:31:00.000Z",
+      },
+    };
+
+    expect(countPendingDiffComments(commentsByKey)).toBe(1);
+  });
+
+  it("builds annotations for one file and replaces a saved comment with the active editor", () => {
+    const commentsByKey: Record<string, DiffInlineComment> = {
+      "src/app.ts:additions:7": {
+        key: "src/app.ts:additions:7",
+        filePath: "src/app.ts",
+        side: "additions",
+        lineNumber: 7,
+        body: "Use the shared helper here.",
+        collapsed: false,
+        createdAt: "2026-05-16T03:30:00.000Z",
+      },
+      "src/other.ts:additions:1": {
+        key: "src/other.ts:additions:1",
+        filePath: "src/other.ts",
+        side: "additions",
+        lineNumber: 1,
+        body: "Other file",
+        collapsed: false,
+        createdAt: "2026-05-16T03:31:00.000Z",
+      },
+    };
+
+    const annotations = buildDiffCommentAnnotations({
+      filePath: "src/app.ts",
+      commentsByKey,
+      activeEditor: {
+        key: "src/app.ts:additions:7",
+        filePath: "src/app.ts",
+        side: "additions",
+        lineNumber: 7,
+        draft: "Edited body",
+      },
+    });
+
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0]).toMatchObject({
+      side: "additions",
+      lineNumber: 7,
+      metadata: {
+        kind: "editor",
+        editor: {
+          draft: "Edited body",
+        },
+      },
+    });
+  });
+});

--- a/t3code/apps/web/src/components/DiffPanelComments.logic.test.ts
+++ b/t3code/apps/web/src/components/DiffPanelComments.logic.test.ts
@@ -1,13 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   buildDiffCommentAnnotations,
   buildDiffCommentKey,
+  buildDiffCommentResetKey,
+  clearDiffCommentSessionsForTests,
   countPendingDiffComments,
+  readDiffCommentSession,
   type DiffInlineComment,
+  writeDiffCommentSession,
 } from "./DiffPanelComments.logic";
 
 describe("DiffPanelComments logic", () => {
+  beforeEach(() => {
+    clearDiffCommentSessionsForTests();
+  });
+
   it("builds stable keys that distinguish side and line", () => {
     expect(
       buildDiffCommentKey({
@@ -48,6 +56,55 @@ describe("DiffPanelComments logic", () => {
     };
 
     expect(countPendingDiffComments(commentsByKey)).toBe(1);
+  });
+
+  it("builds stable reset keys that are scoped to patch content", () => {
+    const first = buildDiffCommentResetKey({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      patch: "diff --git a/src/app.ts b/src/app.ts\n+one",
+    });
+    const matching = buildDiffCommentResetKey({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      patch: "diff --git a/src/app.ts b/src/app.ts\n+one",
+    });
+    const changedPatch = buildDiffCommentResetKey({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      patch: "diff --git a/src/app.ts b/src/app.ts\n+two",
+    });
+
+    expect(first).toBe(matching);
+    expect(first).not.toBe(changedPatch);
+    expect(first).not.toContain("diff --git");
+  });
+
+  it("stores pending comments per reset key", () => {
+    const resetKey = buildDiffCommentResetKey({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      patch: "patch-a",
+    });
+    const otherResetKey = buildDiffCommentResetKey({
+      threadId: "thread-1",
+      turnId: "turn-2",
+      patch: "patch-a",
+    });
+    const comment: DiffInlineComment = {
+      key: "src/app.ts:additions:7",
+      filePath: "src/app.ts",
+      side: "additions",
+      lineNumber: 7,
+      body: "Use the shared helper here.",
+      collapsed: false,
+      createdAt: "2026-05-16T03:30:00.000Z",
+    };
+
+    writeDiffCommentSession(resetKey, { [comment.key]: comment });
+
+    expect(readDiffCommentSession(resetKey)).toEqual({ [comment.key]: comment });
+    expect(readDiffCommentSession(otherResetKey)).toEqual({});
   });
 
   it("builds annotations for one file and replaces a saved comment with the active editor", () => {
@@ -95,5 +152,46 @@ describe("DiffPanelComments logic", () => {
         },
       },
     });
+  });
+
+  it("sorts annotations by line number and side", () => {
+    const commentsByKey: Record<string, DiffInlineComment> = {
+      "src/app.ts:additions:10": {
+        key: "src/app.ts:additions:10",
+        filePath: "src/app.ts",
+        side: "additions",
+        lineNumber: 10,
+        body: "Later",
+        collapsed: false,
+        createdAt: "2026-05-16T03:30:00.000Z",
+      },
+      "src/app.ts:deletions:2": {
+        key: "src/app.ts:deletions:2",
+        filePath: "src/app.ts",
+        side: "deletions",
+        lineNumber: 2,
+        body: "Earlier",
+        collapsed: false,
+        createdAt: "2026-05-16T03:31:00.000Z",
+      },
+    };
+
+    const annotations = buildDiffCommentAnnotations({
+      filePath: "src/app.ts",
+      commentsByKey,
+      activeEditor: {
+        key: "src/app.ts:additions:2",
+        filePath: "src/app.ts",
+        side: "additions",
+        lineNumber: 2,
+        draft: "Inline draft",
+      },
+    });
+
+    expect(annotations.map((annotation) => `${annotation.lineNumber}:${annotation.side}`)).toEqual([
+      "2:additions",
+      "2:deletions",
+      "10:additions",
+    ]);
   });
 });

--- a/t3code/apps/web/src/components/DiffPanelComments.logic.ts
+++ b/t3code/apps/web/src/components/DiffPanelComments.logic.ts
@@ -1,0 +1,124 @@
+import type { DiffLineAnnotation } from "@pierre/diffs";
+
+export type DiffCommentSide = "deletions" | "additions";
+
+export interface DiffInlineComment {
+  readonly key: string;
+  readonly filePath: string;
+  readonly lineNumber: number;
+  readonly side: DiffCommentSide;
+  readonly body: string;
+  readonly collapsed: boolean;
+  readonly createdAt: string;
+}
+
+export interface DiffCommentEditor {
+  readonly key: string;
+  readonly filePath: string;
+  readonly lineNumber: number;
+  readonly side: DiffCommentSide;
+  readonly draft: string;
+}
+
+export type DiffCommentAnnotationMetadata =
+  | {
+      readonly kind: "comment";
+      readonly comment: DiffInlineComment;
+    }
+  | {
+      readonly kind: "editor";
+      readonly editor: DiffCommentEditor;
+    };
+
+const diffCommentSessionStore = new Map<string, Record<string, DiffInlineComment>>();
+
+export function buildDiffCommentKey(input: {
+  readonly filePath: string;
+  readonly lineNumber: number;
+  readonly side: DiffCommentSide;
+}): string {
+  return `${input.filePath}:${input.side}:${input.lineNumber}`;
+}
+
+function hashString(value: string): string {
+  let hash = 5381;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(index);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function buildDiffCommentResetKey(input: {
+  readonly threadId: string | null;
+  readonly turnId: string | null;
+  readonly patch: string | undefined;
+}): string {
+  return `${input.threadId ?? "no-thread"}:${input.turnId ?? "conversation"}:${hashString(input.patch ?? "")}`;
+}
+
+export function readDiffCommentSession(
+  resetKey: string,
+): Record<string, DiffInlineComment> {
+  return { ...(diffCommentSessionStore.get(resetKey) ?? {}) };
+}
+
+export function writeDiffCommentSession(
+  resetKey: string,
+  commentsByKey: Readonly<Record<string, DiffInlineComment>>,
+): void {
+  if (Object.keys(commentsByKey).length === 0) {
+    diffCommentSessionStore.delete(resetKey);
+    return;
+  }
+  diffCommentSessionStore.set(resetKey, { ...commentsByKey });
+}
+
+export function clearDiffCommentSessionsForTests(): void {
+  diffCommentSessionStore.clear();
+}
+
+export function countPendingDiffComments(
+  commentsByKey: Readonly<Record<string, DiffInlineComment>>,
+): number {
+  return Object.values(commentsByKey).filter((comment) => comment.body.trim().length > 0).length;
+}
+
+export function buildDiffCommentAnnotations(input: {
+  readonly filePath: string;
+  readonly commentsByKey: Readonly<Record<string, DiffInlineComment>>;
+  readonly activeEditor: DiffCommentEditor | null;
+}): Array<DiffLineAnnotation<DiffCommentAnnotationMetadata>> {
+  const annotations: Array<DiffLineAnnotation<DiffCommentAnnotationMetadata>> = [];
+
+  for (const comment of Object.values(input.commentsByKey)) {
+    if (comment.filePath !== input.filePath || comment.key === input.activeEditor?.key) {
+      continue;
+    }
+    annotations.push({
+      side: comment.side,
+      lineNumber: comment.lineNumber,
+      metadata: {
+        kind: "comment",
+        comment,
+      },
+    });
+  }
+
+  if (input.activeEditor?.filePath === input.filePath) {
+    annotations.push({
+      side: input.activeEditor.side,
+      lineNumber: input.activeEditor.lineNumber,
+      metadata: {
+        kind: "editor",
+        editor: input.activeEditor,
+      },
+    });
+  }
+
+  return annotations.toSorted((left, right) => {
+    if (left.lineNumber !== right.lineNumber) {
+      return left.lineNumber - right.lineNumber;
+    }
+    return left.side.localeCompare(right.side);
+  });
+}

--- a/t3code/apps/web/src/components/DiffPanelComments.logic.ts
+++ b/t3code/apps/web/src/components/DiffPanelComments.logic.ts
@@ -56,9 +56,7 @@ export function buildDiffCommentResetKey(input: {
   return `${input.threadId ?? "no-thread"}:${input.turnId ?? "conversation"}:${hashString(input.patch ?? "")}`;
 }
 
-export function readDiffCommentSession(
-  resetKey: string,
-): Record<string, DiffInlineComment> {
+export function readDiffCommentSession(resetKey: string): Record<string, DiffInlineComment> {
   return { ...(diffCommentSessionStore.get(resetKey) ?? {}) };
 }
 


### PR DESCRIPTION
/claim #846

## Summary
- Add line-number driven inline comment editors inside the diff panel using the supported `@pierre/diffs` click and annotation APIs.
- Render saved comments as collapsible diff annotations with markdown, edit, delete, save, and cancel controls.
- Scope pending comments by thread, turn, and patch content so switching diffs resets or restores the correct draft set.
- Show a pending diff comment count badge in the diff toolbar.

## Notes
- No provenance or attribution metadata files were added.

## Verification
- `npx --yes bun run --filter @t3tools/web test -- src/components/DiffPanelComments.logic.test.ts`
- `npx --yes bun run --filter @t3tools/web typecheck`
- `npx --yes bun run fmt:check -- apps/web/src/components/DiffPanel.tsx apps/web/src/components/DiffPanelComments.logic.ts apps/web/src/components/DiffPanelComments.logic.test.ts`
- `git diff --check`