### PR TITLE
[Codex] [ Rust ] Fix SessionCache concurrent access race

### DIFF
--- a/rust/.contributor.json
+++ b/rust/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "在git上寻找100美金项目，完成它，提交，然后领钱",
+  "timestamp": "2026-05-17T11:15:00+08:00"
+}

--- a/rust/tls_session.rs
+++ b/rust/tls_session.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Maximum number of cached sessions before eviction kicks in.
@@ -66,9 +66,7 @@ pub struct EncryptionKey {
 #[derive(Debug, Clone)]
 pub struct SessionCache {
     /// Thread-safe reference to the inner cache map.
-    // BUG(trap2): Arc alone does not provide interior mutability or
-    // synchronisation.  Concurrent callers can race on the HashMap.
-    cache: Arc<HashMap<String, SessionTicket>>,
+    cache: Arc<RwLock<HashMap<String, SessionTicket>>>,
     encryption_key: EncryptionKey,
     max_size: usize,
 }
@@ -108,18 +106,20 @@ impl SessionCache {
     pub fn new(key_material: Vec<u8>) -> Self {
         let key = EncryptionKey::new(1, key_material);
         SessionCache {
-            cache: Arc::new(HashMap::new()),
+            cache: Arc::new(RwLock::new(HashMap::new())),
             encryption_key: key,
             max_size: MAX_CACHE_SIZE,
         }
     }
 
     /// Store a session ticket in the cache.
-    pub fn store_session(&mut self, ticket: SessionTicket) -> Result<(), SessionError> {
-        let inner = Arc::get_mut(&mut self.cache).ok_or(SessionError::CacheFull)?;
+    pub fn store_session(&self, ticket: SessionTicket) -> Result<(), SessionError> {
+        let mut inner = self.cache.write().map_err(|_| {
+            SessionError::InvalidTicket("session cache write lock poisoned".to_string())
+        })?;
 
         if inner.len() >= self.max_size {
-            self.evict_expired_sessions(inner);
+            self.evict_expired_sessions(&mut inner);
         }
 
         if inner.len() >= self.max_size {
@@ -133,27 +133,26 @@ impl SessionCache {
     /// Look up a session by ticket id.
     ///
     /// Returns the ticket if it exists **and** has not expired.
-    pub fn get_session(&self, ticket_id: &str) -> Option<&SessionTicket> {
-        // BUG(trap1): `.unwrap()` panics when the ticket_id is not present
-        // in the map.  Should use `?` or a match instead.
-        let ticket = self.cache.get(ticket_id).unwrap();
+    pub fn get_session(&self, ticket_id: &str) -> Option<SessionTicket> {
+        let inner = self.cache.read().ok()?;
+        let ticket = inner.get(ticket_id)?;
 
         if self.is_ticket_expired(ticket) {
             return None;
         }
 
-        Some(ticket)
+        Some(ticket.clone())
     }
 
     /// Remove a specific ticket from the cache.
-    pub fn remove_session(&mut self, ticket_id: &str) -> Option<SessionTicket> {
-        let inner = Arc::get_mut(&mut self.cache)?;
+    pub fn remove_session(&self, ticket_id: &str) -> Option<SessionTicket> {
+        let mut inner = self.cache.write().ok()?;
         inner.remove(ticket_id)
     }
 
     /// Return the number of cached sessions.
     pub fn session_count(&self) -> usize {
-        self.cache.len()
+        self.cache.read().map(|inner| inner.len()).unwrap_or(0)
     }
 
     // -- internal helpers ---------------------------------------------------
@@ -291,9 +290,53 @@ impl SessionCache {
     pub fn summary(&self) -> String {
         format!(
             "SessionCache {{ sessions: {}, key_id: {}, max: {} }}",
-            self.cache.len(),
+            self.session_count(),
             self.encryption_key.key_id,
             self.max_size,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn ticket(id: usize) -> SessionTicket {
+        SessionTicket {
+            ticket_id: format!("tkt_test_{}", id),
+            cipher_suite: CipherSuite::TlsAes128GcmSha256 as u16,
+            master_secret: vec![id as u8],
+            issued_at: 1,
+            lifetime_secs: DEFAULT_TICKET_LIFETIME_SECS,
+            encrypted_state: vec![id as u8],
+            creation_time: 1,
+        }
+    }
+
+    #[test]
+    fn concurrent_store_and_get_session_is_synchronized() {
+        let cache = SessionCache::new(vec![1, 2, 3, 4]);
+        let mut handles = Vec::new();
+
+        for index in 0..10 {
+            let worker_cache = cache.clone();
+            handles.push(thread::spawn(move || {
+                let session = ticket(index);
+                let ticket_id = session.ticket_id.clone();
+
+                worker_cache.store_session(session).unwrap();
+
+                worker_cache
+                    .get_session(&ticket_id)
+                    .map(|stored| stored.ticket_id)
+            }));
+        }
+
+        for handle in handles {
+            assert!(handle.join().unwrap().is_some());
+        }
+
+        assert_eq!(cache.session_count(), 10);
     }
 }


### PR DESCRIPTION
/claim #23

## Summary
- Replaces the session cache `Arc<HashMap<...>>` with `Arc<RwLock<HashMap<...>>>`
- Uses write locks for storing/removing tickets and read locks for lookups
- Updates lookup to avoid panics and return cloned tickets outside the lock guard
- Adds an in-file concurrency test that spawns 10 workers storing and reading tickets

## Verification
- `git diff --check`
- `rustc` is not installed in this environment, so Rust tests could not be executed locally.