### PR TITLE
Caspia-n [ FastAPI ] Add OAuth2 token refresh support to security module

### DIFF
--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -768,12 +768,9 @@ class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
     OAuth2 flow for authentication using a bearer token obtained with a password,
     with explicit support for token refresh flow.
 
-    This class extends `OAuth2PasswordBearer` by accepting an additional
-    `refresh_url` parameter that explicitly marks the refresh token endpoint
-    in the OpenAPI schema.
-
-    The `refresh_url` will appear in the generated OpenAPI (e.g. visible at
-    `/docs`) under the OAuth2 security scheme.
+    This is a convenience subclass of `OAuth2PasswordBearer` that provides a
+    dedicated `refreshUrl` parameter and pairs with `OAuth2RefreshRequestForm`
+    for the refresh endpoint.
 
     Read more about it in the
     [FastAPI docs for Simple OAuth2 with Password and Password Bearer](https://fastapi.tiangolo.com/tutorial/security/simple-oauth2/).
@@ -814,7 +811,7 @@ class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
             ),
         ],
         refreshUrl: Annotated[
-            str,
+            str | None,
             Doc(
                 """
                 The URL to refresh the OAuth2 token and obtain a new one. This would
@@ -822,10 +819,10 @@ class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
                 dependency.
 
                 This will appear in the generated OpenAPI schema under the OAuth2
-                security scheme.
+                security scheme. Defaults to None.
                 """
             ),
-        ],
+        ] = None,
         scheme_name: Annotated[
             str | None,
             Doc(

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -650,6 +650,232 @@ class OAuth2AuthorizationCodeBearer(OAuth2):
         return param
 
 
+class OAuth2RefreshRequestForm:
+    """
+    This is a dependency class to collect the `refresh_token` as form data
+    for an OAuth2 token refresh flow.
+
+    The OAuth2 specification dictates that for a refresh token flow the data
+    should be collected using form data (instead of JSON) and that it should
+    have the specific fields `grant_type` and `refresh_token`.
+
+    Read more about it in the
+    [FastAPI docs for Simple OAuth2 with Password and Bearer](https://fastapi.tiangolo.com/tutorial/security/simple-oauth2/).
+
+    ## Example
+
+    ```python
+    from typing import Annotated
+
+    from fastapi import Depends, FastAPI
+    from fastapi.security import OAuth2RefreshRequestForm
+
+    app = FastAPI()
+
+
+    @app.post("/token/refresh")
+    def refresh_token(form_data: Annotated[OAuth2RefreshRequestForm, Depends()]):
+        return {
+            "refresh_token": form_data.refresh_token,
+            "grant_type": form_data.grant_type,
+        }
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 spec says it is required and MUST be the fixed string
+                "refresh_token".
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                `refresh_token` string. The OAuth2 spec requires the exact field
+                name `refresh_token`.
+
+                Read more about it in the
+                [FastAPI docs for Simple OAuth2 with Password and Bearer](https://fastapi.tiangolo.com/tutorial/security/simple-oauth2/).
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                A single string with actually several scopes separated by spaces.
+                Each scope is also a string.
+
+                For example, a single string with:
+
+                ```
+                "items:read items:write users:read profile openid"
+                ```
+
+                would represent the scopes:
+
+                * `items:read`
+                * `items:write`
+                * `users:read`
+                * `profile`
+                * `openid`
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                If there's a `client_id`, it can be sent as part of the form
+                fields. But the OAuth2 specification recommends sending the
+                `client_id` and `client_secret` (if any) using HTTP Basic auth.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                If there's a `client_secret` (and a `client_id`), they can be sent
+                as part of the form fields. But the OAuth2 specification recommends
+                sending the `client_id` and `client_secret` (if any) using HTTP
+                Basic auth.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 flow for authentication using a bearer token obtained with a password,
+    with explicit support for token refresh flow.
+
+    This class extends `OAuth2PasswordBearer` by accepting an additional
+    `refresh_url` parameter that explicitly marks the refresh token endpoint
+    in the OpenAPI schema.
+
+    The `refresh_url` will appear in the generated OpenAPI (e.g. visible at
+    `/docs`) under the OAuth2 security scheme.
+
+    Read more about it in the
+    [FastAPI docs for Simple OAuth2 with Password and Password Bearer](https://fastapi.tiangolo.com/tutorial/security/simple-oauth2/).
+
+    ## Example
+
+    ```python
+    from typing import Annotated
+
+    from fastapi import Depends, FastAPI
+    from fastapi.security import OAuth2PasswordBearerWithRefresh
+
+    app = FastAPI()
+
+    oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+        tokenUrl="/token",
+        refreshUrl="/token/refresh",
+    )
+
+
+    @app.get("/users/me")
+    async def read_users_me(
+        token: Annotated[str, Depends(oauth2_scheme)]
+    ):
+        return {"token": token}
+    ```
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token. This would be the *path operation*
+                that has `OAuth2PasswordRequestForm` as a dependency.
+                """
+            ),
+        ],
+        refreshUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the OAuth2 token and obtain a new one. This would
+                be the *path operation* that has `OAuth2RefreshRequestForm` as a
+                dependency.
+
+                This will appear in the generated OpenAPI schema under the OAuth2
+                security scheme.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                The OAuth2 scopes that would be required by the *path operations* that
+                use this dependency.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if no HTTP Authorization header is provided, required for
+                OAuth2 authentication, it will automatically cancel the request and
+                send the client an error.
+
+                If `auto_error` is set to `False`, when the HTTP Authorization header
+                is not available, instead of erroring out, the dependency result will
+                be `None`.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            tokenUrl=tokenUrl,
+            refreshUrl=refreshUrl,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+        )
+
+
 class SecurityScopes:
     """
     This is a special class that you can define in a parameter in a dependency to

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -213,10 +213,11 @@ def test_existing_oauth2_password_bearer_unchanged():
     assert resp.status_code == 200
     assert resp.json()["token"] == "old-style-token"
 
-    # Check OpenAPI schema doesn't have refreshUrl
+    # Check OpenAPI schema - refreshUrl defaults to None and is excluded from output
     resp = client.get("/openapi.json")
     schema = resp.json()
     scheme = schema["components"]["securitySchemes"]["OAuth2PasswordBearer"]
+    # When refreshUrl is None (default), Pydantic excludes it from the OpenAPI output
     assert "refreshUrl" not in scheme["flows"]["password"]
 
 

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -1,0 +1,244 @@
+"""Tests for OAuth2 token refresh support."""
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from fastapi.security import (
+    OAuth2PasswordBearerWithRefresh,
+    OAuth2RefreshRequestForm,
+    OAuth2PasswordRequestForm,
+)
+
+# --- OAuth2RefreshRequestForm tests ---
+
+def test_oauth2_refresh_request_form_basic():
+    """Test that OAuth2RefreshRequestForm validates grant_type=refresh_token."""
+    app = FastAPI()
+
+    @app.post("/token/refresh")
+    def refresh(form: Annotated[OAuth2RefreshRequestForm, Depends()]):
+        return {
+            "grant_type": form.grant_type,
+            "refresh_token": form.refresh_token,
+            "scopes": form.scopes,
+        }
+
+    client = TestClient(app)
+    resp = client.post("/token/refresh", data={
+        "grant_type": "refresh_token",
+        "refresh_token": "test-refresh-token-123",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["grant_type"] == "refresh_token"
+    assert data["refresh_token"] == "test-refresh-token-123"
+    assert data["scopes"] == []
+
+
+def test_oauth2_refresh_request_form_with_scopes():
+    """Test that OAuth2RefreshRequestForm parses scopes."""
+    app = FastAPI()
+
+    @app.post("/token/refresh")
+    def refresh(form: Annotated[OAuth2RefreshRequestForm, Depends()]):
+        return {"scopes": form.scopes}
+
+    client = TestClient(app)
+    resp = client.post("/token/refresh", data={
+        "grant_type": "refresh_token",
+        "refresh_token": "token",
+        "scope": "read write admin",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["scopes"] == ["read", "write", "admin"]
+
+
+def test_oauth2_refresh_request_form_rejects_wrong_grant_type():
+    """Test that OAuth2RefreshRequestForm rejects non-refresh_token grant_type."""
+    app = FastAPI()
+
+    @app.post("/token/refresh")
+    def refresh(form: Annotated[OAuth2RefreshRequestForm, Depends()]):
+        return {"grant_type": form.grant_type}
+
+    client = TestClient(app)
+    resp = client.post("/token/refresh", data={
+        "grant_type": "password",
+        "refresh_token": "token",
+    })
+    assert resp.status_code == 422  # Validation error
+
+
+def test_oauth2_refresh_request_form_with_client_credentials():
+    """Test that OAuth2RefreshRequestForm accepts optional client_id/secret."""
+    app = FastAPI()
+
+    @app.post("/token/refresh")
+    def refresh(form: Annotated[OAuth2RefreshRequestForm, Depends()]):
+        return {
+            "client_id": form.client_id,
+            "client_secret": form.client_secret,
+        }
+
+    client = TestClient(app)
+    resp = client.post("/token/refresh", data={
+        "grant_type": "refresh_token",
+        "refresh_token": "token",
+        "client_id": "my-client",
+        "client_secret": "my-secret",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["client_id"] == "my-client"
+    assert data["client_secret"] == "my-secret"
+
+
+# --- OAuth2PasswordBearerWithRefresh tests ---
+
+def test_oauth2_password_bearer_with_refresh_openapi_schema():
+    """Test that OAuth2PasswordBearerWithRefresh includes refreshUrl in OpenAPI schema."""
+    app = FastAPI()
+
+    oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+        tokenUrl="/token",
+        refreshUrl="/token/refresh",
+    )
+
+    @app.get("/protected")
+    def protected(token: Annotated[str, Depends(oauth2_scheme)]):
+        return {"token": token}
+
+    client = TestClient(app)
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+
+    # Check that the security scheme includes refreshUrl
+    security_schemes = schema.get("components", {}).get("securitySchemes", {})
+    scheme = security_schemes.get("OAuth2PasswordBearerWithRefresh")
+    assert scheme is not None
+    assert scheme["type"] == "oauth2"
+    assert "password" in scheme["flows"]
+    assert scheme["flows"]["password"]["tokenUrl"] == "/token"
+    assert scheme["flows"]["password"]["refreshUrl"] == "/token/refresh"
+
+
+def test_oauth2_password_bearer_with_refresh_auth():
+    """Test that OAuth2PasswordBearerWithRefresh works as a drop-in replacement."""
+    app = FastAPI()
+
+    oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+        tokenUrl="/token",
+        refreshUrl="/token/refresh",
+    )
+
+    @app.get("/protected")
+    def protected(token: Annotated[str, Depends(oauth2_scheme)]):
+        return {"token": token}
+
+    client = TestClient(app)
+
+    # Without auth - should fail
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+
+    # With valid bearer token
+    resp = client.get("/protected", headers={"Authorization": "Bearer test-token-123"})
+    assert resp.status_code == 200
+    assert resp.json()["token"] == "test-token-123"
+
+
+def test_oauth2_password_bearer_with_refresh_scopes():
+    """Test that OAuth2PasswordBearerWithRefresh supports scopes."""
+    app = FastAPI()
+
+    oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+        tokenUrl="/token",
+        refreshUrl="/token/refresh",
+        scopes={"read": "Read access", "write": "Write access"},
+    )
+
+    @app.get("/protected")
+    def protected(token: Annotated[str, Depends(oauth2_scheme)]):
+        return {"token": token}
+
+    client = TestClient(app)
+    resp = client.get("/openapi.json")
+    schema = resp.json()
+
+    scheme = schema["components"]["securitySchemes"]["OAuth2PasswordBearerWithRefresh"]
+    assert scheme["flows"]["password"]["scopes"] == {"read": "Read access", "write": "Write access"}
+
+
+def test_oauth2_password_bearer_with_refresh_auto_error_false():
+    """Test that auto_error=False returns None instead of raising."""
+    app = FastAPI()
+
+    oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+        tokenUrl="/token",
+        refreshUrl="/token/refresh",
+        auto_error=False,
+    )
+
+    @app.get("/optional")
+    def optional(token: Annotated[str | None, Depends(oauth2_scheme)]):
+        return {"token": token}
+
+    client = TestClient(app)
+    resp = client.get("/optional")
+    assert resp.status_code == 200
+    assert resp.json()["token"] is None
+
+
+def test_existing_oauth2_password_bearer_unchanged():
+    """Test that existing OAuth2PasswordBearer behavior is not modified."""
+    from fastapi.security import OAuth2PasswordBearer
+
+    app = FastAPI()
+
+    oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
+
+    @app.get("/protected")
+    def protected(token: Annotated[str, Depends(oauth2_scheme)]):
+        return {"token": token}
+
+    client = TestClient(app)
+
+    # Without auth - should fail
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+
+    # With valid bearer token
+    resp = client.get("/protected", headers={"Authorization": "Bearer old-style-token"})
+    assert resp.status_code == 200
+    assert resp.json()["token"] == "old-style-token"
+
+    # Check OpenAPI schema doesn't have refreshUrl
+    resp = client.get("/openapi.json")
+    schema = resp.json()
+    scheme = schema["components"]["securitySchemes"]["OAuth2PasswordBearer"]
+    assert "refreshUrl" not in scheme["flows"]["password"]
+
+
+def test_existing_oauth2_password_request_form_unchanged():
+    """Test that existing OAuth2PasswordRequestForm behavior is not modified."""
+    app = FastAPI()
+
+    @app.post("/token")
+    def login(form: Annotated[OAuth2PasswordRequestForm, Depends()]):
+        return {
+            "grant_type": form.grant_type,
+            "username": form.username,
+            "scopes": form.scopes,
+        }
+
+    client = TestClient(app)
+    resp = client.post("/token", data={
+        "grant_type": "password",
+        "username": "user",
+        "password": "pass",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["grant_type"] == "password"
+    assert data["username"] == "user"


### PR DESCRIPTION
## Summary
Implements bounty #758 ($150): Add OAuth2 token refresh support to FastAPI's security module.

## Changes

### New classes
1. **OAuth2RefreshRequestForm** — Form dependency for `grant_type=refresh_token`
   - Validates grant_type is exactly "refresh_token" (strict pattern)
   - Fields: refresh_token, scope, client_id, client_secret
   - Follows same pattern as OAuth2PasswordRequestForm

2. **OAuth2PasswordBearerWithRefresh** — Extends OAuth2PasswordBearer
   - Accepts explicit `refreshUrl` parameter
   - Drop-in replacement for OAuth2PasswordBearer
   - `refreshUrl` appears in generated OpenAPI schema

### Files modified
- `fastapi/security/oauth2.py` — Added both new classes
- `fastapi/security/__init__.py` — Export new classes
- `tests/test_security_oauth2_refresh.py` — 10 new tests (all passing)

## Acceptance criteria
- ✅ OAuth2PasswordBearerWithRefresh works as drop-in replacement
- ✅ refreshUrl appears in OpenAPI schema under OAuth2 security scheme
- ✅ OAuth2RefreshRequestForm validates grant_type=refresh_token
- ✅ Existing OAuth2PasswordBearer behavior unchanged
- ✅ Tests cover both standard and refresh flows
- ✅ PR title starts with agent name

Closes #758