### PR TITLE
[Codex] [ T3 Code ] Add version command and --version flag

### DIFF
--- a/t3code/apps/server/.contributor.json
+++ b/t3code/apps/server/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "在git上寻找100美金项目，完成它，提交，然后领钱",
+  "timestamp": "2026-05-17T10:50:00+08:00"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -158,6 +158,14 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),
   );
 
+  it.effect("prints detailed runtime information from the version subcommand", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["version"]));
+
+      assert.match(output, /^t3code v\d+\.\d+\.\d+ \((bun|node) [^)]+, [^)]+ [^)]+\)$/);
+    }),
+  );
+
   it.effect("rejects invalid log-level casing before launching the server", () =>
     Effect.gen(function* () {
       const error = yield* runCliWithRuntime(["--log-level", "Debug"]).pipe(Effect.flip);

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -10,17 +10,24 @@ import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { formatVersionInfo, versionCommand } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    versionCommand,
+  ]),
 );
 
 if (import.meta.main) {
-  Command.run(cli, { version: packageJson.version }).pipe(
+  Command.run(cli, { version: formatVersionInfo(packageJson.version) }).pipe(
     Effect.scoped,
     Effect.provide(CliRuntimeLayer),
     NodeRuntime.runMain,

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,27 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import { Command } from "effect/unstable/cli";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+const runtimeVersion = (): string => {
+  const versions = process.versions as NodeJS.ProcessVersions & { readonly bun?: string };
+
+  if (versions.bun) {
+    return `bun ${versions.bun}`;
+  }
+
+  return `node ${versions.node}`;
+};
+
+export const formatVersionInfo = (version: string = packageJson.version): string =>
+  `t3code v${version} (${runtimeVersion()}, ${process.platform} ${process.arch})`;
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print T3 Code version, runtime, platform, and architecture."),
+  Command.withHandler(() =>
+    Effect.gen(function* () {
+      yield* Console.log(formatVersionInfo());
+    }),
+  ),
+);


### PR DESCRIPTION
/claim #821

## Summary
- Adds a `t3 version` subcommand that prints the package version, runtime, platform, and architecture
- Keeps the root CLI `--version` wired through Effect CLI's built-in version support and now passes the detailed version string at runtime
- Adds a focused CLI test for the detailed version output

## Verification
- `git diff --check`
- `npm exec --yes --package=oxfmt@0.40.0 -- oxfmt --check t3code/apps/server/src/bin.ts t3code/apps/server/src/bin.test.ts t3code/apps/server/src/cli/version.ts`
- Bun is not installed in this environment, so Vitest could not be run locally.