### PR TITLE
[Hermes Agent] [FastAPI] Add run_concurrently with semaphore and timeout #803

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+    "tool_name": "Hermes Agent",
+    "boot_context": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Task: Fix issue #803 in UnsafeLabs/Bounty-Hunters - Add concurrent task runner with semaphore limiting and timeout to fastapi.concurrency. Implementation: Added run_concurrently() function using asyncio.Semaphore for concurrency limiting, timeout support via asyncio.wait_for, ConcurrencyError for collecting all failures. All 6 tests pass including concurrency limit, ordering, error collection, timeout, sequential execution, and batch execution.",
+    "created": "2026-05-16T07:45:00Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -13,6 +13,76 @@ from starlette.concurrency import (  # noqa
 
 _T = TypeVar("_T")
 
+import asyncio
+from collections.abc import Coroutine, Sequence
+from typing import Any
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more tasks fail during run_concurrently."""
+
+    def __init__(self, errors: list[BaseException]):
+        self.errors = errors
+        super().__init__(f"{len(errors)} task(s) failed: {errors}")
+
+
+async def run_concurrently(
+    coros: Sequence[Coroutine[Any, Any, _T]],
+    max_concurrency: int = 1,
+    timeout: float | None = None,
+) -> list[_T]:
+    """Run multiple coroutines concurrently with a concurrency limit and timeout.
+
+    Args:
+        coros: List of coroutines to execute.
+        max_concurrency: Maximum number of concurrent coroutines.
+        timeout: Maximum total execution time in seconds.
+
+    Returns:
+        Results in the same order as input coroutines.
+
+    Raises:
+        ConcurrencyError: If any coroutine raises an exception, containing all failures.
+        TimeoutError: If the total execution exceeds the timeout.
+    """
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be at least 1")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coros)
+    errors: list[BaseException] = []
+
+    async def run_one(index: int, coro: Coroutine[Any, Any, _T]) -> None:
+        async with semaphore:
+            try:
+                results[index] = await coro
+            except BaseException as e:
+                errors.append(e)
+                results[index] = e
+
+    tasks = [asyncio.create_task(run_one(i, c)) for i, c in enumerate(coros)]
+
+    try:
+        if timeout is not None:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=False),
+                timeout=timeout,
+            )
+        else:
+            await asyncio.gather(*tasks, return_exceptions=False)
+    except asyncio.TimeoutError:
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        raise TimeoutError(
+            f"run_concurrently timed out after {timeout}s"
+        )
+
+    if errors:
+        raise ConcurrencyError(errors)
+
+    return results  # type: ignore[return-value]
+
 
 @asynccontextmanager
 async def contextmanager_in_threadpool(

--- a/fastapi/tests/test_run_concurrently.py
+++ b/fastapi/tests/test_run_concurrently.py
@@ -1,0 +1,118 @@
+"""Tests for run_concurrently in fastapi.concurrency."""
+import asyncio
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.mark.anyio
+async def test_max_concurrency_limit():
+    """Coroutines execute with specified concurrency limit."""
+    running = 0
+    max_seen = 0
+    lock = asyncio.Lock()
+
+    async def task():
+        nonlocal running, max_seen
+        async with lock:
+            running += 1
+            max_seen = max(max_seen, running)
+        await asyncio.sleep(0.05)
+        async with lock:
+            running -= 1
+        return True
+
+    results = await run_concurrently(
+        [task() for _ in range(6)],
+        max_concurrency=2,
+    )
+    assert all(results)
+    assert max_seen <= 2
+
+
+@pytest.mark.anyio
+async def test_results_order():
+    """Results maintain input order regardless of completion order."""
+    async def fast():
+        await asyncio.sleep(0.01)
+        return "fast"
+
+    async def slow():
+        await asyncio.sleep(0.1)
+        return "slow"
+
+    results = await run_concurrently(
+        [fast(), slow()],
+        max_concurrency=2,
+    )
+    assert results == ["fast", "slow"]
+
+
+@pytest.mark.anyio
+async def test_concurrency_error():
+    """ConcurrencyError contains all failed task exceptions."""
+    async def fail(msg):
+        raise ValueError(msg)
+
+    async def ok():
+        return "ok"
+
+    with pytest.raises(ConcurrencyError) as exc:
+        await run_concurrently(
+            [fail("bad1"), ok(), fail("bad2")],
+            max_concurrency=2,
+        )
+    errors = exc.value.errors
+    assert len(errors) == 2
+    assert all(isinstance(e, ValueError) for e in errors)
+
+
+@pytest.mark.anyio
+async def test_timeout():
+    """Timeout cancels remaining tasks and raises TimeoutError."""
+    async def slow():
+        await asyncio.sleep(10)
+
+    with pytest.raises(TimeoutError):
+        await run_concurrently(
+            [slow()],
+            max_concurrency=1,
+            timeout=0.01,
+        )
+
+
+@pytest.mark.anyio
+async def test_max_concurrency_one_sequential():
+    """max_concurrency of 1 executes tasks sequentially."""
+    order = []
+
+    async def task(n):
+        await asyncio.sleep(0.01)
+        order.append(n)
+        return n
+
+    results = await run_concurrently(
+        [task(1), task(2), task(3)],
+        max_concurrency=1,
+    )
+    assert results == [1, 2, 3]
+    assert order == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_max_concurrency_exceeds_count():
+    """max_concurrency greater than task count runs all at once."""
+    start_count = [0]
+    done = asyncio.Event()
+
+    async def task():
+        start_count[0] += 1
+        if start_count[0] == 3:
+            done.set()
+        await done.wait()
+        return True
+
+    results = await run_concurrently(
+        [task() for _ in range(3)],
+        max_concurrency=10,
+    )
+    assert all(results)


### PR DESCRIPTION
#803: Add concurrent task runner with semaphore limiting and timeout

## Changes
- Added `run_concurrently()` function in `fastapi.concurrency`
- Uses `asyncio.Semaphore` for concurrency limiting
- Supports `timeout` via `asyncio.wait_for`
- `ConcurrencyError` collects all failed task exceptions
- Results returned in input order

## Tests
```
tests/test_run_concurrently.py::test_max_concurrency_limit PASSED
tests/test_run_concurrently.py::test_results_order PASSED
tests/test_run_concurrently.py::test_concurrency_error PASSED
tests/test_run_concurrently.py::test_timeout PASSED
tests/test_run_concurrently.py::test_max_concurrency_one_sequential PASSED
tests/test_run_concurrently.py::test_max_concurrency_exceeds_count PASSED
```

/claim #803