### PR TITLE
[ Python ] Fix Extended Master Secret derivation (#573)

### DIFF
--- a/python/test_tls_handshake_ems.py
+++ b/python/test_tls_handshake_ems.py
@@ -1,0 +1,56 @@
+import hashlib
+
+from tls_handshake import TLSHandshake
+
+
+def _prepared_handshake(ems_enabled):
+    handshake = TLSHandshake()
+    handshake.client_random = b"c" * 32
+    handshake.server_random = b"s" * 32
+    handshake._pre_master_secret = b"p" * 48
+    handshake.negotiated_ems = ems_enabled
+    handshake.handshake_hash.update(b"client/server handshake transcript")
+    return handshake
+
+
+def test_ems_master_secret_uses_rfc7627_label_and_session_hash():
+    handshake = _prepared_handshake(True)
+    calls = []
+
+    def capture_prf(secret, label, seed, output_len):
+        calls.append((secret, label, seed, output_len))
+        return b"m" * output_len
+
+    handshake._prf = capture_prf
+    handshake._derive_master_secret()
+
+    assert handshake.master_secret == b"m" * 48
+    assert calls == [
+        (
+            b"p" * 48,
+            b"extended master secret",
+            hashlib.sha256(b"client/server handshake transcript").digest(),
+            48,
+        )
+    ]
+
+
+def test_non_ems_master_secret_keeps_legacy_label_and_random_seed():
+    handshake = _prepared_handshake(False)
+    calls = []
+
+    def capture_prf(secret, label, seed, output_len):
+        calls.append((secret, label, seed, output_len))
+        return b"m" * output_len
+
+    handshake._prf = capture_prf
+    handshake._derive_master_secret()
+
+    assert calls == [
+        (
+            b"p" * 48,
+            b"master secret",
+            b"c" * 32 + b"s" * 32,
+            48,
+        )
+    ]

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -293,14 +293,12 @@ class TLSHandshake:
         if self.client_random is None or self.server_random is None:
             raise ValueError("Client/server random not set")
 
-        seed = self.client_random + self.server_random
-
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
+            seed = self.handshake_hash.copy().digest()
         else:
             label = b"master secret"
+            seed = self.client_random + self.server_random
 
         self.master_secret = self._prf(
             self._pre_master_secret, label, seed, 48


### PR DESCRIPTION
## Summary
- fixes Extended Master Secret derivation to use the RFC 7627 `extended master secret` PRF label
- uses the current handshake transcript hash as the EMS seed
- keeps the legacy non-EMS `master secret` path unchanged
- adds focused regression coverage for EMS and non-EMS derivation

/claim #573

## Acceptance criteria
- EMS branch no longer derives with the normal master-secret label
- EMS seed is the session hash instead of `client_random + server_random`
- non-EMS derivation remains backward-compatible

## Demo / verification
Non-UI change; the focused regression test demonstrates the behavior:
```
python3 -m pytest python/test_tls_handshake_ems.py
Pytest: 2 passed
```

## Tests
- `python3 -m py_compile python/tls_handshake.py python/test_tls_handshake_ems.py`
- `python3 -m pytest python/test_tls_handshake_ems.py`

Addresses #573.