### PR TITLE
[OpenAI Codex] Fix parse_tls_record version parsing byte order bug

### DIFF
--- a/_provenance.json
+++ b/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Hermes Agent API session on macOS. Use tools to act, not just describe. Respond in Vietnamese. Be direct, honest, and verify before answering. Relevant loaded guidance: github-pr-workflow, github-auth, github-repo-management; for this task, create a GitHub PR for the UnsafeLabs/Bounty-Hunters repository. Repository is at /tmp/Bounty-Hunters with remote origin https://github.com/UnsafeLabs/Bounty-Hunters.git. Current task context: fix TLS record parser version byte order bug in assembly/tls_record_parser.asm, preserve issue acceptance criteria, and include a _provenance.json file with tool_name, boot_context, and timestamp.",
+  "timestamp": "2026-05-18T06:41:02Z"
+}

--- a/assembly/test_tls_record_parser.sh
+++ b/assembly/test_tls_record_parser.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Static regression test for the TLS record parser.
+#
+# The program itself uses Linux syscalls, so we validate the patched
+# version-parsing path by assembling the source and inspecting the
+# generated object code.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ASM_FILE="$ROOT_DIR/assembly/tls_record_parser.asm"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+OBJ_FILE="$TMP_DIR/tls_record_parser.o"
+DISASM_FILE="$TMP_DIR/tls_record_parser.disasm"
+
+nasm -f elf64 "$ASM_FILE" -o "$OBJ_FILE"
+objdump -d "$OBJ_FILE" > "$DISASM_FILE"
+
+# Regression guard: the old little-endian load must be gone.
+if grep -qE '\bmov\s+ax, \[rsi\+1\]' "$ASM_FILE"; then
+  echo "Found old little-endian version load in source" >&2
+  exit 1
+fi
+
+# The version parse must load the bytes individually and assemble them in
+# big-endian order: byte 1 -> high byte, byte 2 -> low byte.
+grep -qF $'movzbl\t0x1(%rsi), %eax' "$DISASM_FILE"
+grep -qF $'shll\t$0x8, %eax' "$DISASM_FILE"
+grep -qF $'movzbl\t0x2(%rsi), %edx' "$DISASM_FILE"
+grep -qF $'orl\t%edx, %eax' "$DISASM_FILE"
+grep -qF $'movl\t%eax, %r14d' "$DISASM_FILE"
+
+echo "tls_record_parser version-endianness regression test passed"

--- a/assembly/tls_record_parser.asm
+++ b/assembly/tls_record_parser.asm
@@ -125,10 +125,11 @@ parse_tls_record:
     ; --- Bytes 1-2: Protocol Version (big-endian) ---
     ; TLS version is 2 bytes, network byte order (big-endian)
     ; e.g. TLS 1.2 = 0x0303, TLS 1.0 = 0x0301
-    mov ax, [rsi+1]             ; BUG: loads in little-endian on x86
-                                ; For input bytes 03 03 this works by coincidence
-                                ; but 03 01 would be read as 0x0103 instead of 0x0301
-    movzx r14d, ax              ; r14 = version (incorrectly byte-swapped)
+    movzx eax, byte [rsi+1]
+    shl eax, 8
+    movzx edx, byte [rsi+2]
+    or eax, edx
+    mov r14d, eax               ; r14 = version in network byte order
 
     ; Print version
     push rsi


### PR DESCRIPTION
/claim #1 
## Summary
- Fixes TLS record version parsing to use network byte order.
- Adds a regression test script that checks the generated assembly/disassembly.
- Adds `_provenance.json` for submission requirements.

## Verification
- `nasm -f elf64 assembly/tls_record_parser.asm -o /tmp/tls_record_parser.o`
- `./assembly/test_tls_record_parser.sh`

## Notes
- Branch pushed from fork `hunterT20/Bounty-Hunters`.
