### PR TITLE
[Codex] [ Go ] Prefer ChaCha20-Poly1305 over AES-GCM on ARM64

### DIFF
--- a/go/.contributor.json
+++ b/go/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "在git上寻找100美金项目，完成它，提交，然后领钱",
+  "timestamp": "2026-05-17T11:25:00+08:00"
+}

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -208,6 +208,10 @@ func (r *SuiteRegistry) FilterWeakSuites(suites []*CipherSuite) []*CipherSuite {
 // BUG(4): The AEAD comparison is inverted — non-AEAD suites end up
 // ranked above AEAD suites.
 func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
+	return r.sortByPreferenceForArch(suites, runtime.GOARCH)
+}
+
+func (r *SuiteRegistry) sortByPreferenceForArch(suites []*CipherSuite, arch string) []*CipherSuite {
 	sorted := make([]*CipherSuite, len(suites))
 	copy(sorted, suites)
 
@@ -217,6 +221,10 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 		// BUG(4): operator is flipped; should be si.IsAEAD && !sj.IsAEAD
 		if si.IsAEAD != sj.IsAEAD {
 			return !si.IsAEAD && sj.IsAEAD
+		}
+
+		if arch == "arm64" && si.IsAEAD && sj.IsAEAD && isChaCha20Suite(si) != isChaCha20Suite(sj) {
+			return isChaCha20Suite(si)
 		}
 
 		// Higher strength first
@@ -229,6 +237,10 @@ func (r *SuiteRegistry) SortByPreference(suites []*CipherSuite) []*CipherSuite {
 	})
 
 	return sorted
+}
+
+func isChaCha20Suite(suite *CipherSuite) bool {
+	return suite != nil && suite.ID == tls.TLS_CHACHA20_POLY1305_SHA256
 }
 
 // ConcurrentLookup demonstrates a batch lookup of suite IDs from

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,43 @@
+package tlscipher
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestSortByPreferencePrefersChaCha20OnARM64(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	ordered := registry.sortByPreferenceForArch(
+		registry.FilterWeakSuites(registry.knownSuites),
+		"arm64",
+	)
+
+	if indexOfSuite(ordered, tls.TLS_CHACHA20_POLY1305_SHA256) >
+		indexOfSuite(ordered, tls.TLS_AES_256_GCM_SHA384) {
+		t.Fatal("expected ChaCha20-Poly1305 to be preferred over AES-GCM on arm64")
+	}
+}
+
+func TestSortByPreferenceKeepsAESPreferenceOnAMD64(t *testing.T) {
+	registry := NewSuiteRegistry(StrengthWeak)
+
+	ordered := registry.sortByPreferenceForArch(
+		registry.FilterWeakSuites(registry.knownSuites),
+		"amd64",
+	)
+
+	if indexOfSuite(ordered, tls.TLS_AES_256_GCM_SHA384) >
+		indexOfSuite(ordered, tls.TLS_CHACHA20_POLY1305_SHA256) {
+		t.Fatal("expected AES-GCM to keep preference over ChaCha20-Poly1305 on amd64")
+	}
+}
+
+func indexOfSuite(suites []*CipherSuite, id uint16) int {
+	for index, suite := range suites {
+		if suite.ID == id {
+			return index
+		}
+	}
+	return len(suites)
+}


### PR DESCRIPTION
/claim #12

## Summary
- Adds architecture-aware cipher-suite ordering for server preferences
- Prefers TLS_CHACHA20_POLY1305_SHA256 over AES-GCM suites on arm64 platforms
- Preserves the existing AES-GCM preference on amd64
- Adds focused tests for arm64 and amd64 ordering behavior

## Verification
- `git diff --check`
- Go is not installed in this environment, so `gofmt` and `go test` could not be run locally.