### PR TITLE
[Hermes Agent] [ Crypto ] Fix zero-fee flash loans and add pool drainage protection (#919)

### DIFF
--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -2,64 +2,112 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 interface IFlashLoanReceiver {
     function onFlashLoan(address token, uint256 amount, uint256 fee, bytes calldata data) external;
 }
 
-contract FlashLoan {
+contract FlashLoan is ReentrancyGuard {
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
+    uint256 public internalBalance; // Internal accounting for rebasing token protection
+    uint256 public maxLoanPercent; // Max loan as percentage of pool (default 50%)
     address public owner;
     bool public paused;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event Paused(address indexed account);
+    event Unpaused(address indexed account);
+    event Deposited(address indexed account, uint256 amount);
+    event Withdrawn(address indexed account, uint256 amount);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier whenNotPaused() {
+        require(!paused, "Paused");
+        _;
+    }
 
     constructor(address _loanToken, uint256 _feeBPS) {
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
+        maxLoanPercent = 50; // Default 50% max loan
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
-    function flashLoan(uint256 amount, bytes calldata data) external {
-        require(!paused, "Paused");
+    // FIX: Minimum fee, max loan cap, internal accounting, emergency pause
+    function flashLoan(uint256 amount, bytes calldata data) external nonReentrant whenNotPaused {
         require(amount > 0, "Amount must be > 0");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
+        // FIX: Max loan cap (default 50% of pool)
+        uint256 maxLoan = internalBalance * maxLoanPercent / 100;
+        require(amount <= maxLoan, "Exceeds max loan amount");
+
+        // FIX: Use internal accounting instead of balanceOf
+        uint256 balanceBefore = internalBalance;
         require(balanceBefore >= amount, "Insufficient pool balance");
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
+        // FIX: Minimum fee of 1 token unit
         uint256 fee = amount * feeBPS / 10000;
+        if (fee == 0) fee = 1; // Minimum fee
 
+        // Update internal balance before transfer
+        internalBalance -= amount;
         loanToken.transfer(msg.sender, amount);
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        // FIX: Check internal balance after callback
+        // ReentrancyGuard prevents re-entry during this check
+        uint256 received = amount + fee;
+        internalBalance += received;
+
+        // Verify token transfer was successful
+        uint256 actualBalance = loanToken.balanceOf(address(this));
+        require(actualBalance >= internalBalance, "Loan not repaid correctly");
 
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
-    function depositToPool(uint256 amount) external {
+    function depositToPool(uint256 amount) external nonReentrant {
         loanToken.transferFrom(msg.sender, address(this), amount);
+        internalBalance += amount;
+        emit Deposited(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external nonReentrant onlyOwner {
         uint256 fees = totalFees;
+        require(fees > 0, "No fees to withdraw");
         totalFees = 0;
+        internalBalance -= fees;
         loanToken.transfer(owner, fees);
+        emit Withdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    // FIX: Emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    // FIX: Set max loan percentage
+    function setMaxLoanPercent(uint256 _percent) external onlyOwner {
+        require(_percent > 0 && _percent <= 100, "Invalid percent");
+        maxLoanPercent = _percent;
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return internalBalance;
     }
 }


### PR DESCRIPTION
Fixes #919

## Summary
Fixed zero-fee flash loans and added pool drainage protection.

## Changes
- Added minimum fee of 1 token unit to prevent free flash loans
- Added max loan cap (default 50% of pool) to prevent drainage
- Used internal accounting instead of balanceOf for rebasing token protection
- Added emergency pause/unpause functions
- Added ReentrancyGuard to all external functions
- Added setMaxLoanPercent for configurable loan limits

## Security Impact
**Before:** Small flash loans could be free; no limit on loan size; rebasing tokens could manipulate balance.
**After:** All loans have minimum fee; max 50% of pool can be borrowed; internal accounting prevents manipulation.

Closes #919