### PR TITLE
Add Developer and Git menus to Electron menu bar

### DIFF
--- a/t3code/apps/desktop/.contributor.json
+++ b/t3code/apps/desktop/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "在git上寻找100美金项目，完成它，提交，然后领钱",
+  "timestamp": "2026-05-17T11:40:00+08:00"
+}

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -129,4 +129,51 @@ describe("DesktopApplicationMenu", () => {
       assert.equal(yield* Deferred.await(selectedAction), "open-settings");
     }),
   );
+
+  it.effect("adds Developer and Git menus that dispatch renderer actions", () =>
+    Effect.gen(function* () {
+      const selectedAction = yield* Deferred.make<string>();
+      const applicationMenuTemplate =
+        yield* Deferred.make<readonly Electron.MenuItemConstructorOptions[]>();
+
+      yield* Effect.gen(function* () {
+        const menu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
+        yield* menu.configure;
+      }).pipe(
+        Effect.provide(
+          DesktopApplicationMenu.layer.pipe(
+            Layer.provideMerge(makeElectronMenuLayer(applicationMenuTemplate)),
+            Layer.provideMerge(makeDesktopWindowLayer(selectedAction)),
+            Layer.provideMerge(desktopUpdatesLayer),
+            Layer.provideMerge(electronDialogLayer),
+            Layer.provideMerge(electronAppLayer),
+            Layer.provideMerge(
+              DesktopEnvironment.layer(environmentInput).pipe(
+                Layer.provide(Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({}))),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      const template = yield* Deferred.await(applicationMenuTemplate);
+      const developerMenu = template.find((item) => item.label === "Developer");
+      const gitMenu = template.find((item) => item.label === "Git");
+      assert.isDefined(developerMenu);
+      assert.isDefined(gitMenu);
+      if (!Array.isArray(developerMenu.submenu) || !Array.isArray(gitMenu.submenu)) {
+        throw new Error("Expected Developer and Git menu submenus to be arrays.");
+      }
+      assert.isDefined(developerMenu.submenu.find((item) => item.label === "Toggle Terminal"));
+      const stageAllItem = gitMenu.submenu.find((item) => item.label === "Stage All Changes");
+      assert.isDefined(stageAllItem);
+      const stageAllClick = stageAllItem.click;
+      if (typeof stageAllClick !== "function") {
+        throw new Error("Expected Stage All Changes menu item to have a click handler.");
+      }
+
+      stageAllClick({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
+      assert.equal(yield* Deferred.await(selectedAction), "git.stage-all");
+    }),
+  );
 });

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -124,9 +124,10 @@ const make = Effect.gen(function* () {
     const checkForUpdatesClick = () => {
       runMenuEffect("check-for-updates", handleCheckForUpdatesMenuClick);
     };
-    const settingsClick = () => {
-      runMenuEffect("open-settings", dispatchMenuAction("open-settings"));
+    const dispatchMenuActionClick = (action: string) => () => {
+      runMenuEffect(action, dispatchMenuAction(action));
     };
+    const settingsClick = dispatchMenuActionClick("open-settings");
     const template: Electron.MenuItemConstructorOptions[] = [];
 
     if (environment.platform === "darwin") {
@@ -174,6 +175,56 @@ const make = Effect.gen(function* () {
         ],
       },
       { role: "editMenu" },
+      {
+        label: "Developer",
+        submenu: [
+          {
+            label: "Toggle Terminal",
+            accelerator: "CmdOrCtrl+`",
+            click: dispatchMenuActionClick("developer.toggle-terminal"),
+          },
+          {
+            label: "Clear Terminal",
+            accelerator: "CmdOrCtrl+K",
+            click: dispatchMenuActionClick("developer.clear-terminal"),
+          },
+          {
+            label: "Restart Backend",
+            click: dispatchMenuActionClick("developer.restart-backend"),
+          },
+          { type: "separator" },
+          { role: "toggleDevTools" },
+        ],
+      },
+      {
+        label: "Git",
+        submenu: [
+          {
+            label: "Stage All Changes",
+            accelerator: "CmdOrCtrl+Shift+A",
+            click: dispatchMenuActionClick("git.stage-all"),
+          },
+          {
+            label: "Commit...",
+            accelerator: "CmdOrCtrl+Enter",
+            click: dispatchMenuActionClick("git.commit"),
+          },
+          {
+            label: "Pull",
+            click: dispatchMenuActionClick("git.pull"),
+          },
+          {
+            label: "Push",
+            accelerator: "CmdOrCtrl+Shift+P",
+            click: dispatchMenuActionClick("git.push"),
+          },
+          { type: "separator" },
+          {
+            label: "Create Branch...",
+            click: dispatchMenuActionClick("git.create-branch"),
+          },
+        ],
+      },
       {
         label: "View",
         submenu: [


### PR DESCRIPTION
## Summary
- add native Developer and Git menus to the Electron application menu bar
- route backend and Git menu selections through the existing DesktopWindow menu-action IPC path
- add coverage that the new menus are installed and dispatch the expected action

## Testing
- git diff --check
- not run: Bun is not installed in this local environment, so the desktop Vitest suite could not be executed

/claim #831