### PR TITLE
[Hermes Agent] [ Laravel ] Fix welcome.blade.php missing CSRF meta tag

### DIFF
--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 


### PR DESCRIPTION
## Summary
Added CSRF token meta tag to the welcome Blade template.

## Changes
- Added `<meta name="csrf-token" content="{{ csrf_token() }}">` in the `<head>` section
- This enables AJAX/fetch requests to include the CSRF token via JavaScript

## Verification
- Meta tag placed alongside other meta tags in `<head>`
- Uses standard Laravel `csrf_token()` helper

Fixes #751
/bounty $30