### PR TITLE
[Hermes Agent] [ FastAPI ] Add run_concurrently with semaphore limiting and timeout

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+    "identity": "Hermes Agent",
+    "runtime_instructions": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Task: Fix issue 803 - Add concurrent task runner with semaphore limiting and timeout.",
+    "timestamp": "2026-05-17T08:00:00Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -13,6 +13,76 @@ from starlette.concurrency import (  # noqa
 
 _T = TypeVar("_T")
 
+import asyncio
+from collections.abc import Coroutine, Sequence
+from typing import Any
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more tasks fail during run_concurrently."""
+
+    def __init__(self, errors: list[BaseException]):
+        self.errors = errors
+        super().__init__(f"{len(errors)} task(s) failed: {errors}")
+
+
+async def run_concurrently(
+    coros: Sequence[Coroutine[Any, Any, _T]],
+    max_concurrency: int = 1,
+    timeout: float | None = None,
+) -> list[_T]:
+    """Run multiple coroutines concurrently with a concurrency limit and timeout.
+
+    Args:
+        coros: List of coroutines to execute.
+        max_concurrency: Maximum number of concurrent coroutines.
+        timeout: Maximum total execution time in seconds.
+
+    Returns:
+        Results in the same order as input coroutines.
+
+    Raises:
+        ConcurrencyError: If any coroutine raises an exception, containing all failures.
+        TimeoutError: If the total execution exceeds the timeout.
+    """
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be at least 1")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coros)
+    errors: list[BaseException] = []
+
+    async def run_one(index: int, coro: Coroutine[Any, Any, _T]) -> None:
+        async with semaphore:
+            try:
+                results[index] = await coro
+            except BaseException as e:
+                errors.append(e)
+                results[index] = e
+
+    tasks = [asyncio.create_task(run_one(i, c)) for i, c in enumerate(coros)]
+
+    try:
+        if timeout is not None:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=False),
+                timeout=timeout,
+            )
+        else:
+            await asyncio.gather(*tasks, return_exceptions=False)
+    except asyncio.TimeoutError:
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        raise TimeoutError(
+            f"run_concurrently timed out after {timeout}s"
+        )
+
+    if errors:
+        raise ConcurrencyError(errors)
+
+    return results  # type: ignore[return-value]
+
 
 @asynccontextmanager
 async def contextmanager_in_threadpool(

--- a/fastapi/tests/test_run_concurrently.py
+++ b/fastapi/tests/test_run_concurrently.py
@@ -1,0 +1,70 @@
+import asyncio
+import pytest
+from fastapi.concurrency import run_concurrently, ConcurrencyError
+
+@pytest.mark.anyio
+async def test_max_concurrency_limit():
+    import asyncio
+    active = 0
+    max_active = 0
+    lock = asyncio.Lock()
+    async def task():
+        nonlocal active, max_active
+        async with lock:
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.05)
+            active -= 1
+        return True
+    results = await run_concurrently([task() for _ in range(5)], max_concurrency=2)
+    assert max_active <= 2
+    assert len(results) == 5
+
+@pytest.mark.anyio
+async def test_results_order():
+    async def task(n):
+        await asyncio.sleep(0.01 * (5 - n))
+        return n
+    results = await run_concurrently([task(i) for i in range(5)], max_concurrency=5)
+    assert results == list(range(5))
+
+@pytest.mark.anyio
+async def test_concurrency_error():
+    async def fail(msg):
+        raise ValueError(msg)
+    async def ok():
+        return "ok"
+    with pytest.raises(ConcurrencyError) as exc:
+        await run_concurrently([fail("bad1"), ok(), fail("bad2")], max_concurrency=2)
+    assert len(exc.value.errors) == 2
+
+@pytest.mark.anyio
+async def test_timeout():
+    async def slow():
+        await asyncio.sleep(10)
+    with pytest.raises(TimeoutError):
+        await run_concurrently([slow()], max_concurrency=1, timeout=0.01)
+
+@pytest.mark.anyio
+async def test_max_concurrency_one_sequential():
+    order = []
+    async def task(n):
+        await asyncio.sleep(0.01)
+        order.append(n)
+        return n
+    results = await run_concurrently([task(1), task(2), task(3)], max_concurrency=1)
+    assert results == [1, 2, 3]
+    assert order == [1, 2, 3]
+
+@pytest.mark.anyio
+async def test_max_concurrency_exceeds_count():
+    done = asyncio.Event()
+    started = []
+    async def task():
+        started.append(1)
+        if len(started) == 3:
+            done.set()
+        await done.wait()
+        return True
+    results = await run_concurrently([task() for _ in range(3)], max_concurrency=10)
+    assert all(results)


### PR DESCRIPTION
Fix #803

Added run_concurrently function using asyncio Semaphore for concurrency limiting. Supports timeout via asyncio wait_for. ConcurrencyError collects all failed task exceptions. Results returned in input order.

Tests: 6 passing