### PR TITLE
Codex [ Crypto ] Fix SimpleSwap slippage and deadline checks

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -9,10 +9,12 @@ contract SimpleSwap {
     uint256 public reserveA;
     uint256 public reserveB;
     uint256 public fee; // basis points, e.g. 30 = 0.3%
+    uint256 private constant BPS_DENOMINATOR = 10_000;
 
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_fee <= BPS_DENOMINATOR, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
@@ -25,10 +27,11 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut, uint256 deadline)
+        external
+        returns (uint256 amountOut)
+    {
+        require(block.timestamp <= deadline, "Deadline expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
@@ -37,14 +40,10 @@ contract SimpleSwap {
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
+        amountOut = _getAmountOut(amountIn, reserveIn, reserveOut);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+
         inputToken.transferFrom(msg.sender, address(this), amountIn);
-
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
         outputToken.transfer(msg.sender, amountOut);
 
         if (isTokenA) {
@@ -59,11 +58,17 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
+
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-        return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+
+        return _getAmountOut(amountIn, reserveIn, reserveOut);
+    }
+
+    function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) internal view returns (uint256) {
+        uint256 amountInWithFee = amountIn * (BPS_DENOMINATOR - fee);
+        return (reserveOut * amountInWithFee) / (reserveIn * BPS_DENOMINATOR + amountInWithFee);
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Adamchaua",
+  "generation_context": "Solve and submit one GitHub bounty PR for UnsafeLabs/Bounty-Hunters issue #913.",
+  "completed_at": "2026-05-18T11:52:40Z"
+}


### PR DESCRIPTION
Fixes #913.

Changes:
- Adds minAmountOut and deadline parameters to SimpleSwap.swap.
- Reverts with clear errors when slippage is exceeded or a transaction is expired.
- Uses a single fixed-point constant-product calculation that applies basis-point fees without pre-truncating feeAmount.
- Adds required _meta.json metadata file.

Validation:
- solc is not installed in this environment, so no Solidity compile was available.
- npx hardhat --version completed successfully, but this repo does not include a Hardhat/Foundry config for the Solidity folder.