### PR TITLE
Codex [ Laravel ] Add User observer, UUIDs, and active scope

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-#[Fillable(['name', 'email', 'password'])]
+#[Fillable(['uuid', 'name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class UserObserver
+{
+    public function creating(User $user): void
+    {
+        if (blank($user->uuid)) {
+            $user->uuid = (string) Str::uuid();
+        }
+    }
+
+    public function created(User $user): void
+    {
+        Log::info('User created', [
+            'user_id' => $user->getKey(),
+            'uuid' => $user->uuid,
+            'email' => $user->email,
+        ]);
+    }
+
+    public function deleted(User $user): void
+    {
+        Log::info('User deleted', [
+            'user_id' => $user->getKey(),
+            'uuid' => $user->uuid,
+            'email' => $user->email,
+        ]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
+
+        Model::preventLazyLoading($this->app->environment(['local', 'testing']));
     }
 }

--- a/laravel/app/Scopes/ActiveScope.php
+++ b/laravel/app/Scopes/ActiveScope.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ActiveScope implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  Builder<Model>  $builder
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where($model->qualifyColumn('active'), true);
+    }
+}

--- a/laravel/database/migrations/2026_05_16_000001_add_uuid_to_users_table.php
+++ b/laravel/database/migrations/2026_05_16_000001_add_uuid_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable()->unique()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/laravel/tests/Feature/EloquentInfrastructureTest.php
+++ b/laravel/tests/Feature/EloquentInfrastructureTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Scopes\ActiveScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+use Tests\TestCase;
+
+class EloquentInfrastructureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_scope_filters_active_records_and_can_be_removed(): void
+    {
+        Schema::create('active_scope_records', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->boolean('active')->default(true);
+        });
+
+        ActiveScopeRecord::query()->create(['name' => 'Visible', 'active' => true]);
+        ActiveScopeRecord::withoutGlobalScope(ActiveScope::class)->create([
+            'name' => 'Hidden',
+            'active' => false,
+        ]);
+
+        $this->assertSame(['Visible'], ActiveScopeRecord::query()->pluck('name')->all());
+        $this->assertSame(
+            ['Hidden', 'Visible'],
+            ActiveScopeRecord::withoutGlobalScope(ActiveScope::class)->orderBy('name')->pluck('name')->all(),
+        );
+    }
+
+    public function test_user_observer_generates_uuid_and_logs_lifecycle_events(): void
+    {
+        Log::spy();
+
+        $user = User::factory()->create();
+
+        $this->assertNotEmpty($user->uuid);
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'uuid' => $user->uuid,
+        ]);
+
+        $user->delete();
+
+        Log::shouldHaveReceived('info')
+            ->with('User created', Mockery::on(fn (array $context) => $context['uuid'] === $user->uuid))
+            ->once();
+        Log::shouldHaveReceived('info')
+            ->with('User deleted', Mockery::on(fn (array $context) => $context['uuid'] === $user->uuid))
+            ->once();
+    }
+
+    public function test_lazy_loading_is_prevented_in_testing_environment(): void
+    {
+        $this->assertTrue(Model::preventsLazyLoading());
+    }
+}
+
+class ActiveScopeRecord extends Model
+{
+    protected $table = 'active_scope_records';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new ActiveScope());
+    }
+}


### PR DESCRIPTION
/claim #792

## Summary
- Add reusable `App\Scopes\ActiveScope` that filters opt-in models by `active = true` and can be removed with `withoutGlobalScope`.
- Add `UserObserver` to assign UUIDs before creation and log created/deleted lifecycle events.
- Add a nullable unique `uuid` column migration for users and include `uuid` in the User fillable attributes.
- Register the observer in `AppServiceProvider` and enable lazy-loading prevention in local/testing environments.
- Add feature coverage for scope filtering/opt-out, observer UUID/log behavior, and lazy-loading prevention.

## Verification
- `git diff --check`
- Static check: `rg -n "class ActiveScope|qualifyColumn\('active'\)|class UserObserver|Str::uuid|User::observe|preventLazyLoading|uuid'\)->nullable\(\)->unique|withoutGlobalScope\(ActiveScope::class\)|preventsLazyLoading|User created|User deleted" laravel/app laravel/database laravel/tests -S`
- PHP and Composer are not installed in this environment, so the Laravel PHPUnit suite could not be executed locally.

No attribution metadata file was added.