### PR TITLE
Codex [ Laravel ] add Slack notification service

### DIFF
--- a/laravel/app/Services/SlackNotifier.php
+++ b/laravel/app/Services/SlackNotifier.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+
+class SlackNotifier
+{
+    public function __construct(
+        private readonly ?string $webhookUrl = null,
+        private readonly ?string $defaultChannel = null,
+    ) {}
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     *
+     * @throws RequestException
+     */
+    public static function send(string $message, ?string $channel = null, array $blocks = []): void
+    {
+        app(self::class)->notify($message, $channel, $blocks);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     *
+     * @throws RequestException
+     */
+    public function notify(string $message, ?string $channel = null, array $blocks = []): void
+    {
+        $webhookUrl = $this->webhookUrl ?? config('services.slack.webhook_url');
+
+        if (! is_string($webhookUrl) || $webhookUrl === '') {
+            throw new \InvalidArgumentException('Slack webhook URL is not configured.');
+        }
+
+        $payload = $this->payload($message, $channel, $blocks);
+        $response = $this->post($webhookUrl, $payload);
+
+        if ($response->serverError()) {
+            $response = $this->post($webhookUrl, $payload);
+        }
+
+        $response->throw();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     * @return array<string, mixed>
+     */
+    private function payload(string $message, ?string $channel, array $blocks): array
+    {
+        $payload = [
+            'text' => $message,
+        ];
+
+        $resolvedChannel = $channel ?? $this->defaultChannel ?? config('services.slack.default_channel');
+
+        if (is_string($resolvedChannel) && $resolvedChannel !== '') {
+            $payload['channel'] = $resolvedChannel;
+        }
+
+        if ($blocks !== []) {
+            $payload['blocks'] = $blocks;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    protected function post(string $webhookUrl, array $payload): Response
+    {
+        return Http::timeout(5)->post($webhookUrl, $payload);
+    }
+}

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -29,6 +29,8 @@ return [
     ],
 
     'slack' => [
+        'webhook_url' => env('SLACK_WEBHOOK_URL'),
+        'default_channel' => env('SLACK_DEFAULT_CHANNEL'),
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/laravel/tests/Feature/SlackNotifierTest.php
+++ b/laravel/tests/Feature/SlackNotifierTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SlackNotifier;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SlackNotifierTest extends TestCase
+{
+    public function test_it_sends_slack_payload_with_default_channel_and_blocks(): void
+    {
+        config()->set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+        config()->set('services.slack.default_channel', '#alerts');
+
+        Http::fake([
+            'hooks.slack.test/*' => Http::response('ok'),
+        ]);
+
+        SlackNotifier::send('Deploy failed', blocks: [
+            ['type' => 'section', 'text' => ['type' => 'mrkdwn', 'text' => '*Deploy failed*']],
+        ]);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://hooks.slack.test/services/default'
+                && $request['text'] === 'Deploy failed'
+                && $request['channel'] === '#alerts'
+                && $request['blocks'][0]['type'] === 'section';
+        });
+    }
+
+    public function test_channel_override_replaces_default_channel(): void
+    {
+        config()->set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+        config()->set('services.slack.default_channel', '#alerts');
+
+        Http::fake([
+            'hooks.slack.test/*' => Http::response('ok'),
+        ]);
+
+        SlackNotifier::send('Queue recovered', '#ops');
+
+        Http::assertSent(fn (Request $request): bool => $request['channel'] === '#ops');
+    }
+
+    public function test_client_uses_five_second_timeout(): void
+    {
+        $this->assertStringContainsString('Http::timeout(5)', file_get_contents(app_path('Services/SlackNotifier.php')));
+
+        config()->set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+
+        Http::fake([
+            'hooks.slack.test/*' => Http::response('ok'),
+        ]);
+
+        SlackNotifier::send('Timeout check');
+
+        Http::assertSent(fn (Request $request): bool => $request['text'] === 'Timeout check');
+    }
+
+    public function test_server_errors_retry_once_before_succeeding(): void
+    {
+        config()->set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+
+        Http::fakeSequence()
+            ->push('temporary failure', 500)
+            ->push('ok', 200);
+
+        SlackNotifier::send('Retry this');
+
+        Http::assertSentCount(2);
+    }
+
+    public function test_client_errors_throw_without_retrying(): void
+    {
+        config()->set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+
+        Http::fake([
+            'hooks.slack.test/*' => Http::response('bad request', 400),
+        ]);
+
+        $this->expectException(RequestException::class);
+
+        try {
+            SlackNotifier::send('Do not retry');
+        } finally {
+            Http::assertSentCount(1);
+        }
+    }
+}


### PR DESCRIPTION
﻿/claim #791

## Summary
- Adds `App\Services\SlackNotifier` with config-driven webhook URL and default channel.
- Supports channel override, message text, and optional Slack block attachments.
- Sends through Laravel HTTP client with a 5 second timeout, retries once on 5xx responses, and throws immediately on 4xx responses.
- Adds `services.slack.webhook_url` and `services.slack.default_channel` config entries.

## Testing
- `git diff --check`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app php:8.4-cli sh -lc 'for file in app/Services/SlackNotifier.php config/services.php tests/Feature/SlackNotifierTest.php; do php -l "$file" || exit 1; done'`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app composer:2 ./vendor/bin/pint app/Services/SlackNotifier.php config/services.php tests/Feature/SlackNotifierTest.php`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app composer:2 sh -lc 'cp .env.example .env 2>/dev/null || true; php artisan key:generate --force --no-interaction >/dev/null; php artisan test tests/Feature/SlackNotifierTest.php'` -> 5 passed, 7 assertions

## Provenance note
I did not include `_generation.json` because it requests hidden session initialization/instructions. The implementation and validation are contained in this PR.
