### PR TITLE
[Codex] [ Crypto ] Fix zero-fee flash loans and pool drainage protection

### DIFF
--- a/solidity/.contributor.json
+++ b/solidity/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "在git上寻找100美金项目，完成它，提交，然后领钱",
+  "timestamp": "2026-05-17T10:00:00+08:00"
+}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -11,10 +11,15 @@ contract FlashLoan {
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
+    uint256 public poolBalance;
     address public owner;
     bool public paused;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event Deposited(address indexed depositor, uint256 amount);
+    event FeesWithdrawn(address indexed owner, uint256 amount);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
 
     constructor(address _loanToken, uint256 _feeBPS) {
         loanToken = IERC20(_loanToken);
@@ -22,44 +27,89 @@ contract FlashLoan {
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
-    function flashLoan(uint256 amount, bytes calldata data) external {
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier whenNotPaused() {
         require(!paused, "Paused");
+        _;
+    }
+
+    modifier nonRebasingOnly() {
+        require(
+            loanToken.balanceOf(address(this)) == poolBalance + totalFees,
+            "Unaccounted token balance"
+        );
+        _;
+    }
+
+    function calculateFee(uint256 amount) public view returns (uint256) {
+        uint256 proportionalFee = amount * feeBPS / 10000;
+        return proportionalFee == 0 ? 1 : proportionalFee;
+    }
+
+    function maxLoanAmount() public view returns (uint256) {
+        return poolBalance / 2;
+    }
+
+    function flashLoan(uint256 amount, bytes calldata data) external {
+        flashLoan(amount, data, msg.sender);
+    }
+
+    function flashLoan(
+        uint256 amount,
+        bytes calldata data,
+        address receiver
+    ) public whenNotPaused nonRebasingOnly {
         require(amount > 0, "Amount must be > 0");
+        require(receiver != address(0), "Invalid receiver");
+        require(amount <= maxLoanAmount(), "Amount exceeds loan cap");
+        require(poolBalance >= amount, "Insufficient pool balance");
 
         uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        uint256 fee = calculateFee(amount);
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
+        require(loanToken.transfer(receiver, amount), "Transfer failed");
 
-        loanToken.transfer(msg.sender, amount);
+        IFlashLoanReceiver(receiver).onFlashLoan(address(loanToken), amount, fee, data);
 
-        IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
-
-        // BUG: balanceOf can be manipulated by rebasing tokens
         uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(balanceAfter == balanceBefore + fee, "Loan not repaid exactly");
 
         totalFees += fee;
-        emit FlashLoanExecuted(msg.sender, amount, fee);
+        emit FlashLoanExecuted(receiver, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(amount > 0, "Amount must be > 0");
+        uint256 balanceBefore = loanToken.balanceOf(address(this));
+        require(loanToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+        uint256 received = loanToken.balanceOf(address(this)) - balanceBefore;
+        require(received > 0, "No tokens received");
+        poolBalance += received;
+        emit Deposited(msg.sender, received);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner nonRebasingOnly {
         uint256 fees = totalFees;
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        require(loanToken.transfer(owner, fees), "Transfer failed");
+        emit FeesWithdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolBalance;
     }
 }

--- a/solidity/contracts/test/FlashLoanBorrower.sol
+++ b/solidity/contracts/test/FlashLoanBorrower.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../FlashLoan.sol";
+
+contract FlashLoanBorrower is IFlashLoanReceiver {
+    address public immutable lender;
+    IERC20 public immutable token;
+
+    constructor(address _lender, address _token) {
+        lender = _lender;
+        token = IERC20(_token);
+    }
+
+    function onFlashLoan(address loanToken, uint256 amount, uint256 fee, bytes calldata) external {
+        require(msg.sender == lender, "Unexpected lender");
+        require(loanToken == address(token), "Unexpected token");
+        require(token.transfer(msg.sender, amount + fee), "Repayment failed");
+    }
+}

--- a/solidity/contracts/test/MockToken.sol
+++ b/solidity/contracts/test/MockToken.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/solidity/test/FlashLoan.test.js
+++ b/solidity/test/FlashLoan.test.js
@@ -1,0 +1,62 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("FlashLoan", function () {
+  async function deployFixture() {
+    const [owner, borrower] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockToken");
+    const token = await Token.deploy("Loan Token", "LOAN");
+    const FlashLoan = await ethers.getContractFactory("FlashLoan");
+    const flashLoan = await FlashLoan.deploy(await token.getAddress(), 100);
+    const Borrower = await ethers.getContractFactory("FlashLoanBorrower");
+    const receiver = await Borrower.connect(borrower).deploy(
+      await flashLoan.getAddress(),
+      await token.getAddress()
+    );
+
+    await token.mint(owner.address, 1000000);
+    await token.approve(await flashLoan.getAddress(), 1000000);
+    await flashLoan.depositToPool(100000);
+
+    return { owner, borrower, token, flashLoan, receiver };
+  }
+
+  it("charges a minimum fee for small loans", async function () {
+    const { flashLoan, token, receiver } = await deployFixture();
+
+    await token.mint(await receiver.getAddress(), 1);
+    await expect(flashLoan.flashLoan(1, "0x", await receiver.getAddress()))
+      .to.emit(flashLoan, "FlashLoanExecuted")
+      .withArgs(await receiver.getAddress(), 1, 1);
+    expect(await flashLoan.totalFees()).to.equal(1);
+  });
+
+  it("rejects loans above fifty percent of pool balance", async function () {
+    const { flashLoan, receiver } = await deployFixture();
+
+    await expect(
+      flashLoan.flashLoan(50001, "0x", await receiver.getAddress())
+    ).to.be.revertedWith("Amount exceeds loan cap");
+  });
+
+  it("rejects unaccounted balance changes before lending", async function () {
+    const { flashLoan, token, receiver } = await deployFixture();
+
+    await token.mint(await flashLoan.getAddress(), 1);
+    await expect(
+      flashLoan.flashLoan(1000, "0x", await receiver.getAddress())
+    ).to.be.revertedWith("Unaccounted token balance");
+  });
+
+  it("pauses and unpauses flash loans", async function () {
+    const { flashLoan, receiver } = await deployFixture();
+
+    await flashLoan.pause();
+    await expect(
+      flashLoan.flashLoan(1000, "0x", await receiver.getAddress())
+    ).to.be.revertedWith("Paused");
+
+    await flashLoan.unpause();
+    expect(await flashLoan.paused()).to.equal(false);
+  });
+});


### PR DESCRIPTION
/claim #919

## Summary
- Adds a 1-token minimum flash-loan fee so small loans cannot truncate to zero fee
- Caps flash loans at 50% of internally tracked pool liquidity
- Adds internal pool/fee accounting and strict balance checks to reject unaccounted rebasing or direct-transfer balance changes
- Adds owner pause/unpause controls and fee withdrawal events
- Adds Hardhat-style coverage for minimum fees, loan caps, unaccounted balances, and pause/unpause behavior

## Verification
- `git diff --check`
- Solidity test framework was not present in this sparse repository checkout, so contract test execution was not available locally.