### PR TITLE
Codex [ Crypto ] Fix yield vault reward expiry

### DIFF
--- a/solidity/contracts/MockERC20.sol
+++ b/solidity/contracts/MockERC20.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockERC20 is IERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals = 18;
+    uint256 public override totalSupply;
+
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "insufficient allowance");
+        allowance[from][msg.sender] = allowed - amount;
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/solidity/contracts/YieldVault.sol
+++ b/solidity/contracts/YieldVault.sol
@@ -29,22 +29,22 @@ contract YieldVault {
         rewardDistributor = msg.sender;
     }
 
-    // BUG: Does not cap at periodFinish — accrues phantom rewards after period ends
-    function rewardPerToken() public view returns (uint256) {
-        if (totalSupply == 0) return rewardPerTokenStored;
-        return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / totalSupply
-        );
+    function lastTimeRewardApplicable() public view returns (uint256) {
+        return block.timestamp < periodFinish ? block.timestamp : periodFinish;
     }
 
-    // BUG: Uses uncapped rewardPerToken
+    function rewardPerToken() public view returns (uint256) {
+        if (totalSupply == 0) return rewardPerTokenStored;
+        return rewardPerTokenStored + ((lastTimeRewardApplicable() - lastUpdateTime) * rewardRate / totalSupply);
+    }
+
     function earned(address account) public view returns (uint256) {
         return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / 1e18 + rewards[account];
     }
 
     modifier updateReward(address account) {
         rewardPerTokenStored = rewardPerToken();
-        lastUpdateTime = block.timestamp;
+        lastUpdateTime = lastTimeRewardApplicable();
         if (account != address(0)) {
             rewards[account] = earned(account);
             userRewardPerTokenPaid[account] = rewardPerTokenStored;
@@ -77,10 +77,10 @@ contract YieldVault {
         }
     }
 
-    // BUG: No access control — anyone can call
-    // BUG: Precision loss in rewardRate calculation
     function notifyRewardAmount(uint256 reward, uint256 duration) external updateReward(address(0)) {
-        rewardRate = reward / duration;
+        require(msg.sender == rewardDistributor, "Not reward distributor");
+        require(duration > 0, "Duration must be positive");
+        rewardRate = reward * 1e18 / duration;
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + duration;
     }

--- a/solidity/contracts/_contributor.json
+++ b/solidity/contracts/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex",
+  "runtime_instructions": "Runtime instructions are not disclosed by the agent.",
+  "timestamp": "2026-05-18T00:00:00Z"
+}

--- a/solidity/test/YieldVault.t.sol
+++ b/solidity/test/YieldVault.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../contracts/YieldVault.sol";
+import "../contracts/MockERC20.sol";
+
+interface Vm {
+    function warp(uint256) external;
+    function prank(address) external;
+    function expectRevert(bytes memory) external;
+}
+
+contract YieldVaultTest {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    MockERC20 private stakingToken;
+    MockERC20 private rewardToken;
+    YieldVault private vault;
+
+    address private constant ALICE = address(0xA11CE);
+    address private constant BOB = address(0xB0B);
+
+    function setUp() public {
+        stakingToken = new MockERC20("Stake", "STK");
+        rewardToken = new MockERC20("Reward", "RWD");
+        vault = new YieldVault(address(stakingToken), address(rewardToken));
+
+        stakingToken.mint(ALICE, 1_000 ether);
+        stakingToken.mint(BOB, 1_000 ether);
+        rewardToken.mint(address(vault), 1_000 ether);
+
+        vm.prank(ALICE);
+        stakingToken.approve(address(vault), type(uint256).max);
+        vm.prank(BOB);
+        stakingToken.approve(address(vault), type(uint256).max);
+    }
+
+    function testRewardAccruesDuringPeriod() public {
+        vault.notifyRewardAmount(100 ether, 100);
+
+        vm.prank(ALICE);
+        vault.deposit(100 ether);
+
+        vm.warp(block.timestamp + 25);
+
+        assertApproxEqAbs(vault.earned(ALICE), 25 ether, 1 wei);
+        assertEq(vault.rewardPerToken(), 0.25 ether);
+    }
+
+    function testRewardFreezesAfterPeriodFinish() public {
+        vault.notifyRewardAmount(100 ether, 100);
+
+        vm.prank(ALICE);
+        vault.deposit(100 ether);
+
+        vm.warp(block.timestamp + 100);
+        uint256 earnedAtFinish = vault.earned(ALICE);
+        uint256 rewardPerTokenAtFinish = vault.rewardPerToken();
+
+        vm.warp(block.timestamp + 500);
+
+        assertEq(vault.earned(ALICE), earnedAtFinish);
+        assertEq(vault.rewardPerToken(), rewardPerTokenAtFinish);
+    }
+
+    function testNoPhantomRewardsForDepositsAfterExpiry() public {
+        vault.notifyRewardAmount(100 ether, 100);
+
+        vm.warp(block.timestamp + 150);
+        vm.prank(ALICE);
+        vault.deposit(100 ether);
+
+        vm.warp(block.timestamp + 50);
+
+        assertEq(vault.earned(ALICE), 0);
+    }
+
+    function testUnauthorizedNotifyRewardAmountReverts() public {
+        vm.prank(BOB);
+        vm.expectRevert(bytes("Not reward distributor"));
+        vault.notifyRewardAmount(100 ether, 100);
+    }
+
+    function testPrecisionLossStaysBelowOneBasisPoint() public {
+        uint256 reward = 1 ether;
+        uint256 duration = 3;
+        vault.notifyRewardAmount(reward, duration);
+
+        vm.prank(ALICE);
+        vault.deposit(1 ether);
+
+        vm.warp(block.timestamp + duration);
+
+        uint256 paid = vault.earned(ALICE);
+        uint256 error = reward > paid ? reward - paid : paid - reward;
+        assertLt(error * 10_000, reward);
+    }
+
+    function testWithdrawAndClaimStillWork() public {
+        vault.notifyRewardAmount(100 ether, 100);
+
+        vm.prank(ALICE);
+        vault.deposit(100 ether);
+        vm.warp(block.timestamp + 10);
+        vm.prank(ALICE);
+        vault.withdraw(40 ether);
+        vm.prank(ALICE);
+        vault.claimReward();
+
+        assertEq(vault.balanceOf(ALICE), 60 ether);
+        assertGt(rewardToken.balanceOf(ALICE), 0);
+    }
+
+    function assertEq(uint256 actual, uint256 expected) internal pure {
+        require(actual == expected, "assert eq failed");
+    }
+
+    function assertGt(uint256 actual, uint256 minimum) internal pure {
+        require(actual > minimum, "assert gt failed");
+    }
+
+    function assertLt(uint256 actual, uint256 maximum) internal pure {
+        require(actual < maximum, "assert lt failed");
+    }
+
+    function assertApproxEqAbs(uint256 actual, uint256 expected, uint256 maxDelta) internal pure {
+        uint256 delta = actual > expected ? actual - expected : expected - actual;
+        require(delta <= maxDelta, "assert approx failed");
+    }
+}


### PR DESCRIPTION
Fixes #914.\n\n- Caps reward accrual at periodFinish.\n- Uses scaled rewardRate to avoid precision loss.\n- Restricts reward notification to rewardDistributor.\n- Adds phantom reward regression coverage.\n\nValidation: solc compile via local solc-js succeeded.