### PR TITLE
money 💵 [ Laravel ] Fix phpunit coverage config, add route/model tests, and add CSRF meta tag

### DIFF
--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -11,12 +11,25 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Route">
+            <directory>tests/Routes</directory>
+        </testsuite>
+        <testsuite name="Model">
+            <directory>tests/Models</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>
             <directory>app</directory>
         </include>
     </source>
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>

--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 

--- a/laravel/tests/Models/UserModelTest.php
+++ b/laravel/tests/Models/UserModelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Models;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_be_created_with_factory(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+        $this->assertNotNull($user->id);
+    }
+
+    public function test_user_password_is_hashed(): void
+    {
+        $user = User::factory()->create([
+            'password' => 'secret123',
+        ]);
+
+        $this->assertNotEquals('secret123', $user->password);
+    }
+
+    public function test_user_email_is_unique(): void
+    {
+        User::factory()->create(['email' => 'unique@example.com']);
+
+        $this->expectException(\Illuminate\Database\UniqueConstraintViolationException::class);
+
+        User::factory()->create(['email' => 'unique@example.com']);
+    }
+}

--- a/laravel/tests/Routes/WebRoutesTest.php
+++ b/laravel/tests/Routes/WebRoutesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Routes;
+
+use Tests\TestCase;
+
+class WebRoutesTest extends TestCase
+{
+    public function test_home_page_returns_successful_response(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_home_page_contains_app_name(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertSee(config('app.name'));
+    }
+
+    public function test_api_routes_return_json(): void
+    {
+        $response = $this->getJson('/api/user');
+
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Changes

### #794 ($55) - Fix phpunit coverage config
- Add HTML, text, and clover coverage report outputs
- Add Route and Model test suites to phpunit.xml
- Add `WebRoutesTest` covering home page and API routes
- Add `UserModelTest` covering factory, password hashing, and email uniqueness

### #751 ($30) - Fix welcome.blade.php CSRF meta tag
- Add `csrf-token` meta tag for CSRF protection

Closes #794, closes #751