### PR TITLE
Codex [ Crypto ] Fix SimpleSwap slippage and deadline protection

### DIFF
--- a/solidity/_meta.json
+++ b/solidity/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "GUIDE_AI_KIEM_TIEN.md dựa vào tài liệu này làm theo giúp tôi",
+  "completed_at": "2026-05-17T02:03:18+07:00"
+}

--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract SimpleSwap {
+    uint256 public constant FEE_DENOMINATOR = 10000;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
     uint256 public reserveA;
@@ -13,6 +15,7 @@ contract SimpleSwap {
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_fee < FEE_DENOMINATOR, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
@@ -25,26 +28,26 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
+        require(block.timestamp <= deadline, "Deadline expired");
 
         bool isTokenA = tokenIn == address(tokenA);
         (IERC20 inputToken, IERC20 outputToken, uint256 reserveIn, uint256 reserveOut) = isTokenA
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
+        amountOut = _getAmountOut(reserveIn, reserveOut, amountIn);
+        require(amountOut > 0, "Insufficient output amount");
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+
         inputToken.transferFrom(msg.sender, address(this), amountIn);
-
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
         outputToken.transfer(msg.sender, amountOut);
 
         if (isTokenA) {
@@ -59,11 +62,21 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-        return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+        return _getAmountOut(reserveIn, reserveOut, amountIn);
+    }
+
+    function _getAmountOut(
+        uint256 reserveIn,
+        uint256 reserveOut,
+        uint256 amountIn
+    ) internal view returns (uint256) {
+        require(reserveIn > 0 && reserveOut > 0, "Insufficient liquidity");
+
+        uint256 amountInWithFee = amountIn * (FEE_DENOMINATOR - fee);
+        return (reserveOut * amountInWithFee) / (reserveIn * FEE_DENOMINATOR + amountInWithFee);
     }
 }

--- a/solidity/tests/simple-swap-source-check.js
+++ b/solidity/tests/simple-swap-source-check.js
@@ -1,0 +1,38 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "contracts", "SimpleSwap.sol"),
+  "utf8",
+);
+
+assert(
+  source.includes(
+    "function swap(\n        address tokenIn,\n        uint256 amountIn,\n        uint256 minAmountOut,\n        uint256 deadline",
+  ),
+  "swap must accept minAmountOut and deadline parameters",
+);
+
+assert(
+  source.includes('require(block.timestamp <= deadline, "Deadline expired");'),
+  "swap must reject expired transactions",
+);
+
+assert(
+  source.includes('require(amountOut >= minAmountOut, "Slippage exceeded");'),
+  "swap must enforce caller-provided slippage protection",
+);
+
+assert(
+  source.includes("amountIn * (FEE_DENOMINATOR - fee)") &&
+    source.includes("reserveIn * FEE_DENOMINATOR + amountInWithFee"),
+  "output math must apply basis-point fees without early fee truncation",
+);
+
+assert(
+  !source.includes("uint256 feeAmount = amountIn * fee / 10000"),
+  "old early-truncating fee calculation must not be used",
+);
+
+console.log("SimpleSwap source checks passed");


### PR DESCRIPTION
/claim #913

## Summary
- Adds `minAmountOut` and `deadline` to `SimpleSwap.swap` with clear `Slippage exceeded` and `Deadline expired` reverts.
- Computes swap output with the fee applied in the constant-product numerator/denominator, avoiding the old early-truncating `feeAmount = amountIn * fee / 10000` path.
- Keeps `getAmountOut` consistent with swap execution, validates token/liquidity inputs, and rejects zero-output swaps.
- Adds a lightweight Node source regression check for the new swap API, deadline/slippage guards, and fee-adjusted math.

## Metadata note
- `solidity/_meta.json` records the public initial user request only. Hidden runtime/developer/system instructions are not included.

## Verification
- `node solidity/tests/simple-swap-source-check.js`
- `git diff --check`
- `git diff --cached --check`
- Temp compile check with `solc@0.8.20` and `@openzeppelin/contracts`: `solc compile ok`
