### PR TITLE
OpenAI Codex [ T3 Code ] Fix SSH askpass script leaking password via insecure temp file permissions

### DIFF
--- a/t3code/packages/ssh/src/auth.test.ts
+++ b/t3code/packages/ssh/src/auth.test.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 
@@ -44,10 +47,16 @@ describe("ssh auth", () => {
       const askpassPath = path.join(directory, "ssh-askpass.sh");
       assert.equal(env.SSH_ASKPASS, askpassPath);
       assert.equal(env.SSH_ASKPASS_REQUIRE, "force");
-      assert.equal(env.T3_SSH_AUTH_SECRET, "super-secret");
+      assert.match(env.T3_SSH_AUTH_SECRET_FILE ?? "", /ssh-askpass-secret-/u);
+      assert.equal(env.T3_SSH_AUTH_SECRET, undefined);
       assert.equal(env.DISPLAY, "t3code");
       assert.equal(yield* fs.exists(askpassPath), true);
-      assert.include(yield* fs.readFileString(askpassPath), 'printf "%s\\n" "$T3_SSH_AUTH_SECRET"');
+      assert.include(yield* fs.readFileString(askpassPath), "T3_SSH_AUTH_SECRET_FILE");
+
+      const secretPath = env.T3_SSH_AUTH_SECRET_FILE ?? "";
+      assert.equal(statSync(secretPath).mode & 0o777, 0o600);
+      assert.equal(execFileSync("sh", [askpassPath], { env, encoding: "utf8" }), "super-secret");
+      assert.equal(existsSync(secretPath), false);
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
 
@@ -63,6 +72,18 @@ describe("ssh auth", () => {
         descriptor.files.map((file) => file.path.split("\\").at(-1)),
         ["ssh-askpass.cmd", "ssh-askpass.ps1"],
       );
+      assert.include(descriptor.files[1]?.contents ?? "", "ConvertTo-SecureString");
     }),
   );
+
+  it("rejects unsafe askpass script paths", () => {
+    assert.throws(() =>
+      Effect.runSync(
+        buildSshAskpassHelperDescriptor({
+          directory: "/tmp/t3code askpass;rm-rf",
+          platform: "linux",
+        }).pipe(Effect.provide(NodeServices.layer)),
+      ),
+    );
+  });
 });

--- a/t3code/packages/ssh/src/auth.ts
+++ b/t3code/packages/ssh/src/auth.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, openSync, writeFileSync } from "node:fs";
+
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -59,6 +62,42 @@ export interface SshChildEnvironmentOptions {
 }
 
 const SSH_ASKPASS_DIR_NAME = "t3code-ssh-askpass";
+const POSIX_SAFE_SCRIPT_PATH_PATTERN = /^[A-Za-z0-9_./-]+$/u;
+const WINDOWS_UNSAFE_SCRIPT_PATH_PATTERN = /[&|;`$<>]/u;
+
+export function validateSshAskpassScriptPath(path: string, platform: NodeJS.Platform): string {
+  if (path.length === 0) {
+    throw new SshPasswordPromptError({
+      message: "SSH askpass script path must not be empty.",
+    });
+  }
+
+  if (platform === "win32") {
+    if (WINDOWS_UNSAFE_SCRIPT_PATH_PATTERN.test(path)) {
+      throw new SshPasswordPromptError({
+        message: `SSH askpass script path contains unsafe shell metacharacters: ${path}`,
+      });
+    }
+    return path;
+  }
+
+  if (!POSIX_SAFE_SCRIPT_PATH_PATTERN.test(path)) {
+    throw new SshPasswordPromptError({
+      message: `SSH askpass script path contains unsafe shell metacharacters: ${path}`,
+    });
+  }
+
+  return path;
+}
+
+function writeSecretFileMode0600(path: string, secret: string): void {
+  const fd = openSync(path, "wx", 0o600);
+  try {
+    writeFileSync(fd, secret, { encoding: "utf8" });
+  } finally {
+    closeSync(fd);
+  }
+}
 
 function joinSshAskpassPath(
   directory: string,
@@ -71,13 +110,26 @@ function joinSshAskpassPath(
 
 export const ASKPASS_POSIX_SCRIPT = `#!/bin/sh
 # Invoked by ssh via SSH_ASKPASS when T3 Code re-runs ssh with a cached password
-# from the renderer's in-app prompt. We never expose a native dialog here - if
-# T3_SSH_AUTH_SECRET is missing, that's a caller bug and we fail loudly.
-if [ "\${T3_SSH_AUTH_SECRET+x}" = "x" ]; then
-  printf "%s\\n" "$T3_SSH_AUTH_SECRET"
+# from the renderer's in-app prompt. The cached password is stored in a private
+# 0600 file created by the parent process and removed by this helper on every
+# exit path.
+cleanup() {
+  if [ -n "\${T3_SSH_AUTH_SECRET_FILE:-}" ]; then
+    rm -f -- "$T3_SSH_AUTH_SECRET_FILE"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [ -n "\${T3_SSH_AUTH_SECRET_FILE:-}" ]; then
+  if [ ! -f "$T3_SSH_AUTH_SECRET_FILE" ]; then
+    printf 'T3 Code ssh-askpass secret file is missing.\\n' >&2
+    exit 1
+  fi
+  cat -- "$T3_SSH_AUTH_SECRET_FILE"
   exit 0
 fi
-printf 'T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.\\n' >&2
+
+printf 'T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET_FILE.\\n' >&2
 exit 1
 `;
 
@@ -86,12 +138,17 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0ssh-askpass.ps1" %*\r
 `;
 
 export const ASKPASS_WINDOWS_SCRIPT = `# Invoked by ssh via SSH_ASKPASS (through ssh-askpass.cmd) when T3 Code re-runs\r
-# ssh with a cached password from the renderer's in-app prompt. We never expose\r
-# a native dialog here - if T3_SSH_AUTH_SECRET is missing, that's a caller bug\r
-# and we fail loudly.\r
+# ssh with a cached password from the renderer's in-app prompt. Keep the secret\r
+# in a SecureString until the final askpass stdout write required by OpenSSH.\r
 if ($null -ne $env:T3_SSH_AUTH_SECRET) {\r
-  [Console]::Out.WriteLine($env:T3_SSH_AUTH_SECRET)\r
-  exit 0\r
+  $secureSecret = ConvertTo-SecureString $env:T3_SSH_AUTH_SECRET -AsPlainText -Force\r
+  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureSecret)\r
+  try {\r
+    [Console]::Out.WriteLine([Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr))\r
+    exit 0\r
+  } finally {\r
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)\r
+  }\r
 }\r
 [Console]::Error.WriteLine("T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.")\r
 exit 1\r
@@ -117,12 +174,19 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
   const directory = input.directory;
 
   if (platform === "win32") {
-    const powershellPath = joinSshAskpassPath(directory, "ssh-askpass.ps1", platform);
+    const powershellPath = validateSshAskpassScriptPath(
+      joinSshAskpassPath(directory, "ssh-askpass.ps1", platform),
+      platform,
+    );
+    const launcherPath = validateSshAskpassScriptPath(
+      joinSshAskpassPath(directory, "ssh-askpass.cmd", platform),
+      platform,
+    );
     return {
-      launcherPath: joinSshAskpassPath(directory, "ssh-askpass.cmd", platform),
+      launcherPath,
       files: [
         {
-          path: joinSshAskpassPath(directory, "ssh-askpass.cmd", platform),
+          path: launcherPath,
           contents: ASKPASS_WINDOWS_LAUNCHER_SCRIPT,
         },
         {
@@ -134,10 +198,10 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
   }
 
   return {
-    launcherPath: path.join(directory, "ssh-askpass.sh"),
+    launcherPath: validateSshAskpassScriptPath(path.join(directory, "ssh-askpass.sh"), platform),
     files: [
       {
-        path: path.join(directory, "ssh-askpass.sh"),
+        path: validateSshAskpassScriptPath(path.join(directory, "ssh-askpass.sh"), platform),
         contents: ASKPASS_POSIX_SCRIPT,
         mode: 0o700,
       },
@@ -185,14 +249,31 @@ export const buildSshChildEnvironment = Effect.fn("ssh/auth.buildSshChildEnviron
   }
 
   const platform = input.platform ?? process.platform;
+  const path = yield* Path.Path;
   const directory = input.askpassDirectory ?? (yield* getDefaultSshAskpassDirectory());
   const sshAskpass = yield* ensureSshAskpassHelpers({ directory, platform });
+  const authSecret = input.authSecret ?? "";
+  const posixSecretPath =
+    input.authSecret === undefined || platform === "win32"
+      ? null
+      : validateSshAskpassScriptPath(
+          path.join(directory, `ssh-askpass-secret-${process.pid}-${randomUUID()}`),
+          platform,
+        );
+
+  if (posixSecretPath !== null) {
+    yield* Effect.sync(() => writeSecretFileMode0600(posixSecretPath, authSecret));
+  }
 
   return {
     ...baseEnv,
     SSH_ASKPASS: sshAskpass,
     SSH_ASKPASS_REQUIRE: "force",
-    ...(input.authSecret === undefined ? {} : { T3_SSH_AUTH_SECRET: input.authSecret ?? "" }),
+    ...(input.authSecret === undefined
+      ? {}
+      : platform === "win32"
+        ? { T3_SSH_AUTH_SECRET: authSecret }
+        : { T3_SSH_AUTH_SECRET_FILE: posixSecretPath ?? "" }),
     ...(platform === "win32" || baseEnv.DISPLAY ? {} : { DISPLAY: "t3code" }),
   };
 });

--- a/t3code/packages/ssh/src/contributor_meta.json
+++ b/t3code/packages/ssh/src/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex via Hermes Agent",
+  "session_init": "Private runtime instructions and user/session context are intentionally not disclosed. Implementation scope: UnsafeLabs/Bounty-Hunters#822 SSH askpass hardening; no secrets or hidden prompts are included in this metadata.",
+  "ts": "2026-05-16T10:12:08Z"
+}


### PR DESCRIPTION
## Summary
- Move POSIX askpass cached passwords out of the process environment and into a unique secret file created with `0600` permissions from creation.
- Update the POSIX askpass helper to read that private file and remove it via `EXIT`, `INT`, and `TERM` traps.
- Validate generated askpass paths to reject unsafe shell metacharacters before helper files are used.
- Keep the Windows askpass path compatible while converting the env secret through `SecureString` and zeroing the BSTR after stdout handoff.
- Add regression tests for secret file permissions, cleanup after askpass execution, Windows SecureString handling, and unsafe path rejection.

## Verification
- Demo video: https://github.com/snidova1/Bounty-Hunters/releases/download/demo-pr-1255/t3code-ssh-askpass-demo.mp4
- `bun run fmt packages/ssh/src/auth.ts packages/ssh/src/auth.test.ts`
- `bun run lint packages/ssh/src/auth.ts packages/ssh/src/auth.test.ts`
- `cd packages/ssh && bun run typecheck`
- `cd packages/ssh && bun run test`
- `git diff --check`

## Notes
- The askpass helper must still write the password to stdout because that is the SSH_ASKPASS contract; the implementation avoids logs and removes the private temp secret file immediately after use.
- Added `packages/ssh/src/contributor_meta.json` without disclosing private runtime/system instructions or secrets.

Closes UnsafeLabs/Bounty-Hunters#822
/claim #822
