### PR TITLE
Codex [ Laravel ] Fix Slack notification service

### DIFF
--- a/laravel/app/Services/SlackNotifier.php
+++ b/laravel/app/Services/SlackNotifier.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+
+class SlackNotifier
+{
+    public static function send(string $message, ?string $channel = null, array $blocks = []): Response
+    {
+        return app(self::class)->sendMessage($message, $channel, $blocks);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     */
+    public function sendMessage(string $message, ?string $channel = null, array $blocks = []): Response
+    {
+        $webhookUrl = config('services.slack.webhook_url');
+
+        if (blank($webhookUrl)) {
+            throw new InvalidArgumentException('Slack webhook URL is not configured.');
+        }
+
+        $payload = $this->buildPayload($message, $channel, $blocks);
+        $response = $this->postWebhook($webhookUrl, $payload);
+
+        if ($response->serverError()) {
+            $response = $this->postWebhook($webhookUrl, $payload);
+        }
+
+        return $response->throw();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     * @return array<string, mixed>
+     */
+    private function buildPayload(string $message, ?string $channel, array $blocks): array
+    {
+        $payload = [
+            'text' => $message,
+        ];
+
+        $targetChannel = $channel ?: config('services.slack.default_channel');
+
+        if (filled($targetChannel)) {
+            $payload['channel'] = $targetChannel;
+        }
+
+        if ($blocks !== []) {
+            $payload['blocks'] = $blocks;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function postWebhook(string $webhookUrl, array $payload): Response
+    {
+        return Http::timeout(5)->post($webhookUrl, $payload);
+    }
+}

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -29,6 +29,9 @@ return [
     ],
 
     'slack' => [
+        'webhook_url' => env('SLACK_WEBHOOK_URL'),
+        'default_channel' => env('SLACK_DEFAULT_CHANNEL'),
+
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/laravel/tests/Feature/SlackNotifierTest.php
+++ b/laravel/tests/Feature/SlackNotifierTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SlackNotifier;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class SlackNotifierTest extends TestCase
+{
+    private const WEBHOOK_URL = 'https://hooks.slack.test/services/T000/B000/secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('services.slack.webhook_url', self::WEBHOOK_URL);
+        Config::set('services.slack.default_channel', '#alerts');
+    }
+
+    public function test_it_sends_slack_payload_with_default_channel_and_blocks(): void
+    {
+        Http::fake([
+            self::WEBHOOK_URL => Http::response('ok'),
+        ]);
+
+        SlackNotifier::send('Deploy complete', blocks: [
+            ['type' => 'section', 'text' => ['type' => 'mrkdwn', 'text' => 'Done']],
+        ]);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === self::WEBHOOK_URL
+                && $request['text'] === 'Deploy complete'
+                && $request['channel'] === '#alerts'
+                && $request['blocks'][0]['type'] === 'section';
+        });
+    }
+
+    public function test_channel_override_replaces_default_channel(): void
+    {
+        Http::fake([
+            self::WEBHOOK_URL => Http::response('ok'),
+        ]);
+
+        SlackNotifier::send('Incident opened', '#incidents');
+
+        Http::assertSent(fn ($request) => $request['channel'] === '#incidents');
+    }
+
+    public function test_server_errors_are_retried_once(): void
+    {
+        Http::fakeSequence()
+            ->push('temporary failure', 500)
+            ->push('ok', 200);
+
+        SlackNotifier::send('Retry me');
+
+        Http::assertSentCount(2);
+    }
+
+    public function test_client_errors_throw_without_retry(): void
+    {
+        Http::fake([
+            self::WEBHOOK_URL => Http::response('bad request', 400),
+        ]);
+
+        try {
+            SlackNotifier::send('Do not retry');
+            $this->fail('Expected Slack client error to throw.');
+        } catch (RequestException) {
+            Http::assertSentCount(1);
+        }
+    }
+
+    public function test_missing_webhook_url_throws_configuration_error(): void
+    {
+        Config::set('services.slack.webhook_url', null);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        SlackNotifier::send('Missing config');
+    }
+}


### PR DESCRIPTION
/claim #791

## Summary
- Add `App\Services\SlackNotifier` with a facade-style `SlackNotifier::send(...)` convenience method.
- Read Slack webhook URL and default channel from `services.slack` config.
- Send Slack webhook payloads with text, optional channel override, and optional blocks.
- Use a 5-second HTTP timeout, retry once on 5xx responses, and throw immediately on 4xx responses.
- Add HTTP fake coverage for payload structure, channel override, retry-on-5xx, no retry-on-4xx, and missing webhook config.

## Verification
- `git diff --check`
- Static check: `rg -n "class SlackNotifier|static function send|timeout\(5\)|serverError\(|throw\(|webhook_url|default_channel|Http::fake|assertSentCount\(2\)|assertSentCount\(1\)|RequestException" laravel/app laravel/config laravel/tests -S`
- PHP and Composer are not installed in this environment, so the Laravel PHPUnit suite could not be executed locally.

No generation metadata file was added.