### PR TITLE
Codex [ Laravel ] add failed job monitoring

### DIFF
--- a/laravel/app/Console/Commands/FailedJobSummary.php
+++ b/laravel/app/Console/Commands/FailedJobSummary.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class FailedJobSummary extends Command
+{
+    protected $signature = 'queue:failed-summary';
+
+    protected $description = 'Display failed jobs grouped by exception type';
+
+    public function handle(): int
+    {
+        $rows = DB::table(config('queue.failed.table', 'failed_jobs'))
+            ->select('exception')
+            ->get()
+            ->groupBy(fn (object $job): string => $this->exceptionClass($job->exception ?? ''))
+            ->map(fn ($jobs, string $exception): array => [
+                'Exception' => $exception,
+                'Count' => $jobs->count(),
+            ])
+            ->sortByDesc('Count')
+            ->values()
+            ->all();
+
+        if ($rows === []) {
+            $this->info('No failed jobs found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(['Exception', 'Count'], $rows);
+
+        return self::SUCCESS;
+    }
+
+    private function exceptionClass(string $exception): string
+    {
+        if ($exception === '') {
+            return 'Unknown';
+        }
+
+        $unserialized = @unserialize($exception);
+
+        if ($unserialized instanceof Throwable) {
+            return $unserialized::class;
+        }
+
+        if (preg_match('/^([A-Za-z_\\\\][A-Za-z0-9_\\\\]*)[:\\s]/', $exception, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return 'Unknown';
+    }
+}

--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class LogFailedJob
+{
+    public function handle(JobFailed $event): void
+    {
+        Log::error('Queue job failed', [
+            'connection' => $event->connectionName,
+            'queue' => $event->job->getQueue(),
+            'job_id' => $event->job->getJobId(),
+            'job_name' => $event->job->resolveName(),
+            'payload' => $event->job->payload(),
+            'exception' => $this->formatException($event->exception),
+        ]);
+    }
+
+    /**
+     * @return array{class: class-string<Throwable>, message: string, code: int|string, file: string, line: int, trace: string}
+     */
+    private function formatException(Throwable $exception): array
+    {
+        return [
+            'class' => $exception::class,
+            'message' => $exception->getMessage(),
+            'code' => $exception->getCode(),
+            'file' => $exception->getFile(),
+            'line' => $exception->getLine(),
+            'trace' => $exception->getTraceAsString(),
+        ];
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Queue::failing(function (JobFailed $event): void {
+            app(LogFailedJob::class)->handle($event);
+        });
     }
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\FailedJobSummary;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -10,6 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        FailedJobSummary::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/queue.php
+++ b/laravel/config/queue.php
@@ -41,6 +41,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'max_tries' => (int) env('DB_QUEUE_MAX_TRIES', 3),
             'after_commit' => false,
         ],
 

--- a/laravel/tests/Feature/FailedJobMonitoringTest.php
+++ b/laravel/tests/Feature/FailedJobMonitoringTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Listeners\LogFailedJob;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class FailedJobMonitoringTest extends TestCase
+{
+    public function test_failed_job_listener_logs_job_metadata(): void
+    {
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Queue job failed', Mockery::on(function (array $context): bool {
+                return $context['connection'] === 'database'
+                    && $context['queue'] === 'emails'
+                    && $context['job_id'] === 'job-123'
+                    && $context['job_name'] === 'App\\Jobs\\SendEmail'
+                    && $context['payload'] === ['displayName' => 'App\\Jobs\\SendEmail']
+                    && $context['exception']['class'] === RuntimeException::class
+                    && $context['exception']['message'] === 'SMTP rejected message';
+            }));
+
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('getQueue')->andReturn('emails');
+        $job->shouldReceive('getJobId')->andReturn('job-123');
+        $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\SendEmail');
+        $job->shouldReceive('payload')->andReturn(['displayName' => 'App\\Jobs\\SendEmail']);
+
+        (new LogFailedJob)->handle(new JobFailed(
+            'database',
+            $job,
+            new RuntimeException('SMTP rejected message'),
+        ));
+    }
+
+    public function test_database_queue_failed_job_limits_are_configured(): void
+    {
+        $this->assertSame(90, config('queue.connections.database.retry_after'));
+        $this->assertSame(3, config('queue.connections.database.max_tries'));
+    }
+
+    public function test_failed_job_summary_groups_failed_jobs_by_exception_class(): void
+    {
+        Schema::create('failed_jobs', function ($table): void {
+            $table->id();
+            $table->string('uuid')->nullable();
+            $table->text('connection')->nullable();
+            $table->text('queue')->nullable();
+            $table->longText('payload')->nullable();
+            $table->longText('exception');
+            $table->timestamp('failed_at')->nullable();
+        });
+
+        DB::table('failed_jobs')->insert([
+            [
+                'uuid' => 'first-runtime',
+                'exception' => RuntimeException::class.': SMTP rejected message',
+            ],
+            [
+                'uuid' => 'second-runtime',
+                'exception' => RuntimeException::class.': Timeout while sending',
+            ],
+            [
+                'uuid' => 'invalid-argument',
+                'exception' => \InvalidArgumentException::class.': Missing recipient',
+            ],
+        ]);
+
+        $this->artisan('queue:failed-summary')
+            ->expectsTable(
+                ['Exception', 'Count'],
+                [
+                    [RuntimeException::class, 2],
+                    [\InvalidArgumentException::class, 1],
+                ],
+            )
+            ->assertSuccessful();
+    }
+}


### PR DESCRIPTION
/claim #789

## Summary
- Adds `LogFailedJob` listener for Laravel `JobFailed` events with connection, queue, job id/name, payload, and exception details.
- Registers the listener in `AppServiceProvider` and adds the `queue:failed-summary` Artisan command grouped by exception class.
- Sets database queue `retry_after` to 90 and `max_tries` to 3, with focused tests for listener metadata and queue config.

## Testing
- `git diff --check`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app php:8.4-cli sh -lc 'for file in app/Providers/AppServiceProvider.php app/Listeners/LogFailedJob.php app/Console/Commands/FailedJobSummary.php bootstrap/app.php config/queue.php tests/Feature/FailedJobMonitoringTest.php; do php -l "$file" || exit 1; done'`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app composer:2 ./vendor/bin/pint app/Providers/AppServiceProvider.php app/Listeners/LogFailedJob.php app/Console/Commands/FailedJobSummary.php bootstrap/app.php config/queue.php tests/Feature/FailedJobMonitoringTest.php`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app composer:2 php artisan test tests/Feature/FailedJobMonitoringTest.php`

## Provenance note
I did not include `contributor_meta.json` because it requests hidden session initialization/instructions. The implementation and validation are fully contained in this PR.
