### PR TITLE
Codex GPT-5 [ Crypto ] Fix MultiSigWallet confirmation race

### DIFF
--- a/_provenance.json
+++ b/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "System: You are an AI assistant accessed via an API. Developer: You are Codex, based on GPT-5, running as a coding agent in the Codex CLI. Follow coding-agent rules: protect user changes, avoid destructive git commands, use concise final messages, prefer fast search, edit carefully, validate work when possible, and for bounty submissions include required provenance.",
+  "timestamp": "2026-05-18T11:53:42Z"
+}

--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -5,6 +5,7 @@ contract MultiSigWallet {
     address[] public owners;
     uint256 public required;
     uint256 public transactionCount;
+    bool private executing;
 
     struct Transaction {
         address to;
@@ -13,8 +14,14 @@ contract MultiSigWallet {
         bool executed;
     }
 
+    struct Confirmation {
+        bool confirmed;
+        uint256 confirmedBlock;
+        uint256 revokedBlock;
+    }
+
     mapping(uint256 => Transaction) public transactions;
-    mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => Confirmation)) public confirmations;
     mapping(address => bool) public isOwner;
 
     event Submitted(uint256 indexed txId);
@@ -27,61 +34,82 @@ contract MultiSigWallet {
         _;
     }
 
+    modifier nonReentrant() {
+        require(!executing, "Execution in progress");
+        executing = true;
+        _;
+        executing = false;
+    }
+
     constructor(address[] memory _owners, uint256 _required) {
         require(_owners.length > 0, "No owners");
         require(_required > 0 && _required <= _owners.length, "Invalid required");
         for (uint256 i = 0; i < _owners.length; i++) {
+            require(_owners[i] != address(0), "Invalid owner");
+            require(!isOwner[_owners[i]], "Duplicate owner");
             isOwner[_owners[i]] = true;
         }
         owners = _owners;
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid target");
+        require(data.length == 0 || to.code.length > 0, "Target not contract");
+
         uint256 txId = transactionCount++;
-        transactions[txId] = Transaction({
-            to: to,
-            value: value,
-            data: data,
-            executed: false
-        });
+        transactions[txId] = Transaction({to: to, value: value, data: data, executed: false});
         emit Submitted(txId);
         return txId;
     }
 
     function confirmTransaction(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(!confirmations[txId][msg.sender], "Already confirmed");
-        confirmations[txId][msg.sender] = true;
+        Confirmation storage confirmation = confirmations[txId][msg.sender];
+        require(!confirmation.confirmed, "Already confirmed");
+        confirmation.confirmed = true;
+        confirmation.confirmedBlock = block.number;
+        confirmation.revokedBlock = 0;
         emit Confirmed(txId, msg.sender);
     }
 
     function revokeConfirmation(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(confirmations[txId][msg.sender], "Not confirmed");
-        confirmations[txId][msg.sender] = false;
+        Confirmation storage confirmation = confirmations[txId][msg.sender];
+        require(confirmation.confirmed, "Not confirmed");
+        confirmation.confirmed = false;
+        confirmation.revokedBlock = block.number;
         emit Revoked(txId, msg.sender);
     }
 
+    function isConfirmedAtBlock(uint256 txId, address owner, uint256 blockNumber) public view returns (bool) {
+        Confirmation storage confirmation = confirmations[txId][owner];
+        return confirmation.confirmedBlock != 0 && confirmation.confirmedBlock <= blockNumber
+            && (confirmation.revokedBlock == 0 || confirmation.revokedBlock > blockNumber);
+    }
+
     function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
+        return getConfirmationCountAtBlock(txId, block.number);
+    }
+
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
         for (uint256 i = 0; i < owners.length; i++) {
-            if (confirmations[txId][owners[i]]) count++;
+            if (isConfirmedAtBlock(txId, owners[i], blockNumber)) count++;
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
-
+    function executeTransaction(uint256 txId) external onlyOwner nonReentrant {
         Transaction storage txn = transactions[txId];
-        txn.executed = true;
+        require(!txn.executed, "Already executed");
+
+        uint256 executionBlock = block.number;
+        require(getConfirmationCountAtBlock(txId, executionBlock) >= required, "Not enough confirmations");
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
         require(success, "Execution failed");
+        require(getConfirmationCountAtBlock(txId, executionBlock) >= required, "Confirmations revoked");
 
+        txn.executed = true;
         emit Executed(txId);
     }
 


### PR DESCRIPTION
Fixes #916

## Changes
- Replace boolean confirmations with timestamped confirmation records that track confirm and revoke blocks.
- Add block-level confirmation queries via isConfirmedAtBlock and getConfirmationCountAtBlock.
- Guard executeTransaction with nonReentrant and re-check the execution-block confirmation snapshot after the external call.
- Reject zero-address targets and contract-call payloads to EOAs during submission.
- Include required _provenance.json.

## Validation
- git diff --check
- python3 sanity check for required contract changes

Note: solc/forge are not installed in this environment, so Solidity compilation and gas measurement could not be run locally.