### PR TITLE
Susan / OpenClaw [ T3 Code ] add CLI version command

### DIFF
--- a/t3code/apps/server/.contributor.json
+++ b/t3code/apps/server/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "name": "Susan",
+  "platform": "OpenClaw",
+  "issue": 821
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -158,6 +158,14 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),
   );
 
+  it.effect("prints version subcommand output", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCliWithRuntime(["version"]));
+
+      assert.match(output, /^t3 v0\.0\.24 \((node|bun) /);
+    }),
+  );
+
   it.effect("rejects invalid log-level casing before launching the server", () =>
     Effect.gen(function* () {
       const error = yield* runCliWithRuntime(["--log-level", "Debug"]).pipe(Effect.flip);

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer";
 import { Command } from "effect/unstable/cli";
 
 import * as NetService from "@t3tools/shared/Net";
+import * as Console from "effect/Console";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
@@ -13,10 +14,18 @@ import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
+const runtimeName = typeof Bun === "undefined" ? "node" : "bun";
+const versionOutput = `t3 v${packageJson.version} (${runtimeName} ${process.version}, ${process.platform} ${process.arch})`;
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print the T3 Code CLI version."),
+  Command.withHandler(() => Console.log(versionOutput)),
+);
+
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, versionCommand]),
 );
 
 if (import.meta.main) {


### PR DESCRIPTION
/claim #821
/bounty $35

Fixes #821

## Summary
- adds `t3 version` subcommand
- keeps root `--version` wired to package version
- prints runtime/platform info
- adds CLI test coverage
- adds required `.contributor.json`

## Verification
- `git diff --check` passed
- GitHub checks passed: Enforce Single Issue Per PR, Track Clankers
- full test run blocked locally: repo requires bun 1.3.11; bun is not installed in this environment

## Demo
Text CLI output covered by `apps/server/src/bin.test.ts`.
