### PR TITLE
Fix Laravel password hashing rounds

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,18 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Hash passwords using the configured bcrypt cost.
+     */
+    public function setPasswordAttribute(?string $value): void
+    {
+        $rounds = config('hashing.bcrypt.rounds');
+
+        $this->attributes['password'] = $value !== null && ! Hash::isHashed($value)
+            ? Hash::make($value, $rounds === null ? [] : ['rounds' => $rounds])
+            : $value;
     }
 }

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -15,7 +15,7 @@ class UserFactory extends Factory
     /**
      * The current password being used by the factory.
      */
-    protected static ?string $password;
+    protected static array $password = [];
 
     /**
      * Define the model's default state.
@@ -24,11 +24,17 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $rounds = config('hashing.bcrypt.rounds');
+        $passwordCacheKey = $rounds === null ? 'default' : (string) $rounds;
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$password[$passwordCacheKey] ??= Hash::make(
+                'password',
+                $rounds === null ? [] : ['rounds' => $rounds]
+            ),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_password_mutator_uses_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 12]);
+
+        $user = new User([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'secret-password',
+        ]);
+
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+        $this->assertSame(12, password_get_info($user->password)['options']['cost']);
+    }
+
+    public function test_user_password_mutator_does_not_rehash_existing_hashes(): void
+    {
+        $hash = Hash::make('secret-password', ['rounds' => 10]);
+
+        $user = new User([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => $hash,
+        ]);
+
+        $this->assertSame($hash, $user->password);
+    }
+
+    public function test_user_factory_password_uses_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 11]);
+
+        $attributes = User::factory()->definition();
+
+        $this->assertTrue(Hash::check('password', $attributes['password']));
+        $this->assertSame(11, password_get_info($attributes['password'])['options']['cost']);
+    }
+}


### PR DESCRIPTION
## Summary
- replaces the Laravel `User` password `hashed` cast with a mutator that passes `config("hashing.bcrypt.rounds")` to `Hash::make`
- updates `UserFactory` to use the same configured bcrypt rounds when generating the cached test password
- adds focused unit tests for configured rounds and avoiding rehashing existing hashes

## Acceptance criteria
- User model password hashing respects `config("hashing.bcrypt.rounds")`
- User factory password generation respects the same configured rounds
- Existing hashed passwords are preserved instead of being rehashed

## Tests
- Not run: this environment does not have `php` or `composer` installed, so the Laravel test suite cannot execute here.
- Static verification: `git diff --check` passed; self-review found no secrets/debug/TODO/local paths.

/claim #745