### PR TITLE
D3CC [ FastAPI ] feat: Paginator with offset and cursor-based pagination

### DIFF
--- a/_generation.json
+++ b/_generation.json
@@ -1,0 +1,6 @@
+{
+  "generated_by": "D3CC AI",
+  "generated_at": "2026-05-16T17:21:52Z",
+  "model": "claude-sonnet-4-20250514",
+  "repository": "UnsafeLabs/Bounty-Hunters"
+}

--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "D3CC-GiMax",
+  "platform_config": "GiMax D3 Multi-Platform Automated Bounty Hunter - FastAPI pagination utility with offset and cursor support",
+  "date": "2026-05-16T11:59:01Z"
+}

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -191,3 +191,19 @@ class Paginator:
             return _json.loads(data)
         except Exception:
             return {}
+
+    async def __aiter__(self):
+        """Async iterator for use in async contexts.
+
+        Usage:
+            paginator = Paginator(query, limit=20)
+            async for item in paginator:
+                await process(item)
+        """
+        while True:
+            page = self.next_page()
+            if not page.items:
+                break
+            for item in page.items:
+                yield item
+

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,193 @@
+"""FastAPI pagination utility with offset and cursor-based pagination.
+
+Provides a dependency-injectable pagination system that works with any
+data source and returns standardized paginated responses.
+"""
+
+from __future__ import annotations
+
+import base64 as _base64
+import json as _json
+from typing import Annotated, Any, Generic, Optional, TypeVar
+
+from pydantic import BaseModel
+
+from .param_functions import Query
+
+T = TypeVar("T")
+
+
+class PaginationParams:
+    """Dependency-injectable pagination parameters."""
+
+    def __init__(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        cursor: Optional[str] = None,
+    ) -> None:
+        self.page = max(1, page)
+        self.page_size = max(1, min(page_size, 100))
+        self.cursor = cursor
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    """Standardized paginated response model."""
+
+    items: list[T]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+    next_cursor: Optional[str] = None
+
+
+def paginate(
+    page: Annotated[
+        int,
+        Query(
+            default=1,
+            ge=1,
+            description="Page number (1-based)",
+        ),
+    ] = 1,
+    page_size: Annotated[
+        int,
+        Query(
+            default=20,
+            ge=1,
+            le=100,
+            description="Number of items per page",
+        ),
+    ] = 20,
+) -> PaginationParams:
+    """Dependency that extracts pagination parameters from query string.
+
+    Can be injected into any FastAPI route:
+
+    ```python
+    @app.get("/items")
+    def list_items(p: PaginationParams = Depends(paginate)):
+        return paginator.paginate(...)
+    ```
+    """
+    return PaginationParams(page=page, page_size=page_size)
+
+
+class Paginator:
+    """Utility for creating paginated responses from data sources."""
+
+    @staticmethod
+    def paginate_offset(
+        items: list[Any],
+        total: int,
+        page: int,
+        page_size: int,
+    ) -> dict[str, Any]:
+        """Build an offset-based paginated response dict.
+
+        Args:
+            items: The items for the current page.
+            total: Total number of items across all pages.
+            page: Current page number (1-based, will be clamped to >= 1).
+            page_size: Number of items per page (will be clamped to >= 1).
+
+        Returns:
+            A dict matching the PaginatedResponse schema.
+        """
+        page = max(1, page)
+        page_size = max(1, page_size)
+        total_pages = max(1, (total + page_size - 1) // page_size) if total > 0 else 1
+
+        return {
+            "items": items,
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "has_next": page < total_pages,
+            "has_previous": page > 1,
+        }
+
+    @staticmethod
+    def paginate_cursor(
+        items: list[Any],
+        page_size: int,
+        cursor_field: str = "id",
+        cursor: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Build a cursor-based paginated response dict.
+
+        The cursor encodes the value of ``cursor_field`` from the last
+        item in the current page so the client can pass it back to request
+        the next page.
+
+        Args:
+            items: The items for the current page (should contain one extra
+                   item to detect has_next).
+            page_size: Requested page size.
+            cursor_field: The field to use as the cursor value.
+            cursor: The cursor from the request (ignored in response, used
+                    by the caller for filtering).
+
+        Returns:
+            A dict matching the PaginatedResponse schema.
+        """
+        page_size = max(1, page_size)
+
+        has_next = len(items) > page_size
+        if has_next:
+            items = items[:page_size]
+
+        next_cursor: Optional[str] = None
+        if has_next and items:
+            last_item = items[-1]
+            cursor_value = None
+            if isinstance(last_item, dict):
+                cursor_value = last_item.get(cursor_field)
+            elif hasattr(last_item, cursor_field):
+                cursor_value = getattr(last_item, cursor_field)
+
+            if cursor_value is not None:
+                cursor_data = _json.dumps(
+                    {cursor_field: cursor_value, "page_size": page_size}
+                )
+                next_cursor = _base64.urlsafe_b64encode(
+                    cursor_data.encode()
+                ).decode().rstrip("=")
+
+        return {
+            "items": items,
+            "total": len(items),
+            "page": 1,
+            "page_size": page_size,
+            "total_pages": 1,
+            "has_next": has_next,
+            "has_previous": False,
+            "next_cursor": next_cursor,
+        }
+
+    @staticmethod
+    def decode_cursor(cursor: str) -> dict[str, Any]:
+        """Decode a cursor string back to its original data.
+
+        Returns the decoded dict, or an empty dict if decoding fails.
+        """
+        try:
+            padding = 4 - len(cursor) % 4
+            if padding != 4:
+                cursor += "=" * padding
+            data = _base64.urlsafe_b64decode(cursor)
+            return _json.loads(data)
+        except Exception:
+            return {}

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,248 @@
+"""Tests for fastapi.fastapi.pagination module."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from fastapi.pagination import (
+    PaginatedResponse,
+    PaginationParams,
+    Paginator,
+    decode_cursor,
+    paginate,
+)
+
+
+class TestItem(BaseModel):
+    id: int
+    name: str
+
+
+class TestPaginationParams:
+    """PaginationParams computed properties."""
+
+    def test_offset_defaults(self) -> None:
+        p = PaginationParams(page=1, page_size=20)
+        assert p.offset == 0
+        assert p.limit == 20
+
+    def test_offset_page_3(self) -> None:
+        p = PaginationParams(page=3, page_size=10)
+        assert p.offset == 20
+        assert p.limit == 10
+
+    def test_clamp_negative_page(self) -> None:
+        p = PaginationParams(page=-5, page_size=10)
+        assert p.page == 1
+        assert p.offset == 0
+
+    def test_clamp_zero_page(self) -> None:
+        p = PaginationParams(page=0, page_size=10)
+        assert p.page == 1
+
+    def test_clamp_zero_page_size(self) -> None:
+        p = PaginationParams(page=1, page_size=0)
+        assert p.page_size == 1
+
+    def test_clamp_large_page_size(self) -> None:
+        p = PaginationParams(page=1, page_size=200)
+        assert p.page_size == 100
+
+
+class TestPaginateDependency:
+    """paginate() dependency function."""
+
+    def test_default_values(self) -> None:
+        app = FastAPI()
+
+        @app.get("/items")
+        def get_items(p: PaginationParams = Depends(paginate)):
+            return {"page": p.page, "page_size": p.page_size}
+
+        client = TestClient(app)
+        resp = client.get("/items")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["page"] == 1
+        assert data["page_size"] == 20
+
+    def test_custom_query_params(self) -> None:
+        app = FastAPI()
+
+        @app.get("/items")
+        def get_items(p: PaginationParams = Depends(paginate)):
+            return {"page": p.page, "page_size": p.page_size, "offset": p.offset}
+
+        client = TestClient(app)
+        resp = client.get("/items?page=3&page_size=15")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["page"] == 3
+        assert data["page_size"] == 15
+        assert data["offset"] == 30
+
+
+class TestPaginateOffset:
+    """Paginator.paginate_offset()."""
+
+    def test_first_page(self) -> None:
+        items = [{"id": i, "name": f"item_{i}"} for i in range(5)]
+        result = Paginator.paginate_offset(items=items, total=25, page=1, page_size=5)
+        assert len(result["items"]) == 5
+        assert result["total"] == 25
+        assert result["page"] == 1
+        assert result["page_size"] == 5
+        assert result["total_pages"] == 5
+        assert result["has_next"] is True
+        assert result["has_previous"] is False
+
+    def test_last_page(self) -> None:
+        items = [{"id": i, "name": f"item_{i}"} for i in range(5)]
+        result = Paginator.paginate_offset(items=items, total=25, page=5, page_size=5)
+        assert result["has_next"] is False
+        assert result["has_previous"] is True
+        assert result["total_pages"] == 5
+
+    def test_middle_page(self) -> None:
+        items = [{"id": i} for i in range(10)]
+        result = Paginator.paginate_offset(items=items, total=50, page=2, page_size=10)
+        assert result["has_next"] is True
+        assert result["has_previous"] is True
+        assert result["page"] == 2
+        assert result["total_pages"] == 5
+
+    def test_empty_items(self) -> None:
+        result = Paginator.paginate_offset(items=[], total=0, page=1, page_size=10)
+        assert result["items"] == []
+        assert result["total"] == 0
+        assert result["total_pages"] == 1
+        assert result["has_next"] is False
+        assert result["has_previous"] is False
+
+    def test_single_item_total(self) -> None:
+        result = Paginator.paginate_offset(items=[{"id": 1}], total=1, page=1, page_size=10)
+        assert result["total_pages"] == 1
+        assert result["has_next"] is False
+
+    def test_clamp_page_zero(self) -> None:
+        result = Paginator.paginate_offset(items=[], total=10, page=0, page_size=5)
+        assert result["page"] == 1
+
+    def test_clamp_page_negative(self) -> None:
+        result = Paginator.paginate_offset(items=[], total=10, page=-1, page_size=5)
+        assert result["page"] == 1
+
+    def test_clamp_page_size_zero(self) -> None:
+        result = Paginator.paginate_offset(items=[], total=10, page=1, page_size=0)
+        assert result["page_size"] == 1
+
+    def test_total_pages_with_remainder(self) -> None:
+        result = Paginator.paginate_offset(items=[], total=23, page=1, page_size=5)
+        assert result["total_pages"] == 5
+
+
+class TestPaginateCursor:
+    """Paginator.paginate_cursor()."""
+
+    def test_has_next_with_extra_item(self) -> None:
+        items = [{"id": i} for i in range(6)]  # 6 items, page_size=5
+        result = Paginator.paginate_cursor(items=items, page_size=5, cursor_field="id")
+        assert len(result["items"]) == 5
+        assert result["has_next"] is True
+        assert result["next_cursor"] is not None
+        assert result["has_previous"] is False
+
+    def test_no_next_when_exact_count(self) -> None:
+        items = [{"id": i} for i in range(5)]
+        result = Paginator.paginate_cursor(items=items, page_size=5, cursor_field="id")
+        assert result["has_next"] is False
+        assert result["next_cursor"] is None
+
+    def test_empty_items(self) -> None:
+        result = Paginator.paginate_cursor(items=[], page_size=10, cursor_field="id")
+        assert result["has_next"] is False
+        assert result["next_cursor"] is None
+
+    def test_cursor_encodes_id(self) -> None:
+        items = [{"id": 42, "name": "last"}]
+        result = Paginator.paginate_cursor(items=items, page_size=0, cursor_field="id")
+        assert result["next_cursor"] is not None
+        decoded = Paginator.decode_cursor(result["next_cursor"])
+        assert decoded.get("id") == 42
+
+    def test_object_items_cursor(self) -> None:
+        class Obj:
+            def __init__(self, id_val):
+                self.id = id_val
+        items = [Obj(99)]
+        result = Paginator.paginate_cursor(items=items, page_size=0, cursor_field="id")
+        assert result["next_cursor"] is not None
+        decoded = Paginator.decode_cursor(result["next_cursor"])
+        assert decoded.get("id") == 99
+
+    def test_clamp_page_size(self) -> None:
+        result = Paginator.paginate_cursor(items=[{"id": 1}, {"id": 2}], page_size=0)
+        assert result["page_size"] == 1
+        assert len(result["items"]) == 1
+
+
+class TestDecodeCursor:
+    """Paginator.decode_cursor()."""
+
+    def test_valid_cursor(self) -> None:
+        import base64 as b64
+        import json as j
+        data = j.dumps({"id": 42, "page_size": 10})
+        cursor = b64.urlsafe_b64encode(data.encode()).decode().rstrip("=")
+        result = Paginator.decode_cursor(cursor)
+        assert result["id"] == 42
+        assert result["page_size"] == 10
+
+    def test_invalid_nonsense(self) -> None:
+        result = Paginator.decode_cursor("not-a-valid-cursor!!!")
+        assert result == {}
+
+    def test_empty_cursor(self) -> None:
+        result = Paginator.decode_cursor("")
+        assert result == {}
+
+
+class TestPaginatedResponse:
+    """PaginatedResponse generic model."""
+
+    def test_basic_model(self) -> None:
+        response = PaginatedResponse[TestItem](
+            items=[TestItem(id=1, name="foo"), TestItem(id=2, name="bar")],
+            total=20,
+            page=1,
+            page_size=10,
+            total_pages=2,
+            has_next=True,
+            has_previous=False,
+        )
+        data = response.model_dump()
+        assert data["items"][0]["id"] == 1
+        assert data["total"] == 20
+        assert data["has_next"] is True
+
+    def test_json_serialization(self) -> None:
+        response = PaginatedResponse[int](
+            items=[1, 2, 3],
+            total=3,
+            page=1,
+            page_size=3,
+            total_pages=1,
+            has_next=False,
+            has_previous=False,
+        )
+        json_str = response.model_dump_json()
+        assert "items" in json_str
+        assert '"total":3' in json_str
+
+from fastapi import Depends


### PR DESCRIPTION
/bounty $700

## Summary

Implements `fastapi/fastapi/pagination.py` with offset and cursor-based pagination as described in #802.

### Components

**PaginationParams** - Dataclass holding page, page_size, cursor with computed offset/limit properties.

**PaginatedResponse[T]** - Generic Pydantic model returning:
- `items`: list of typed items
- `total`, `page`, `page_size`, `total_pages`
- `has_next`, `has_previous` flags
- `next_cursor` for cursor-based navigation

**paginate()** - Dependency function using `Query` for injection into any route.

**Paginator** - Static utility class:
- `paginate_offset()` - Traditional page/offset calculation
- `paginate_cursor()` - Cursor-based with encoded next_cursor
- `decode_cursor()` - Decodes url-safe base64 cursors

### Edge Cases
- Page 0 or negative → clamped to 1
- page_size 0 or negative → clamped to 1
- page_size > 100 → clamped to 100
- Empty results → total_pages=1, has_next=False, has_previous=False
- Cursor decode failure → returns empty dict

/claim #802

Closes #802