### PR TITLE
fix: PriceOracle staleness check, round validation, fallback oracle

### DIFF
--- a/.generation_meta.json
+++ b/.generation_meta.json
@@ -1,0 +1,17 @@
+{
+  "agent": "whutlichao",
+  "initial_directives": "你是一个 AI 开发专家，专注于 Solidity 智能合约安全审计和修复。你的任务是分析并修复 PriceOracle.sol 中的漏洞：缺少价格陈旧性检查、未验证 round 完整性、未拒绝零/负价格、缺少回退预言机。遵循 Chainlink 最佳实践，使用 Foundry 编写完整测试。",
+  "date": "2026-05-19T10:30:00Z",
+  "bounty": "#915",
+  "changes": [
+    "Added fallback oracle with address validation",
+    "Added _getValidatedPrice internal function with round completeness check",
+    "Added require(price > 0) for negative/zero price rejection",
+    "Added staleness check using MAX_STALENESS with block.timestamp",
+    "Added StalePrice event emission on stale data",
+    "Added FallbackUsed event when switching to fallback",
+    "Added MaxStalenessUpdated event for config changes",
+    "Added setPrimaryFeed and setFallbackFeed owner functions",
+    "Updated constructor to accept fallback feed address"
+  ]
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,34 +14,79 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
-    uint256 public MAX_STALENESS = 3600;
+    uint256 public MAX_STALENESS = 3600; // 1 hour
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed oracle, uint256 lastUpdated, uint256 staleness);
+    event FallbackUsed(address indexed primary, address indexed fallback);
+    event MaxStalenessUpdated(uint256 oldValue, uint256 newValue);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
+    /// @notice Get the latest price, falling back to secondary oracle if primary is stale.
+    /// @return price The validated price from the best available oracle.
     function getLatestPrice() external view returns (int256) {
+        // Try primary feed first
+        (int256 price, bool isStale) = _getValidatedPrice(primaryFeed);
+
+        if (!isStale && price > 0) {
+            emit PriceQueried(price, block.timestamp);
+            return price;
+        }
+
+        // Primary is stale or invalid — try fallback
+        if (isStale) {
+            emit FallbackUsed(address(primaryFeed), address(fallbackFeed));
+        }
+
+        (int256 fallbackPrice, bool fallbackStale) = _getValidatedPrice(fallbackFeed);
+
+        require(!fallbackStale, "Both oracles return stale data");
+        require(fallbackPrice > 0, "Invalid price from fallback oracle");
+
+        emit PriceQueried(fallbackPrice, block.timestamp);
+        return fallbackPrice;
+    }
+
+    /// @notice Validate a Chainlink oracle response for staleness, completeness, and price validity.
+    /// @param feed The oracle to query.
+    /// @return price The validated price, or 0 if invalid.
+    /// @return isStale True if the oracle returned stale data.
+    function _getValidatedPrice(AggregatorV3Interface feed)
+        internal
+        view
+        returns (int256 price, bool isStale)
+    {
         (
             uint80 roundId,
-            int256 price,
+            int256 answer,
             ,
             uint256 updatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) = feed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        // Check round completeness
+        require(answeredInRound >= roundId, "Incomplete round");
 
-        return price;
+        // Check for negative or zero price
+        require(answer > 0, "Invalid price");
+
+        // Check staleness
+        uint256 staleness = block.timestamp - updatedAt;
+        if (staleness >= MAX_STALENESS) {
+            emit StalePrice(address(feed), updatedAt, staleness);
+            return (0, true);
+        }
+
+        return (answer, false);
     }
 
     function getDecimals() external view returns (uint8) {
@@ -50,6 +95,22 @@ contract PriceOracle {
 
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
+        require(_maxStaleness > 0, "Max staleness must be > 0");
+        uint256 oldValue = MAX_STALENESS;
         MAX_STALENESS = _maxStaleness;
+        emit MaxStalenessUpdated(oldValue, _maxStaleness);
+    }
+
+    /// @notice Update oracle addresses (owner only).
+    function setPrimaryFeed(address _feed) external {
+        require(msg.sender == owner, "Not owner");
+        require(_feed != address(0), "Invalid address");
+        primaryFeed = AggregatorV3Interface(_feed);
+    }
+
+    function setFallbackFeed(address _feed) external {
+        require(msg.sender == owner, "Not owner");
+        require(_feed != address(0), "Invalid address");
+        fallbackFeed = AggregatorV3Interface(_feed);
     }
 }

--- a/solidity/test/PriceOracle.t.sol
+++ b/solidity/test/PriceOracle.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/PriceOracle.sol";
+
+/// @notice Mock Chainlink aggregator for testing.
+contract MockAggregator {
+    uint80 public roundId = 1;
+    int256 public answer = 2000e8;
+    uint256 public startedAt;
+    uint256 public updatedAt;
+    uint80 public answeredInRound = 1;
+    uint8 public _decimals = 8;
+
+    function setRoundData(
+        uint80 _roundId,
+        int256 _answer,
+        uint256 _updatedAt,
+        uint80 _answeredInRound
+    ) external {
+        roundId = _roundId;
+        answer = _answer;
+        updatedAt = _updatedAt;
+        answeredInRound = _answeredInRound;
+    }
+
+    function latestRoundData() external view returns (
+        uint80, int256, uint256, uint256, uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+}
+
+contract PriceOracleTest is Test {
+    PriceOracle public oracle;
+    MockAggregator public primaryFeed;
+    MockAggregator public fallbackFeed;
+
+    function setUp() public {
+        primaryFeed = new MockAggregator();
+        fallbackFeed = new MockAggregator();
+        oracle = new PriceOracle(address(primaryFeed), address(fallbackFeed));
+
+        // Set current timestamp for staleness checks
+        vm.warp(1_700_000_000);
+    }
+
+    /// @notice Valid price from primary oracle.
+    function test_ValidPrice() public {
+        primaryFeed.setRoundData(1, 2000e8, block.timestamp, 1);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2000e8);
+    }
+
+    /// @notice Negative price reverts.
+    function test_Revert_NegativePrice() public {
+        primaryFeed.setRoundData(1, -100e8, block.timestamp, 1);
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    /// @notice Zero price reverts.
+    function test_Revert_ZeroPrice() public {
+        primaryFeed.setRoundData(1, 0, block.timestamp, 1);
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    /// @notice Incomplete round reverts.
+    function test_Revert_IncompleteRound() public {
+        // answeredInRound < roundId
+        primaryFeed.setRoundData(5, 2000e8, block.timestamp, 3);
+        vm.expectRevert("Incomplete round");
+        oracle.getLatestPrice();
+    }
+
+    /// @notice Stale primary oracle falls back to secondary.
+    function test_FallbackOnStalePrimary() public {
+        // Primary: updated 2 hours ago (stale)
+        primaryFeed.setRoundData(1, 2000e8, block.timestamp - 7200, 1);
+        // Fallback: fresh data
+        fallbackFeed.setRoundData(1, 2100e8, block.timestamp, 1);
+
+        vm.expectEmit(true, true, false, true);
+        emit StalePrice(address(primaryFeed), block.timestamp - 7200, 7200);
+        vm.expectEmit(true, true, false, false);
+        emit FallbackUsed(address(primaryFeed), address(fallbackFeed));
+
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2100e8);
+    }
+
+    /// @notice Both oracles stale reverts.
+    function test_Revert_BothOraclesStale() public {
+        primaryFeed.setRoundData(1, 2000e8, block.timestamp - 7200, 1);
+        fallbackFeed.setRoundData(1, 2100e8, block.timestamp - 7200, 1);
+
+        vm.expectRevert("Both oracles return stale data");
+        oracle.getLatestPrice();
+    }
+
+    /// @notice Primary valid, fallback stale: uses primary.
+    function test_PrimaryValidFallbackStale() public {
+        primaryFeed.setRoundData(1, 2000e8, block.timestamp, 1);
+        fallbackFeed.setRoundData(1, 2100e8, block.timestamp - 7200, 1);
+
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2000e8);
+    }
+
+    /// @notice Owner can update MAX_STALENESS.
+    function test_SetMaxStaleness() public {
+        oracle.setMaxStaleness(1800);
+        assertEq(oracle.MAX_STALENESS(), 1800);
+    }
+
+    /// @notice Non-owner cannot update MAX_STALENESS.
+    function test_Revert_SetMaxStaleness_NotOwner() public {
+        vm.prank(address(0xdead));
+        vm.expectRevert("Not owner");
+        oracle.setMaxStaleness(1800);
+    }
+
+    /// @notice Primary oracle with exactly MAX_STALENESS minus 1 second is valid.
+    function test_Edge_JustBeforeStaleness() public {
+        primaryFeed.setRoundData(1, 2000e8, block.timestamp - 3599, 1);
+        fallbackFeed.setRoundData(1, 0, block.timestamp, 1); // invalid fallback
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2000e8);
+    }
+
+    /// @notice Primary oracle at exactly MAX_STALENESS is stale.
+    function test_Edge_ExactlyAtStaleness() public {
+        primaryFeed.setRoundData(1, 2000e8, block.timestamp - 3600, 1);
+        fallbackFeed.setRoundData(1, 2100e8, block.timestamp, 1);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2100e8); // falls back
+    }
+}


### PR DESCRIPTION
- Add _getValidatedPrice() with Chainlink best practices: Round completeness check, zero/negative price rejection, staleness check
- Add fallback oracle with FallbackUsed and StalePrice events
- Revert if both oracles return stale data
- Owner-only setters for primaryFeed, fallbackFeed, MAX_STALENESS
- 11 Foundry tests covering all edge cases
- Include .generation_meta.json

Closes #915
/bounty $200