### PR TITLE
[Codex] [ Laravel ] Implement lightweight RBAC with permissions

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "在git上寻找100美金项目，完成它，提交，然后领钱",
+  "timestamp": "2026-05-17T10:20:00+08:00"
+}

--- a/laravel/app/Http/Middleware/CheckRole.php
+++ b/laravel/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        $user = $request->user();
+
+        abort_if(! $user || ! method_exists($user, 'hasRole') || ! $user->hasRole($role), 403);
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Permission extends Model
+{
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Role extends Model
+{
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+
+    public function givePermissionTo(Permission|string $permission): static
+    {
+        $permission = $permission instanceof Permission
+            ? $permission
+            : Permission::query()->firstOrCreate([
+                'name' => $permission,
+                'guard_name' => $this->guard_name,
+            ]);
+
+        $this->permissions()->syncWithoutDetaching([$permission->getKey()]);
+
+        return $this;
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\HasRoles;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Collection;
+
+trait HasRoles
+{
+    public function roles(): MorphToMany
+    {
+        return $this->morphToMany(Role::class, 'model', 'model_has_roles')
+            ->withTimestamps();
+    }
+
+    public function permissions(): MorphToMany
+    {
+        return $this->morphToMany(Permission::class, 'model', 'model_has_permissions')
+            ->withTimestamps();
+    }
+
+    public function assignRole(Role|string $role): static
+    {
+        $role = $this->resolveRole($role);
+        $this->roles()->syncWithoutDetaching([$role->getKey()]);
+
+        return $this;
+    }
+
+    public function removeRole(Role|string $role): static
+    {
+        $role = $this->resolveRole($role);
+        $this->roles()->detach($role->getKey());
+
+        return $this;
+    }
+
+    public function givePermissionTo(Permission|string $permission): static
+    {
+        $permission = $this->resolvePermission($permission);
+        $this->permissions()->syncWithoutDetaching([$permission->getKey()]);
+
+        return $this;
+    }
+
+    public function hasRole(Role|string $role): bool
+    {
+        $roleName = $role instanceof Role ? $role->name : $role;
+
+        return $this->roles()
+            ->where('name', $roleName)
+            ->exists();
+    }
+
+    public function hasPermission(Permission|string $permission): bool
+    {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
+        if ($this->permissions()->where('name', $permissionName)->exists()) {
+            return true;
+        }
+
+        return $this->roles()
+            ->whereHas('permissions', fn ($query) => $query->where('name', $permissionName))
+            ->exists();
+    }
+
+    /**
+     * @return Collection<int, Permission>
+     */
+    public function getAllPermissions(): Collection
+    {
+        $directPermissions = $this->permissions()->get();
+        $rolePermissions = $this->roles()
+            ->with('permissions')
+            ->get()
+            ->flatMap(fn (Role $role) => $role->permissions);
+
+        return $directPermissions
+            ->merge($rolePermissions)
+            ->unique('id')
+            ->values();
+    }
+
+    protected function resolveRole(Role|string $role): Role
+    {
+        if ($role instanceof Role) {
+            return $role;
+        }
+
+        return Role::query()->firstOrCreate([
+            'name' => $role,
+            'guard_name' => $this->getDefaultGuardName(),
+        ]);
+    }
+
+    protected function resolvePermission(Permission|string $permission): Permission
+    {
+        if ($permission instanceof Permission) {
+            return $permission;
+        }
+
+        return Permission::query()->firstOrCreate([
+            'name' => $permission,
+            'guard_name' => $this->getDefaultGuardName(),
+        ]);
+    }
+
+    protected function getDefaultGuardName(): string
+    {
+        return config('auth.defaults.guard', 'web');
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/database/migrations/2026_05_17_000000_create_roles_and_permissions_tables.php
+++ b/laravel/database/migrations/2026_05_17_000000_create_roles_and_permissions_tables.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['role_id', 'permission_id']);
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+
+            $table->primary(['permission_id', 'model_id', 'model_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/tests/Feature/RbacTest.php
+++ b/laravel/tests/Feature/RbacTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RbacTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_be_assigned_and_removed_from_role(): void
+    {
+        $user = User::factory()->create();
+
+        $user->assignRole('admin');
+
+        $this->assertTrue($user->hasRole('admin'));
+
+        $user->removeRole('admin');
+
+        $this->assertFalse($user->fresh()->hasRole('admin'));
+    }
+
+    public function test_user_inherits_permissions_from_roles_and_direct_permissions(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::query()->create(['name' => 'editor', 'guard_name' => 'web']);
+        $publish = Permission::query()->create(['name' => 'posts.publish', 'guard_name' => 'web']);
+
+        $role->givePermissionTo($publish);
+        $user->assignRole($role);
+        $user->givePermissionTo('posts.update');
+
+        $this->assertTrue($user->hasPermission('posts.publish'));
+        $this->assertTrue($user->hasPermission('posts.update'));
+        $this->assertFalse($user->hasPermission('posts.delete'));
+        $this->assertEqualsCanonicalizing(
+            ['posts.publish', 'posts.update'],
+            $user->getAllPermissions()->pluck('name')->all()
+        );
+    }
+
+    public function test_role_middleware_rejects_users_without_required_role(): void
+    {
+        Route::get('/rbac-admin-area', fn () => 'ok')->middleware('role:admin');
+
+        $this->actingAs(User::factory()->create())
+            ->get('/rbac-admin-area')
+            ->assertForbidden();
+    }
+
+    public function test_role_middleware_allows_users_with_required_role(): void
+    {
+        Route::get('/rbac-editor-area', fn () => 'ok')->middleware('role:editor');
+
+        $user = User::factory()->create();
+        $user->assignRole('editor');
+
+        $this->actingAs($user)
+            ->get('/rbac-editor-area')
+            ->assertOk()
+            ->assertSee('ok');
+    }
+}


### PR DESCRIPTION
/claim #788

## Summary
- Adds Role and Permission models with role-permission and polymorphic user pivot tables
- Adds a HasRoles trait for assign/remove role, direct permissions, inherited role permissions, and merged permission lookup
- Registers a role middleware alias and implements CheckRole for protected routes
- Applies HasRoles to the User model
- Adds feature tests for role assignment/removal, inherited/direct permissions, and middleware allow/deny behavior

## Verification
- `git diff --check`
- PHP/Composer are not installed in this local environment, so `php -l` and PHPUnit could not be run here.