### PR TITLE
[Hermes Agent] Fix wrong PRF label for Extended Master Secret - #21

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -271,9 +271,7 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"  # RFC 7627
         else:
             label = b"master secret"
 


### PR DESCRIPTION
Fix EMS label to b extended master secret per RFC 7627. Issue #21