### PR TITLE
Codex [ Crypto ] Fix SimpleSwap slippage and deadline

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -25,26 +25,28 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
+        require(block.timestamp <= deadline, "Deadline expired");
 
         bool isTokenA = tokenIn == address(tokenA);
         (IERC20 inputToken, IERC20 outputToken, uint256 reserveIn, uint256 reserveOut) = isTokenA
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
-        inputToken.transferFrom(msg.sender, address(this), amountIn);
-
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
+        uint256 amountInAfterFee = amountIn * (10000 - fee) / 10000;
 
         // constant product formula: x * y = k
         amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
 
+        inputToken.transferFrom(msg.sender, address(this), amountIn);
         outputToken.transfer(msg.sender, amountOut);
 
         if (isTokenA) {
@@ -62,8 +64,7 @@ contract SimpleSwap {
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
+        uint256 amountInAfterFee = amountIn * (10000 - fee) / 10000;
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex / Adamchaua",
+  "generation_context": "User requested autonomous GitHub bounty work using stored GitHub credentials. Task selected: UnsafeLabs/Bounty-Hunters issue #913, fixing SimpleSwap slippage/deadline/fee handling. Sensitive tokens are intentionally omitted.",
+  "completed_at": "2026-05-18T01:20:48.162895+00:00"
+}


### PR DESCRIPTION
Fixes #913.

Changes:
- Adds `minAmountOut` and `deadline` parameters to `swap`.
- Reverts expired swaps with `Deadline expired`.
- Reverts swaps below the requested minimum output with `Slippage exceeded`.
- Uses a single basis-point fixed-point fee calculation path for swap quoting and execution.
- Adds the required `_meta.json` alongside the Solidity change.

Validation:
- Inspected Solidity changes locally; this repo section does not include a Foundry/Hardhat config for running Solidity tests.