### PR TITLE
D3CC [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/_generation.json
+++ b/solidity/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "D3CC",
+  "pre_task_context": "Task: Fix first-depositor price manipulation in LiquidityPool (#918). Implement MINIMUM_LIQUIDITY lock at address(0), use internal reserves for removeLiquidity, add sync() function. All per acceptance criteria.",
+  "timestamp": "2026-05-16T15:59:37.117338+00:00"
+}

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,11 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,8 +27,10 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
             lpTokens = sqrt(amountA * amountB);
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
+            require(lpTokens > 0, "First deposit too small");
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,27 +46,32 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        require(amountA > 0 && amountB > 0, "Insufficient liquidity");
 
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
 
         reserveA -= amountA;
         reserveB -= amountB;
 
+        tokenA.transfer(msg.sender, amountA);
+        tokenB.transfer(msg.sender, amountB);
+
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        uint256 balA = tokenA.balanceOf(address(this));
+        uint256 balB = tokenB.balanceOf(address(this));
+        reserveA = balA;
+        reserveB = balB;
+        emit Sync(balA, balB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/test/LiquidityPool.test.js
+++ b/solidity/test/LiquidityPool.test.js
@@ -1,0 +1,216 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("LiquidityPool - First Depositor Protection", function () {
+    let TokenA, TokenB, LiquidityPool;
+    let tokenA, tokenB, pool;
+    let owner, attacker, user;
+
+    const INITIAL_SUPPLY = ethers.parseEther("1000000");
+    const MINIMUM_LIQUIDITY = 1000n;
+
+    beforeEach(async function () {
+        [owner, attacker, user] = await ethers.getSigners();
+
+        TokenA = await ethers.getContractFactory("ERC20Mock");
+        TokenB = await ethers.getContractFactory("ERC20Mock");
+        tokenA = await TokenA.deploy("TokenA", "TKA", INITIAL_SUPPLY);
+        tokenB = await TokenB.deploy("TokenB", "TKB", INITIAL_SUPPLY);
+
+        LiquidityPool = await ethers.getContractFactory("LiquidityPool");
+        pool = await LiquidityPool.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+
+        for (const signer of [owner, attacker, user]) {
+            await tokenA.transfer(await signer.getAddress(), ethers.parseEther("10000"));
+            await tokenB.transfer(await signer.getAddress(), ethers.parseEther("10000"));
+        }
+    });
+
+    describe("First Deposit - Minimum Liquidity Lock", function () {
+        it("should lock MINIMUM_LIQUIDITY LP tokens at address(0)", async function () {
+            const amountA = ethers.parseEther("100");
+            const amountB = ethers.parseEther("100");
+
+            await tokenA.connect(owner).approve(await pool.getAddress(), amountA);
+            await tokenB.connect(owner).approve(await pool.getAddress(), amountB);
+            await pool.connect(owner).addLiquidity(amountA, amountB);
+
+            const lockedBalance = await pool.balanceOf(ethers.ZeroAddress);
+            expect(lockedBalance).to.equal(MINIMUM_LIQUIDITY);
+        });
+
+        it("should subtract locked amount from first depositor LP tokens", async function () {
+            const amountA = ethers.parseEther("100");
+            const amountB = ethers.parseEther("100");
+
+            await tokenA.connect(owner).approve(await pool.getAddress(), amountA);
+            await tokenB.connect(owner).approve(await pool.getAddress(), amountB);
+            await pool.connect(owner).addLiquidity(amountA, amountB);
+
+            const ownerBalance = await pool.balanceOf(await owner.getAddress());
+            const sqrtProduct = BigInt(Math.floor(Math.sqrt(Number(ethers.parseEther("100")) * Number(ethers.parseEther("100")) / 1e18))) * ethers.parseEther("1");
+            const expectedLP = (sqrtProduct / ethers.parseEther("1")) * ethers.parseEther("1") - MINIMUM_LIQUIDITY;
+            expect(ownerBalance).to.equal(expectedLP);
+            expect(ownerBalance).to.be.gt(0);
+        });
+
+        it("should revert first deposit that is too small", async function () {
+            const amountA = 1n;
+            const amountB = 1n;
+
+            await tokenA.connect(owner).approve(await pool.getAddress(), amountA);
+            await tokenB.connect(owner).approve(await pool.getAddress(), amountB);
+            await expect(
+                pool.connect(owner).addLiquidity(amountA, amountB)
+            ).to.be.revertedWith("First deposit too small");
+        });
+    });
+
+    describe("Price Manipulation Prevention", function () {
+        it("should prevent first-depositor price manipulation via tiny deposit + donation", async function () {
+            const smallAmount = ethers.parseEther("1");
+            const largeAmount = ethers.parseEther("10000");
+
+            await tokenA.connect(owner).approve(await pool.getAddress(), smallAmount);
+            await tokenB.connect(owner).approve(await pool.getAddress(), smallAmount);
+            await pool.connect(owner).addLiquidity(smallAmount, smallAmount);
+
+            await tokenA.connect(owner).approve(await pool.getAddress(), largeAmount);
+            await tokenB.connect(owner).approve(await pool.getAddress(), largeAmount);
+
+            const lpBefore = await pool.balanceOf(await owner.getAddress());
+            await pool.connect(owner).addLiquidity(largeAmount, largeAmount);
+            const lpAfter = await pool.balanceOf(await owner.getAddress());
+            const lpReceived = lpAfter - lpBefore;
+
+            const expectedRatio = largeAmount * (await pool.totalSupply()) / (await pool.reserveA());
+            const ratio = lpReceived * ethers.parseEther("1") / expectedRatio;
+            expect(ratio).to.be.lte(ethers.parseEther("1") + 1n);
+            expect(ratio).to.be.gte(ethers.parseEther("1") - 1n);
+        });
+
+        it("should use correct proportional formula after first deposit", async function () {
+            const firstAmount = ethers.parseEther("100");
+            await tokenA.connect(owner).approve(await pool.getAddress(), firstAmount);
+            await tokenB.connect(owner).approve(await pool.getAddress(), firstAmount);
+            await pool.connect(owner).addLiquidity(firstAmount, firstAmount);
+
+            const secondAmount = ethers.parseEther("50");
+            await tokenA.connect(user).approve(await pool.getAddress(), secondAmount);
+            await tokenB.connect(user).approve(await pool.getAddress(), secondAmount);
+            await pool.connect(user).addLiquidity(secondAmount, secondAmount);
+
+            const totalSupply = await pool.totalSupply();
+            const userLP = await pool.balanceOf(await user.getAddress());
+            const expectedShare = secondAmount * totalSupply / (await pool.reserveA());
+            const diff = userLP > expectedShare ? userLP - expectedShare : expectedShare - userLP;
+            expect(diff).to.be.lte(1n);
+        });
+    });
+
+    describe("removeLiquidity - Internal Reserves", function () {
+        beforeEach(async function () {
+            const amount = ethers.parseEther("100");
+            await tokenA.connect(owner).approve(await pool.getAddress(), amount);
+            await tokenB.connect(owner).approve(await pool.getAddress(), amount);
+            await pool.connect(owner).addLiquidity(amount, amount);
+        });
+
+        it("should use internal reserves (not balanceOf) for removeLiquidity", async function () {
+            const lpTokens = await pool.balanceOf(await owner.getAddress());
+            const reserveABefore = await pool.reserveA();
+            const reserveBBefore = await pool.reserveB();
+            const totalSupplyBefore = await pool.totalSupply();
+
+            const tx = await pool.connect(owner).removeLiquidity(lpTokens);
+            const receipt = await tx.wait();
+
+            const balA = await tokenA.balanceOf(await owner.getAddress());
+            expect(balA).to.be.gt(ethers.parseEther("90"));
+
+            const reserveAAfter = await pool.reserveA();
+            expect(reserveAAfter).to.be.lt(reserveABefore);
+        });
+
+        it("should not be affected by direct token donations (donation attack)", async function () {
+            const lpTokens = (await pool.balanceOf(await owner.getAddress())) / 2n;
+
+            await tokenA.connect(attacker).transfer(await pool.getAddress(), ethers.parseEther("99999"));
+            await tokenB.connect(attacker).transfer(await pool.getAddress(), ethers.parseEther("99999"));
+
+            const balBeforeA = await tokenA.balanceOf(await owner.getAddress());
+            await pool.connect(owner).removeLiquidity(lpTokens);
+            const balAfterA = await tokenA.balanceOf(await owner.getAddress());
+
+            const reserveA = await pool.reserveA();
+            const totalSupply = await pool.totalSupply();
+            const expectedAmount = lpTokens * reserveA / totalSupply + lpTokens * reserveA / totalSupply;
+
+            const received = balAfterA - balBeforeA;
+            const diff = received > expectedAmount ? received - expectedAmount : expectedAmount - received;
+            const largeDiff = diff > ethers.parseEther("1");
+            expect(largeDiff).to.be.false;
+        });
+    });
+
+    describe("sync() - Recovery from Donation Attacks", function () {
+        it("should update reserves to match actual balances", async function () {
+            const amountA = ethers.parseEther("100");
+            const amountB = ethers.parseEther("100");
+            await tokenA.connect(owner).approve(await pool.getAddress(), amountA);
+            await tokenB.connect(owner).approve(await pool.getAddress(), amountB);
+            await pool.connect(owner).addLiquidity(amountA, amountB);
+
+            const reserveABefore = await pool.reserveA();
+            const reserveBBefore = await pool.reserveB();
+
+            await tokenA.connect(attacker).transfer(await pool.getAddress(), ethers.parseEther("5000"));
+
+            const balA = await tokenA.balanceOf(await pool.getAddress());
+            expect(balA).to.be.gt(reserveABefore);
+
+            await pool.connect(owner).sync();
+
+            const reserveAAfter = await pool.reserveA();
+            expect(reserveAAfter).to.equal(balA);
+            expect(reserveAAfter).to.be.gt(reserveABefore);
+            expect(await pool.reserveB()).to.equal(reserveBBefore);
+        });
+
+        it("should emit Sync event", async function () {
+            const amount = ethers.parseEther("100");
+            await tokenA.connect(owner).approve(await pool.getAddress(), amount);
+            await tokenB.connect(owner).approve(await pool.getAddress(), amount);
+            await pool.connect(owner).addLiquidity(amount, amount);
+
+            await expect(pool.connect(owner).sync())
+                .to.emit(pool, "Sync")
+                .withArgs(amount, amount);
+        });
+    });
+
+    describe("End-to-End Attack Scenario", function () {
+        it("should withstand full donation + price manipulation attack", async function () {
+            const legitAmount = ethers.parseEther("100");
+            await tokenA.connect(owner).approve(await pool.getAddress(), legitAmount);
+            await tokenB.connect(owner).approve(await pool.getAddress(), legitAmount);
+            const lp1 = await pool.connect(owner).addLiquidity(legitAmount, legitAmount);
+
+            await tokenA.connect(attacker).transfer(await pool.getAddress(), ethers.parseEther("99999"));
+            await tokenB.connect(attacker).transfer(await pool.getAddress(), ethers.parseEther("99999"));
+
+            const donateAmount = ethers.parseEther("200");
+            await tokenA.connect(user).approve(await pool.getAddress(), donateAmount);
+            await tokenB.connect(user).approve(await pool.getAddress(), donateAmount);
+            await pool.connect(user).addLiquidity(donateAmount, donateAmount);
+
+            const userLP = await pool.balanceOf(await user.getAddress());
+            const totalSupply = await pool.totalSupply();
+            const userShare = userLP * ethers.parseEther("100") / totalSupply;
+            const ownerShare = ethers.parseEther("100") - userShare;
+
+            expect(userLP).to.be.gt(0);
+            expect(userShare).to.be.lte(ethers.parseEther("10"));
+        });
+    });
+});


### PR DESCRIPTION
/claim #918

## Fix Summary

Prevents the classic Uniswap V2 first-depositor price manipulation attack on the LiquidityPool contract.

### Changes

| File | Change |
|------|--------|
| `solidity/contracts/LiquidityPool.sol` | 3 fixes applied |
| `solidity/test/LiquidityPool.test.js` | 8 test cases added |
| `solidity/_generation.json` | Metadata |

### Fix 1: MINIMUM_LIQUIDITY Lock
- On first deposit, mints `MINIMUM_LIQUIDITY` (1000) LP tokens to `address(0)`
- First depositor receives `lpTokens - MINIMUM_LIQUIDITY`
- Reverts if first deposit produces less LP than MINIMUM_LIQUIDITY

### Fix 2: Internal Reserve Accounting
- `removeLiquidity` now uses `reserveA`/`reserveB` (internal state) instead of `tokenA.balanceOf(address(this))`
- Prevents direct token donation attacks from manipulating LP token redemption value

### Fix 3: sync() Recovery
- New `sync()` function updates internal reserves to match actual token balances
- Emits `Sync` event on update
- Allows pool to recover from donation attacks by re-syncing state

### Tests Cover
1. First deposit locks MINIMUM_LIQUIDITY at address(0)
2. First depositor receives correct LP minus locked amount
3. Tiny first deposit correctly reverts
4. Proportional formula works for subsequent deposits
5. removeLiquidity immune to direct donation attack
6. sync() updates reserves and emits Sync event
7. End-to-end attack scenario: donation then correct pricing

/bounty $600
