### PR TITLE
Codex [ Crypto ] Fix MultiSigWallet confirmation race condition

### DIFF
--- a/solidity/_provenance.json
+++ b/solidity/_provenance.json
@@ -1,0 +1,1 @@
+{"tool_name":"Codex","boot_context":"Codex CLI coding agent with repository editing, shell, GitHub CLI, and bounty triage context; prioritize safe non-destructive edits, preserve user changes, validate when possible, and implement the requested bounty fix.","timestamp":"2026-05-19T01:58:00Z"}

--- a/solidity/contracts/MultiSigReentrantAttacker.sol
+++ b/solidity/contracts/MultiSigReentrantAttacker.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./MultiSigWallet.sol";
+
+contract MultiSigReentrantAttacker {
+    MultiSigWallet public immutable wallet;
+    uint256 public immutable targetTxId;
+    bool public attempted;
+
+    constructor(MultiSigWallet _wallet, uint256 _targetTxId) {
+        wallet = _wallet;
+        targetTxId = _targetTxId;
+    }
+
+    receive() external payable {
+        if (!attempted) {
+            attempted = true;
+            wallet.revokeConfirmation(targetTxId);
+        }
+    }
+}

--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -13,9 +13,18 @@ contract MultiSigWallet {
         bool executed;
     }
 
+    struct Confirmation {
+        bool confirmed;
+        uint256 confirmedAtBlock;
+        uint256 revokedAtBlock;
+    }
+
     mapping(uint256 => Transaction) public transactions;
-    mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => Confirmation)) public confirmations;
+    mapping(uint256 => uint256) public confirmationSnapshots;
     mapping(address => bool) public isOwner;
+
+    bool private locked;
 
     event Submitted(uint256 indexed txId);
     event Confirmed(uint256 indexed txId, address indexed owner);
@@ -25,6 +34,13 @@ contract MultiSigWallet {
     modifier onlyOwner() {
         require(isOwner[msg.sender], "Not owner");
         _;
+    }
+
+    modifier nonReentrant() {
+        require(!locked, "Reentrant call");
+        locked = true;
+        _;
+        locked = false;
     }
 
     constructor(address[] memory _owners, uint256 _required) {
@@ -37,8 +53,12 @@ contract MultiSigWallet {
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid target");
+        if (data.length > 0) {
+            require(to.code.length > 0, "Target not contract");
+        }
+
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
@@ -52,31 +72,51 @@ contract MultiSigWallet {
 
     function confirmTransaction(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(!confirmations[txId][msg.sender], "Already confirmed");
-        confirmations[txId][msg.sender] = true;
+        require(!confirmations[txId][msg.sender].confirmed, "Already confirmed");
+        confirmations[txId][msg.sender] = Confirmation({
+            confirmed: true,
+            confirmedAtBlock: block.number,
+            revokedAtBlock: 0
+        });
         emit Confirmed(txId, msg.sender);
     }
 
     function revokeConfirmation(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(confirmations[txId][msg.sender], "Not confirmed");
-        confirmations[txId][msg.sender] = false;
+        require(confirmations[txId][msg.sender].confirmed, "Not confirmed");
+        confirmations[txId][msg.sender].confirmed = false;
+        confirmations[txId][msg.sender].revokedAtBlock = block.number;
         emit Revoked(txId, msg.sender);
     }
 
     function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
         for (uint256 i = 0; i < owners.length; i++) {
-            if (confirmations[txId][owners[i]]) count++;
+            if (confirmations[txId][owners[i]].confirmed) count++;
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
+    function isConfirmedAtBlock(uint256 txId, address owner, uint256 blockNumber) public view returns (bool) {
+        Confirmation memory confirmation = confirmations[txId][owner];
+        return confirmation.confirmedAtBlock != 0
+            && confirmation.confirmedAtBlock <= blockNumber
+            && (confirmation.revokedAtBlock == 0 || confirmation.revokedAtBlock > blockNumber);
+    }
 
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
+        for (uint256 i = 0; i < owners.length; i++) {
+            if (isConfirmedAtBlock(txId, owners[i], blockNumber)) count++;
+        }
+    }
+
+    function executeTransaction(uint256 txId) external onlyOwner nonReentrant {
         Transaction storage txn = transactions[txId];
+        require(!txn.executed, "Already executed");
+
+        uint256 snapshotBlock = block.number;
+        uint256 confirmationCount = getConfirmationCountAtBlock(txId, snapshotBlock);
+        require(confirmationCount >= required, "Not enough confirmations");
+
+        confirmationSnapshots[txId] = confirmationCount;
         txn.executed = true;
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);


### PR DESCRIPTION
/claim #916

## What changed
- Replaced boolean-only confirmation tracking with block-aware confirmation metadata (`confirmedAtBlock`, `revokedAtBlock`).
- Added `isConfirmedAtBlock` and `getConfirmationCountAtBlock` to execute against a block-level confirmation snapshot.
- Rejected zero-address transaction targets and rejected calldata submissions to EOAs.
- Added a callback attacker contract fixture and the required provenance file.

## Validation
- `git diff --check`

Note: this repository does not include a Solidity test harness or compiler config in the checkout, and `forge`/`solc` are not installed in this environment, so I could not run Solidity compilation/tests locally.