### PR TITLE
Hermes [ T3 Code ] define turbo dependency graph

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes",
+  "generation_context": "Task selected from public GitHub issue #828 in UnsafeLabs/Bounty-Hunters. Goal: fix t3code/turbo.json missing dependency graph for incremental builds. Work performed in a local clone using public issue details; no privileged repository access available.",
+  "completed_at": "2026-05-15T23:40:43Z"
+}

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,43 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/web#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/client-runtime#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/desktop#build": {
+      "dependsOn": ["@t3tools/web#build", "t3#build"],
+      "outputs": ["dist/**", "dist-electron/**"]
+    },
+    "@t3tools/contracts#build": {
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/client-runtime#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/shared#build"],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/shared#build": {
+      "dependsOn": ["@t3tools/contracts#build"],
+      "outputs": ["dist/**"]
+    },
+    "effect-acp#build": {
+      "outputs": ["dist/**"]
+    },
+    "effect-codex-app-server#build": {
+      "outputs": ["dist/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
## Summary
- Adds explicit Turbo package build dependencies for the T3 Code workspace
- Ensures web/desktop/app builds wait for their required internal packages
- Adds metadata for the generated patch context

## Verification
- `node -e "JSON.parse(require(\"fs\").readFileSync(\"t3code/turbo.json\",\"utf8\"))"`
- `cd t3code && npx turbo run build --dry=json`

Fixes #828