### PR TITLE
Codex [ Laravel ] Fix DatabaseSeeder duplicate user and add roles

### DIFF
--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    /** @use HasFactory<\Database\Factories\RoleFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(2),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_16_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_16_000000_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::query()->firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => Hash::make('password'),
+            ],
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default application roles.
+     */
+    public function run(): void
+    {
+        $roles = [
+            'admin' => 'Full access to manage users, content, and application settings.',
+            'editor' => 'Can create, edit, and publish application content.',
+            'viewer' => 'Read-only access to application content.',
+        ];
+
+        foreach ($roles as $name => $description) {
+            Role::query()->firstOrCreate(
+                ['name' => $name],
+                ['description' => $description],
+            );
+        }
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_can_run_more_than_once(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertDatabaseCount('users', 1);
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+            'name' => 'Test User',
+        ]);
+
+        $this->assertDatabaseCount('roles', 3);
+        $this->assertDatabaseHas('roles', ['name' => 'admin']);
+        $this->assertDatabaseHas('roles', ['name' => 'editor']);
+        $this->assertDatabaseHas('roles', ['name' => 'viewer']);
+    }
+
+    public function test_role_seeder_is_idempotent(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertDatabaseCount('roles', 3);
+    }
+
+    public function test_role_factory_creates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertDatabaseHas('roles', [
+            'id' => $role->id,
+            'name' => $role->name,
+        ]);
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- Make the seeded test user idempotent with `firstOrCreate` so repeated `db:seed` runs do not violate the unique email constraint.
- Add a `roles` table migration, `Role` model, `RoleFactory`, and idempotent `RoleSeeder` for `admin`, `editor`, and `viewer` roles.
- Call `RoleSeeder` from `DatabaseSeeder` after the test user is ensured.
- Add feature coverage for repeatable database seeding, idempotent role seeding, and role factory creation.

## Verification
- `git diff --check`
- Static check: `rg -n "firstOrCreate|RoleSeeder|create\('roles'|name'\)->unique|admin|editor|viewer|Role::factory|assertDatabaseCount\('roles'|test@example.com" laravel/database laravel/app laravel/tests -S`
- PHP and Composer are not installed in this environment, so the Laravel PHPUnit suite could not be executed locally.

No provenance metadata file was added.