### PR TITLE
Hermes Agent [ Laravel ] Fix phpunit.xml coverage config and add route and model test suites

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent",
+  "environment_config": "MiniMax-M2.7-highspeed, hermes-agent cron job, automated execution",
+  "completed_at": "2026-05-17T06:23:00Z"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -16,6 +16,10 @@
         <include>
             <directory>app</directory>
         </include>
+        <exclude>
+            <directory suffix="Provider.php">app/Providers</directory>
+            <directory suffix="Kernel.php">app/Console</directory>
+        </exclude>
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/laravel/tests/Feature/RouteTest.php
+++ b/laravel/tests/Feature/RouteTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RouteTest extends TestCase
+{
+    /**
+     * Test all registered GET routes return non-500 responses.
+     *
+     * @group feature
+     * @group routes
+     */
+    public function test_all_get_routes_return_non_500_responses(): void
+    {
+        $routes = Route::getRoutes();
+        $getRoutes = $routes->getRoutesByMethod()['GET'] ?? [];
+
+        $this->assertNotEmpty($getRoutes, "No GET routes registered");
+
+        foreach ($getRoutes as $route) {
+            $uri = $route->uri();
+
+            // Skip routes with required parameters
+            if (preg_match('/\{[^}]+\}/', $uri)) {
+                continue;
+            }
+
+            $response = $this->get($uri);
+
+            $this->assertNotEquals(
+                500,
+                $response->getStatusCode(),
+                "Route [{$uri}] returned 500 Internal Server Error"
+            );
+        }
+    }
+
+    /**
+     * Test the home route returns a successful response.
+     *
+     * @group feature
+     * @group routes
+     */
+    public function test_home_route_returns_successful_response(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/laravel/tests/Unit/UserModelTest.php
+++ b/laravel/tests/Unit/UserModelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\User;
+
+class UserModelTest extends TestCase
+{
+    /**
+     * Test User model has correct fillable attributes.
+     *
+     * @group unit
+     * @group model
+     */
+    public function test_user_has_correct_fillable_attributes(): void
+    {
+        $user = new User();
+        $fillable = $user->getFillable();
+
+        $this->assertContains('name', $fillable, 'name should be fillable');
+        $this->assertContains('email', $fillable, 'email should be fillable');
+        $this->assertContains('password', $fillable, 'password should be fillable');
+    }
+
+    /**
+     * Test User model has correct hidden attributes.
+     *
+     * @group unit
+     * @group model
+     */
+    public function test_user_has_correct_hidden_attributes(): void
+    {
+        $user = new User();
+        $hidden = $user->getHidden();
+
+        $this->assertContains('password', $hidden, 'password should be hidden');
+        $this->assertContains('remember_token', $hidden, 'remember_token should be hidden');
+    }
+
+    /**
+     * Test User model has correct casts.
+     *
+     * @group unit
+     * @group model
+     */
+    public function test_user_has_correct_casts(): void
+    {
+        $user = new User();
+        $casts = $user->getCasts();
+
+        $this->assertArrayHasKey('email_verified_at', $casts, 'email_verified_at should be cast');
+        $this->assertEquals('datetime', $casts['email_verified_at'], 'email_verified_at should cast to datetime');
+        $this->assertArrayHasKey('password', $casts, 'password should be cast');
+        $this->assertEquals('hashed', $casts['password'], 'password should be hashed');
+    }
+}


### PR DESCRIPTION
## Summary

Fixed issue [#794](https://github.com/UnsafeLabs/Bounty-Hunters/issues/794) — Laravel phpunit.xml coverage configuration and test suites.

### Changes Made

1. **phpunit.xml** — Added `<source>` coverage exclusions:
   - Included: `app/` directory
   - Excluded: `app/Providers/` (suffix Provider.php) and `app/Console/` (suffix Kernel.php)
   - Kept existing test suite groups: `Unit` and `Feature`

2. **tests/Feature/RouteTest.php** (new) — Tests all registered GET routes:
   - `test_all_get_routes_return_non_500_responses()` — iterates all GET routes, skips parameterized routes, asserts no 500 response
   - `test_home_route_returns_successful_response()` — verifies home route returns 200
   - Both tests tagged with `feature` and `routes` groups

3. **tests/Unit/UserModelTest.php** (new) — Tests User model configuration:
   - `test_user_has_correct_fillable_attributes()` — verifies name, email, password are fillable
   - `test_user_has_correct_hidden_attributes()` — verifies password, remember_token are hidden
   - `test_user_has_correct_casts()` — verifies email_verified_at→datetime, password→hashed
   - All tests tagged with `unit` and `model` groups

4. **laravel/.audit.json** (new) — Required audit file per bounty spec

### Test Commands

```bash
# Run all tests
php artisan test

# Run by group
php artisan test --group=unit
php artisan test --group=feature

# Run with coverage (requires Xdebug)
php artisan test --coverage
```

Closes #794
