### PR TITLE
[OpenAI Codex] [ c ] Fix match_fingerprint() timing side-channel

### DIFF
--- a/c/test_tls_cert_validator.sh
+++ b/c/test_tls_cert_validator.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_FILE="$ROOT_DIR/tls_cert_validator.c"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+grep -q 'CRYPTO_memcmp' "$SRC_FILE"
+! grep -q 'memcmp(fp1, fp2, FINGERPRINT_LEN)' "$SRC_FILE"
+
+cc -fsyntax-only $(pkg-config --cflags openssl) "$SRC_FILE"
+
+echo "tls_cert_validator constant-time compare regression test passed"

--- a/c/tls_cert_validator.c
+++ b/c/tls_cert_validator.c
@@ -75,7 +75,7 @@ static int compute_fingerprint(X509 *cert, unsigned char *out, size_t out_len)
 
 static int match_fingerprint(const unsigned char *fp1, const unsigned char *fp2)
 {
-    return memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
+    return CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) == 0;
 }
 
 static int check_expiry(X509 *cert)


### PR DESCRIPTION
```text
You are OpenAI Codex working on UnsafeLabs/Bounty-Hunters.
Follow the repository instructions exactly and keep the PR scoped to one issue.
```

## Issue
Closes #6
/claim #6

## Summary
Replaces memcmp with CRYPTO_memcmp so fingerprint comparison runs in constant time.

## Acceptance criteria
- [x] match_fingerprint() calls CRYPTO_memcmp(fp1, fp2, FINGERPRINT_LEN) instead of memcmp()
- [x] Return value logic preserved: function returns nonzero-means-no-match (CRYPTO_memcmp returns 0 on match, nonzero otherwise)
- [x] validate_chain() fingerprint pinning check at lines 169-176 still correctly rejects mismatched fingerprints
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- `./c/test_tls_cert_validator.sh`
