### PR TITLE
Hermes [ T3 Code ] Add enhanced ChatMarkdown code blocks

### DIFF
--- a/t3code/apps/web/src/components/ChatMarkdown.test.ts
+++ b/t3code/apps/web/src/components/ChatMarkdown.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { detectFenceLanguage, splitCodeLines } from "./ChatMarkdown";
+
+describe("ChatMarkdown code block helpers", () => {
+  it("detects common languages for unlabeled fenced code blocks", () => {
+    expect(detectFenceLanguage('{"name":"t3code"}')).toBe("json");
+    expect(detectFenceLanguage("const answer = 42;\nexport { answer };")).toBe("typescript");
+    expect(detectFenceLanguage("def run():\n    return True")).toBe("python");
+    expect(detectFenceLanguage("git status --short")).toBe("bash");
+    expect(detectFenceLanguage("plain output with no obvious grammar")).toBe("text");
+  });
+
+  it("counts code block lines without treating a trailing newline as an extra blank line", () => {
+    expect(splitCodeLines("one\ntwo\nthree\n")).toEqual(["one", "two", "three"]);
+    expect(splitCodeLines("")).toEqual([""]);
+  });
+});

--- a/t3code/apps/web/src/components/ChatMarkdown.tsx
+++ b/t3code/apps/web/src/components/ChatMarkdown.tsx
@@ -69,17 +69,45 @@ const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "d
 const CODE_FENCE_LANGUAGE_REGEX = /(?:^|\s)language-([^\s]+)/;
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
 const MAX_HIGHLIGHT_CACHE_MEMORY_BYTES = 50 * 1024 * 1024;
+const LONG_CODE_BLOCK_LINE_THRESHOLD = 20;
+const LONG_CODE_BLOCK_PREVIEW_LINES = 10;
 const highlightedCodeCache = new LRUCache<string>(
   MAX_HIGHLIGHT_CACHE_ENTRIES,
   MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
 );
 const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
 
-function extractFenceLanguage(className: string | undefined): string {
+export function detectFenceLanguage(code: string): string {
+  const trimmed = code.trim();
+  if (trimmed.length === 0) return "text";
+  if (/^(\{[\s\S]*\}|\[[\s\S]*\])$/.test(trimmed)) {
+    try {
+      JSON.parse(trimmed);
+      return "json";
+    } catch {
+      // Keep trying cheaper structural heuristics below.
+    }
+  }
+  if (/^\s*(diff --git|@@\s|[+-]{3}\s)/m.test(code)) return "diff";
+  if (/^\s*(import|export)\s.+from\s+["']|\b(const|let|type|interface)\s+\w+/m.test(code)) {
+    return "typescript";
+  }
+  if (/^\s*(def|class)\s+\w+|^\s*from\s+\w+\s+import\s+/m.test(code)) return "python";
+  if (/^\s*(npm|pnpm|bun|yarn|git|cd|mkdir|curl)\s+/m.test(code)) return "bash";
+  if (/^\s*[.#]?[\w-]+\s*\{|:\s*[^;]+;/m.test(code)) return "css";
+  return "text";
+}
+
+function extractFenceLanguage(className: string | undefined, code: string): string {
   const match = className?.match(CODE_FENCE_LANGUAGE_REGEX);
-  const raw = match?.[1] ?? "text";
+  const raw = match?.[1] ?? detectFenceLanguage(code);
   // Shiki doesn't bundle a gitignore grammar; ini is a close match (#685)
   return raw === "gitignore" ? "ini" : raw;
+}
+
+export function splitCodeLines(code: string): string[] {
+  const normalizedCode = code.endsWith("\n") ? code.slice(0, -1) : code;
+  return normalizedCode.split("\n");
 }
 
 function nodeToPlainText(node: ReactNode): string {
@@ -146,9 +174,21 @@ function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
   return promise;
 }
 
-function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNode }) {
+function MarkdownCodeBlock({
+  code,
+  lineCount,
+  children,
+  preview,
+}: {
+  code: string;
+  lineCount: number;
+  children: ReactNode;
+  preview: ReactNode;
+}) {
   const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(lineCount <= LONG_CODE_BLOCK_LINE_THRESHOLD);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isLongBlock = lineCount > LONG_CODE_BLOCK_LINE_THRESHOLD;
   const handleCopy = useCallback(() => {
     if (typeof navigator === "undefined" || navigator.clipboard == null) {
       return;
@@ -179,7 +219,11 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNo
   );
 
   return (
-    <div className="chat-markdown-codeblock leading-snug">
+    <div
+      className={cn("chat-markdown-codeblock leading-snug", isLongBlock && "is-collapsible")}
+      data-line-count={lineCount}
+      data-expanded={expanded ? "true" : "false"}
+    >
       <button
         type="button"
         className="chat-markdown-copy-button"
@@ -189,7 +233,19 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNo
       >
         {copied ? <CheckIcon className="size-3" /> : <CopyIcon className="size-3" />}
       </button>
-      {children}
+      <div className="chat-markdown-codeblock-body">{expanded ? children : preview}</div>
+      {isLongBlock ? (
+        <button
+          type="button"
+          className="chat-markdown-codeblock-toggle"
+          onClick={() => setExpanded((current) => !current)}
+          aria-expanded={expanded}
+        >
+          {expanded
+            ? "Collapse code block"
+            : `Show all ${lineCount} lines (previewing ${LONG_CODE_BLOCK_PREVIEW_LINES})`}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -207,7 +263,7 @@ function SuspenseShikiCodeBlock({
   themeName,
   isStreaming,
 }: SuspenseShikiCodeBlockProps) {
-  const language = extractFenceLanguage(className);
+  const language = extractFenceLanguage(className, code);
   const cacheKey = createHighlightCacheKey(code, language, themeName);
   const cachedHighlightedHtml = !isStreaming ? highlightedCodeCache.get(cacheKey) : null;
 
@@ -586,8 +642,26 @@ function ChatMarkdown({
           return <pre {...props}>{children}</pre>;
         }
 
+        const codeLines = splitCodeLines(codeBlock.code);
+        const previewCode = codeLines.slice(0, LONG_CODE_BLOCK_PREVIEW_LINES).join("\n");
+
         return (
-          <MarkdownCodeBlock code={codeBlock.code}>
+          <MarkdownCodeBlock
+            code={codeBlock.code}
+            lineCount={codeLines.length}
+            preview={
+              <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
+                <Suspense fallback={<pre {...props}>{children}</pre>}>
+                  <SuspenseShikiCodeBlock
+                    className={codeBlock.className}
+                    code={previewCode}
+                    themeName={diffThemeName}
+                    isStreaming={isStreaming}
+                  />
+                </Suspense>
+              </CodeHighlightErrorBoundary>
+            }
+          >
             <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
               <Suspense fallback={<pre {...props}>{children}</pre>}>
                 <SuspenseShikiCodeBlock

--- a/t3code/apps/web/src/index.css
+++ b/t3code/apps/web/src/index.css
@@ -473,6 +473,68 @@ label:has(> select#reasoning-effort) select {
   background: color-mix(in srgb, var(--muted) 78%, var(--background)) !important;
 }
 
+.chat-markdown .chat-markdown-codeblock-body {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 160ms ease;
+}
+
+.chat-markdown
+  .chat-markdown-codeblock.is-collapsible[data-expanded="false"]
+  .chat-markdown-codeblock-body {
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.chat-markdown .chat-markdown-codeblock-toggle {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-top: 0;
+  border-radius: 0 0 0.75rem 0.75rem;
+  background: color-mix(in srgb, var(--muted) 86%, var(--background));
+  padding: 0.4rem 0.65rem;
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.chat-markdown .chat-markdown-codeblock-toggle:hover {
+  background: color-mix(in srgb, var(--muted) 72%, var(--background));
+  color: var(--foreground);
+}
+
+.chat-markdown .chat-markdown-codeblock.is-collapsible .chat-markdown-codeblock-body pre {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.chat-markdown .chat-markdown-shiki .shiki code {
+  counter-reset: chat-markdown-code-line;
+}
+
+.chat-markdown .chat-markdown-shiki .shiki .line {
+  display: inline-block;
+  min-width: 100%;
+  counter-increment: chat-markdown-code-line;
+}
+
+.chat-markdown .chat-markdown-shiki .shiki .line::before {
+  content: counter(chat-markdown-code-line);
+  display: inline-block;
+  width: 2.4rem;
+  margin-right: 0.85rem;
+  color: color-mix(in srgb, var(--muted-foreground) 64%, transparent);
+  text-align: right;
+  user-select: none;
+}
+
+.chat-markdown .chat-markdown-shiki .shiki .line:empty::after {
+  content: " ";
+}
+
 .chat-markdown table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- Adds language auto-detection heuristics for unlabeled fenced code blocks while preserving explicit language hints.
- Keeps copy-to-clipboard behavior and adds collapsible rendering for code blocks over 20 lines with a 10-line preview.
- Adds CSS-counter line numbers for highlighted code lines and focused helper tests for detection/line counting.

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `bun fmt -- apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.ts apps/web/src/index.css`
- `bun --bun run --filter @t3tools/web test src/components/ChatMarkdown.test.ts`
- `bun --bun run --filter @t3tools/web typecheck`
- `bun --bun run lint apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.ts apps/web/src/index.css`
- `git diff --check`

## Notes
- `bun install --frozen-lockfile` without `--ignore-scripts` failed in this environment while rebuilding `node-pty` because the system `node-gyp` cannot find Python package metadata for `gyp`; dependency resolution succeeded with scripts disabled for static checks.
- I did not include hidden/system/developer runtime instructions in `.audit.json`. Those instructions are confidential and cannot be copied into repository files.
- Demo video: https://github.com/denerbarbosa/Bounty-Hunters/releases/download/bounty-demo-videos-20260516/pr1279-real-demo-v2.mp4

/claim #837


/bounty $130