### PR TITLE
[Codex] [ Laravel ] Add rate limiting middleware and session fallback

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "在git上寻找100美金项目，完成它，提交，然后领钱",
+  "timestamp": "2026-05-17T10:35:00+08:00"
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\RateLimiter;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -11,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->configureSessionFallback();
     }
 
     /**
@@ -19,6 +22,53 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('web', function (Request $request) {
+            return Limit::perMinute(60)->by($this->rateLimitKey($request));
+        });
+    }
+
+    protected function configureSessionFallback(): void
+    {
+        $driver = config('session.driver');
+
+        if (! is_string($driver) || $this->sessionDriverIsAvailable($driver)) {
+            return;
+        }
+
+        config(['session.driver' => config('session.fallback', 'file')]);
+    }
+
+    protected function sessionDriverIsAvailable(string $driver): bool
+    {
+        return match ($driver) {
+            'array', 'cookie', 'file' => true,
+            'database' => $this->configuredDatabaseSessionStoreExists(),
+            'dynamodb', 'memcached', 'redis' => $this->configuredCacheStoreExists(),
+            default => false,
+        };
+    }
+
+    protected function configuredDatabaseSessionStoreExists(): bool
+    {
+        $connection = config('session.connection') ?: config('database.default');
+        $connections = config('database.connections', []);
+
+        return is_string($connection)
+            && array_key_exists($connection, is_array($connections) ? $connections : [])
+            && filled(config('session.table'));
+    }
+
+    protected function configuredCacheStoreExists(): bool
+    {
+        $store = config('session.store') ?: config('cache.default');
+        $stores = config('cache.stores', []);
+
+        return is_string($store)
+            && array_key_exists($store, is_array($stores) ? $stores : []);
+    }
+
+    protected function rateLimitKey(Request $request): string
+    {
+        return 'web:'.($request->user()?->getAuthIdentifier() ?: $request->ip());
     }
 }

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -22,6 +22,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Session Driver Fallback
+    |--------------------------------------------------------------------------
+    |
+    | When the configured session driver cannot be resolved, the application
+    | falls back to this driver so web requests can still be served safely.
+    |
+    */
+
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Lifetime
     |--------------------------------------------------------------------------
     |

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,26 @@
 <?php
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('throttle:web')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/rate-limit/debug', function (Request $request) {
+        $key = 'web:'.($request->user()?->getAuthIdentifier() ?: $request->ip());
+        $remaining = RateLimiter::remaining($key, 60);
+
+        return response()->json([
+            'limit' => 60,
+            'remaining' => $remaining,
+            'retry_after' => RateLimiter::availableIn($key),
+            'key' => $key,
+        ])->withHeaders([
+            'X-RateLimit-Limit' => '60',
+            'X-RateLimit-Remaining' => (string) $remaining,
+        ]);
+    });
 });

--- a/laravel/tests/Feature/RateLimitTest.php
+++ b/laravel/tests/Feature/RateLimitTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class RateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_web_routes_are_rate_limited_for_guests_by_ip(): void
+    {
+        RateLimiter::clear('web:127.0.0.1');
+
+        for ($i = 0; $i < 60; $i++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')->assertStatus(429);
+    }
+
+    public function test_rate_limiter_distinguishes_authenticated_users(): void
+    {
+        $firstUser = User::factory()->create();
+        $secondUser = User::factory()->create();
+
+        RateLimiter::clear('web:'.$firstUser->getAuthIdentifier());
+        RateLimiter::clear('web:'.$secondUser->getAuthIdentifier());
+
+        for ($i = 0; $i < 60; $i++) {
+            $this->actingAs($firstUser)->get('/')->assertOk();
+        }
+
+        $this->actingAs($firstUser)->get('/')->assertStatus(429);
+        $this->actingAs($secondUser)->get('/')->assertOk();
+    }
+
+    public function test_debug_route_returns_rate_limit_headers(): void
+    {
+        RateLimiter::clear('web:127.0.0.1');
+
+        $this->get('/rate-limit/debug')
+            ->assertOk()
+            ->assertHeader('X-RateLimit-Limit', '60')
+            ->assertJsonPath('limit', 60);
+    }
+
+    public function test_session_fallback_driver_is_configured(): void
+    {
+        $this->assertSame('file', config('session.fallback'));
+    }
+}


### PR DESCRIPTION
/claim #749

## Summary
- Registers a `web` rate limiter that allows 60 requests per minute by authenticated user id or guest IP
- Wraps web routes in `throttle:web`
- Adds `/rate-limit/debug` for rate limit state and headers
- Adds `session.fallback` config and startup fallback to `file` when the configured session driver is unavailable
- Adds feature tests for guest throttling, authenticated-user buckets, debug headers, and fallback config

## Verification
- `git diff --check`
- PHP/Composer are not installed in this local environment, so PHPUnit could not be run here.