### PR TITLE
money 💵 [ FastAPI ] Add concurrent task runner with semaphore limiting

### DIFF
--- a/fastapi/fastapi/_generation.json
+++ b/fastapi/fastapi/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "money 💵 (Hermes Agent)",
+  "pre_task_context": "Cameron Jiang (蒋承轩) is building bounty portfolio. Task #803 - add concurrent task runner.",
+  "timestamp": "2026-05-19T20:35:00+08:00"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
 from typing import TypeVar
@@ -39,3 +39,82 @@ async def contextmanager_in_threadpool(
         await anyio.to_thread.run_sync(
             cm.__exit__, None, None, None, limiter=exit_limiter
         )
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more coroutines fail during concurrent execution.
+
+    Attributes:
+        errors: A list of (index, exception) tuples for each failed coroutine.
+        results: Partial results for coroutines that completed successfully.
+    """
+
+    def __init__(
+        self,
+        errors: list[tuple[int, Exception]],
+        results: list[_T],
+    ) -> None:
+        self.errors = errors
+        self.results = results
+        messages = [f"Task {idx}: {e!r}" for idx, e in errors]
+        super().__init__("\n".join(messages))
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    *,
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    """Run multiple coroutines concurrently with a concurrency limit.
+
+    Args:
+        coroutines: A sequence of coroutines to execute.
+        max_concurrency: Maximum number of coroutines to run simultaneously.
+        timeout: Optional total timeout in seconds. Raises TimeoutError
+            if exceeded.
+
+    Returns:
+        Results in the same order as the input coroutines.
+
+    Raises:
+        ConcurrencyError: If any coroutine raises an exception. Contains
+            partial results and all collected errors.
+        TimeoutError: If the timeout is exceeded.
+    """
+    import asyncio
+
+    count = len(coroutines)
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[_T] = [None] * count  # type: ignore[assignment]
+    errors: list[tuple[int, Exception]] = []
+
+    async def _run_one(idx: int, coro: Awaitable[_T]) -> None:
+        async with semaphore:
+            try:
+                results[idx] = await coro
+            except Exception as exc:
+                errors.append((idx, exc))
+
+    tasks = [asyncio.create_task(_run_one(i, c)) for i, c in enumerate(coroutines)]
+
+    try:
+        if timeout is not None:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks),
+                timeout=timeout,
+            )
+        else:
+            await asyncio.gather(*tasks)
+    except asyncio.TimeoutError:
+        for t in tasks:
+            t.cancel()
+        raise
+
+    if errors:
+        raise ConcurrencyError(
+            errors=errors,
+            results=results,  # type: ignore[arg-type]
+        )
+
+    return results  # type: ignore[return-value]


### PR DESCRIPTION
## Changes — closes #803

- Add `run_concurrently()` with `asyncio.Semaphore` limiting
- Add `ConcurrencyError` exception collecting all failures
- Results maintained in input order
- Timeout support with task cancellation