### PR TITLE
Fix zero-fee flash loans and add pool drainage protection (#919)

### DIFF
--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 interface IFlashLoanReceiver {
     function onFlashLoan(address token, uint256 amount, uint256 fee, bytes calldata data) external;
@@ -14,6 +15,8 @@ contract FlashLoan {
     address public owner;
     bool public paused;
 
+    uint256 public constant MAX_LOAN_PERCENT = 80; // Cannot borrow more than 80% of pool
+
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
 
     constructor(address _loanToken, uint256 _feeBPS) {
@@ -22,43 +25,47 @@ contract FlashLoan {
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
     function flashLoan(uint256 amount, bytes calldata data) external {
         require(!paused, "Paused");
         require(amount > 0, "Amount must be > 0");
 
         uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        
+        // FIXED: Added pool drainage protection
+        require(amount <= (balanceBefore * MAX_LOAN_PERCENT) / 100, "Loan amount too high");
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
+        // FIXED: Use Math.ceilDiv to round up, preventing zero-fee loans for small amounts
+        uint256 fee = Math.ceilDiv(amount * feeBPS, 10000);
+        require(fee > 0, "Fee evaluates to zero");
 
         loanToken.transfer(msg.sender, amount);
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        // FIXED: Enforce explicit pull payment to mitigate rebasing manipulation instead of passive balance check
+        require(loanToken.transferFrom(msg.sender, address(this), amount + fee), "Repayment transfer failed");
 
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(loanToken.transferFrom(msg.sender, address(this), amount), "Deposit failed");
     }
 
     function withdrawFees() external {
         require(msg.sender == owner, "Not owner");
         uint256 fees = totalFees;
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        require(loanToken.transfer(owner, fees), "Transfer failed");
     }
 
-    // BUG: No emergency pause function
+    // FIXED: Added emergency pause
+    function togglePause() external {
+        require(msg.sender == owner, "Not owner");
+        paused = !paused;
+    }
+
     function getPoolBalance() external view returns (uint256) {
         return loanToken.balanceOf(address(this));
     }


### PR DESCRIPTION
Resolves #919. Implemented `Math.ceilDiv` for fee calculations to enforce non-zero fees. Added `MAX_LOAN_PERCENT` constraint to protect pool liquidity. Updated repayment validation to explicit pull to mitigate rebasing vulnerabilities. Added emergency pause.