### PR TITLE
Codex [ Crypto ] Fix liquidity pool first depositor manipulation

### DIFF
--- a/solidity/_generation.json
+++ b/solidity/_generation.json
@@ -1,0 +1,1 @@
+{"agent":"Codex","pre_task_context":"System: You are an AI assistant accessed via an API. Developer: You are Codex, based on GPT-5. User task assignment: Solve and submit one GitHub bounty PR for UnsafeLabs/Bounty-Hunters issue #918.","timestamp":"2026-05-18T13:10:53Z"}

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,12 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
+    address private constant DEAD_ADDRESS = address(1);
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -23,19 +24,23 @@ contract LiquidityPool is ERC20 {
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(amountA > 0 && amountB > 0, "Amounts must be > 0");
 
-        if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
+        uint256 currentSupply = totalSupply();
+        if (currentSupply == 0) {
             lpTokens = sqrt(amountA * amountB);
+            require(lpTokens > MINIMUM_LIQUIDITY, "Insufficient liquidity");
+            lpTokens -= MINIMUM_LIQUIDITY;
+            _mint(DEAD_ADDRESS, MINIMUM_LIQUIDITY);
         } else {
-            uint256 lpFromA = amountA * totalSupply() / reserveA;
-            uint256 lpFromB = amountB * totalSupply() / reserveB;
+            uint256 lpFromA = amountA * currentSupply / reserveA;
+            uint256 lpFromB = amountB * currentSupply / reserveB;
             lpTokens = lpFromA < lpFromB ? lpFromA : lpFromB;
+            require(lpTokens > 0, "Insufficient liquidity");
         }
 
-        require(lpTokens > 0, "Insufficient liquidity");
+        tokenA.transferFrom(msg.sender, address(this), amountA);
+        tokenB.transferFrom(msg.sender, address(this), amountB);
         _mint(msg.sender, lpTokens);
 
         reserveA += amountA;
@@ -44,27 +49,30 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        uint256 currentSupply = totalSupply();
+        amountA = lpTokens * reserveA / currentSupply;
+        amountB = lpTokens * reserveB / currentSupply;
+        require(amountA > 0 && amountB > 0, "Insufficient liquidity burned");
 
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
 
         reserveA -= amountA;
         reserveB -= amountB;
 
+        tokenA.transfer(msg.sender, amountA);
+        tokenB.transfer(msg.sender, amountB);
+
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/test/LiquidityPool.t.sol
+++ b/solidity/test/LiquidityPool.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../contracts/LiquidityPool.sol";
+
+interface Vm {
+    function prank(address) external;
+    function expectRevert(bytes memory) external;
+}
+
+contract TestERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "insufficient allowance");
+        require(balanceOf[from] >= amount, "insufficient balance");
+        allowance[from][msg.sender] = allowed - amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+contract LiquidityPoolTest {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    TestERC20 private tokenA;
+    TestERC20 private tokenB;
+    LiquidityPool private pool;
+
+    address private constant ALICE = address(0xA11CE);
+    address private constant BOB = address(0xB0B);
+    address private constant ATTACKER = address(0xBAD);
+
+    function setUp() public {
+        tokenA = new TestERC20("Token A", "TKA");
+        tokenB = new TestERC20("Token B", "TKB");
+        pool = new LiquidityPool(address(tokenA), address(tokenB));
+
+        _fundAndApprove(ALICE, 1_000_000 ether);
+        _fundAndApprove(BOB, 1_000_000 ether);
+        _fundAndApprove(ATTACKER, 1_000_000 ether);
+    }
+
+    function testFirstDepositLocksMinimumLiquidity() public {
+        vm.prank(ALICE);
+        uint256 minted = pool.addLiquidity(10_000, 10_000);
+
+        assertEq(pool.MINIMUM_LIQUIDITY(), 1000);
+        assertEq(pool.balanceOf(address(0)), 1000);
+        assertEq(minted, 9_000);
+        assertEq(pool.balanceOf(ALICE), 9_000);
+        assertEq(pool.totalSupply(), 10_000);
+        assertEq(pool.reserveA(), 10_000);
+        assertEq(pool.reserveB(), 10_000);
+    }
+
+    function testFirstDepositBelowMinimumReverts() public {
+        vm.prank(ALICE);
+        vm.expectRevert(bytes("Insufficient liquidity"));
+        pool.addLiquidity(100, 100);
+    }
+
+    function testSubsequentDepositsUseInternalReserveRatio() public {
+        vm.prank(ALICE);
+        pool.addLiquidity(10_000, 10_000);
+
+        tokenA.transfer(address(pool), 90_000);
+        tokenB.transfer(address(pool), 90_000);
+
+        vm.prank(BOB);
+        uint256 minted = pool.addLiquidity(1_000, 1_000);
+
+        assertEq(minted, 1_000);
+        assertEq(pool.balanceOf(BOB), 1_000);
+        assertEq(pool.reserveA(), 11_000);
+        assertEq(pool.reserveB(), 11_000);
+    }
+
+    function testDonationDoesNotIncreaseWithdrawalAmount() public {
+        vm.prank(ALICE);
+        pool.addLiquidity(10_000, 10_000);
+
+        tokenA.transfer(address(pool), 90_000);
+        tokenB.transfer(address(pool), 90_000);
+
+        uint256 aliceBeforeA = tokenA.balanceOf(ALICE);
+        uint256 aliceBeforeB = tokenB.balanceOf(ALICE);
+        vm.prank(ALICE);
+        pool.removeLiquidity(pool.balanceOf(ALICE));
+
+        assertEq(tokenA.balanceOf(ALICE) - aliceBeforeA, 9_000);
+        assertEq(tokenB.balanceOf(ALICE) - aliceBeforeB, 9_000);
+        assertEq(pool.reserveA(), 1_000);
+        assertEq(pool.reserveB(), 1_000);
+    }
+
+    function testSyncRecoversDonatedBalances() public {
+        vm.prank(ALICE);
+        pool.addLiquidity(10_000, 10_000);
+
+        tokenA.transfer(address(pool), 5_000);
+        tokenB.transfer(address(pool), 7_000);
+        pool.sync();
+
+        assertEq(pool.reserveA(), tokenA.balanceOf(address(pool)));
+        assertEq(pool.reserveB(), tokenB.balanceOf(address(pool)));
+        assertEq(pool.reserveA(), 15_000);
+        assertEq(pool.reserveB(), 17_000);
+    }
+
+    function testFirstDepositorPriceManipulationAttemptFails() public {
+        vm.prank(ATTACKER);
+        vm.expectRevert(bytes("Insufficient liquidity"));
+        pool.addLiquidity(1, 1);
+    }
+
+    function _fundAndApprove(address account, uint256 amount) internal {
+        tokenA.mint(account, amount);
+        tokenB.mint(account, amount);
+        vm.prank(account);
+        tokenA.approve(address(pool), type(uint256).max);
+        vm.prank(account);
+        tokenB.approve(address(pool), type(uint256).max);
+    }
+
+    function assertEq(uint256 actual, uint256 expected) internal pure {
+        require(actual == expected, "assert eq failed");
+    }
+}


### PR DESCRIPTION
Fixes #918.\n\n- Locks minimum initial liquidity to prevent first-depositor LP price manipulation.\n- Adds a sync event and reserve sync helper.\n- Adds first-depositor manipulation regression coverage.\n\nValidation: solc compile via local solc-js succeeded.