### PR TITLE
[E-Jie] [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,7 +18,7 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
+    // admin field removed — replaced by Ownable's owner()
 
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
@@ -25,33 +26,32 @@ contract GovernanceToken is ERC20 {
 
     constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // FIX: Replaced tx.origin with msg.sender to prevent phishing attacks
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid address");
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    // FIX: Replaced tx.origin with msg.sender to prevent phishing attacks
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    // FIX: Replaced tx.origin admin check with onlyOwner modifier
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Fix: tx.origin phishing vulnerability in GovernanceToken (#1568)

### Changes
1. **Replace `tx.origin` with `msg.sender`** in `delegateVote()` — prevents phishing contracts from delegating votes on behalf of users.
2. **Replace `tx.origin` with `msg.sender`** in `revokeDelegate()` — same fix for revocation.
3. **Replace `tx.origin == admin` with `onlyOwner` modifier** in `snapshot()` — uses OpenZeppelin Ownable for proper access control.
4. **Add `require(msg.sender != address(0))`** check to prevent null address delegation.
5. **Import and inherit OpenZeppelin `Ownable`** — replaces manual admin tracking.

### Security Impact
- Eliminates the tx.origin phishing vector that allowed malicious contracts to steal voting delegation rights.
- Proper access control via Ownable instead of tx.origin-based admin check.

Closes #1568