### PR TITLE
feat(laravel): lightweight RBAC with roles & permissions (closes #788)

### DIFF
--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PermissionFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Permission extends Model
+{
+    /** @use HasFactory<PermissionFactory> */
+    use HasFactory;
+
+    /**
+     * The roles that include this permission.
+     *
+     * @return BelongsToMany<Role, $this>
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+
+    /**
+     * The permissions assigned to the role.
+     *
+     * @return BelongsToMany<Permission, $this>
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\HasRoles;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Collection;
+
+trait HasRoles
+{
+    /**
+     * Roles assigned directly to the model.
+     *
+     * @return BelongsToMany<Role, $this>
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->morphToMany(Role::class, 'model', 'model_has_roles')
+            ->withTimestamps();
+    }
+
+    /**
+     * Permissions assigned directly to the model.
+     *
+     * @return BelongsToMany<Permission, $this>
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->morphToMany(Permission::class, 'model', 'model_has_permissions')
+            ->withTimestamps();
+    }
+
+    public function assignRole(Role|string $role): static
+    {
+        $roleModel = $this->resolveRole($role);
+        $this->roles()->syncWithoutDetaching([$roleModel->id]);
+
+        return $this;
+    }
+
+    public function removeRole(Role|string $role): static
+    {
+        $roleModel = $this->resolveRole($role);
+        $this->roles()->detach($roleModel->id);
+
+        return $this;
+    }
+
+    public function givePermissionTo(Permission|string $permission): static
+    {
+        $permissionModel = $this->resolvePermission($permission);
+        $this->permissions()->syncWithoutDetaching([$permissionModel->id]);
+
+        return $this;
+    }
+
+    public function revokePermissionTo(Permission|string $permission): static
+    {
+        $permissionModel = $this->resolvePermission($permission);
+        $this->permissions()->detach($permissionModel->id);
+
+        return $this;
+    }
+
+    public function hasRole(Role|string $role): bool
+    {
+        $roleName = $role instanceof Role ? $role->name : $role;
+
+        return $this->roles()
+            ->where('name', $roleName)
+            ->exists();
+    }
+
+    public function hasPermissionTo(Permission|string $permission): bool
+    {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
+        return $this->permissions()
+            ->where('name', $permissionName)
+            ->exists()
+            || $this->roles()
+                ->whereHas('permissions', fn ($query) => $query->where('name', $permissionName))
+                ->exists();
+    }
+
+    /**
+     * @return Collection<int, Permission>
+     */
+    public function getAllPermissions(): Collection
+    {
+        $directPermissions = $this->permissions()->get();
+        $rolePermissions = Permission::query()
+            ->whereHas('roles', fn ($query) => $query->whereIn('roles.id', $this->roles()->pluck('roles.id')))
+            ->get();
+
+        return $directPermissions
+            ->merge($rolePermissions)
+            ->unique('id')
+            ->values();
+    }
+
+    protected function resolveRole(Role|string $role): Role
+    {
+        if ($role instanceof Role) {
+            return $role;
+        }
+
+        return Role::query()->where('name', $role)->firstOrFail();
+    }
+
+    protected function resolvePermission(Permission|string $permission): Permission
+    {
+        if ($permission instanceof Permission) {
+            return $permission;
+        }
+
+        return Permission::query()->where('name', $permission)->firstOrFail();
+    }
+}

--- a/laravel/database/factories/PermissionFactory.php
+++ b/laravel/database/factories/PermissionFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Permission;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Permission>
+ */
+class PermissionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<Permission>
+     */
+    protected $model = Permission::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(),
+            'guard_name' => 'web',
+        ];
+    }
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<Role>
+     */
+    protected $model = Role::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(),
+            'guard_name' => 'web',
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_19_000000_create_roles_and_permissions_tables.php
+++ b/laravel/database/migrations/2026_05_19_000000_create_roles_and_permissions_tables.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['role_id', 'permission_id']);
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+
+            $table->primary(['permission_id', 'model_id', 'model_type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/tests/Feature/RolePermissionTest.php
+++ b/laravel/tests/Feature/RolePermissionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RolePermissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_be_assigned_roles_and_permissions(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::factory()->create(['name' => 'admin']);
+        $permission = Permission::factory()->create(['name' => 'posts.update']);
+
+        $role->permissions()->attach($permission);
+        $user->assignRole($role);
+
+        $this->assertTrue($user->hasRole('admin'));
+        $this->assertTrue($user->hasPermissionTo('posts.update'));
+        $this->assertCount(1, $user->getAllPermissions());
+    }
+
+    public function test_user_can_receive_direct_permission(): void
+    {
+        $user = User::factory()->create();
+        $permission = Permission::factory()->create(['name' => 'reports.view']);
+
+        $user->givePermissionTo('reports.view');
+
+        $this->assertTrue($user->hasPermissionTo($permission));
+    }
+
+    public function test_role_and_permission_assignments_can_be_removed(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::factory()->create(['name' => 'editor']);
+        $permission = Permission::factory()->create(['name' => 'posts.delete']);
+
+        $user->assignRole('editor');
+        $user->givePermissionTo('posts.delete');
+        $user->removeRole($role);
+        $user->revokePermissionTo($permission);
+
+        $this->assertFalse($user->hasRole('editor'));
+        $this->assertFalse($user->hasPermissionTo('posts.delete'));
+    }
+}


### PR DESCRIPTION
## Summary
Add lightweight Role-Based Access Control for the Laravel application.

## Changes
- **Role model** — Eloquent model with `BelongsToMany` to Permission
- **Permission model** — Eloquent model with `BelongsToMany` to Role  
- **HasRoles trait** — mixin for User with `assignRole`, `removeRole`, `givePermissionTo`, `revokePermissionTo`, `hasRole`, `hasPermissionTo`, `getAllPermissions`
- **Migration** — 5 tables: `roles`, `permissions`, `role_has_permissions`, `model_has_roles`, `model_has_permissions`
- **Factories** — `RoleFactory`, `PermissionFactory`
- **Tests** — 3 feature tests covering assignment, direct permissions, and removal

Closes #788