### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -33,6 +33,11 @@ import {
   browserApiCorsAllowedMethods,
   browserApiCorsHeaders,
 } from "./httpCors.ts";
+import {
+  collectPrometheusMetrics,
+  isMetricsAuthDisabled,
+  prometheusContentType,
+} from "./observability/PrometheusMetrics.ts";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
@@ -132,6 +137,22 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
           Effect.succeed(HttpServerResponse.text("Trace export failed.", { status: 502 })),
         ),
       );
+  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+);
+
+export const metricsRouteLayer = HttpRouter.add(
+  "GET",
+  "/metrics",
+  Effect.gen(function* () {
+    if (!isMetricsAuthDisabled()) {
+      yield* requireAuthenticatedRequest;
+    }
+
+    const body = yield* collectPrometheusMetrics;
+    return HttpServerResponse.text(body, {
+      status: 200,
+      contentType: prometheusContentType,
+    });
   }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
 );
 

--- a/t3code/apps/server/src/observability/PrometheusMetrics.test.ts
+++ b/t3code/apps/server/src/observability/PrometheusMetrics.test.ts
@@ -1,0 +1,64 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Metric from "effect/Metric";
+
+import {
+  activeSessionsGauge,
+  collectPrometheusMetrics,
+  gitOperationsTotal,
+  memoryUsageBytesGauge,
+  rpcDurationSecondsHistogram,
+  rpcRequestsTotalCounter,
+} from "./PrometheusMetrics.ts";
+
+describe("PrometheusMetrics", () => {
+  it.effect("exports the required metric families in Prometheus text format", () =>
+    Effect.gen(function* () {
+      yield* Metric.update(activeSessionsGauge, 2);
+      yield* Metric.update(memoryUsageBytesGauge, 12_345);
+      yield* Metric.update(
+        Metric.withAttributes(rpcRequestsTotalCounter, [["method", "server.getDiagnostics"]]),
+        3,
+      );
+      yield* Metric.update(Metric.withAttributes(gitOperationsTotal, [["operation", "status"]]), 1);
+      yield* Metric.update(
+        Metric.withAttributes(rpcDurationSecondsHistogram, [["method", "server.getDiagnostics"]]),
+        0.25,
+      );
+
+      const text = yield* collectPrometheusMetrics;
+
+      assert.match(text, /^# HELP active_sessions /m);
+      assert.match(text, /^# TYPE active_sessions gauge$/m);
+      assert.match(text, /^active_sessions 2$/m);
+      assert.match(text, /^# TYPE rpc_requests_total counter$/m);
+      assert.match(text, /^rpc_requests_total\{method="server.getDiagnostics"\} 3$/m);
+      assert.match(text, /^# TYPE rpc_duration_seconds histogram$/m);
+      assert.match(
+        text,
+        /^rpc_duration_seconds_bucket\{method="server.getDiagnostics",le="0\.5"\} 1$/m,
+      );
+      assert.match(text, /^rpc_duration_seconds_count\{method="server.getDiagnostics"\} 1$/m);
+      assert.match(text, /^rpc_duration_seconds_sum\{method="server.getDiagnostics"\} 0\.25$/m);
+      assert.match(text, /^git_operations_total\{operation="status"\} 1$/m);
+      assert.match(text, /^memory_usage_bytes \d+$/m);
+    }),
+  );
+
+  it.effect("increments counter metrics from Effect.Metric events", () =>
+    Effect.gen(function* () {
+      yield* Metric.update(
+        Metric.withAttributes(rpcRequestsTotalCounter, [["method", "server.ping"]]),
+        1,
+      );
+      yield* Metric.update(
+        Metric.withAttributes(rpcRequestsTotalCounter, [["method", "server.ping"]]),
+        1,
+      );
+
+      const text = yield* collectPrometheusMetrics;
+
+      assert.match(text, /^rpc_requests_total\{method="server.ping"\} 2$/m);
+    }),
+  );
+});

--- a/t3code/apps/server/src/observability/PrometheusMetrics.ts
+++ b/t3code/apps/server/src/observability/PrometheusMetrics.ts
@@ -1,0 +1,156 @@
+import * as Effect from "effect/Effect";
+import * as Metric from "effect/Metric";
+
+const PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+export const prometheusContentType = PROMETHEUS_CONTENT_TYPE;
+
+export const activeSessionsGauge = Metric.gauge("active_sessions", {
+  description: "Current number of active provider sessions.",
+});
+
+export const rpcRequestsTotalCounter = Metric.counter("rpc_requests_total", {
+  description: "Total RPC requests handled by the server.",
+});
+
+export const rpcDurationSecondsHistogram = Metric.histogram("rpc_duration_seconds", {
+  description: "RPC request duration in seconds.",
+  boundaries: Metric.boundariesFromIterable([
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+  ]),
+});
+
+export const gitOperationsTotal = Metric.counter("git_operations_total", {
+  description: "Total git operations executed by the server runtime.",
+});
+
+export const memoryUsageBytesGauge = Metric.gauge("memory_usage_bytes", {
+  description: "Resident memory used by the server process in bytes.",
+});
+
+const REQUIRED_FAMILIES = [
+  ["active_sessions", "gauge", "Current number of active provider sessions."],
+  ["rpc_requests_total", "counter", "Total RPC requests handled by the server."],
+  ["rpc_duration_seconds", "histogram", "RPC request duration in seconds."],
+  ["git_operations_total", "counter", "Total git operations executed by the server runtime."],
+  ["memory_usage_bytes", "gauge", "Resident memory used by the server process in bytes."],
+] as const;
+
+const METRIC_ALIASES: Readonly<Record<string, string>> = {
+  t3_rpc_requests_total: "rpc_requests_total",
+  t3_rpc_request_duration: "rpc_duration_seconds",
+  t3_git_commands_total: "git_operations_total",
+};
+
+const escapeHelp = (value: string) => value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+
+const escapeLabelValue = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+
+const formatNumber = (value: number | bigint): string => {
+  if (typeof value === "bigint") return value.toString();
+  if (Number.isNaN(value)) return "NaN";
+  if (value === Infinity) return "+Inf";
+  if (value === -Infinity) return "-Inf";
+  return String(value);
+};
+
+const formatLabelEntries = (entries: ReadonlyArray<readonly [string, string]>): string => {
+  if (entries.length === 0) return "";
+  return `{${entries.map(([key, value]) => `${key}="${escapeLabelValue(value)}"`).join(",")}}`;
+};
+
+const sortedLabelEntries = (attributes: Readonly<Record<string, string>> | undefined) =>
+  Object.entries(attributes ?? {}).sort(([left], [right]) => left.localeCompare(right));
+
+const formatLabels = (attributes: Readonly<Record<string, string>> | undefined): string =>
+  formatLabelEntries(sortedLabelEntries(attributes));
+
+const formatLabelsWithExtra = (
+  attributes: Readonly<Record<string, string>> | undefined,
+  extra: Readonly<Record<string, string>>,
+): string => formatLabelEntries([...sortedLabelEntries(attributes), ...sortedLabelEntries(extra)]);
+
+const normalizeMetricName = (snapshot: Metric.Metric.Snapshot): string =>
+  METRIC_ALIASES[snapshot.id] ?? snapshot.id;
+
+const shouldExportSnapshot = (snapshot: Metric.Metric.Snapshot): boolean =>
+  REQUIRED_FAMILIES.some(([name]) => name === normalizeMetricName(snapshot));
+
+const emitCounter = (
+  name: string,
+  snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Counter" }>,
+) => `${name}${formatLabels(snapshot.attributes)} ${formatNumber(snapshot.state.count)}`;
+
+const emitGauge = (
+  name: string,
+  snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Gauge" }>,
+) => `${name}${formatLabels(snapshot.attributes)} ${formatNumber(snapshot.state.value)}`;
+
+const emitHistogram = (
+  name: string,
+  snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Histogram" }>,
+): ReadonlyArray<string> => {
+  const bucketLines = snapshot.state.buckets.map(
+    ([upperBound, count]) =>
+      `${name}_bucket${formatLabelsWithExtra(snapshot.attributes, {
+        le: upperBound === Infinity ? "+Inf" : formatNumber(upperBound),
+      })} ${formatNumber(count)}`,
+  );
+  return [
+    ...bucketLines,
+    `${name}_count${formatLabels(snapshot.attributes)} ${formatNumber(snapshot.state.count)}`,
+    `${name}_sum${formatLabels(snapshot.attributes)} ${formatNumber(snapshot.state.sum)}`,
+  ];
+};
+
+const emitSnapshot = (snapshot: Metric.Metric.Snapshot): ReadonlyArray<string> => {
+  const name = normalizeMetricName(snapshot);
+  switch (snapshot.type) {
+    case "Counter":
+      return [emitCounter(name, snapshot)];
+    case "Gauge":
+      return [emitGauge(name, snapshot)];
+    case "Histogram":
+      return emitHistogram(name, snapshot);
+    default:
+      return [];
+  }
+};
+
+export const renderPrometheusMetrics = (
+  snapshots: ReadonlyArray<Metric.Metric.Snapshot>,
+): string => {
+  const lines: Array<string> = [];
+  const snapshotsByFamily = new Map<string, Array<Metric.Metric.Snapshot>>();
+  for (const snapshot of snapshots) {
+    if (!shouldExportSnapshot(snapshot)) continue;
+    const name = normalizeMetricName(snapshot);
+    const existing = snapshotsByFamily.get(name) ?? [];
+    existing.push(snapshot);
+    snapshotsByFamily.set(name, existing);
+  }
+
+  for (const [name, type, description] of REQUIRED_FAMILIES) {
+    lines.push(`# HELP ${name} ${escapeHelp(description)}`);
+    lines.push(`# TYPE ${name} ${type}`);
+    for (const snapshot of snapshotsByFamily.get(name) ?? []) {
+      lines.push(...emitSnapshot(snapshot));
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+};
+
+export const collectPrometheusMetrics = Effect.gen(function* () {
+  yield* Metric.update(memoryUsageBytesGauge, process.memoryUsage().rss);
+  const snapshots = yield* Metric.snapshot;
+  return renderPrometheusMetrics(snapshots);
+});
+
+export const isMetricsAuthDisabled = (env: NodeJS.ProcessEnv = process.env): boolean => {
+  const value = env.METRICS_AUTH_DISABLED;
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && !["0", "false", "no", "off"].includes(normalized);
+};

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -5,6 +5,7 @@ import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 import { ServerConfig } from "./config.ts";
 import {
   attachmentsRouteLayer,
+  metricsRouteLayer,
   otlpTracesProxyRouteLayer,
   projectFaviconRouteLayer,
   serverEnvironmentRouteLayer,
@@ -305,6 +306,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   authSessionRouteLayer,
   authWebSocketTokenRouteLayer,
   attachmentsRouteLayer,
+  metricsRouteLayer,
   orchestrationDispatchRouteLayer,
   orchestrationSnapshotRouteLayer,
   otlpTracesProxyRouteLayer,


### PR DESCRIPTION
## Summary
- Adds a `/metrics` endpoint exporting Prometheus text format metrics
- Wires Effect.Metric-backed counters, gauges, and histogram rendering
- Keeps endpoint authenticated by default, with `METRICS_AUTH_DISABLED` opt-out for ops/local deployments
- Adds focused tests for metric formatting and counter accumulation

## Verification
- `cd t3code/apps/server && bun run test src/observability/PrometheusMetrics.test.ts`
- `cd t3code/apps/server && bun run typecheck`
- `cd t3code/apps/server && bun run test`
- `cd t3code && bun run fmt:check`

/claim #833

AI-assisted with Hermes/Codex.