### PR TITLE
D3CC [ Laravel ] Implement lightweight role-based access control with permissions

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "D3CC",
+  "initialized_with": "Task: Implement lightweight RBAC with permissions for Laravel (#788). Create Role/Permission models, HasRoles trait, CheckRole middleware, pivot tables, apply to User model.",
+  "timestamp": "2026-05-16T17:04:32.096739+00:00"
+}

--- a/laravel/app/Http/Middleware/CheckRole.php
+++ b/laravel/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        if (! $request->user() || ! $request->user()->hasRole($role)) {
+            abort(403, 'Forbidden');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    protected $fillable = ['name', 'guard_name'];
+
+    protected $hidden = ['pivot'];
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_has_permissions');
+    }
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(config('auth.providers.users.model', User::class), 'model_has_permissions', 'permission_id', 'model_id');
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    protected $fillable = ['name', 'guard_name'];
+
+    protected $hidden = ['pivot'];
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_has_permissions');
+    }
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(config('auth.providers.users.model', User::class), 'model_has_roles', 'role_id', 'model_id');
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,20 +2,20 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Traits\HasRoles;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Collection;
+
+trait HasRoles
+{
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Role::class,
+            'model_has_roles',
+            'model_id',
+            'role_id'
+        );
+    }
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Permission::class,
+            'model_has_permissions',
+            'model_id',
+            'permission_id'
+        );
+    }
+
+    public function assignRole(string $roleName): self
+    {
+        $role = Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'web']);
+        $this->roles()->syncWithoutDetaching([$role->id]);
+        return $this;
+    }
+
+    public function removeRole(string $roleName): self
+    {
+        $role = Role::where('name', $roleName)->first();
+        if ($role) {
+            $this->roles()->detach($role->id);
+        }
+        return $this;
+    }
+
+    public function hasRole(string $roleName): bool
+    {
+        return $this->roles()->where('name', $roleName)->exists();
+    }
+
+    public function hasPermission(string $permissionName): bool
+    {
+        if ($this->permissions()->where('name', $permissionName)->exists()) {
+            return true;
+        }
+
+        return $this->roles()
+            ->whereHas('permissions', fn ($q) => $q->where('name', $permissionName))
+            ->exists();
+    }
+
+    public function getAllPermissions(): Collection
+    {
+        $directPermissions = $this->permissions()->get();
+
+        $rolePermissions = $this->roles()
+            ->with('permissions')
+            ->get()
+            ->flatMap(fn (Role $role) => $role->permissions);
+
+        return $directPermissions->merge($rolePermissions)->unique('id');
+    }
+
+    public function givePermissionTo(string $permissionName): self
+    {
+        $permission = Permission::firstOrCreate(['name' => $permissionName, 'guard_name' => 'web']);
+        $this->permissions()->syncWithoutDetaching([$permission->id]);
+        return $this;
+    }
+
+    public function revokePermissionTo(string $permissionName): self
+    {
+        $permission = Permission::where('name', $permissionName)->first();
+        if ($permission) {
+            $this->permissions()->detach($permission->id);
+        }
+        return $this;
+    }
+}

--- a/laravel/database/migrations/2026_05_16_000000_create_roles_permissions_tables.php
+++ b/laravel/database/migrations/2026_05_16_000000_create_roles_permissions_tables.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained('roles')->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained('permissions')->cascadeOnDelete();
+            $table->primary(['role_id', 'permission_id']);
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained('roles')->cascadeOnDelete();
+            $table->morphs('model');
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained('permissions')->cascadeOnDelete();
+            $table->morphs('model');
+            $table->primary(['permission_id', 'model_id', 'model_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/tests/Feature/RbacTest.php
+++ b/laravel/tests/Feature/RbacTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RbacTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_assign_role(): void
+    {
+        $this->user->assignRole('admin');
+        $this->assertTrue($this->user->hasRole('admin'));
+    }
+
+    public function test_remove_role(): void
+    {
+        $this->user->assignRole('admin');
+        $this->user->removeRole('admin');
+        $this->assertFalse($this->user->hasRole('admin'));
+    }
+
+    public function test_has_role_returns_false_for_unknown(): void
+    {
+        $this->assertFalse($this->user->hasRole('nonexistent'));
+    }
+
+    public function test_has_direct_permission(): void
+    {
+        $this->user->givePermissionTo('edit-posts');
+        $this->assertTrue($this->user->hasPermission('edit-posts'));
+    }
+
+    public function test_has_permission_inherited_through_role(): void
+    {
+        $role = Role::create(['name' => 'editor', 'guard_name' => 'web']);
+        $permission = Permission::create(['name' => 'publish-posts', 'guard_name' => 'web']);
+        $role->permissions()->attach($permission->id);
+
+        $this->user->assignRole('editor');
+        $this->assertTrue($this->user->hasPermission('publish-posts'));
+    }
+
+    public function test_has_permission_returns_false_for_unknown(): void
+    {
+        $this->assertFalse($this->user->hasPermission('nonexistent'));
+    }
+
+    public function test_get_all_permissions_merges_direct_and_role(): void
+    {
+        $this->user->givePermissionTo('direct-perm');
+
+        $role = Role::create(['name' => 'moderator', 'guard_name' => 'web']);
+        $perm = Permission::create(['name' => 'role-perm', 'guard_name' => 'web']);
+        $role->permissions()->attach($perm->id);
+        $this->user->assignRole('moderator');
+
+        $all = $this->user->getAllPermissions();
+        $names = $all->pluck('name')->toArray();
+
+        $this->assertContains('direct-perm', $names);
+        $this->assertContains('role-perm', $names);
+    }
+
+    public function test_check_role_middleware_grants_access(): void
+    {
+        $this->user->assignRole('admin');
+        $this->actingAs($this->user);
+
+        $response = $this->get('/admin');
+        $response->assertStatus(200);
+    }
+
+    public function test_check_role_middleware_denies_403(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->get('/admin');
+        $response->assertStatus(403);
+    }
+
+    public function test_check_role_middleware_denies_unauthenticated(): void
+    {
+        $response = $this->get('/admin');
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
/claim #788

## Fix Summary

Implements a complete lightweight RBAC system without external packages.

### Changes

| File | Change |
|------|--------|
| `Models/Role.php` | New model with id, name, guard_name, timestamps |
| `Models/Permission.php` | New model with id, name, guard_name, timestamps |
| `Traits/HasRoles.php` | New trait: assignRole, removeRole, hasRole, hasPermission, getAllPermissions, givePermissionTo, revokePermissionTo |
| `Middleware/CheckRole.php` | New middleware: accepts role name, returns 403 if user lacks role |
| `Models/User.php` | Added HasRoles trait |
| `database/migrations/` | 5 tables: roles, permissions, role_has_permissions, model_has_roles, model_has_permissions |
| `tests/Feature/RbacTest.php` | 10 test cases |
| `.contributor.json` | Metadata |

### Architecture

```
User (HasRoles trait)
 ├── assignRole('admin')
 ├── hasRole('admin') → bool
 ├── hasPermission('edit-posts') → checks direct + role-inherited
 ├── getAllPermissions() → merged direct + role permissions
 └── roles() → BelongsToMany(Role)

Role
 ├── permissions() → BelongsToMany(Permission)
 └── role_has_permissions (pivot)

Permission
 ├── roles() → BelongsToMany(Role)
 └── model_has_permissions (pivot, polymorphic)

Middleware: CheckRole:admin → 403 if !hasRole('admin')
```

### Tests Cover
1. assignRole makes hasRole return true
2. removeRole makes hasRole return false
3. hasRole returns false for unknown roles
4. hasPermission returns true for direct permissions
5. hasPermission inherits through role
6. hasPermission returns false for unknown
7. getAllPermissions merges direct + role permissions
8. CheckRole middleware grants access with correct role
9. CheckRole middleware returns 403 without role
10. CheckRole middleware returns 403 for unauthenticated

/bounty $175
