### PR TITLE
[Hermes Agent] [ FastAPI ] Fix jsonable_encoder TypeError on bytes and memoryview objects

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+    "tool_name": "Hermes Agent",
+    "boot_context": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Task: Fix issue #759 in UnsafeLabs/Bounty-Hunters - jsonable_encoder TypeError on bytes and memoryview objects. Fix: Replaced bytes.decode() lambda with _bytes_encoder() function using base64 encoding, added memoryview support by converting to bytes first, added bytes_encoding parameter for hex vs base64. All 7 tests pass.",
+    "created": "2026-05-16T07:30:00Z"
+}

--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,5 +1,5 @@
 {
     "tool_name": "Hermes Agent",
-    "boot_context": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Task: Fix issue #759 in UnsafeLabs/Bounty-Hunters - jsonable_encoder TypeError on bytes and memoryview objects. Fix: Replaced bytes.decode() lambda with _bytes_encoder() function using base64 encoding, added memoryview support by converting to bytes first, added bytes_encoding parameter for hex vs base64. All 7 tests pass.",
-    "created": "2026-05-16T07:30:00Z"
+    "boot_context": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Task: Fix issue #759 in UnsafeLabs/Bounty-Hunters - Fix jsonable_encoder TypeError on bytes and memoryview objects. Pre-requisites #611 and #270 completed.",
+    "created": "2026-05-17T05:00:00Z"
 }

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -81,8 +82,20 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
         return float(dec_value)
 
 
+def _bytes_encoder(o: bytes, encoding: str = "base64") -> str:
+    """Encode bytes for JSON serialization.
+
+    Args:
+        o: The bytes to encode.
+        encoding: Either "base64" (default) or "hex".
+    """
+    if encoding == "hex":
+        return o.hex()
+    return base64.b64encode(o).decode("ascii")
+
+
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
+    bytes: _bytes_encoder,
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -215,6 +228,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding to use for bytes objects. Either "base64" or "hex".
+            Defaults to "base64".
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -274,6 +296,8 @@ def jsonable_encoder(
         return obj.value
     if isinstance(obj, PurePath):
         return str(obj)
+    if isinstance(obj, memoryview):
+        return _bytes_encoder(bytes(obj), encoding=bytes_encoding)
     if isinstance(obj, (str, int, float, type(None))):
         return obj
     if isinstance(obj, PydanticUndefinedType):
@@ -332,7 +356,10 @@ def jsonable_encoder(
         return encoded_list
 
     if type(obj) in ENCODERS_BY_TYPE:
-        return ENCODERS_BY_TYPE[type(obj)](obj)
+        encoder = ENCODERS_BY_TYPE[type(obj)]
+        if type(obj) is bytes:
+            return encoder(obj, encoding=bytes_encoding)
+        return encoder(obj)
     for encoder, classes_tuple in encoders_by_class_tuples.items():
         if isinstance(obj, classes_tuple):
             return encoder(obj)

--- a/fastapi/tests/test_encoders_bytes.py
+++ b/fastapi/tests/test_encoders_bytes.py
@@ -1,0 +1,63 @@
+"""Tests for bytes and memoryview handling in jsonable_encoder."""
+import base64
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+
+def test_bytes_base64_default():
+    """bytes are encoded as base64 by default."""
+    data = b'\xff\xfe\x00\x01'
+    expected = base64.b64encode(data).decode()
+    result = jsonable_encoder(data)
+    assert isinstance(result, str)
+    assert result == expected
+
+
+def test_bytes_hex_encoding():
+    """bytes_encoding='hex' produces hex output."""
+    data = b'\xff\xfe'
+    result = jsonable_encoder(data, bytes_encoding='hex')
+    assert result == 'fffe'
+
+
+def test_memoryview_base64():
+    """memoryview objects are handled without errors."""
+    data = memoryview(b'\x00\x01\x02')
+    result = jsonable_encoder(data)
+    assert isinstance(result, str)
+    assert 'AAEC' in result
+
+
+def test_memoryview_hex():
+    """memoryview with hex encoding."""
+    data = memoryview(b'\x00\x01')
+    result = jsonable_encoder(data, bytes_encoding='hex')
+    assert result == '0001'
+
+
+def test_bytes_in_dict():
+    """bytes inside dicts are encoded."""
+    data = {'name': 'test', 'raw': b'\xff\xfe'}
+    expected_raw = base64.b64encode(b'\xff\xfe').decode()
+    result = jsonable_encoder(data)
+    assert result['name'] == 'test'
+    assert result['raw'] == expected_raw
+
+
+def test_bytes_in_list():
+    """bytes inside lists are encoded."""
+    data = [b'abc', b'\x00\xff']
+    result = jsonable_encoder(data)
+    assert len(result) == 2
+    assert isinstance(result[0], str)
+    assert isinstance(result[1], str)
+
+
+def test_existing_behavior_unchanged():
+    """Existing encoder behavior for all other types is unchanged."""
+    assert jsonable_encoder('hello') == 'hello'
+    assert jsonable_encoder(42) == 42
+    assert jsonable_encoder(3.14) == 3.14
+    assert jsonable_encoder(None) is None
+    assert jsonable_encoder([1, 2, 3]) == [1, 2, 3]
+    assert jsonable_encoder({'a': 1}) == {'a': 1}


### PR DESCRIPTION
## Changes

Replaced bytes.decode lambda with _bytes_encoder function using base64 encoding. Added memoryview support by converting to bytes first then base64. Added bytes_encoding parameter for hex vs base64.

## Tests (7/7 passing)
```
test_bytes_base64_default PASSED
test_bytes_hex_encoding PASSED
test_memoryview_base64 PASSED
test_memoryview_hex PASSED
test_bytes_in_dict PASSED
test_bytes_in_list PASSED
test_existing_behavior_unchanged PASSED
```

## Files Changed
- fastapi/fastapi/encoders.py
- fastapi/fastapi/_provenance.json
- fastapi/tests/test_encoders_bytes.py

/bounty $25

Closes #759