### PR TITLE
Fix PriceOracle missing staleness check and fallback mechanism (#915)

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,34 +14,58 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event FallbackActivated(uint256 timestamp);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
+    function _getValidPrice(AggregatorV3Interface feed) internal view returns (bool isValid, int256 validPrice) {
+        try feed.latestRoundData() returns (
             uint80 roundId,
             int256 price,
-            ,
+            uint256 /* startedAt */,
             uint256 updatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) {
+            if (price > 0 && 
+                answeredInRound >= roundId && 
+                updatedAt > 0 && 
+                block.timestamp - updatedAt <= MAX_STALENESS) 
+            {
+                return (true, price);
+            }
+        } catch {
+            // feed call failed
+        }
+        return (false, 0);
+    }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+    // FIXED: Added staleness check, >0 check, round completeness, and a fallback oracle mechanism
+    function getLatestPrice() external returns (int256) {
+        (bool primaryValid, int256 primaryPrice) = _getValidPrice(primaryFeed);
+        
+        if (primaryValid) {
+            emit PriceQueried(primaryPrice, block.timestamp);
+            return primaryPrice;
+        }
 
-        return price;
+        emit FallbackActivated(block.timestamp);
+        
+        require(address(fallbackFeed) != address(0), "Primary failed and no fallback");
+        
+        (bool fallbackValid, int256 fallbackPrice) = _getValidPrice(fallbackFeed);
+        require(fallbackValid, "Both oracles failed or stale");
+        
+        emit PriceQueried(fallbackPrice, block.timestamp);
+        return fallbackPrice;
     }
 
     function getDecimals() external view returns (uint8) {
@@ -51,5 +75,10 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+    
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
     }
 }


### PR DESCRIPTION
Resolves #915. Introduced standard validation checks for Chainlink `latestRoundData` (price > 0, staleness via `updatedAt`, and round completeness). Added a `fallbackFeed` parameter to the constructor and integrated failover logic if the primary feed throws or returns invalid data.