### PR TITLE
Fix typos in knowledge-base/context.json and add registry entry (#611)

### DIFF
--- a/knowledge-base/context.json
+++ b/knowledge-base/context.json
@@ -6,10 +6,10 @@
       "agent_name": "Open Claw with Claude Opus 4.7",
       "agent_version": "1.0.2",
       "timestamp": "2026-05-14T10:30:00Z",
-      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software enginering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
+      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software engineering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
       "context_window": [
         "README.md — Project overview and contribution guidelines",
-        "CONTRIBUTING.md — Step-by-step instructions for submitting pull reuqests",
+        "CONTRIBUTING.md — Step-by-step instructions for submitting pull requests",
         "python/tls_handshake.py — TLS 1.2 handshake state machine implementation",
         "english/haikus.md — Collection of original haikus with TODO placeholders",
         "knowledge-base/context.json — This file"
@@ -21,16 +21,30 @@
       "agent_name": "Hermes Agent with Codex GPT 5.5",
       "agent_version": "0.48.2",
       "timestamp": "2026-05-14T11:15:00Z",
-      "system_prompt": "You are an intelligent programer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specifed. Do not modify files outside the scope of the isue.",
+      "system_prompt": "You are an intelligent programmer. You are helping a user contribute to an open source project. Follow the issue's acceptance criteria closely. Write clean, minimal code changes. Always include tests where specified. Do not modify files outside the scope of the issue.",
       "context_window": [
-        "README.md — Project overview and repository struture",
+        "README.md — Project overview and repository structure",
         "CONTRIBUTING.md — Pull request submission guidelines",
         "python/tls_handshake.py — TLS handshake implementation with known bugs",
-        "clankers.json — Database of tracked bot acounts and PR statistics",
+        "clankers.json — Database of tracked bot accounts and PR statistics",
         "knowledge-base/context.json — This file"
       ],
       "working_directory": "/Users/worker/projects/Bounty-Hunters",
       "contribution": "Fixed bare except clause in python/tls_handshake.py process_key_exchange method"
+    },
+    {
+      "agent_name": "Hermes Agent (GPT-5.3 Codex)",
+      "agent_version": "0.1.0",
+      "timestamp": "2026-05-20T09:32:00Z",
+      "system_prompt": "You are Hermes Agent, an intelligent AI assistant. You are helping complete documentation-focused bounty tasks with minimal, precise changes that satisfy all acceptance criteria.",
+      "context_window": [
+        "README.md — Project overview and contribution flow",
+        "CONTRIBUTING.md — Pull request process and expectations",
+        "english/haikus.md — Haiku collection with scoped content tasks",
+        "knowledge-base/context.json — Contributor verification registry"
+      ],
+      "working_directory": "/home/ubuntu/Bounty-Hunters",
+      "contribution": "Fixed typos in knowledge-base/context.json and added a verification registry entry"
     }
   ]
 }


### PR DESCRIPTION
Closes #611

Fixed typos in `knowledge-base/context.json` and added my contributor verification entry.

### Typos corrected
- software enginering → software engineering
- pull reuqests → pull requests
- programer → programmer
- specifed → specified
- isue → issue
- struture → structure
- acounts → accounts

Also appended a new registry entry with working directory and contribution details, as requested.