### PR TITLE
OpenAI Codex [ T3 Code ] Rework ACP token refresh replay after unauthorized requests

### DIFF
--- a/t3code/packages/effect-acp/src/.provenance.json
+++ b/t3code/packages/effect-acp/src/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex via Hermes Agent",
+  "config_snapshot": "Private runtime/system/developer instructions, user profile, memory, and secrets are intentionally not disclosed. Loaded public task context before this rework: GitHub issue UnsafeLabs/Bounty-Hunters#829 acceptance criteria for T3 Code ACP token refresh; GitHub PR workflow guidance; repository CONTRIBUTING guidance as referenced by the issue bot. Implementation scope: add ACP 401 token-refresh retry, refresh-token storage, onSessionExpired callback, Effect.acquireUseRelease cleanup, session recreation/replay, typed AuthenticationError failure path, and tests. No hidden prompts, credentials, or private messaging context are included in this metadata.",
+  "created": "2026-05-16T11:10:36Z"
+}

--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -22,8 +22,28 @@ import { makeInMemoryStdio } from "./_internal/stdio.ts";
 
 const InitializeRequest = jsonRpcRequest("initialize", AcpSchema.InitializeRequest);
 const InitializeResponse = jsonRpcResponse(AcpSchema.InitializeResponse);
+const AuthenticateRequest = jsonRpcRequest("authenticate", AcpSchema.AuthenticateRequest);
+const AuthenticateResponse = jsonRpcResponse(AcpSchema.AuthenticateResponse);
+const PromptRequest = jsonRpcRequest("session/prompt", AcpSchema.PromptRequest);
+const PromptResponse = jsonRpcResponse(AcpSchema.PromptResponse);
+const decodeAuthenticateRequest = Schema.decodeEffect(Schema.fromJsonString(AuthenticateRequest));
+const decodePromptRequest = Schema.decodeEffect(Schema.fromJsonString(PromptRequest));
 const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
+const textEncoder = new TextEncoder();
+
+const encodeRawJsonl = (value: unknown) => textEncoder.encode(`${JSON.stringify(value)}\n`);
+const encodeRpcFailureJsonl = (id: string | number, error: AcpSchema.Error) =>
+  encodeRawJsonl({
+    jsonrpc: "2.0",
+    id,
+    error: {
+      _tag: "Cause",
+      code: 0,
+      message: JSON.stringify([{ _tag: "Fail", error }]),
+      data: [{ _tag: "Fail", error }],
+    },
+  });
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/acp-mock-peer.ts"),
 );
@@ -372,6 +392,140 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
 
         assert.equal(yield* Ref.get(successfulHandlers), 1);
       }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+    }),
+  );
+
+  it.effect("refreshes authentication once and replays a prompt after a 401", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+      const expiredSessions = yield* Ref.make<Array<string>>([]);
+      const acp = yield* AcpClient.make(stdio, {
+        onSessionExpired: (sessionId) =>
+          Ref.update(expiredSessions, (current) => [...current, sessionId ?? "unknown"]),
+      }).pipe(Effect.provideService(Scope.Scope, scope));
+
+      const authenticateFiber = yield* acp.agent
+        .authenticate({ methodId: "cursor_login" })
+        .pipe(Effect.forkScoped);
+      const authenticateOutbound = yield* Queue.take(output);
+      const authenticateRequest = yield* decodeAuthenticateRequest(authenticateOutbound);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: authenticateRequest.id,
+          result: { _meta: { accessToken: "access-1", refreshToken: "refresh-1" } },
+        }),
+      );
+      yield* Fiber.join(authenticateFiber);
+
+      const promptFiber = yield* acp.agent
+        .prompt({
+          sessionId: "expired-session",
+          prompt: [{ type: "text", text: "hello" }],
+        })
+        .pipe(Effect.forkScoped);
+
+      const firstPromptOutbound = yield* Queue.take(output);
+      const firstPromptRequest = yield* decodePromptRequest(firstPromptOutbound);
+      yield* Queue.offer(
+        input,
+        encodeRpcFailureJsonl(firstPromptRequest.id, {
+          code: -32000,
+          message: "401 Unauthorized",
+          data: { status: 401 },
+        }),
+      );
+
+      const refreshOutbound = yield* Queue.take(output);
+      const refreshRequest = yield* decodeAuthenticateRequest(refreshOutbound);
+      assert.equal(refreshRequest.params.methodId, "cursor_login");
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: refreshRequest.id,
+          result: { _meta: { accessToken: "access-2", refreshToken: "refresh-2" } },
+        }),
+      );
+
+      const replayedPromptOutbound = yield* Queue.take(output);
+      const replayedPromptRequest = yield* decodePromptRequest(replayedPromptOutbound);
+      assert.equal(replayedPromptRequest.params.sessionId, "expired-session");
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(PromptResponse, {
+          jsonrpc: "2.0",
+          id: replayedPromptRequest.id,
+          result: { stopReason: "end_turn" },
+        }),
+      );
+
+      assert.deepEqual(yield* Fiber.join(promptFiber), { stopReason: "end_turn" });
+      assert.deepEqual(yield* Ref.get(expiredSessions), ["expired-session"]);
+      yield* Scope.close(scope, Exit.void);
+    }),
+  );
+
+  it.effect("fails queued requests with AuthenticationError when refresh fails", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+      const acp = yield* AcpClient.make(stdio).pipe(Effect.provideService(Scope.Scope, scope));
+
+      const authenticateFiber = yield* acp.agent
+        .authenticate({ methodId: "cursor_login" })
+        .pipe(Effect.forkScoped);
+      const authenticateOutbound = yield* Queue.take(output);
+      const authenticateRequest = yield* decodeAuthenticateRequest(authenticateOutbound);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: authenticateRequest.id,
+          result: { _meta: { accessToken: "access-1", refreshToken: "refresh-1" } },
+        }),
+      );
+      yield* Fiber.join(authenticateFiber);
+
+      const promptExitFiber = yield* Effect.exit(
+        acp.agent.prompt({
+          sessionId: "expired-session",
+          prompt: [{ type: "text", text: "hello" }],
+        }),
+      ).pipe(Effect.forkScoped);
+
+      const firstPromptOutbound = yield* Queue.take(output);
+      const firstPromptRequest = yield* decodePromptRequest(firstPromptOutbound);
+      yield* Queue.offer(
+        input,
+        encodeRpcFailureJsonl(firstPromptRequest.id, {
+          code: -32000,
+          message: "401 Unauthorized",
+          data: { status: 401 },
+        }),
+      );
+
+      const refreshOutbound = yield* Queue.take(output);
+      const refreshRequest = yield* decodeAuthenticateRequest(refreshOutbound);
+      yield* Queue.offer(
+        input,
+        encodeRpcFailureJsonl(refreshRequest.id, {
+          code: -32000,
+          message: "refresh token expired",
+          data: { status: 401 },
+        }),
+      );
+
+      const promptExit = yield* Fiber.join(promptExitFiber);
+      if (promptExit._tag !== "Failure") {
+        assert.fail("Expected prompt to fail when refresh fails");
+      }
+      const rendered = Cause.pretty(promptExit.cause);
+      assert.include(rendered, "AuthenticationError");
+      assert.include(rendered, "refresh token expired");
+      yield* Scope.close(scope, Exit.void);
     }),
   );
 

--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -24,9 +24,15 @@ const InitializeRequest = jsonRpcRequest("initialize", AcpSchema.InitializeReque
 const InitializeResponse = jsonRpcResponse(AcpSchema.InitializeResponse);
 const AuthenticateRequest = jsonRpcRequest("authenticate", AcpSchema.AuthenticateRequest);
 const AuthenticateResponse = jsonRpcResponse(AcpSchema.AuthenticateResponse);
+const NewSessionRequest = jsonRpcRequest("session/new", AcpSchema.NewSessionRequest);
+const NewSessionResponse = jsonRpcResponse(AcpSchema.NewSessionResponse);
+const CloseSessionRequest = jsonRpcRequest("session/close", AcpSchema.CloseSessionRequest);
+const CloseSessionResponse = jsonRpcResponse(AcpSchema.CloseSessionResponse);
 const PromptRequest = jsonRpcRequest("session/prompt", AcpSchema.PromptRequest);
 const PromptResponse = jsonRpcResponse(AcpSchema.PromptResponse);
 const decodeAuthenticateRequest = Schema.decodeEffect(Schema.fromJsonString(AuthenticateRequest));
+const decodeNewSessionRequest = Schema.decodeEffect(Schema.fromJsonString(NewSessionRequest));
+const decodeCloseSessionRequest = Schema.decodeEffect(Schema.fromJsonString(CloseSessionRequest));
 const decodePromptRequest = Schema.decodeEffect(Schema.fromJsonString(PromptRequest));
 const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
@@ -395,7 +401,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
     }),
   );
 
-  it.effect("refreshes authentication once and replays a prompt after a 401", () =>
+  it.effect("refreshes authentication once and replays concurrent prompts after a 401", () =>
     Effect.gen(function* () {
       const { stdio, input, output } = yield* makeInMemoryStdio();
       const scope = yield* Scope.make();
@@ -420,18 +426,49 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
       );
       yield* Fiber.join(authenticateFiber);
 
-      const promptFiber = yield* acp.agent
+      const sessionFiber = yield* acp.agent
+        .createSession({ cwd: process.cwd(), mcpServers: [] })
+        .pipe(Effect.forkScoped);
+      const newSessionOutbound = yield* Queue.take(output);
+      const newSessionRequest = yield* decodeNewSessionRequest(newSessionOutbound);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(NewSessionResponse, {
+          jsonrpc: "2.0",
+          id: newSessionRequest.id,
+          result: { sessionId: "session-1" },
+        }),
+      );
+      assert.equal((yield* Fiber.join(sessionFiber)).sessionId, "session-1");
+
+      const firstPromptFiber = yield* acp.agent
         .prompt({
-          sessionId: "expired-session",
-          prompt: [{ type: "text", text: "hello" }],
+          sessionId: "session-1",
+          prompt: [{ type: "text", text: "first" }],
+        })
+        .pipe(Effect.forkScoped);
+      const secondPromptFiber = yield* acp.agent
+        .prompt({
+          sessionId: "session-1",
+          prompt: [{ type: "text", text: "second" }],
         })
         .pipe(Effect.forkScoped);
 
       const firstPromptOutbound = yield* Queue.take(output);
+      const secondPromptOutbound = yield* Queue.take(output);
       const firstPromptRequest = yield* decodePromptRequest(firstPromptOutbound);
+      const secondPromptRequest = yield* decodePromptRequest(secondPromptOutbound);
       yield* Queue.offer(
         input,
         encodeRpcFailureJsonl(firstPromptRequest.id, {
+          code: -32000,
+          message: "401 Unauthorized",
+          data: { status: 401 },
+        }),
+      );
+      yield* Queue.offer(
+        input,
+        encodeRpcFailureJsonl(secondPromptRequest.id, {
           code: -32000,
           message: "401 Unauthorized",
           data: { status: 401 },
@@ -441,6 +478,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
       const refreshOutbound = yield* Queue.take(output);
       const refreshRequest = yield* decodeAuthenticateRequest(refreshOutbound);
       assert.equal(refreshRequest.params.methodId, "cursor_login");
+      assert.equal(refreshRequest.params._meta?.refreshToken, "refresh-1");
       yield* Queue.offer(
         input,
         yield* encodeJsonl(AuthenticateResponse, {
@@ -450,20 +488,55 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
         }),
       );
 
-      const replayedPromptOutbound = yield* Queue.take(output);
-      const replayedPromptRequest = yield* decodePromptRequest(replayedPromptOutbound);
-      assert.equal(replayedPromptRequest.params.sessionId, "expired-session");
+      const closeOutbound = yield* Queue.take(output);
+      const closeRequest = yield* decodeCloseSessionRequest(closeOutbound);
+      assert.equal(closeRequest.params.sessionId, "session-1");
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(CloseSessionResponse, {
+          jsonrpc: "2.0",
+          id: closeRequest.id,
+          result: {},
+        }),
+      );
+
+      const recreatedSessionOutbound = yield* Queue.take(output);
+      const recreatedSessionRequest = yield* decodeNewSessionRequest(recreatedSessionOutbound);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(NewSessionResponse, {
+          jsonrpc: "2.0",
+          id: recreatedSessionRequest.id,
+          result: { sessionId: "session-2" },
+        }),
+      );
+
+      const firstReplayedPromptOutbound = yield* Queue.take(output);
+      const secondReplayedPromptOutbound = yield* Queue.take(output);
+      const firstReplayedPromptRequest = yield* decodePromptRequest(firstReplayedPromptOutbound);
+      const secondReplayedPromptRequest = yield* decodePromptRequest(secondReplayedPromptOutbound);
+      assert.equal(firstReplayedPromptRequest.params.sessionId, "session-2");
+      assert.equal(secondReplayedPromptRequest.params.sessionId, "session-2");
       yield* Queue.offer(
         input,
         yield* encodeJsonl(PromptResponse, {
           jsonrpc: "2.0",
-          id: replayedPromptRequest.id,
+          id: firstReplayedPromptRequest.id,
+          result: { stopReason: "end_turn" },
+        }),
+      );
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(PromptResponse, {
+          jsonrpc: "2.0",
+          id: secondReplayedPromptRequest.id,
           result: { stopReason: "end_turn" },
         }),
       );
 
-      assert.deepEqual(yield* Fiber.join(promptFiber), { stopReason: "end_turn" });
-      assert.deepEqual(yield* Ref.get(expiredSessions), ["expired-session"]);
+      assert.deepEqual(yield* Fiber.join(firstPromptFiber), { stopReason: "end_turn" });
+      assert.deepEqual(yield* Fiber.join(secondPromptFiber), { stopReason: "end_turn" });
+      assert.deepEqual(yield* Ref.get(expiredSessions), ["session-1"]);
       yield* Scope.close(scope, Exit.void);
     }),
   );
@@ -489,9 +562,24 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
       );
       yield* Fiber.join(authenticateFiber);
 
+      const sessionFiber = yield* acp.agent
+        .createSession({ cwd: process.cwd(), mcpServers: [] })
+        .pipe(Effect.forkScoped);
+      const newSessionOutbound = yield* Queue.take(output);
+      const newSessionRequest = yield* decodeNewSessionRequest(newSessionOutbound);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(NewSessionResponse, {
+          jsonrpc: "2.0",
+          id: newSessionRequest.id,
+          result: { sessionId: "session-1" },
+        }),
+      );
+      yield* Fiber.join(sessionFiber);
+
       const promptExitFiber = yield* Effect.exit(
         acp.agent.prompt({
-          sessionId: "expired-session",
+          sessionId: "session-1",
           prompt: [{ type: "text", text: "hello" }],
         }),
       ).pipe(Effect.forkScoped);
@@ -515,6 +603,18 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
           code: -32000,
           message: "refresh token expired",
           data: { status: 401 },
+        }),
+      );
+
+      const closeOutbound = yield* Queue.take(output);
+      const closeRequest = yield* decodeCloseSessionRequest(closeOutbound);
+      assert.equal(closeRequest.params.sessionId, "session-1");
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(CloseSessionResponse, {
+          jsonrpc: "2.0",
+          id: closeRequest.id,
+          result: {},
         }),
       );
 

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -3,7 +3,10 @@ import * as Effect from "effect/Effect";
 import * as Stdio from "effect/Stdio";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import * as RpcServer from "effect/unstable/rpc/RpcServer";
@@ -26,6 +29,7 @@ export interface AcpClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
+  readonly onSessionExpired?: (sessionId: string | undefined) => Effect.Effect<void, never>;
 }
 
 type AcpClientRaw = {
@@ -306,6 +310,33 @@ interface BufferedNotificationHandler<A> {
   readonly pending: Array<A>;
 }
 
+interface AuthState {
+  readonly methodId: string | undefined;
+  readonly accessToken: string | undefined;
+  readonly refreshToken: string | undefined;
+  readonly generation: number;
+}
+
+const getMetaString = (meta: { readonly [x: string]: unknown } | null | undefined, key: string) => {
+  const value = meta?.[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+const getStatus = (data: unknown) =>
+  typeof data === "object" && data !== null && "status" in data
+    ? (data as { readonly status?: unknown }).status
+    : undefined;
+
+const isUnauthorizedError = (error: AcpError.AcpError) =>
+  error._tag === "AcpRequestError" &&
+  (error.code === -32000 || error.code === -32603) &&
+  (getStatus(error.data) === 401 || /\b401\b|unauthori[sz]ed/i.test(error.errorMessage));
+
+const getSessionId = (payload: unknown) =>
+  typeof payload === "object" && payload !== null && "sessionId" in payload
+    ? (payload as { readonly sessionId?: unknown }).sessionId
+    : undefined;
+
 export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpClientOptions = {},
@@ -456,6 +487,108 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     generateRequestId: () => nextRpcRequestId++ as never,
   }).pipe(Effect.provideService(RpcClient.Protocol, transport.clientProtocol));
 
+  const authStateRef = yield* Ref.make<AuthState>({
+    methodId: undefined,
+    accessToken: undefined,
+    refreshToken: undefined,
+    generation: 0,
+  });
+  const refreshSemaphore = yield* Semaphore.make(1);
+
+  const storeAuthentication = (
+    request: AcpSchema.AuthenticateRequest,
+    response: AcpSchema.AuthenticateResponse,
+  ) =>
+    Ref.update(authStateRef, (state) => ({
+      methodId: request.methodId,
+      accessToken: getMetaString(response._meta, "accessToken") ?? state.accessToken,
+      refreshToken: getMetaString(response._meta, "refreshToken") ?? state.refreshToken,
+      generation: state.generation + 1,
+    }));
+
+  const authenticate = (payload: AcpSchema.AuthenticateRequest) =>
+    callRpc(rpc[AGENT_METHODS.authenticate](payload)).pipe(
+      Effect.tap((response) => storeAuthentication(payload, response)),
+    );
+
+  const reauthenticate = (sessionId: string | undefined, generation: number) =>
+    refreshSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        const state = yield* Ref.get(authStateRef);
+        if (state.generation !== generation) {
+          return;
+        }
+        if (!state.methodId) {
+          return yield* Effect.fail(
+            new AcpError.AuthenticationError({
+              errorMessage:
+                "Authentication required, but no previous authentication method is available",
+            }),
+          );
+        }
+
+        if (options.onSessionExpired) {
+          yield* options.onSessionExpired(sessionId);
+        }
+
+        yield* authenticate({
+          methodId: state.methodId,
+          _meta: {
+            ...(state.refreshToken ? { refreshToken: state.refreshToken } : {}),
+            ...(state.accessToken ? { previousAccessToken: state.accessToken } : {}),
+          },
+        }).pipe(
+          Effect.mapError(
+            (error) =>
+              new AcpError.AuthenticationError({
+                errorMessage: error.message,
+                cause: error,
+              }),
+          ),
+        );
+      }),
+    );
+
+  const withAuthRefresh = <A>(effect: Effect.Effect<A, AcpError.AcpError>, payload?: unknown) =>
+    Effect.gen(function* () {
+      const generation = yield* Ref.get(authStateRef).pipe(Effect.map((state) => state.generation));
+      const attemptedRefreshRef = yield* Ref.make(false);
+      const sessionId = getSessionId(payload);
+      return yield* effect.pipe(
+        Effect.catchIf(isUnauthorizedError, (error) =>
+          Effect.gen(function* () {
+            const attemptedRefresh = yield* Ref.get(attemptedRefreshRef);
+            if (attemptedRefresh) {
+              return yield* Effect.fail(
+                new AcpError.AuthenticationError({
+                  errorMessage: error.message,
+                  cause: error,
+                }),
+              );
+            }
+            yield* Ref.set(attemptedRefreshRef, true);
+            yield* reauthenticate(
+              typeof sessionId === "string" ? sessionId : undefined,
+              generation,
+            );
+            return yield* Effect.fail(error);
+          }),
+        ),
+        Effect.retry({
+          schedule: Schedule.recurs(1),
+          while: isUnauthorizedError,
+        }),
+        Effect.catchIf(isUnauthorizedError, (error) =>
+          Effect.fail(
+            new AcpError.AuthenticationError({
+              errorMessage: error.message,
+              cause: error,
+            }),
+          ),
+        ),
+      );
+    });
+
   return AcpClient.of({
     raw: {
       notifications: transport.incoming,
@@ -464,18 +597,25 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     },
     agent: {
       initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
-      authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
+      authenticate,
       logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
+      createSession: (payload) =>
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_new](payload)), payload),
+      loadSession: (payload) =>
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_load](payload)), payload),
+      listSessions: (payload) =>
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_list](payload)), payload),
+      forkSession: (payload) =>
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_fork](payload)), payload),
+      resumeSession: (payload) =>
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_resume](payload)), payload),
       closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      setSessionModel: (payload) =>
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_set_model](payload)), payload),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)), payload),
+      prompt: (payload) =>
+        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_prompt](payload)), payload),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -317,6 +317,11 @@ interface AuthState {
   readonly generation: number;
 }
 
+interface SessionState {
+  readonly createPayload: AcpSchema.NewSessionRequest | undefined;
+  readonly currentSessionId: string | undefined;
+}
+
 const getMetaString = (meta: { readonly [x: string]: unknown } | null | undefined, key: string) => {
   const value = meta?.[key];
   return typeof value === "string" ? value : undefined;
@@ -336,6 +341,11 @@ const getSessionId = (payload: unknown) =>
   typeof payload === "object" && payload !== null && "sessionId" in payload
     ? (payload as { readonly sessionId?: unknown }).sessionId
     : undefined;
+
+const replaceSessionId = <A>(payload: A, sessionId: string): A =>
+  typeof payload === "object" && payload !== null && "sessionId" in payload
+    ? ({ ...payload, sessionId } as A)
+    : payload;
 
 export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
@@ -493,6 +503,10 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     refreshToken: undefined,
     generation: 0,
   });
+  const sessionStateRef = yield* Ref.make<SessionState>({
+    createPayload: undefined,
+    currentSessionId: undefined,
+  });
   const refreshSemaphore = yield* Semaphore.make(1);
 
   const storeAuthentication = (
@@ -511,6 +525,42 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
       Effect.tap((response) => storeAuthentication(payload, response)),
     );
 
+  const createSession = (payload: AcpSchema.NewSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_new](payload)).pipe(
+      Effect.tap((response) =>
+        Ref.set(sessionStateRef, {
+          createPayload: payload,
+          currentSessionId: response.sessionId,
+        }),
+      ),
+    );
+
+  const closeExpiredSession = (sessionId: string | undefined) =>
+    typeof sessionId === "string"
+      ? callRpc(rpc[AGENT_METHODS.session_close]({ sessionId })).pipe(Effect.ignore)
+      : Effect.void;
+
+  const recreateSessionIfCurrentExpired = (expiredSessionId: string | undefined) =>
+    Effect.gen(function* () {
+      const sessionState = yield* Ref.get(sessionStateRef);
+      if (
+        typeof expiredSessionId !== "string" ||
+        sessionState.currentSessionId !== expiredSessionId ||
+        !sessionState.createPayload
+      ) {
+        return;
+      }
+      yield* createSession(sessionState.createPayload).pipe(
+        Effect.mapError(
+          (error) =>
+            new AcpError.AuthenticationError({
+              errorMessage: error.message,
+              cause: error,
+            }),
+        ),
+      );
+    });
+
   const reauthenticate = (sessionId: string | undefined, generation: number) =>
     refreshSemaphore.withPermits(1)(
       Effect.gen(function* () {
@@ -527,34 +577,56 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
           );
         }
 
+        const methodId = state.methodId;
+
         if (options.onSessionExpired) {
           yield* options.onSessionExpired(sessionId);
         }
 
-        yield* authenticate({
-          methodId: state.methodId,
-          _meta: {
-            ...(state.refreshToken ? { refreshToken: state.refreshToken } : {}),
-            ...(state.accessToken ? { previousAccessToken: state.accessToken } : {}),
-          },
-        }).pipe(
-          Effect.mapError(
-            (error) =>
-              new AcpError.AuthenticationError({
-                errorMessage: error.message,
-                cause: error,
-              }),
-          ),
+        yield* Effect.acquireUseRelease(
+          Effect.succeed(sessionId),
+          () =>
+            authenticate({
+              methodId,
+              _meta: {
+                ...(state.refreshToken ? { refreshToken: state.refreshToken } : {}),
+                ...(state.accessToken ? { previousAccessToken: state.accessToken } : {}),
+              },
+            }).pipe(
+              Effect.mapError(
+                (error) =>
+                  new AcpError.AuthenticationError({
+                    errorMessage: error.message,
+                    cause: error,
+                  }),
+              ),
+            ),
+          (expiredSessionId) => closeExpiredSession(expiredSessionId),
         );
+        yield* recreateSessionIfCurrentExpired(sessionId);
       }),
     );
 
-  const withAuthRefresh = <A>(effect: Effect.Effect<A, AcpError.AcpError>, payload?: unknown) =>
+  const replayPayload = <A>(payload: A, expiredSessionId: string | undefined) =>
+    Effect.gen(function* () {
+      const sessionState = yield* Ref.get(sessionStateRef);
+      return typeof expiredSessionId === "string" && sessionState.currentSessionId
+        ? replaceSessionId(payload, sessionState.currentSessionId)
+        : payload;
+    });
+
+  const withAuthRefresh = <A, P>(
+    payload: P,
+    run: (payload: P) => Effect.Effect<A, AcpError.AcpError>,
+  ) =>
     Effect.gen(function* () {
       const generation = yield* Ref.get(authStateRef).pipe(Effect.map((state) => state.generation));
       const attemptedRefreshRef = yield* Ref.make(false);
       const sessionId = getSessionId(payload);
-      return yield* effect.pipe(
+      return yield* Effect.flatMap(
+        replayPayload(payload, typeof sessionId === "string" ? sessionId : undefined),
+        run,
+      ).pipe(
         Effect.catchIf(isUnauthorizedError, (error) =>
           Effect.gen(function* () {
             const attemptedRefresh = yield* Ref.get(attemptedRefreshRef);
@@ -599,23 +671,36 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
       initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
       authenticate,
       logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_new](payload)), payload),
+      createSession: (payload) => withAuthRefresh(payload, createSession),
       loadSession: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_load](payload)), payload),
+        withAuthRefresh(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_load](nextPayload)),
+        ),
       listSessions: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_list](payload)), payload),
+        withAuthRefresh(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_list](nextPayload)),
+        ),
       forkSession: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_fork](payload)), payload),
+        withAuthRefresh(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_fork](nextPayload)),
+        ),
       resumeSession: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_resume](payload)), payload),
+        withAuthRefresh(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_resume](nextPayload)),
+        ),
       closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
       setSessionModel: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_set_model](payload)), payload),
+        withAuthRefresh(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_set_model](nextPayload)),
+        ),
       setSessionConfigOption: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)), payload),
+        withAuthRefresh(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_set_config_option](nextPayload)),
+        ),
       prompt: (payload) =>
-        withAuthRefresh(callRpc(rpc[AGENT_METHODS.session_prompt](payload)), payload),
+        withAuthRefresh(payload, (nextPayload) =>
+          callRpc(rpc[AGENT_METHODS.session_prompt](nextPayload)),
+        ),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>

--- a/t3code/packages/effect-acp/src/errors.ts
+++ b/t3code/packages/effect-acp/src/errors.ts
@@ -47,6 +47,18 @@ export class AcpTransportError extends Schema.TaggedErrorClass<AcpTransportError
   },
 ) {}
 
+export class AuthenticationError extends Schema.TaggedErrorClass<AuthenticationError>()(
+  "AuthenticationError",
+  {
+    errorMessage: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {
+  override get message() {
+    return this.errorMessage;
+  }
+}
+
 export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()("AcpRequestError", {
   code: AcpSchema.ErrorCode,
   errorMessage: Schema.String,
@@ -129,6 +141,7 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
 }
 
 export const AcpError = Schema.Union([
+  AuthenticationError,
   AcpRequestError,
   AcpSpawnError,
   AcpProcessExitedError,


### PR DESCRIPTION
## Summary
- Rework ACP refresh handling after the rejected #1245 attempt to meet the full #829 acceptance flow.
- Store access/refresh tokens separately, detect 401/unauthorized ACP responses, and retry through an `Effect.retry` path that attempts refresh once.
- Add `onSessionExpired(sessionId)` before refresh, wrap refresh in `Effect.acquireUseRelease`, close the expired session, recreate the session from the saved create payload, and replay queued/concurrent prompts against the new session ID.
- Convert refresh failure into a typed `AuthenticationError` for waiting requests.
- Add required `packages/effect-acp/src/.provenance.json` metadata without disclosing private runtime instructions or secrets.

## Verification
- `bun run fmt packages/effect-acp/src/client.ts packages/effect-acp/src/client.test.ts`
- `cd packages/effect-acp && bun run typecheck`
- `cd packages/effect-acp && bun run test` — 18 tests passed
- `bun run lint packages/effect-acp/src/client.ts packages/effect-acp/src/client.test.ts packages/effect-acp/src/errors.ts`
- `git diff --check`

Closes UnsafeLabs/Bounty-Hunters#829
/claim #829
