### PR TITLE
Fix PriceOracle missing staleness check and fallback mechanism (#915)

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,33 +14,58 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
-    event PriceQueried(int256 price, uint256 timestamp);
+    event PriceQueried(int256 price, uint256 timestamp, bool usedFallback);
+    event FallbackFeedSet(address indexed fallbackFeed);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
+    // FIX: Added staleness check, price validation, round completeness, and fallback
     function getLatestPrice() external view returns (int256) {
+        try primaryFeed.latestRoundData() returns (
+            uint80 roundId,
+            int256 price,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) {
+            // Check round completeness
+            require(answeredInRound >= roundId, "Round not complete");
+            // Check staleness
+            require(block.timestamp - updatedAt < MAX_STALENESS, "Price is stale");
+            // Check price validity
+            require(price > 0, "Invalid price");
+            
+            return price;
+        } catch {
+            // Fallback to secondary oracle
+            return _getFallbackPrice();
+        }
+    }
+
+    // FIX: Added fallback oracle support
+    function _getFallbackPrice() internal view returns (int256) {
+        require(address(fallbackFeed) != address(0), "No fallback feed");
+        
         (
             uint80 roundId,
             int256 price,
             ,
             uint256 updatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
-
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
-
+        ) = fallbackFeed.latestRoundData();
+        
+        require(answeredInRound >= roundId, "Fallback round not complete");
+        require(block.timestamp - updatedAt < MAX_STALENESS, "Fallback price is stale");
+        require(price > 0, "Invalid fallback price");
+        
         return price;
     }
 
@@ -51,5 +76,11 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        emit FallbackFeedSet(_fallbackFeed);
     }
 }


### PR DESCRIPTION
Fixes #915

## Summary
Added staleness check, price validation, round completeness check, and fallback oracle support.

## Changes
- Added `answeredInRound >= roundId` check for round completeness
- Added `block.timestamp - updatedAt < MAX_STALENESS` staleness check
- Added `price > 0` validation
- Added fallback oracle with try-catch on primary feed failure
- Added `setFallbackFeed()` owner function

## Security Impact
**Before:** Oracle could return stale, negative, or incomplete prices without fallback.
**After:** All price queries are validated; primary failures gracefully fall back to secondary oracle.

Closes #915