### PR TITLE
money 💵 [ Laravel ] Add failed job monitoring listener and summary command

### DIFF
--- a/laravel/app/Console/Commands/QueueFailedSummary.php
+++ b/laravel/app/Console/Commands/QueueFailedSummary.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class QueueFailedSummary extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:failed-summary';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Display a summary of failed jobs grouped by exception type';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $failures = DB::table('failed_jobs')
+            ->selectRaw("json_extract(payload, '$.data.commandName') as job_class")
+            ->selectRaw('exception')
+            ->selectRaw('failed_at')
+            ->orderBy('failed_at', 'desc')
+            ->get();
+
+        if ($failures->isEmpty()) {
+            $this->info('No failed jobs found.');
+
+            return self::SUCCESS;
+        }
+
+        // Group by exception type
+        $grouped = $failures->groupBy(function ($failure) {
+            // Extract exception class from the exception string
+            if (preg_match('/^([\\\\\w]+)/', $failure->exception, $matches)) {
+                return $matches[1];
+            }
+
+            return 'Unknown';
+        });
+
+        $rows = [];
+        foreach ($grouped as $exceptionClass => $items) {
+            $rows[] = [
+                'exception' => $exceptionClass,
+                'count' => $items->count(),
+                'latest' => $items->first()->failed_at,
+                'job' => $items->first()->job_class ?? 'Unknown',
+            ];
+        }
+
+        $this->table(
+            ['Exception', 'Count', 'Latest', 'Job'],
+            $rows
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+
+class LogFailedJob
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(JobFailed $event): void
+    {
+        $exception = $event->exception;
+        $job = $event->job;
+
+        Log::error('Job failed', [
+            'job' => $event->connectionName,
+            'queue' => $job->getQueue(),
+            'exception' => $exception->getMessage(),
+            'exception_class' => $exception::class,
+            'payload' => $job->payload(),
+            'failed_at' => now()->toIso8601String(),
+        ]);
+    }
+}

--- a/laravel/app/Listeners/_provenance.json
+++ b/laravel/app/Listeners/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "money 💵 (Hermes Agent)",
+  "boot_context": "money is an intelligent house steward/assistant for Cameron Jiang (蒋承轩). Calm, accurate, analytical style. Default Chinese communication.",
+  "timestamp": "2026-05-19T20:45:00+08:00"
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, LogFailedJob::class);
     }
 }

--- a/laravel/config/queue.php
+++ b/laravel/config/queue.php
@@ -41,6 +41,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'max_tries' => (int) env('DB_QUEUE_MAX_TRIES', 3),
             'after_commit' => false,
         ],
 

--- a/laravel/tests/Feature/FailedJobListenerTest.php
+++ b/laravel/tests/Feature/FailedJobListenerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\TestJob;
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Tests\TestCase;
+
+class FailedJobListenerTest extends TestCase
+{
+    public function test_failed_job_listener_is_registered(): void
+    {
+        Event::fake();
+
+        // Verify the listener is registered for the JobFailed event
+        // by checking the event system
+        $this->assertTrue(
+            Event::hasListeners(JobFailed::class)
+        );
+    }
+
+    public function test_failed_job_listener_logs_job_details(): void
+    {
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Job failed', Mockery::subset([
+                'job' => 'database',
+                'queue' => 'default',
+                'exception' => 'Test failure',
+            ]));
+
+        $job = Mockery::mock('Illuminate\Contracts\Queue\Job');
+        $job->shouldReceive('getQueue')->andReturn('default');
+        $job->shouldReceive('payload')->andReturn(['data' => 'test']);
+
+        $event = new JobFailed(
+            'database',
+            $job,
+            new \RuntimeException('Test failure')
+        );
+
+        $listener = new LogFailedJob();
+        $listener->handle($event);
+
+        // Assertions are in the shouldReceive above
+        $this->assertTrue(true);
+    }
+
+    public function test_queue_config_has_correct_values(): void
+    {
+        $config = config('queue.connections.database');
+
+        $this->assertEquals(90, $config['retry_after']);
+        $this->assertEquals(3, $config['max_tries']);
+    }
+}


### PR DESCRIPTION
## Changes

### #789 ($45) - Failed Job Monitoring
- Add `LogFailedJob` listener logging job details on `JobFailed` event
- Register listener in `AppServiceProvider`
- Add `queue:failed-summary` artisan command grouping by exception type
- Set database queue `retry_after=90` and `max_tries=3`
- Add feature test for listener registration, logging, and config

Closes #789