### PR TITLE
Codex [ Crypto ] Fix PriceOracle staleness fallback

### DIFF
--- a/.generation_meta.json
+++ b/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initial_directives": "User request: Solve and submit one GitHub bounty PR for UnsafeLabs/Bounty-Hunters issue #915. Issue requirements: fix PriceOracle missing staleness checks, invalid price checks, round completeness validation, fallback oracle, StalePrice event, owner-configurable MAX_STALENESS, and tests for valid, stale, negative/zero, incomplete, and both-stale oracle responses.",
+  "date": "2026-05-18T11:39:02Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,33 +14,31 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed staleFeed, uint256 updatedAt);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+    function getLatestPrice() external returns (int256) {
+        (int256 price, uint256 updatedAt, bool isStale) = _readFeed(primaryFeed);
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        if (isStale) {
+            emit StalePrice(address(primaryFeed), updatedAt);
+            (price, , isStale) = _readFeed(fallbackFeed);
+            require(!isStale, "Stale price");
+        }
 
+        emit PriceQueried(price, block.timestamp);
         return price;
     }
 
@@ -48,8 +46,38 @@ contract PriceOracle {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        require(_maxStaleness > 0, "Invalid staleness");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+    }
+
+    function _readFeed(AggregatorV3Interface feed)
+        internal
+        view
+        returns (int256 price, uint256 updatedAt, bool isStale)
+    {
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 feedUpdatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        require(answer > 0, "Invalid price");
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(feedUpdatedAt <= block.timestamp, "Invalid update time");
+
+        return (answer, feedUpdatedAt, block.timestamp - feedUpdatedAt >= MAX_STALENESS);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
     }
 }

--- a/solidity/test/PriceOracle.t.sol
+++ b/solidity/test/PriceOracle.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/PriceOracle.sol";
+
+contract MockAggregatorV3 {
+    uint80 private roundId;
+    int256 private answer;
+    uint256 private updatedAt;
+    uint80 private answeredInRound;
+    uint8 private feedDecimals = 8;
+
+    function setRoundData(
+        uint80 _roundId,
+        int256 _answer,
+        uint256 _updatedAt,
+        uint80 _answeredInRound
+    ) external {
+        roundId = _roundId;
+        answer = _answer;
+        updatedAt = _updatedAt;
+        answeredInRound = _answeredInRound;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, 0, updatedAt, answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return feedDecimals;
+    }
+}
+
+contract PriceOracleTest is Test {
+    PriceOracle private oracle;
+    MockAggregatorV3 private primary;
+    MockAggregatorV3 private fallbackFeed;
+
+    event StalePrice(address indexed staleFeed, uint256 updatedAt);
+
+    function setUp() public {
+        primary = new MockAggregatorV3();
+        fallbackFeed = new MockAggregatorV3();
+        oracle = new PriceOracle(address(primary), address(fallbackFeed));
+    }
+
+    function testValidPrimaryPrice() public {
+        primary.setRoundData(10, 2000e8, block.timestamp, 10);
+        fallbackFeed.setRoundData(10, 1900e8, block.timestamp, 10);
+
+        assertEq(oracle.getLatestPrice(), 2000e8);
+    }
+
+    function testStalePrimaryFallsBackAndEmitsEvent() public {
+        uint256 staleTimestamp = block.timestamp - oracle.MAX_STALENESS();
+        primary.setRoundData(10, 2000e8, staleTimestamp, 10);
+        fallbackFeed.setRoundData(11, 1900e8, block.timestamp, 11);
+
+        vm.expectEmit(true, false, false, true);
+        emit StalePrice(address(primary), staleTimestamp);
+
+        assertEq(oracle.getLatestPrice(), 1900e8);
+    }
+
+    function testInvalidPriceReverts() public {
+        primary.setRoundData(10, 0, block.timestamp, 10);
+
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    function testNegativePriceReverts() public {
+        primary.setRoundData(10, -1, block.timestamp, 10);
+
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    function testIncompleteRoundReverts() public {
+        primary.setRoundData(10, 2000e8, block.timestamp, 9);
+
+        vm.expectRevert("Incomplete round");
+        oracle.getLatestPrice();
+    }
+
+    function testBothFeedsStaleReverts() public {
+        primary.setRoundData(10, 2000e8, block.timestamp - oracle.MAX_STALENESS(), 10);
+        fallbackFeed.setRoundData(11, 1900e8, block.timestamp - oracle.MAX_STALENESS(), 11);
+
+        vm.expectRevert("Stale price");
+        oracle.getLatestPrice();
+    }
+
+    function testOwnerCanConfigureMaxStaleness() public {
+        oracle.setMaxStaleness(7200);
+
+        assertEq(oracle.MAX_STALENESS(), 7200);
+    }
+
+    function testNonOwnerCannotConfigureMaxStaleness() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("Not owner");
+        oracle.setMaxStaleness(7200);
+    }
+}


### PR DESCRIPTION
## Summary
- validate Chainlink oracle answers for positive price, complete rounds, and future timestamps
- add owner-configurable fallback feed and staleness handling with StalePrice event
- add Foundry tests covering valid, stale fallback, invalid price, incomplete round, both-stale, and owner controls

## Testing
- Not run: forge is not installed in this environment

Closes #915