### PR TITLE
feat(t3code): detect runtime environment flags

### DIFF
--- a/t3code/apps/web/src/environments/primary/bootstrap.test.ts
+++ b/t3code/apps/web/src/environments/primary/bootstrap.test.ts
@@ -80,6 +80,11 @@ describe("environmentBootstrap", () => {
       label: "Bootstrapped environment",
       source: "window-origin",
       environmentId: "environment-local",
+      runtime: {
+        isCi: false,
+        isContainer: false,
+        isWsl: false,
+      },
       target: {
         httpBaseUrl: "http://localhost:3773/",
         wsBaseUrl: "ws://localhost:3773/",

--- a/t3code/packages/client-runtime/src/knownEnvironment.test.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.test.ts
@@ -1,7 +1,11 @@
 import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { createKnownEnvironment, getKnownEnvironmentHttpBaseUrl } from "./knownEnvironment.ts";
+import {
+  createKnownEnvironment,
+  detectKnownEnvironmentRuntime,
+  getKnownEnvironmentHttpBaseUrl,
+} from "./knownEnvironment.ts";
 import {
   parseScopedProjectKey,
   parseScopedThreadKey,
@@ -25,6 +29,11 @@ describe("known environment bootstrap helpers", () => {
     ).toEqual({
       id: "ws:Remote environment",
       label: "Remote environment",
+      runtime: {
+        isCi: false,
+        isContainer: false,
+        isWsl: false,
+      },
       source: "manual",
       target: {
         httpBaseUrl: "https://remote.example.com",
@@ -57,6 +66,70 @@ describe("known environment bootstrap helpers", () => {
         }),
       ),
     ).toBe("https://remote.example.com/api");
+  });
+
+  it("exposes detected runtime flags on known environments", () => {
+    const runtime = detectKnownEnvironmentRuntime({
+      env: {
+        GITHUB_ACTIONS: "true",
+        WSL_DISTRO_NAME: "Ubuntu",
+      },
+      fileExists: (path) => path === "/.dockerenv",
+    });
+
+    expect(
+      createKnownEnvironment({
+        label: "CI container",
+        runtime,
+        target: {
+          httpBaseUrl: "http://127.0.0.1:3773",
+          wsBaseUrl: "ws://127.0.0.1:3773",
+        },
+      }).runtime,
+    ).toEqual({
+      isCi: true,
+      isContainer: true,
+      isWsl: true,
+      ciProvider: "github-actions",
+      containerKind: "docker",
+      wslDistroName: "Ubuntu",
+    });
+  });
+
+  it("detects container runtimes from cgroup markers", () => {
+    expect(
+      detectKnownEnvironmentRuntime({
+        readTextFile: (path) =>
+          path === "/proc/1/cgroup" ? "0::/kubepods.slice/kubepods-besteffort.slice" : "",
+      }),
+    ).toMatchObject({
+      isContainer: true,
+      containerKind: "kubernetes",
+    });
+
+    expect(
+      detectKnownEnvironmentRuntime({
+        readTextFile: (path) =>
+          path === "/proc/1/cgroup" ? "0::/system.slice/containerd.service" : "",
+      }),
+    ).toMatchObject({
+      isContainer: true,
+      containerKind: "containerd",
+    });
+  });
+
+  it("detects generic CI and WSL release markers", () => {
+    expect(
+      detectKnownEnvironmentRuntime({
+        env: {
+          CI: "1",
+        },
+        release: "5.15.146.1-microsoft-standard-WSL2",
+      }),
+    ).toMatchObject({
+      isCi: true,
+      isWsl: true,
+    });
   });
 });
 

--- a/t3code/packages/client-runtime/src/knownEnvironment.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.ts
@@ -7,23 +7,234 @@ export interface KnownEnvironmentConnectionTarget {
 
 export type KnownEnvironmentSource = "configured" | "desktop-managed" | "manual" | "window-origin";
 
+export type KnownEnvironmentContainerKind =
+  | "containerd"
+  | "docker"
+  | "kubernetes"
+  | "podman"
+  | "unknown";
+
+export interface KnownEnvironmentRuntimeFlags {
+  readonly isCi: boolean;
+  readonly isContainer: boolean;
+  readonly isWsl: boolean;
+  readonly ciProvider?: string;
+  readonly containerKind?: KnownEnvironmentContainerKind;
+  readonly wslDistroName?: string;
+}
+
+export interface KnownEnvironmentRuntimeDetectionInput {
+  readonly env?: Record<string, string | undefined>;
+  readonly fileExists?: (path: string) => boolean;
+  readonly platform?: string;
+  readonly readTextFile?: (path: string) => string | null | undefined;
+  readonly release?: string;
+}
+
 export interface KnownEnvironment {
   readonly id: string;
   readonly label: string;
+  readonly runtime?: KnownEnvironmentRuntimeFlags;
   readonly source: KnownEnvironmentSource;
   readonly environmentId?: EnvironmentId;
   readonly target: KnownEnvironmentConnectionTarget;
 }
 
+const DEFAULT_KNOWN_ENVIRONMENT_RUNTIME: KnownEnvironmentRuntimeFlags = {
+  isCi: false,
+  isContainer: false,
+  isWsl: false,
+};
+
+const CI_PROVIDER_ENV_KEYS: ReadonlyArray<readonly [string, string]> = [
+  ["GITHUB_ACTIONS", "github-actions"],
+  ["GITLAB_CI", "gitlab-ci"],
+  ["CIRCLECI", "circleci"],
+  ["BUILDKITE", "buildkite"],
+  ["TRAVIS", "travis-ci"],
+  ["APPVEYOR", "appveyor"],
+  ["TF_BUILD", "azure-pipelines"],
+  ["TEAMCITY_VERSION", "teamcity"],
+  ["JENKINS_URL", "jenkins"],
+  ["BITBUCKET_BUILD_NUMBER", "bitbucket-pipelines"],
+  ["VERCEL", "vercel"],
+  ["NETLIFY", "netlify"],
+];
+
+function truthyEnv(value: string | undefined): boolean {
+  if (value === undefined) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false";
+}
+
+function safeFileExists(
+  fileExists: KnownEnvironmentRuntimeDetectionInput["fileExists"],
+  path: string,
+): boolean {
+  if (!fileExists) {
+    return false;
+  }
+
+  try {
+    return fileExists(path);
+  } catch {
+    return false;
+  }
+}
+
+function safeReadTextFile(
+  readTextFile: KnownEnvironmentRuntimeDetectionInput["readTextFile"],
+  path: string,
+): string {
+  if (!readTextFile) {
+    return "";
+  }
+
+  try {
+    return readTextFile(path) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function detectContainerKind(input: KnownEnvironmentRuntimeDetectionInput): {
+  isContainer: boolean;
+  containerKind?: KnownEnvironmentContainerKind;
+} {
+  if (safeFileExists(input.fileExists, "/.dockerenv")) {
+    return {
+      isContainer: true,
+      containerKind: "docker",
+    };
+  }
+
+  const cgroup = safeReadTextFile(input.readTextFile, "/proc/1/cgroup").toLowerCase();
+  if (cgroup.includes("kubepods")) {
+    return {
+      isContainer: true,
+      containerKind: "kubernetes",
+    };
+  }
+  if (cgroup.includes("containerd")) {
+    return {
+      isContainer: true,
+      containerKind: "containerd",
+    };
+  }
+  if (cgroup.includes("docker")) {
+    return {
+      isContainer: true,
+      containerKind: "docker",
+    };
+  }
+  if (cgroup.includes("libpod") || cgroup.includes("podman")) {
+    return {
+      isContainer: true,
+      containerKind: "podman",
+    };
+  }
+
+  return {
+    isContainer: false,
+  };
+}
+
+function detectCiProvider(env: Record<string, string | undefined>): {
+  isCi: boolean;
+  ciProvider?: string;
+} {
+  for (const [key, provider] of CI_PROVIDER_ENV_KEYS) {
+    if (truthyEnv(env[key])) {
+      return {
+        isCi: true,
+        ciProvider: provider,
+      };
+    }
+  }
+
+  return {
+    isCi: truthyEnv(env.CI),
+  };
+}
+
+function detectWsl(input: KnownEnvironmentRuntimeDetectionInput): {
+  isWsl: boolean;
+  wslDistroName?: string;
+} {
+  const env = input.env ?? {};
+  const wslDistroName = env.WSL_DISTRO_NAME?.trim();
+  if (wslDistroName) {
+    return {
+      isWsl: true,
+      wslDistroName,
+    };
+  }
+
+  if (truthyEnv(env.WSL_INTEROP)) {
+    return {
+      isWsl: true,
+    };
+  }
+
+  const release = input.release?.toLowerCase() ?? "";
+  const procVersion = safeReadTextFile(input.readTextFile, "/proc/version").toLowerCase();
+  const isWsl =
+    release.includes("microsoft") || release.includes("wsl") || procVersion.includes("microsoft");
+  return {
+    isWsl,
+  };
+}
+
+export function createKnownEnvironmentRuntimeFlags(
+  overrides: Partial<KnownEnvironmentRuntimeFlags> = {},
+): KnownEnvironmentRuntimeFlags {
+  return {
+    ...DEFAULT_KNOWN_ENVIRONMENT_RUNTIME,
+    ...overrides,
+  };
+}
+
+export function detectKnownEnvironmentRuntime(
+  input: KnownEnvironmentRuntimeDetectionInput = {},
+): KnownEnvironmentRuntimeFlags {
+  const processLike = (
+    globalThis as typeof globalThis & {
+      process?: {
+        env?: Record<string, string | undefined>;
+        platform?: string;
+      };
+    }
+  ).process;
+  const env = input.env ?? processLike?.env ?? {};
+  const container = detectContainerKind(input);
+  const ci = detectCiProvider(env);
+  const wsl = detectWsl({
+    ...input,
+    env,
+    platform: input.platform ?? processLike?.platform,
+  });
+
+  return createKnownEnvironmentRuntimeFlags({
+    ...container,
+    ...ci,
+    ...wsl,
+  });
+}
+
 export function createKnownEnvironment(input: {
   readonly id?: string;
   readonly label: string;
+  readonly runtime?: KnownEnvironmentRuntimeFlags;
   readonly source?: KnownEnvironmentSource;
   readonly target: KnownEnvironmentConnectionTarget;
 }): KnownEnvironment {
   return {
     id: input.id ?? `ws:${input.label}`,
     label: input.label,
+    runtime: input.runtime ?? createKnownEnvironmentRuntimeFlags(),
     source: input.source ?? "manual",
     target: input.target,
   };


### PR DESCRIPTION
/claim #836

## Summary
- Add runtime flags for CI, container, and WSL detection.
- Cover Docker/cgroup, CI providers, and WSL env/release cases with tests.

## Verification
- Tests passed locally.