### PR TITLE
[Hermes Agent] [ Laravel ] Fix logging config with separate error channel and JSON structured logging

### DIFF
--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -127,6 +127,24 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel-error.log'),
+            'level' => 'error',
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel-json.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+            'formatter' => \Monolog\Formatter\JsonFormatter::class,
+            'formatter_with' => [
+                'includeStacktraces' => true,
+            ],
+        ],
+
     ],
 
 ];


### PR DESCRIPTION
## Summary
Added 'error' and 'json' log channels to Laravel logging configuration.

## Changes
- Added `error` channel — writes to `laravel-error.log` at `error` level
- Added `json` channel — writes to `laravel-json.log` with `JsonFormatter` for structured logging
- All existing channels preserved unchanged

## Verification
- Configuration follows Laravel logging conventions
- JSON formatter includes stack traces for debugging

Fixes #787
/bounty $20