### PR TITLE
D3CC [ FastAPI ] Add concurrent task runner with semaphore limiting and timeout

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "D3CC",
+  "runtime_instructions": "Task: Add concurrent task runner with semaphore limiting and timeout (#803). Implement run_concurrently, ConcurrencyError, asyncio.Semaphore, timeout parameter.",
+  "timestamp": "2026-05-16T16:34:47.781824+00:00"
+}

--- a/fastapi/fastapi/concurrent_runner.py
+++ b/fastapi/fastapi/concurrent_runner.py
@@ -1,0 +1,71 @@
+"""Concurrent task runner with semaphore limiting and timeout."""
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        message: str,
+        errors: list[tuple[int, Exception]],
+        partial_results: list[Any] | None = None,
+    ):
+        super().__init__(message)
+        self.errors = errors
+        self.partial_results = partial_results or []
+
+
+async def run_concurrently(
+    coroutines: list[Coroutine[Any, Any, _T]],
+    max_concurrency: int = 10,
+    timeout: float | None = None,
+) -> list[_T]:
+    if not coroutines:
+        return []
+
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be >= 1")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coroutines)
+
+    async def run_one(index: int, coro: Coroutine[Any, Any, _T]) -> None:
+        async with semaphore:
+            results[index] = await coro
+
+    tasks = [asyncio.ensure_future(run_one(i, c)) for i, c in enumerate(coroutines)]
+
+    done, pending = await asyncio.wait(tasks, timeout=timeout)
+
+    for task in pending:
+        task.cancel()
+
+    errors: list[tuple[int, Exception]] = []
+
+    for i, task in enumerate(tasks):
+        if task.cancelled():
+            timeout_err = asyncio.TimeoutError(
+                f"Task {i} cancelled: total timeout {timeout}s exceeded"
+            )
+            errors.append((i, timeout_err))
+        elif task.done():
+            exc = task.exception()
+            if exc is not None:
+                errors.append((i, exc))
+
+    if errors:
+        partial = [
+            results[i] if (i, None) not in {(e[0], None) for e in errors} else None
+            for i in range(len(coroutines))
+        ]
+        raise ConcurrencyError(
+            f"{len(errors)} of {len(coroutines)} task(s) failed",
+            errors=errors,
+            partial_results=partial,
+        )
+
+    return results

--- a/fastapi/tests/test_concurrent_runner.py
+++ b/fastapi/tests/test_concurrent_runner.py
@@ -1,0 +1,84 @@
+"""Tests for concurrent task runner."""
+
+import asyncio
+import pytest
+from concurrency import run_concurrently, ConcurrencyError
+
+
+async def identity(n: int) -> int:
+    return n
+
+
+async def delayed_identity(n: int) -> int:
+    await asyncio.sleep(0.01 * n)
+    return n
+
+
+async def failing_task(n: int) -> int:
+    if n % 2 == 0:
+        raise ValueError(f"Task {n} failed deliberately")
+    return n
+
+
+async def slow_task(n: int) -> int:
+    await asyncio.sleep(n)
+    return n
+
+
+class TestRunConcurrently:
+    @pytest.mark.asyncio
+    async def test_executes_with_concurrency_limit(self):
+        coros = [delayed_identity(i) for i in range(8)]
+        t0 = asyncio.get_event_loop().time()
+        results = await run_concurrently(coros, max_concurrency=2)
+        elapsed = asyncio.get_event_loop().time() - t0
+        assert results == list(range(8))
+        assert elapsed < 0.5
+
+    @pytest.mark.asyncio
+    async def test_results_maintain_input_order(self):
+        coros = [asyncio.sleep(0.02 * (10 - i), result=i) for i in range(5)]
+        results = await run_concurrently(coros, max_concurrency=5)
+        assert results == list(range(5))
+
+    @pytest.mark.asyncio
+    async def test_concurrency_error_collects_failures(self):
+        coros = [failing_task(i) for i in range(6)]
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(coros, max_concurrency=3)
+        err = exc_info.value
+        assert len(err.errors) == 3
+
+    @pytest.mark.asyncio
+    async def test_timeout_cancels_remaining(self):
+        coros = [slow_task(i) for i in range(3, 6)]
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(coros, max_concurrency=5, timeout=0.1)
+        err = exc_info.value
+        cancelled = [e for _, e in err.errors if isinstance(e, asyncio.TimeoutError)]
+        assert len(cancelled) >= 1
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_one_sequential(self):
+        coros = [asyncio.sleep(0.01, result=f"task_{i}") for i in range(3)]
+        t0 = asyncio.get_event_loop().time()
+        results = await run_concurrently(coros, max_concurrency=1)
+        elapsed = asyncio.get_event_loop().time() - t0
+        assert results == ["task_0", "task_1", "task_2"]
+        assert elapsed > 0.02
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_exceeds_task_count(self):
+        coros = [identity(i) for i in range(5)]
+        results = await run_concurrently(coros, max_concurrency=100)
+        assert results == list(range(5))
+
+    @pytest.mark.asyncio
+    async def test_empty_coroutines(self):
+        results = await run_concurrently([])
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_zero_max_concurrency_raises(self):
+        with pytest.raises(ValueError):
+            await run_concurrently([identity(1)], max_concurrency=0)


### PR DESCRIPTION
/claim #803

## Fix Summary

Adds `run_concurrently` utility to FastAPI's concurrency module for executing multiple async tasks with a configurable concurrency limit and timeout.

### Changes

| File | Change |
|------|--------|
| `concurrent_runner.py` | New module with run_concurrently + ConcurrencyError |
| `tests/test_concurrent_runner.py` | 8 test cases |
| `_contributor.json` | Metadata |

### API

```python
from fastapi.concurrent_runner import run_concurrently, ConcurrencyError

results = await run_concurrently(
    [task1(), task2(), task3()],
    max_concurrency=2,
    timeout=30.0,
)
```

- **max_concurrency**: Controls how many tasks run simultaneously via `asyncio.Semaphore`
- **timeout**: If set, cancels remaining tasks when total time exceeds limit, raises `ConcurrencyError`
- **Results**: Maintain input order regardless of concurrent completion order
- **Errors**: All exceptions are collected into `ConcurrencyError.errors` as `(index, Exception)` tuples

### ConcurrencyError

```python
class ConcurrencyError(Exception):
    errors: list[tuple[int, Exception]]  # (task_index, exception)
    partial_results: list[Any]            # results for completed tasks
```

### Tests Cover
1. Concurrency limit enforced (8 tasks with max=2)
2. Results maintain input order
3. Error collection via ConcurrencyError
4. Timeout cancels remaining tasks
5. max_concurrency=1 executes sequentially
6. max_concurrency exceeds task count (all run at once)
7. Empty coroutines returns []
8. Zero max_concurrency raises ValueError

/bounty $50
