### PR TITLE
Hermes [ Laravel ] Fix phpunit coverage and add grouped tests

### DIFF
--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -6,19 +6,24 @@
 >
     <testsuites>
         <testsuite name="Unit">
-            <directory>tests/Unit</directory>
+            <directory suffix="Test.php">tests/Unit</directory>
         </testsuite>
         <testsuite name="Feature">
-            <directory>tests/Feature</directory>
+            <directory suffix="Test.php">tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory>app</directory>
+            <directory suffix=".php">app</directory>
         </include>
+        <exclude>
+            <directory>app/Providers</directory>
+            <directory>app/Console</directory>
+        </exclude>
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/ExampleTest.php
+++ b/laravel/tests/Feature/ExampleTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
+#[Group('feature')]
 class ExampleTest extends TestCase
 {
     /**

--- a/laravel/tests/Feature/RouteTest.php
+++ b/laravel/tests/Feature/RouteTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('feature')]
+class RouteTest extends TestCase
+{
+    public function test_registered_get_routes_do_not_return_server_errors(): void
+    {
+        $getRoutes = collect(Route::getRoutes())
+            ->filter(fn ($route) => in_array('GET', $route->methods(), true))
+            ->reject(fn ($route) => str_contains($route->uri(), '{'));
+
+        $this->assertNotEmpty($getRoutes, 'Expected at least one registered GET route to smoke test.');
+
+        foreach ($getRoutes as $route) {
+            $uri = '/'.ltrim($route->uri(), '/');
+            $uri = $uri === '/' ? '/' : rtrim($uri, '/');
+
+            $response = $this->get($uri);
+
+            $this->assertLessThan(
+                500,
+                $response->getStatusCode(),
+                sprintf('GET %s returned a server error.', $uri),
+            );
+        }
+    }
+}

--- a/laravel/tests/Unit/ExampleTest.php
+++ b/laravel/tests/Unit/ExampleTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Unit;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
+#[Group('unit')]
 class ExampleTest extends TestCase
 {
     /**

--- a/laravel/tests/Unit/UserModelTest.php
+++ b/laravel/tests/Unit/UserModelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('unit')]
+class UserModelTest extends TestCase
+{
+    public function test_user_model_fillable_attributes_are_configured(): void
+    {
+        $user = new User;
+
+        $this->assertSame(['name', 'email', 'password'], $user->getFillable());
+    }
+
+    public function test_user_model_hidden_attributes_are_configured(): void
+    {
+        $user = new User;
+
+        $this->assertSame(['password', 'remember_token'], $user->getHidden());
+    }
+
+    public function test_user_model_casts_are_configured(): void
+    {
+        $user = new User;
+
+        $this->assertSame('datetime', $user->getCasts()['email_verified_at'] ?? null);
+        $this->assertSame('hashed', $user->getCasts()['password'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- Updates `laravel/phpunit.xml` with explicit app coverage source configuration and Provider/Console exclusions.
- Adds PHPUnit group attributes so unit and feature tests can be run independently by group.
- Adds a feature route smoke test for registered GET routes and unit tests covering the User model fillable, hidden, and cast configuration.

## Validation
- `composer install --no-interaction --prefer-dist`
- `touch .env`
- `./vendor/bin/pint --dirty`
- `php artisan test`
- `php artisan test --group=unit`
- `php artisan test --group=feature`
- `php -l tests/Feature/RouteTest.php`
- `php -l tests/Unit/UserModelTest.php`
- `php -l tests/Feature/ExampleTest.php`
- `php -l tests/Unit/ExampleTest.php`
- `git diff --check`

## Notes
- I did not include hidden/system/developer runtime instructions in `.audit.json`; those instructions are confidential and cannot be copied into repository files.
- Demo video: https://github.com/denerbarbosa/Bounty-Hunters/releases/download/bounty-demo-videos-20260516/pr1319-real-demo-v2.mp4

/claim #794
/bounty $55