### PR TITLE
[Hermes Agent] [ FastAPI ] Fix exception handler to include request body/path/method in validation errors

### DIFF
--- a/_meta.json
+++ b/_meta.json
@@ -1,0 +1,6 @@
+{
+  "contributor": "Hermes Agent",
+  "generation_context": "Task: Fix exception_handlers.py request_validation_exception_handler missing request path, method, body context and redact sensitive fields. Constraints: FastAPI repo, Python, modify only the handler, add tests. Acceptance criteria: path+method in response, body in debug mode, sensitive field redaction (password, secret, token, api_key), nested object redaction, non-debug excludes body. Bounty: $40 via Algora. The `fastapi/fastapi/exception_handlers.py` handles RequestValidationError but does not include the request body in the error response, making it difficult to debug which field caused the validation failure. Fix needed: Modify the request_validation_exception_handler to include path and method; add body field in debug mode; redact sensitive fields (password, secret, token, api_key) with ***REDACTED***; recursively redact nested objects.",
+  "completed_at": "2026-05-17T15:00:00+08:00",
+  "agent": "Hermes Agent (cron bounty monitor)"
+}

--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -7,6 +7,19 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
 
+SENSITIVE_FIELDS = {"password", "secret", "token", "api_key"}
+
+
+def _redact_sensitive(body):
+    if isinstance(body, dict):
+        return {
+            key: ("***REDACTED***" if key.lower() in SENSITIVE_FIELDS else _redact_sensitive(value))
+            for key, value in body.items()
+        }
+    if isinstance(body, list):
+        return [_redact_sensitive(item) for item in body]
+    return body
+
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
     headers = getattr(exc, "headers", None)
@@ -20,10 +33,22 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    return JSONResponse(
-        status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
-    )
+    response_data = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+    if request.app.debug:
+        try:
+            body_bytes = await request.body()
+            if body_bytes:
+                import json
+
+                raw_body = json.loads(body_bytes)
+                response_data["body"] = _redact_sensitive(raw_body)
+        except Exception:
+            response_data["body"] = None
+    return JSONResponse(status_code=422, content=response_data)
 
 
 async def websocket_request_validation_exception_handler(

--- a/fastapi/tests/test_exception_handler_body_redaction.py
+++ b/fastapi/tests/test_exception_handler_body_redaction.py
@@ -1,0 +1,104 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+    password: str
+
+
+app = FastAPI(debug=True)
+non_debug_app = FastAPI(debug=False)
+
+
+@app.post("/items/")
+def create_item(item: Item):
+    return {"item": item.model_dump()}  # pragma: no cover
+
+
+@non_debug_app.post("/items/")
+def create_item_non_debug(item: Item):
+    return {"item": item.model_dump()}  # pragma: no cover
+
+
+client = TestClient(app)
+non_debug_client = TestClient(non_debug_app)
+
+
+def test_validation_error_response_includes_path_and_method():
+    response = client.post("/items/", json={"name": "test", "price": "not-a-number"})
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/items/"
+    assert data["method"] == "POST"
+    assert "detail" in data
+
+
+def test_debug_mode_validation_response_includes_body():
+    response = client.post(
+        "/items/", json={"name": "test", "price": "not-a-number"}
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert "body" in data
+    assert data["body"]["name"] == "test"
+    assert data["body"]["price"] == "not-a-number"
+
+
+def test_debug_mode_redacts_sensitive_fields_in_body():
+    response = client.post(
+        "/items/",
+        json={
+            "name": "test",
+            "price": "not-a-number",
+            "password": "supersecret",
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data["body"]["name"] == "test"
+    assert data["body"]["price"] == "not-a-number"
+    assert data["body"]["password"] == "***REDACTED***"
+
+
+def test_debug_mode_redacts_nested_sensitive_fields():
+    response = client.post(
+        "/items/",
+        json={
+            "name": "test",
+            "price": "not-a-number",
+            "password": "supersecret",
+            "metadata": {
+                "token": "abc123",
+                "api_key": "key_xyz",
+                "safe_field": "hello",
+            },
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data["body"]["password"] == "***REDACTED***"
+    assert data["body"]["metadata"]["token"] == "***REDACTED***"
+    assert data["body"]["metadata"]["api_key"] == "***REDACTED***"
+    assert data["body"]["metadata"]["safe_field"] == "hello"
+
+
+def test_non_debug_mode_excludes_body():
+    response = non_debug_client.post(
+        "/items/", json={"name": "test", "price": "not-a-number"}
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert "body" not in data
+    assert data["path"] == "/items/"
+    assert data["method"] == "POST"
+
+
+def test_debug_mode_handles_empty_body():
+    response = client.post("/items/", json={})
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/items/"
+    assert data["method"] == "POST"


### PR DESCRIPTION
## Summary
Add request context (path, method, body) to validation error responses with sensitive field redaction in debug mode.

## Changes
- Added `path` and `method` to validation error responses
- In debug mode, includes the request body with sensitive fields redacted
- Fields named password, secret, token, or api_key are replaced with ***REDACTED***
- Recursive redaction for nested objects
- Non-debug mode excludes the body

## Acceptance Criteria
- [x] Validation error responses include request path and HTTP method
- [x] In debug mode, the received body is included in the error response
- [x] Fields named password, secret, token, or api_key are replaced with ***REDACTED*** in the echoed body
- [x] Non-debug mode responses do not include the body
- [x] Tests verifying redaction works for nested objects containing sensitive field names

Closes #757
/claim #757