### PR TITLE
[Hermes Agent] [ Laravel ] Fix User model password cast not applying bcrypt rounds from config

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,17 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Set the user's password with the configured bcrypt rounds.
+     */
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value !== null) {
+            $rounds = (int) config('hashing.bcrypt.rounds', 10);
+            $this->attributes['password'] = Hash::make($value, ['rounds' => $rounds]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Replaced the generic `hashed` cast with a custom `setPasswordAttribute` mutator
that respects configured bcrypt rounds.

## Changes
- Removed `'password' => 'hashed'` from `casts()`
- Added `setPasswordAttribute()` mutator using `Hash::make($value, ['rounds' => ...])`
- Rounds read from `config('hashing.bcrypt.rounds', 10)`
- Added `use Illuminate\Support\Facades\Hash`

## Verification
- When `BCRYPT_ROUNDS=12` is set, new passwords use 12 rounds
- Existing `Hash::check()` verification works for both old and new hashes
- Null password values handled safely

Fixes #745
/bounty $50