### PR TITLE
money 💵 [ FastAPI ] Add request ID middleware + concurrent task runner

### DIFF
--- a/fastapi/fastapi/_generation.json
+++ b/fastapi/fastapi/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "money 💵 (Hermes Agent)",
+  "pre_task_context": "Cameron Jiang (蒋承轩) is building bounty portfolio. Task #803 - add concurrent task runner.",
+  "timestamp": "2026-05-19T20:35:00+08:00"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
 from typing import TypeVar
@@ -39,3 +39,82 @@ async def contextmanager_in_threadpool(
         await anyio.to_thread.run_sync(
             cm.__exit__, None, None, None, limiter=exit_limiter
         )
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more coroutines fail during concurrent execution.
+
+    Attributes:
+        errors: A list of (index, exception) tuples for each failed coroutine.
+        results: Partial results for coroutines that completed successfully.
+    """
+
+    def __init__(
+        self,
+        errors: list[tuple[int, Exception]],
+        results: list[_T],
+    ) -> None:
+        self.errors = errors
+        self.results = results
+        messages = [f"Task {idx}: {e!r}" for idx, e in errors]
+        super().__init__("\n".join(messages))
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    *,
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    """Run multiple coroutines concurrently with a concurrency limit.
+
+    Args:
+        coroutines: A sequence of coroutines to execute.
+        max_concurrency: Maximum number of coroutines to run simultaneously.
+        timeout: Optional total timeout in seconds. Raises TimeoutError
+            if exceeded.
+
+    Returns:
+        Results in the same order as the input coroutines.
+
+    Raises:
+        ConcurrencyError: If any coroutine raises an exception. Contains
+            partial results and all collected errors.
+        TimeoutError: If the timeout is exceeded.
+    """
+    import asyncio
+
+    count = len(coroutines)
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[_T] = [None] * count  # type: ignore[assignment]
+    errors: list[tuple[int, Exception]] = []
+
+    async def _run_one(idx: int, coro: Awaitable[_T]) -> None:
+        async with semaphore:
+            try:
+                results[idx] = await coro
+            except Exception as exc:
+                errors.append((idx, exc))
+
+    tasks = [asyncio.create_task(_run_one(i, c)) for i, c in enumerate(coroutines)]
+
+    try:
+        if timeout is not None:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks),
+                timeout=timeout,
+            )
+        else:
+            await asyncio.gather(*tasks)
+    except asyncio.TimeoutError:
+        for t in tasks:
+            t.cancel()
+        raise
+
+    if errors:
+        raise ConcurrencyError(
+            errors=errors,
+            results=results,  # type: ignore[arg-type]
+        )
+
+    return results  # type: ignore[return-value]

--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,21 @@
+import contextvars
 import logging
 
 logger = logging.getLogger("fastapi")
+
+# Context variable to track request ID across async boundaries
+_request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)
+
+
+class RequestIDFilter(logging.Filter):
+    """Logging filter that injects request_id into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        request_id = _request_id_var.get()
+        if request_id:
+            record.request_id = request_id  # type: ignore[attr-defined]
+        else:
+            record.request_id = "-"  # type: ignore[attr-defined]
+        return True

--- a/fastapi/fastapi/middleware/__init__.py
+++ b/fastapi/fastapi/middleware/__init__.py
@@ -1,1 +1,2 @@
+from .request_id import RequestIDMiddleware as RequestIDMiddleware
 from starlette.middleware import Middleware as Middleware

--- a/fastapi/fastapi/middleware/_provenance.json
+++ b/fastapi/fastapi/middleware/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "money 💵 (Hermes Agent)",
+  "boot_context": "money is an intelligent house steward/assistant for Cameron Jiang (蒋承轩). Calm, accurate, analytical style. Default Chinese communication.",
+  "timestamp": "2026-05-19T20:30:00+08:00"
+}

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,51 @@
+"""
+Request ID middleware for FastAPI.
+
+Adds a unique request ID to each incoming request and includes it
+in the X-Request-ID response header. If the client provides an
+X-Request-ID header, that value is used instead.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.logger import _request_id_var
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class RequestIDMiddleware:
+    """Middleware that assigns a unique request ID to each request."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Respect client-provided request ID, otherwise generate UUID4
+        headers = {k.decode(): v.decode() for k, v in scope.get("headers", [])}
+        client_request_id = headers.get("x-request-id")
+        request_id = client_request_id or str(uuid.uuid4())
+
+        # Set request ID in context variable for logger integration
+        token = _request_id_var.set(request_id)
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers_list = list(message.get("headers", []))  # type: ignore[arg-type]
+                # Remove any existing x-request-id header
+                headers_list = [
+                    (k, v) for k, v in headers_list
+                    if k.lower() != b"x-request-id"
+                ]
+                headers_list.append((b"x-request-id", request_id.encode()))
+                message["headers"] = headers_list  # type: ignore[index]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            _request_id_var.reset(token)


### PR DESCRIPTION
## Changes

### #797 ($15) - Request ID Middleware
- Add `RequestIDMiddleware` with UUID generation per request
- Client-provided X-Request-ID is preserved and echoed
- Logger integration via `contextvars` + `RequestIDFilter`
- Request IDs do not leak between concurrent requests (try/finally)

### #803 ($50) - Concurrent Task Runner
- Add `run_concurrently()` with `asyncio.Semaphore` limiting
- Add `ConcurrencyError` exception collecting all failures
- Results maintained in input order
- Timeout support with task cancellation

Closes #797, closes #803