### PR TITLE
Fix reentrancy in StakingVault withdraw and claimRewards (#856)

### DIFF
--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -21,7 +22,7 @@ contract StakingVault {
         rewardRate = _rewardRate;
     }
 
-    function stake(uint256 amount) external {
+    function stake(uint256 amount) external nonReentrant {
         require(amount > 0, "Cannot stake 0");
         stakingToken.transferFrom(msg.sender, address(this), amount);
         _updateReward(msg.sender);
@@ -39,32 +40,34 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    // FIX: Apply checks-effects-interactions pattern + ReentrancyGuard
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
-        require(success, "Transfer failed");
-
-        // State update after external call — vulnerable to reentrancy
+        // State update BEFORE external call (checks-effects-interactions)
         balances[msg.sender] -= amount;
         totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
+
+        // External call after state update
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Transfer failed");
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    // FIX: Apply checks-effects-interactions pattern + ReentrancyGuard
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
-        (bool success, ) = payable(msg.sender).call{value: reward}("");
-        require(success, "Transfer failed");
-
+        // State update BEFORE external call
         rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
+
+        // External call after state update
+        (bool success, ) = payable(msg.sender).call{value: reward}("");
+        require(success, "Transfer failed");
     }
 
     function getStakedBalance(address account) external view returns (uint256) {


### PR DESCRIPTION
## Summary

This PR fixes the reentrancy vulnerability in the `StakingVault` contract (Issue #856).

## Changes

### 1. Added ReentrancyGuard
- Imported OpenZeppelin's `ReentrancyGuard`
- Contract now inherits from `ReentrancyGuard`
- Added `nonReentrant` modifier to all public state-changing functions

### 2. Applied Checks-Effects-Interactions Pattern

**withdraw()**: Balance and totalStaked deduction now happens BEFORE ETH transfer
**claimRewards()**: Reward zeroing now happens BEFORE ETH transfer
**stake()**: Added `nonReentrant` modifier for defense-in-depth

## Security Impact

**Before:** An attacker could use a malicious contract to re-enter `withdraw()` or `claimRewards()` during the ETH transfer, draining the vault.

**After:** 
1. Reentrancy is impossible because state is updated before external calls
2. Even if somehow re-entered, the `nonReentrant` modifier would revert
3. Double protection via both pattern compliance and mutex lock

Closes #856