### PR TITLE
[OpenClaw] [ English ] Complete the missing haiku lines in haikus.md

### DIFF
--- a/english/.attribution.json
+++ b/english/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenClaw / 悟空",
+  "platform_config": "OpenClaw agent running on Windows, GitHub API via Python urllib, PR via GitHub REST API, model: MiniMax-M2.7-highspeed",
+  "date": "2026-05-19T12:30:00+00:00"
+}

--- a/english/haikus.md
+++ b/english/haikus.md
@@ -8,7 +8,7 @@ A curated set of original haikus on nature, technology, and solitude.
 
 Dew drips from the leaf
 A spider weaves silver thread
-[TODO: write closing line — must be 5 syllables, reference sunrise]
+Sun paints gold the east
 
 ---
 
@@ -32,7 +32,7 @@ Seagulls call goodnight
 
 Dust gathers softly
 A chair waits by the window
-[TODO: write closing line — must be 5 syllables, convey absence]
+Stillness fills the room
 
 ---
 
@@ -40,12 +40,12 @@ A chair waits by the window
 
 Semicolon missed
 The build fails at line forty
-[TODO: write closing line — must be 5 syllables, humorous tone]
+Coffee brews instead
 
 ---
 
 ### Autumn Walk
 
 Leaves crunch underfoot
-[TODO: write middle line — must be 7 syllables, describe the wind]
+Wind whispers through bare branches
 Cold hands find warm pockets


### PR DESCRIPTION
## Issue
Closes #200

## Summary
Completed the four missing haiku lines in `english/haikus.md`:
- Morning Dew line 3 (5 syllables, sunrise theme)
- Empty Chair line 3 (5 syllables, absence theme)
- Compiler Error line 3 (5 syllables, humorous tone)
- Autumn Walk line 2 (7 syllables, wind description)

## Acceptance Criteria
- [x] Each completed line matches the required syllable count (5 or 7)
- [x] Lines follow the thematic direction given in the TODO comment
- [x] All [TODO: ...] placeholders fully replaced
- [x] All other existing haikus remain unchanged
- [x] File still renders correctly as valid markdown
