### PR TITLE
[ChatGPT Agent] fix: correct docker image tag typo (#310)

### DIFF
--- a/_meta.json
+++ b/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "syamsy1010",
+  "generation_context": "AI agent created this change by following issue #310 instructions to fix the Docker image tag typo in config/docker-compose.yml.",
+  "completed_at": "2026-05-18T03:00:14Z"
+}

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
```
AI agent was instructed to fix issue #310 by changing the Docker image tag typo from lastest to latest in config/docker-compose.yml, include required metadata, and provide validation evidence.
```

## Issue

Closes #310

## Summary

This PR updates `config/docker-compose.yml` to correct the image tag from `lastest` to `latest`.

It also adds the required `_meta.json` file for the bounty metadata.

## Validation

- Parsed `config/docker-compose.yml` with a YAML parser successfully.
- Ran `git diff --check` with no whitespace errors.
- Confirmed the diff only changes the image tag typo and adds `_meta.json`.

## Demo

Terminal validation was performed locally:
- YAML parser returned `YAML OK`.
- `git diff --check` completed without errors.

A short screen recording/GIF can be added if required by the reviewer.

/claim #310
