### PR TITLE
[tytkk2] [FastAPI] HTTPBasicWithProtection brute force protection

### DIFF
--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,10 @@
 import binascii
+import hashlib
+import math
+import time
 from base64 import b64decode
+from collections import defaultdict
+from collections.abc import Callable
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +15,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -39,7 +44,7 @@ class HTTPAuthorizationCredentials(BaseModel):
     like:
 
     ```
-    Authorization: Bearer deadbeef12346
+    Authorization: Bearer ***
     ```
 
     In this case:
@@ -217,6 +222,198 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    """
+    HTTP Basic authentication with brute force protection.
+
+    Extends `HTTPBasic` with per-IP failed attempt tracking, automatic
+    lockout after exceeding a configurable failure threshold, and
+    timing-safe password verification.
+
+    ## Usage
+
+    ```python
+    from typing import Annotated
+
+    from fastapi import Depends, FastAPI
+    from fastapi.security import HTTPBasicWithProtection, HTTPBasicCredentials
+
+    app = FastAPI()
+
+    security = HTTPBasicWithProtection(
+        max_attempts=5,
+        lockout_window=300,
+        check_password=lambda u, p: u == "admin" and p == "secret",
+    )
+
+
+    @app.get("/users/me")
+    def read_current_user(
+        credentials: Annotated[HTTPBasicCredentials, Depends(security)]
+    ):
+        return {"username": credentials.username}
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        max_attempts: Annotated[
+            int,
+            Doc(
+                """
+                Maximum failed login attempts allowed before lockout.
+                """
+            ),
+        ] = 5,
+        lockout_window: Annotated[
+            int,
+            Doc(
+                """
+                Time window in seconds for tracking failed attempts.
+                """
+            ),
+        ] = 300,
+        check_password: Annotated[
+            Callable[[str, str], bool] | None,
+            Doc(
+                """
+                Optional callable to verify the password:
+                ``check_password(username, password) -> bool``.
+
+                If set, successful verification resets the IP attempt counter.
+                If not set, no password verification is performed (credentials
+                are returned as-is — the caller must verify).
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        realm: Annotated[
+            str | None,
+            Doc(
+                """
+                HTTP Basic authentication realm.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if authentication is not provided,
+                `HTTPBasicWithProtection` will cancel the request and send
+                the client an error.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            scheme_name=scheme_name,
+            realm=realm,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.max_attempts = max_attempts
+        self.lockout_window = lockout_window
+        self.check_password = check_password
+        self._attempts: dict[str, list[float]] = defaultdict(list)
+
+    def _get_client_ip(self, request: Request) -> str:
+        """Extract the client IP from the request."""
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+        return request.client.host if request.client else "unknown"
+
+    def _clear_attempts(self, ip: str) -> None:
+        """Clear the attempt counter for an IP."""
+        self._attempts.pop(ip, None)
+
+    def _is_locked_out(self, ip: str) -> bool:
+        """Check if an IP is currently locked out.
+
+        Returns True if the IP has exceeded max_attempts within the
+        lockout window.
+        """
+        now = time.time()
+        window_start = now - self.lockout_window
+        self._attempts[ip] = [
+            t for t in self._attempts[ip] if t > window_start
+        ]
+        if len(self._attempts[ip]) >= self.max_attempts:
+            oldest = min(self._attempts[ip])
+            remaining = math.ceil(self.lockout_window - (now - oldest))
+            if remaining > 0:
+                return True
+            self._clear_attempts(ip)
+        return False
+
+    async def __call__(  # type: ignore[override]
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        ip = self._get_client_ip(request)
+
+        # Check lockout based on previous failures
+        if self._is_locked_out(ip):
+            headers = self.make_authenticate_headers()
+            headers["Retry-After"] = str(int(self.lockout_window))
+            raise HTTPException(
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many failed login attempts. "
+                       "Please try again later.",
+                headers=headers,
+            )
+
+        credentials = await super().__call__(request)
+        if credentials is None:
+            return None
+
+        if self.check_password is not None:
+            if self.check_password(credentials.username, credentials.password):
+                self._clear_attempts(ip)
+                return credentials
+            else:
+                # Count this failure
+                self._attempts[ip].append(time.time())
+                if self.auto_error:
+                    raise self.make_not_authenticated_error()
+                return None
+
+        return credentials
+
+    @staticmethod
+    def verify_password(plain_password: str, stored_hash: str) -> bool:
+        """Timing-safe password verification using SHA-256.
+
+        Uses a constant-time comparison to prevent timing attacks.
+
+        Args:
+            plain_password: The password provided by the user.
+            stored_hash: The stored SHA-256 hex digest.
+
+        Returns:
+            True if the password matches the hash.
+        """
+        import hmac as _hmac
+        digest = hashlib.sha256(plain_password.encode("utf-8")).hexdigest()
+        return _hmac.compare_digest(digest, stored_hash)
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_httpbasic_protection.py
+++ b/fastapi/tests/test_httpbasic_protection.py
@@ -1,0 +1,174 @@
+"""Tests for HTTPBasicWithProtection brute force protection."""
+
+import time
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def protected_app():
+    """Create a FastAPI app with HTTPBasicWithProtection."""
+    app = FastAPI()
+
+    _users = {"admin": "secret", "user": "pass123"}
+
+    def _check(username: str, password: str) -> bool:
+        return _users.get(username) == password
+
+    security = HTTPBasicWithProtection(
+        max_attempts=3,
+        lockout_window=60,
+        check_password=_check,
+    )
+
+    @app.get("/me")
+    def current_user(credentials: HTTPBasicCredentials = Depends(security)):
+        return {"username": credentials.username}
+
+    return app
+
+
+class TestHTTPBasicWithProtection:
+    """Tests for brute force attack prevention."""
+
+    @pytest.fixture(autouse=True)
+    def _init(self, protected_app):
+        self.app = protected_app
+        self.client = TestClient(self.app)
+
+    def test_successful_auth(self):
+        """Valid credentials return 200."""
+        resp = self.client.get(
+            "/me", auth=("admin", "secret")
+        )
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "admin"
+
+    def test_failed_auth_returns_401(self):
+        """Invalid credentials return 401."""
+        resp = self.client.get(
+            "/me", auth=("admin", "wrongpass")
+        )
+        assert resp.status_code == 401
+
+    def test_lockout_after_max_attempts(self):
+        """After max_attempts failures, 429 is returned."""
+        for i in range(3):
+            resp = self.client.get(
+                "/me", auth=("admin", "wrongpass")
+            )
+            assert resp.status_code == 401
+
+        # 4th attempt should be locked out
+        resp = self.client.get(
+            "/me", auth=("admin", "wrongpass")
+        )
+        assert resp.status_code == 429
+
+    def test_retry_after_header_on_lockout(self):
+        """Lockout response includes Retry-After header."""
+        for i in range(3):
+            self.client.get("/me", auth=("admin", "wrongpass"))
+
+        resp = self.client.get("/me", auth=("admin", "wrongpass"))
+        assert resp.status_code == 429
+        assert "Retry-After" in resp.headers
+
+    def test_success_resets_counter(self):
+        """Successful auth resets the failure counter."""
+        for i in range(2):  # 2 failures
+            self.client.get("/me", auth=("admin", "wrongpass"))
+
+        # Successful auth resets
+        resp = self.client.get("/me", auth=("admin", "secret"))
+        assert resp.status_code == 200
+
+        # One more failure should NOT lock out yet (counter was reset)
+        resp = self.client.get("/me", auth=("admin", "wrongpass"))
+        assert resp.status_code == 401
+
+    def test_different_ips_not_affected(self):
+        """Failure tracking is per-IP."""
+        # Lock out one IP
+        for i in range(3):
+            self.client.get(
+                "/me",
+                auth=("admin", "wrongpass"),
+                headers={"X-Forwarded-For": "10.0.0.1"},
+            )
+
+        # IP 10.0.0.1 should be locked out
+        resp = self.client.get(
+            "/me",
+            auth=("admin", "wrongpass"),
+            headers={"X-Forwarded-For": "10.0.0.1"},
+        )
+        assert resp.status_code == 429
+
+        # Different IP should still be allowed
+        resp = self.client.get(
+            "/me",
+            auth=("admin", "secret"),
+            headers={"X-Forwarded-For": "10.0.0.2"},
+        )
+        assert resp.status_code == 200
+
+    def test_verify_password_static(self):
+        """verify_password uses timing-safe comparison."""
+        # Hash the password
+        password = "mypassword"
+        import hashlib, hmac
+        expected_hash = hashlib.sha256(password.encode()).hexdigest()
+
+        assert HTTPBasicWithProtection.verify_password(password, expected_hash)
+        assert not HTTPBasicWithProtection.verify_password("wrong", expected_hash)
+        assert not HTTPBasicWithProtection.verify_password(password, "wronghash")
+
+    def test_lockout_window_expires(self):
+        """After lockout_window expires, requests are allowed again."""
+        app = FastAPI()
+
+        def _check(username: str, password: str) -> bool:
+            return username == "admin" and password == "secret"
+
+        security = HTTPBasicWithProtection(
+            max_attempts=2,
+            lockout_window=1,  # 1 second window
+            check_password=_check,
+        )
+
+        @app.get("/me")
+        def current_user(credentials: HTTPBasicCredentials = Depends(security)):
+            return {"username": credentials.username}
+
+        client = TestClient(app)
+
+        # 2 failures — 3rd should lock
+        for i in range(2):
+            client.get("/me", auth=("admin", "wrongpass"))
+
+        resp = client.get("/me", auth=("admin", "wrongpass"))
+        assert resp.status_code == 429
+
+        # Wait for lockout to expire
+        time.sleep(1.1)
+
+        # Should be allowed again
+        resp = client.get("/me", auth=("admin", "secret"))
+        assert resp.status_code == 200
+
+    def test_no_password_checker(self):
+        """Without check_password, all credentials are accepted."""
+        security = HTTPBasicWithProtection()
+        app = FastAPI()
+
+        @app.get("/open")
+        def open_endpoint(credentials: HTTPBasicCredentials = Depends(security)):
+            return {"username": credentials.username}
+
+        client = TestClient(app)
+        resp = client.get("/open", auth=("anyone", "anything"))
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
Added `HTTPBasicWithProtection` - extended HTTPBasic with per-IP brute force protection.

### Changes
- **security/http.py**: New `HTTPBasicWithProtection` class
- **security/__init__.py**: Export new class

### Features
- Per-IP failed attempt tracking (configurable max_attempts)
- Configurable lockout_window (default: 300s)
- 429 with Retry-After header on lockout
- Successful auth resets counter
- verify_password with timing-safe comparison
- Per-IP isolation

### Acceptance Criteria
- [x] Failed attempts tracked per IP
- [x] 429 after exceeding max_attempts
- [x] Retry-After header
- [x] Success resets counter
- [x] Constant-time password comparison
- [x] 9 tests pass, backward compatible

/claim #800
/bounty $130