### PR TITLE
Codex [ Laravel ] Add rate limiting middleware to web routes and fix session driver fallback

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "GUIDE_AI_KIEM_TIEN.md dựa vào tài liệu này làm theo giúp tôi",
+  "timestamp": "2026-05-17T01:44:24+07:00"
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Support\WebRateLimit;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +23,47 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for(WebRateLimit::LIMITER, function (Request $request) {
+            return Limit::perMinute(WebRateLimit::MAX_ATTEMPTS)
+                ->by(WebRateLimit::key($request));
+        });
+
+        $this->configureSessionFallback();
+    }
+
+    private function configureSessionFallback(): void
+    {
+        $driver = config('session.driver');
+        $fallback = config('session.fallback', 'file');
+
+        if ($driver === $fallback || $this->sessionDriverAvailable($driver)) {
+            return;
+        }
+
+        config(['session.driver' => $fallback]);
+    }
+
+    private function sessionDriverAvailable(?string $driver): bool
+    {
+        return match ($driver) {
+            'array', 'cookie', 'file' => true,
+            'database' => $this->databaseSessionConnectionAvailable(),
+            'dynamodb', 'memcached', 'redis' => $this->cacheSessionStoreAvailable(),
+            default => false,
+        };
+    }
+
+    private function databaseSessionConnectionAvailable(): bool
+    {
+        $connection = config('session.connection') ?: config('database.default');
+
+        return is_string($connection) && config("database.connections.{$connection}") !== null;
+    }
+
+    private function cacheSessionStoreAvailable(): bool
+    {
+        $store = config('session.store') ?: config('cache.default');
+
+        return is_string($store) && config("cache.stores.{$store}") !== null;
     }
 }

--- a/laravel/app/Support/WebRateLimit.php
+++ b/laravel/app/Support/WebRateLimit.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+
+final class WebRateLimit
+{
+    public const MAX_ATTEMPTS = 60;
+
+    public const LIMITER = 'web';
+
+    public static function key(Request $request): string
+    {
+        $userId = $request->user()?->getAuthIdentifier();
+
+        if ($userId !== null) {
+            return 'web:user:'.$userId;
+        }
+
+        return 'web:ip:'.$request->ip();
+    }
+
+    public static function storageKey(Request $request): string
+    {
+        return md5(self::LIMITER.self::key($request));
+    }
+
+    /**
+     * @return array{type: string, value: string}
+     */
+    public static function source(Request $request): array
+    {
+        $userId = $request->user()?->getAuthIdentifier();
+
+        if ($userId !== null) {
+            return ['type' => 'user', 'value' => (string) $userId];
+        }
+
+        return ['type' => 'ip', 'value' => (string) $request->ip()];
+    }
+}

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -22,6 +22,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fallback Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | When the configured session backend points at a missing connection or
+    | cache store, the application falls back to this driver during boot.
+    |
+    */
+
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Lifetime
     |--------------------------------------------------------------------------
     |

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,31 @@
 <?php
 
+use App\Support\WebRateLimit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware(['throttle:'.WebRateLimit::LIMITER])->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/rate-limit/debug', function (Request $request) {
+        $key = WebRateLimit::storageKey($request);
+        $remaining = RateLimiter::remaining($key, WebRateLimit::MAX_ATTEMPTS);
+        $retryAfter = RateLimiter::tooManyAttempts($key, WebRateLimit::MAX_ATTEMPTS)
+            ? RateLimiter::availableIn($key)
+            : 0;
+
+        return response()->json([
+            'limit' => WebRateLimit::MAX_ATTEMPTS,
+            'remaining' => $remaining,
+            'retry_after' => $retryAfter,
+            'source' => WebRateLimit::source($request),
+        ])->withHeaders([
+            'X-RateLimit-Limit' => WebRateLimit::MAX_ATTEMPTS,
+            'X-RateLimit-Remaining' => $remaining,
+            'Retry-After' => $retryAfter,
+        ]);
+    });
 });

--- a/laravel/tests/Feature/WebRateLimitTest.php
+++ b/laravel/tests/Feature/WebRateLimitTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Providers\AppServiceProvider;
+use App\Support\WebRateLimit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class WebRateLimitTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+        RateLimiter::clear(WebRateLimit::storageKey($request));
+    }
+
+    public function test_guest_web_routes_are_limited_after_sixty_requests(): void
+    {
+        for ($i = 0; $i < WebRateLimit::MAX_ATTEMPTS; $i++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')->assertStatus(429);
+    }
+
+    public function test_debug_route_returns_rate_limit_details_and_headers(): void
+    {
+        $this->get('/rate-limit/debug')
+            ->assertOk()
+            ->assertHeader('X-RateLimit-Limit', (string) WebRateLimit::MAX_ATTEMPTS)
+            ->assertJsonPath('limit', WebRateLimit::MAX_ATTEMPTS)
+            ->assertJsonPath('source.type', 'ip');
+    }
+
+    public function test_rate_limit_key_uses_authenticated_user_before_ip(): void
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.10']);
+        $request->setUserResolver(fn () => new class {
+            public function getAuthIdentifier(): int
+            {
+                return 42;
+            }
+        });
+
+        $this->assertSame('web:user:42', WebRateLimit::key($request));
+    }
+
+    public function test_session_driver_falls_back_when_configured_store_is_missing(): void
+    {
+        config([
+            'session.driver' => 'redis',
+            'session.store' => 'missing-store',
+            'session.fallback' => 'file',
+        ]);
+
+        (new AppServiceProvider(app()))->boot();
+
+        $this->assertSame('file', config('session.driver'));
+    }
+
+    public function test_session_driver_keeps_available_primary_driver(): void
+    {
+        config([
+            'session.driver' => 'array',
+            'session.fallback' => 'file',
+        ]);
+
+        (new AppServiceProvider(app()))->boot();
+
+        $this->assertSame('array', config('session.driver'));
+    }
+}


### PR DESCRIPTION
/claim #749

## Summary
- Registers a named Laravel `web` rate limiter with a 60 requests/minute budget keyed by authenticated user id, falling back to guest IP.
- Wraps all web routes with that limiter and adds `/rate-limit/debug` with current limit, remaining count, retry delay, source details, and rate-limit headers.
- Adds `session.fallback` config and boot-time fallback to `file` when the configured session driver points at a missing connection/store.
- Adds focused feature coverage for guest throttling, debug route headers, authenticated-user keying, fallback on missing store, and preserving valid drivers.

## Notes
- The debug route uses the same hashed storage key shape Laravel's named throttle middleware uses, so its remaining count reflects the active middleware bucket.
- `config/session.php` is preserved intact; this PR only adds the fallback key instead of replacing the file.

## Verification
- `git diff --cached --check`
- `git diff --check`

Not run locally:
- `php artisan test --filter=WebRateLimitTest` because this WSL environment has no `php`, `composer`, `docker`, or non-interactive sudo available.