### PR TITLE
OpenClaw [ Laravel ] Add web route rate limiting and session fallback config

### DIFF
--- a/laravel/_contributor.json
+++ b/laravel/_contributor.json
@@ -1,0 +1,1 @@
+{"identity":"OpenClaw","runtime":"openai-codex/gpt-5.5"}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('web', function (Request $request) {
+            return Limit::perMinute(60)->by(
+                $request->user()?->getAuthIdentifier() ?: $request->ip()
+            );
+        });
     }
 }

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -22,6 +22,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fallback Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | When the configured session backend is unavailable or intentionally
+    | disabled in an environment, application code can use this value to fall
+    | back to the local file session driver instead of failing hard.
+    |
+    */
+
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Lifetime
     |--------------------------------------------------------------------------
     |

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,24 @@
 <?php
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('throttle:web')->group(function (): void {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/rate-limit-headers', function (Request $request) {
+        return response()->json([
+            'limit' => 60,
+            'window_seconds' => 60,
+            'key_type' => $request->user() ? 'user' : 'ip',
+            'key' => $request->user()?->getAuthIdentifier() ?? $request->ip(),
+            'headers' => [
+                'x-ratelimit-limit' => $request->headers->get('x-ratelimit-limit'),
+                'x-ratelimit-remaining' => $request->headers->get('x-ratelimit-remaining'),
+                'retry-after' => $request->headers->get('retry-after'),
+            ],
+        ]);
+    })->name('rate-limit.headers');
 });

--- a/laravel/tests/Feature/RateLimitHeadersTest.php
+++ b/laravel/tests/Feature/RateLimitHeadersTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class RateLimitHeadersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RateLimiter::clear('127.0.0.1');
+    }
+
+    public function test_web_routes_include_rate_limit_headers(): void
+    {
+        $this->get('/rate-limit-headers')
+            ->assertOk()
+            ->assertHeader('X-RateLimit-Limit', '60')
+            ->assertHeader('X-RateLimit-Remaining')
+            ->assertJsonPath('limit', 60)
+            ->assertJsonPath('key_type', 'ip');
+    }
+
+    public function test_web_rate_limiter_returns_too_many_requests_after_sixty_requests(): void
+    {
+        for ($request = 1; $request <= 60; $request++) {
+            $this->get('/rate-limit-headers')->assertOk();
+        }
+
+        $this->get('/rate-limit-headers')
+            ->assertTooManyRequests()
+            ->assertHeader('Retry-After');
+    }
+
+    public function test_session_fallback_driver_defaults_to_file(): void
+    {
+        $this->assertSame('file', config('session.fallback'));
+    }
+}


### PR DESCRIPTION
## Summary
- wraps Laravel web routes with a named `throttle:web` limiter
- registers the limiter to allow 60 requests/minute per authenticated user ID or guest IP
- adds `/rate-limit-headers` for debugging current limiter metadata/headers
- adds `session.fallback`, defaulting to the `file` driver
- adds feature coverage for rate-limit headers, 429 behavior, and fallback config

## Verification
- `git diff --check -- laravel/_contributor.json laravel/app/Providers/AppServiceProvider.php laravel/config/session.php laravel/routes/web.php laravel/tests/Feature/RateLimitHeadersTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --prefer-dist`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test --filter=RateLimitHeadersTest`

The targeted Laravel test passes with warnings caused by the repository not shipping a `.env` file in the local checkout (`file_get_contents(.../laravel/.env): Failed to open stream`), but all 69 assertions pass.

## Notes
- `_contributor.json` added as required by the bounty instructions.
