### PR TITLE
Codex [ Laravel ] Add database health check endpoint

### DIFF
--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    private const MAX_ATTEMPTS = 3;
+    private const RETRY_DELAY_MS = 500;
+
+    public function database(): JsonResponse
+    {
+        $connectionName = (string) config('database.default');
+        $driver = config("database.connections.{$connectionName}.driver");
+        $startedAt = microtime(true);
+        $lastException = null;
+        $retryDelayMs = (int) config('database.health_check.retry_delay_ms', self::RETRY_DELAY_MS);
+
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+            try {
+                $connection = DB::connection($connectionName);
+                $connection->select('select 1');
+
+                return response()->json([
+                    'status' => 'healthy',
+                    'driver' => $connection->getDriverName(),
+                    'latency_ms' => $this->elapsedMilliseconds($startedAt),
+                    'connection_name' => $connectionName,
+                ]);
+            } catch (Throwable $exception) {
+                $lastException = $exception;
+
+                if ($attempt < self::MAX_ATTEMPTS) {
+                    usleep(max(0, $retryDelayMs) * 1000);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'unhealthy',
+            'driver' => $driver,
+            'latency_ms' => $this->elapsedMilliseconds($startedAt),
+            'connection_name' => $connectionName,
+            'error' => $lastException?->getMessage(),
+        ], 503);
+    }
+
+    private function elapsedMilliseconds(float $startedAt): float
+    {
+        return round((microtime(true) - $startedAt) * 1000, 2);
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);

--- a/laravel/tests/Feature/DatabaseHealthControllerTest.php
+++ b/laravel/tests/Feature/DatabaseHealthControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Tests\TestCase;
+
+class DatabaseHealthControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        $response = $this->getJson('/health/database');
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'status' => 'healthy',
+                'driver' => 'sqlite',
+                'connection_name' => 'sqlite',
+            ])
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+            ]);
+
+        $this->assertIsNumeric($response->json('latency_ms'));
+    }
+
+    public function test_database_health_endpoint_returns_503_when_connection_fails(): void
+    {
+        Config::set('database.health_check.retry_delay_ms', 0);
+        DB::shouldReceive('connection')
+            ->times(3)
+            ->with('sqlite')
+            ->andThrow(new RuntimeException('database unavailable'));
+
+        $response = $this->getJson('/health/database');
+
+        $response
+            ->assertStatus(503)
+            ->assertJson([
+                'status' => 'unhealthy',
+                'driver' => 'sqlite',
+                'connection_name' => 'sqlite',
+                'error' => 'database unavailable',
+            ])
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+                'error',
+            ]);
+
+        $this->assertIsNumeric($response->json('latency_ms'));
+    }
+}


### PR DESCRIPTION
/claim #785

## Summary
- Add `HealthController::database` with active connection probing, latency measurement, and JSON health responses.
- Add `GET /health/database` in `routes/web.php`.
- Retry failed database probes 3 times with a default 500ms delay before returning a 503 response with the error message.
- Add feature coverage for healthy responses and the 3-attempt failure path.

## Verification
- `git diff --check`
- Static check: `rg -n "class HealthController|MAX_ATTEMPTS = 3|RETRY_DELAY_MS = 500|select\('select 1'\)|latency_ms|connection_name|/health/database|times\(3\)|assertStatus\(503\)|assertOk" laravel/app laravel/routes laravel/tests -S`
- PHP and Composer are not installed in this environment, so the Laravel PHPUnit suite could not be executed locally.

No metadata file containing hidden runtime context was added.