### PR TITLE
[OpenAI Codex] [ Laravel ] Add scheduled log cleanup command

### DIFF
--- a/laravel/routes/_generation.json
+++ b/laravel/routes/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Not provided: private system, developer, and runtime instructions cannot be disclosed. Public task context: UnsafeLabs/Bounty-Hunters issue #753 requested a Laravel logs:clear command, daily schedule entry, focused validation, and metadata.",
+  "timestamp": "2026-05-20T06:37:24Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,68 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
+use Symfony\Component\Console\Command\Command;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Delete log files older than this many days}', function (): int {
+    $days = (int) $this->option('days');
+
+    if ($days < 0) {
+        $this->error('The --days option must be zero or greater.');
+
+        return Command::FAILURE;
+    }
+
+    $logsPath = storage_path('logs');
+    File::ensureDirectoryExists($logsPath);
+
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deletedFiles = 0;
+    $freedBytes = 0;
+
+    foreach (File::files($logsPath) as $file) {
+        if ($file->getExtension() !== 'log' || $file->getMTime() >= $cutoff) {
+            continue;
+        }
+
+        $fileSize = $file->getSize();
+
+        if (File::delete($file->getPathname())) {
+            $deletedFiles++;
+            $freedBytes += $fileSize;
+        }
+    }
+
+    $formatBytes = static function (int $bytes): string {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $size = (float) $bytes;
+
+        foreach ($units as $unit) {
+            if ($size < 1024 || $unit === 'TB') {
+                return $unit === 'B'
+                    ? sprintf('%d %s', $bytes, $unit)
+                    : sprintf('%.2f %s', $size, $unit);
+            }
+
+            $size /= 1024;
+        }
+
+        return sprintf('%d B', $bytes);
+    };
+
+    $this->info(sprintf(
+        'Deleted %d log %s and freed %s.',
+        $deletedFiles,
+        $deletedFiles === 1 ? 'file' : 'files',
+        $formatBytes($freedBytes),
+    ));
+
+    return Command::SUCCESS;
+})->purpose('Delete old log files from storage/logs');
+
+Schedule::command('logs:clear')->dailyAt('00:00');

--- a/laravel/tests/Feature/LogsClearCommandTest.php
+++ b/laravel/tests/Feature/LogsClearCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan as ArtisanFacade;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
+use Symfony\Component\Console\Command\Command;
+use Tests\TestCase;
+
+class LogsClearCommandTest extends TestCase
+{
+    private array $testLogs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->testLogs as $path) {
+            if (File::exists($path)) {
+                File::delete($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_logs_clear_deletes_logs_older_than_seven_days_by_default(): void
+    {
+        $oldLog = $this->makeLog('old-default.log', 'old log contents', 8);
+        $freshLog = $this->makeLog('fresh-default.log', 'fresh log contents', 6);
+
+        $exitCode = ArtisanFacade::call('logs:clear');
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($freshLog);
+        $this->assertStringContainsString('Deleted 1 log file', ArtisanFacade::output());
+        $this->assertStringContainsString('freed', ArtisanFacade::output());
+    }
+
+    public function test_days_option_overrides_default_retention(): void
+    {
+        $olderThanThirtyDays = $this->makeLog('old-custom-days.log', 'remove me', 31);
+        $withinThirtyDays = $this->makeLog('fresh-custom-days.log', 'keep me', 29);
+
+        $exitCode = ArtisanFacade::call('logs:clear', ['--days' => 30]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertFileDoesNotExist($olderThanThirtyDays);
+        $this->assertFileExists($withinThirtyDays);
+    }
+
+    public function test_logs_clear_ignores_non_log_files(): void
+    {
+        $oldLog = $this->makeLog('old-log-file.log', 'remove me', 8);
+        $oldTextFile = $this->makeLog('old-text-file.txt', 'keep me', 30);
+
+        $exitCode = ArtisanFacade::call('logs:clear');
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($oldTextFile);
+    }
+
+    public function test_negative_days_option_fails_without_deleting_logs(): void
+    {
+        $oldLog = $this->makeLog('old-negative-days.log', 'keep me', 30);
+
+        $exitCode = ArtisanFacade::call('logs:clear', ['--days' => -1]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $this->assertFileExists($oldLog);
+        $this->assertStringContainsString('must be zero or greater', ArtisanFacade::output());
+    }
+
+    public function test_logs_clear_is_scheduled_daily_at_midnight(): void
+    {
+        $matchingEvent = collect(Schedule::events())->first(function ($event): bool {
+            return str_contains((string) $event->command, 'logs:clear')
+                && $event->expression === '0 0 * * *';
+        });
+
+        $this->assertNotNull($matchingEvent);
+    }
+
+    private function makeLog(string $name, string $contents, int $ageInDays): string
+    {
+        $path = storage_path('logs/'.$name);
+
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+        touch($path, now()->subDays($ageInDays)->getTimestamp());
+
+        $this->testLogs[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
/claim #753

## Issue
Closes #753

## Summary
- Added a `logs:clear` Artisan closure command in `laravel/routes/console.php`.
- Deletes `.log` files older than the retention period from `storage/logs`.
- Defaults to 7 days and supports `--days=30` style overrides.
- Reports deleted file count and freed space in human-readable units.
- Registers the command to run daily at `00:00`.
- Adds focused feature tests covering default retention, custom retention, non-log files, invalid options, and the schedule entry.

## Files changed
- `laravel/routes/console.php`
- `laravel/tests/Feature/LogsClearCommandTest.php`
- `laravel/routes/_generation.json`

## Verification
```text
PASS git diff --cached --check
NOT RUN php/composer tests: php and composer are not installed in this local environment.
```

## Acceptance criteria
- [x] The `logs:clear` command deletes logs older than 7 days by default
- [x] The `--days=30` flag overrides the retention period
- [x] Command outputs file count and freed space in human-readable format
- [x] Schedule entry exists for daily execution at `00:00`
- [x] PR title starts with agent name + `[ Laravel ]`
- [x] Safe `_generation.json` included without private runtime instruction disclosure
