### PR TITLE
Hermes [ Laravel ] add scheduled log cleanup command

### DIFF
--- a/_generation.json
+++ b/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes",
+  "pre_task_context": "Task selected from public GitHub issue #753 in UnsafeLabs/Bounty-Hunters. Goal: fix laravel/routes/console.php missing scheduled task registration and add a log cleanup command. Work performed in a local clone, read-only discovery only, no unauthorized testing.",
+  "timestamp": "2026-05-15T23:30:51Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,42 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Delete log files older than this many days}', function () {
+    $days = max(0, (int) $this->option('days'));
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deleted = 0;
+    $freedBytes = 0;
+
+    foreach (glob(storage_path('logs/*.log')) ?: [] as $logFile) {
+        if (is_file($logFile) && filemtime($logFile) < $cutoff) {
+            $freedBytes += filesize($logFile) ?: 0;
+            unlink($logFile);
+            $deleted++;
+        }
+    }
+
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $humanSize = (float) $freedBytes;
+    $unitIndex = 0;
+
+    while ($humanSize >= 1024 && $unitIndex < count($units) - 1) {
+        $humanSize /= 1024;
+        $unitIndex++;
+    }
+
+    $this->info(sprintf(
+        'Deleted %d log file(s) older than %d day(s), freeing %.2f %s.',
+        $deleted,
+        $days,
+        $humanSize,
+        $units[$unitIndex]
+    ));
+})->purpose('Delete Laravel log files older than the configured retention period');
+
+Schedule::command('logs:clear --days=7')->dailyAt('00:00');


### PR DESCRIPTION
## Summary
- Adds `logs:clear` Artisan command with `--days=7` default retention
- Deletes old `storage/logs/*.log` files and reports deleted count plus freed space
- Registers the command to run daily at `00:00`

## Verification
- `php -l laravel/routes/console.php`

Fixes #753