### PR TITLE
[Hermes Agent] [ FastAPI ] Add FastAPITestClient with auth helpers and WebSocket convenience

### DIFF
--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+    "contributor": "Hermes Agent",
+    "environment_config": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Task: Add FastAPITestClient with auth helpers.",
+    "completed_at": "2026-05-17T08:00:00Z"
+}

--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+    "tool_name": "Hermes Agent",
+    "boot_context": "Add FastAPITestClient to fastapi.testclient",
+    "created": "2026-05-17T08:00:00Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,45 @@
 from starlette.testclient import TestClient as TestClient  # noqa
+
+import base64
+from contextlib import contextmanager
+from typing import Any
+from starlette.types import ASGIApp
+
+
+class FastAPITestClient(TestClient):
+    def __init__(self, app: ASGIApp, **kwargs: Any):
+        super().__init__(app, **kwargs)
+        self._auth_headers: dict[str, str] = {}
+
+    def authenticate(self, token: str) -> None:
+        self._auth_headers["Authorization"] = f"Bearer {token}"
+
+    def authenticate_basic(self, username: str, password: str) -> None:
+        credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+        self._auth_headers["Authorization"] = f"Basic {credentials}"
+
+    def reset_auth(self) -> None:
+        self._auth_headers.clear()
+
+    @contextmanager
+    def ws_connect(self, path: str, headers: dict[str, str] | None = None, subprotocols: list[str] | None = None):
+        merged_headers = dict(self._auth_headers)
+        if headers:
+            merged_headers.update(headers)
+        with self.websocket_connect(path, headers=merged_headers, subprotocols=subprotocols) as ws:
+            yield ws
+
+    def assert_status(self, method: str, path: str, expected_status: int, **kwargs: Any) -> Any:
+        kwargs.setdefault("headers", {})
+        kwargs["headers"].update(self._auth_headers)
+        response = self.request(method, path, **kwargs)
+        assert response.status_code == expected_status, (
+            f"Expected status {expected_status}, got {response.status_code}. "
+            f"Response: {response.text[:200]}"
+        )
+        return response
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        kwargs.setdefault("headers", {})
+        kwargs["headers"].update(self._auth_headers)
+        return super().request(method, url, **kwargs)

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,52 @@
+import base64
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import FastAPITestClient, TestClient
+
+app = FastAPI()
+
+@app.get("/me")
+def get_me():
+    return {"user": "testuser"}
+
+def test_authenticate_bearer():
+    client = FastAPITestClient(app)
+    client.authenticate("tokensecret123")
+    response = client.get("/me")
+    assert response.status_code == 200
+    assert response.json() == {"user": "testuser"}
+
+def test_authenticate_basic():
+    client = FastAPITestClient(app)
+    client.authenticate_basic("admin", "password")
+    assert client._auth_headers["Authorization"].startswith("Basic ")
+    encoded = client._auth_headers["Authorization"][6:]
+    decoded = base64.b64decode(encoded).decode()
+    assert decoded == "admin:password"
+
+def test_token_replacement():
+    client = FastAPITestClient(app)
+    client.authenticate("old")
+    client.authenticate("new")
+    assert client._auth_headers["Authorization"] == "Bearer new"
+
+def test_reset_auth():
+    client = FastAPITestClient(app)
+    client.authenticate("token")
+    client.reset_auth()
+    assert len(client._auth_headers) == 0
+
+def test_assert_status_success():
+    client = FastAPITestClient(app)
+    resp = client.assert_status("GET", "/me", 200)
+    assert resp.status_code == 200
+
+def test_assert_status_failure():
+    client = FastAPITestClient(app)
+    with pytest.raises(AssertionError, match="Expected status 404"):
+        client.assert_status("GET", "/me", 404)
+
+def test_existing_import():
+    assert TestClient is not None
+    tc = TestClient(app)
+    assert tc.get("/me").status_code == 200


### PR DESCRIPTION
Fix #804

Added FastAPITestClient extending TestClient with authenticate, authenticate_basic, reset_auth, ws_connect, and assert_status methods.

Tests: 7 passing