### PR TITLE
Caspia-n [ T3 Code ] Add container, CI, and WSL environment detection to client runtime

### DIFF
--- a/t3code/packages/client-runtime/src/knownEnvironment.test.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.test.ts
@@ -1,5 +1,5 @@
 import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createKnownEnvironment, getKnownEnvironmentHttpBaseUrl } from "./knownEnvironment.ts";
 import {
@@ -11,6 +11,7 @@ import {
   scopeProjectRef,
   scopeThreadRef,
 } from "./scoped.ts";
+import { detectEnvironment } from "./knownEnvironment.ts";
 
 describe("known environment bootstrap helpers", () => {
   it("creates known environments from explicit server base urls", () => {
@@ -88,5 +89,90 @@ describe("scoped refs", () => {
     expect(parseScopedThreadKey("environment-test:thread-1")).toEqual(threadRef);
     expect(parseScopedProjectKey("bad-key")).toBeNull();
     expect(parseScopedThreadKey("bad-key")).toBeNull();
+  });
+});
+
+describe("detectEnvironment", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env after each test
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
+    vi.restoreAllMocks();
+  });
+
+  it("detects runtime, platform, and arch", () => {
+    const info = detectEnvironment();
+    expect(info.runtime).toMatch(/^node-v/);
+    expect(info.platform).toBe(process.platform);
+    expect(info.arch).toBe(process.arch);
+  });
+
+  it("detects GitHub Actions CI", () => {
+    process.env.GITHUB_ACTIONS = "true";
+    const info = detectEnvironment();
+    expect(info.isCI).toBe(true);
+    expect(info.ciProvider).toBe("github");
+    delete process.env.GITHUB_ACTIONS;
+  });
+
+  it("detects GitLab CI", () => {
+    process.env.GITLAB_CI = "true";
+    const info = detectEnvironment();
+    expect(info.isCI).toBe(true);
+    expect(info.ciProvider).toBe("gitlab");
+    delete process.env.GITLAB_CI;
+  });
+
+  it("detects Jenkins CI", () => {
+    process.env.JENKINS_URL = "http://jenkins.example.com";
+    const info = detectEnvironment();
+    expect(info.isCI).toBe(true);
+    expect(info.ciProvider).toBe("jenkins");
+    delete process.env.JENKINS_URL;
+  });
+
+  it("detects CircleCI", () => {
+    process.env.CIRCLECI = "true";
+    const info = detectEnvironment();
+    expect(info.isCI).toBe(true);
+    expect(info.ciProvider).toBe("circleci");
+    delete process.env.CIRCLECI;
+  });
+
+  it("detects generic CI", () => {
+    process.env.CI = "true";
+    const info = detectEnvironment();
+    expect(info.isCI).toBe(true);
+    expect(info.ciProvider).toBe("generic");
+    delete process.env.CI;
+  });
+
+  it("returns isCI=false and ciProvider=null when not in CI", () => {
+    // Ensure no CI env vars are set
+    const ciVars = ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "CIRCLECI", "TRAVIS"];
+    const saved: Record<string, string | undefined> = {};
+    for (const v of ciVars) {
+      saved[v] = process.env[v];
+      delete process.env[v];
+    }
+    const info = detectEnvironment();
+    expect(info.isCI).toBe(false);
+    expect(info.ciProvider).toBeNull();
+    // Restore
+    for (const [k, v] of Object.entries(saved)) {
+      if (v !== undefined) process.env[k] = v;
+    }
+  });
+
+  it("does not throw when container files are missing", () => {
+    // In a test environment, /proc/1/cgroup may or may not exist
+    // detectEnvironment should handle this gracefully
+    expect(() => detectEnvironment()).not.toThrow();
   });
 });

--- a/t3code/packages/client-runtime/src/knownEnvironment.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentId, ExecutionEnvironmentDescriptor } from "@t3tools/contracts";
+import { existsSync, readFileSync } from "node:fs";
 
 export interface KnownEnvironmentConnectionTarget {
   readonly httpBaseUrl: string;
@@ -13,6 +14,16 @@ export interface KnownEnvironment {
   readonly source: KnownEnvironmentSource;
   readonly environmentId?: EnvironmentId;
   readonly target: KnownEnvironmentConnectionTarget;
+}
+
+export interface EnvironmentInfo {
+  readonly runtime: string;
+  readonly platform: string;
+  readonly arch: string;
+  readonly isContainer: boolean;
+  readonly isCI: boolean;
+  readonly ciProvider: string | null;
+  readonly isWSL: boolean;
 }
 
 export function createKnownEnvironment(input: {
@@ -49,5 +60,64 @@ export function attachEnvironmentDescriptor(
     ...environment,
     environmentId: descriptor.environmentId,
     label: descriptor.label,
+  };
+}
+
+// --- Container / CI / WSL Detection ---
+
+const CI_ENV_VARS: Record<string, string> = {
+  CI: "generic",
+  GITHUB_ACTIONS: "github",
+  GITLAB_CI: "gitlab",
+  JENKINS_URL: "jenkins",
+  CIRCLECI: "circleci",
+  TRAVIS: "travis",
+  BUILDKITE: "buildkite",
+  DRONE: "drone",
+  TEAMCITY_VERSION: "teamcity",
+  AZURE_PIPELINES: "azure",
+};
+
+function isDockerContainer(): boolean {
+  try {
+    if (existsSync("/.dockerenv")) {
+      return true;
+    }
+    const cgroup = readFileSync("/proc/1/cgroup", "utf8");
+    return cgroup.includes("docker") || cgroup.includes("containerd");
+  } catch {
+    return false;
+  }
+}
+
+function isWSL(): boolean {
+  try {
+    const version = readFileSync("/proc/version", "utf8");
+    return version.toLowerCase().includes("microsoft");
+  } catch {
+    return false;
+  }
+}
+
+function detectCI(): { isCI: boolean; ciProvider: string | null } {
+  for (const [envVar, provider] of Object.entries(CI_ENV_VARS)) {
+    if (process.env[envVar]) {
+      return { isCI: true, ciProvider: provider };
+    }
+  }
+  return { isCI: false, ciProvider: null };
+}
+
+export function detectEnvironment(): EnvironmentInfo {
+  const { isCI, ciProvider } = detectCI();
+
+  return {
+    runtime: `node-${process.version}`,
+    platform: process.platform,
+    arch: process.arch,
+    isContainer: isDockerContainer(),
+    isCI,
+    ciProvider,
+    isWSL: isWSL(),
   };
 }


### PR DESCRIPTION
## Summary
Fixes #836 — Add container, CI, and WSL environment detection to client runtime

## Changes
- Add Docker container detection via /.dockerenv and /proc/1/cgroup
- Add CI detection for GitHub Actions, GitLab CI, Jenkins, CircleCI, Travis, Buildkite, Drone, TeamCity, Azure Pipelines, and generic CI
- Add WSL detection via /proc/version Microsoft string
- Return structured EnvironmentInfo object: runtime, platform, arch, isContainer, isCI, ciProvider, isWSL
- Detection does not throw on missing files or env vars
- Existing runtime and platform detection remains unchanged

## Testing
- Added comprehensive Vitest tests for all detection cases
- Tests mock env vars for each CI provider
- Tests verify graceful handling when container files are missing

/claim #836