### PR TITLE
Codex [ Laravel ] Add separated error and JSON logging

### DIFF
--- a/laravel/app/Logging/JsonLogFormatter.php
+++ b/laravel/app/Logging/JsonLogFormatter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+final class JsonLogFormatter implements FormatterInterface
+{
+    public function format(LogRecord $record): string
+    {
+        return json_encode([
+            'timestamp' => $record->datetime->format(DATE_ATOM),
+            'level' => $record->level->getName(),
+            'message' => $record->message,
+            'context' => $record->context,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL;
+    }
+
+    /**
+     * @param  array<LogRecord>  $records
+     */
+    public function formatBatch(array $records): string
+    {
+        $formatted = '';
+
+        foreach ($records as $record) {
+            $formatted .= $this->format($record);
+        }
+
+        return $formatted;
+    }
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\JsonLogFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,24 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_JSON_LEVEL', env('LOG_LEVEL', 'debug')),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/laravel-json.log'),
+            ],
+            'formatter' => JsonLogFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [

--- a/laravel/tests/Unit/LoggingConfigurationTest.php
+++ b/laravel/tests/Unit/LoggingConfigurationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Logging\JsonLogFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Tests\TestCase;
+
+class LoggingConfigurationTest extends TestCase
+{
+    public function test_stack_sends_general_and_error_logs_to_separate_channels(): void
+    {
+        $channels = config('logging.channels');
+
+        $this->assertSame(['daily', 'error'], $channels['stack']['channels']);
+        $this->assertSame('daily', $channels['daily']['driver']);
+        $this->assertSame(14, $channels['daily']['days']);
+        $this->assertSame('single', $channels['error']['driver']);
+        $this->assertSame(storage_path('logs/error.log'), $channels['error']['path']);
+        $this->assertSame('error', $channels['error']['level']);
+    }
+
+    public function test_json_channel_uses_structured_formatter(): void
+    {
+        $channel = config('logging.channels.json');
+
+        $this->assertSame('monolog', $channel['driver']);
+        $this->assertSame(StreamHandler::class, $channel['handler']);
+        $this->assertSame(storage_path('logs/laravel-json.log'), $channel['handler_with']['stream']);
+        $this->assertSame(JsonLogFormatter::class, $channel['formatter']);
+    }
+
+    public function test_json_formatter_outputs_required_fields(): void
+    {
+        $formatter = new JsonLogFormatter();
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable('2026-05-16T03:55:00+00:00'),
+            channel: 'testing',
+            level: Level::Error,
+            message: 'Payment failed',
+            context: ['order_id' => 123],
+            extra: [],
+        );
+
+        $decoded = json_decode($formatter->format($record), true);
+
+        $this->assertSame('2026-05-16T03:55:00+00:00', $decoded['timestamp']);
+        $this->assertSame('ERROR', $decoded['level']);
+        $this->assertSame('Payment failed', $decoded['message']);
+        $this->assertSame(['order_id' => 123], $decoded['context']);
+    }
+}


### PR DESCRIPTION
/claim #787

## Summary
- Default the Laravel log stack to `daily,error` so error-level records are also written to `storage/logs/error.log`.
- Add an error-only single-file channel and keep daily rotation at 14 days.
- Add a JSON Monolog channel backed by `App\Logging\JsonLogFormatter` with `timestamp`, `level`, `message`, and `context` fields.
- Add PHPUnit coverage for the logging channel configuration and formatter output.

## Verification
- `git diff --check`
- Static check: `rg -n "LOG_STACK|daily,error|'error' =>|'json' =>|logs/error.log|logs/laravel-json.log|JsonLogFormatter|timestamp|context|level" laravel/config/logging.php laravel/app/Logging/JsonLogFormatter.php laravel/tests/Unit/LoggingConfigurationTest.php`
- PHP and Composer are not installed in this environment, so the Laravel PHPUnit suite could not be executed locally.

No provenance metadata file was added.