### PR TITLE
[OpenAI Codex] [ Go ] Fix NegotiateSuite nil pointer dereference when no suite matches

### DIFF
--- a/go/test_tls_cipher.sh
+++ b/go/test_tls_cipher.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat >"$TMP_DIR/go.mod" <<'EOF'
+module tlscipher_test
+
+go 1.22
+EOF
+
+cp "$ROOT_DIR/tls_cipher.go" "$TMP_DIR/"
+cp "$ROOT_DIR/tls_cipher_test.go" "$TMP_DIR/"
+
+(cd "$TMP_DIR" && go test ./...)
+
+echo "tls_cipher negotiate regression tests passed"

--- a/go/tls_cipher.go
+++ b/go/tls_cipher.go
@@ -178,7 +178,10 @@ func (r *SuiteRegistry) NegotiateSuite(clientSuites []uint16) (string, error) {
 		}
 	}
 
-	// BUG(1): nil dereference when no suite matched
+	if selectedSuite == nil {
+		return "", errors.New("tlscipher: no mutually supported cipher suite")
+	}
+
 	return selectedSuite.Name, nil
 }
 

--- a/go/tls_cipher_test.go
+++ b/go/tls_cipher_test.go
@@ -1,0 +1,10 @@
+package tlscipher
+
+import "testing"
+
+func TestNegotiateSuiteReturnsErrorWhenNoMatch(t *testing.T) {
+	reg := NewSuiteRegistry(StrengthWeak)
+	if _, err := reg.NegotiateSuite([]uint16{0xFFFF}); err == nil {
+		t.Fatal("expected error when no cipher suite matches")
+	}
+}


### PR DESCRIPTION
```text
You are OpenAI Codex working on UnsafeLabs/Bounty-Hunters.
Follow the repository instructions exactly and keep the PR scoped to one issue.
```

## Issue
Closes #11
/claim #11

## Summary
Returns a non-nil error instead of dereferencing a nil suite when the client and server share no common cipher suite.

## Acceptance criteria
- [x] NegotiateSuite([]uint16{0xFFFF}) returns ("", non-nil error), no panic
- [x] NegotiateSuite with a valid ID like TLS_AES_128_GCM_SHA256 still returns its name
- [x] All existing tests still pass
- [x] Add new tests covering the fixed bugs

## Verification
- `./go/test_tls_cipher.sh`
