### PR TITLE
[OpenAI Codex] [ Laravel ] Add structured error logging

### DIFF
--- a/laravel/app/Logging/StructuredJsonFormatter.php
+++ b/laravel/app/Logging/StructuredJsonFormatter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+class StructuredJsonFormatter implements FormatterInterface
+{
+    public function format(LogRecord $record): string
+    {
+        return json_encode([
+            'timestamp' => $record->datetime->format(DATE_ATOM),
+            'level' => $record->level->getName(),
+            'message' => $record->message,
+            'context' => $record->context,
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL;
+    }
+
+    /**
+     * @param  array<LogRecord>  $records
+     */
+    public function formatBatch(array $records): string
+    {
+        return implode('', array_map([$this, 'format'], $records));
+    }
+}

--- a/laravel/config/_provenance.json
+++ b/laravel/config/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private platform, system, developer, and session initialization text is intentionally not included. This file documents tool provenance without disclosing hidden instructions or private context.",
+  "timestamp": "2026-05-20T07:00:15Z"
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\StructuredJsonFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,24 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/laravel.json.log'),
+            ],
+            'formatter' => StructuredJsonFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [

--- a/laravel/tests/Feature/LoggingConfigurationTest.php
+++ b/laravel/tests/Feature/LoggingConfigurationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Logging\StructuredJsonFormatter;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class LoggingConfigurationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clearTestLogs();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearTestLogs();
+
+        parent::tearDown();
+    }
+
+    private function clearTestLogs(): void
+    {
+        foreach ([
+            storage_path('logs/error.log'),
+            storage_path('logs/laravel.json.log'),
+            storage_path('logs/laravel.log'),
+        ] as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        foreach (glob(storage_path('logs/laravel-*.log')) ?: [] as $path) {
+            unlink($path);
+        }
+    }
+
+    public function test_default_stack_writes_daily_and_error_channels(): void
+    {
+        $stack = config('logging.channels.stack');
+
+        $this->assertSame('stack', $stack['driver']);
+        $this->assertSame(['daily', 'error'], $stack['channels']);
+    }
+
+    public function test_daily_channel_keeps_fourteen_days(): void
+    {
+        $daily = config('logging.channels.daily');
+
+        $this->assertSame('daily', $daily['driver']);
+        $this->assertSame(14, $daily['days']);
+    }
+
+    public function test_error_channel_writes_error_level_and_above_to_error_log(): void
+    {
+        $error = config('logging.channels.error');
+
+        $this->assertSame('single', $error['driver']);
+        $this->assertSame(storage_path('logs/error.log'), $error['path']);
+        $this->assertSame('error', $error['level']);
+    }
+
+    public function test_json_channel_uses_structured_formatter(): void
+    {
+        $json = config('logging.channels.json');
+
+        $this->assertSame('monolog', $json['driver']);
+        $this->assertSame(StructuredJsonFormatter::class, $json['formatter']);
+        $this->assertSame(storage_path('logs/laravel.json.log'), $json['handler_with']['stream']);
+    }
+
+    public function test_info_messages_stay_out_of_error_log(): void
+    {
+        Log::channel('stack')->info('visible only in daily log');
+
+        $this->assertStringContainsString('visible only in daily log', $this->dailyLogContents());
+        $this->assertFileDoesNotExist(storage_path('logs/error.log'));
+    }
+
+    public function test_error_messages_are_written_to_daily_and_error_logs(): void
+    {
+        Log::channel('stack')->error('visible in both logs');
+
+        $this->assertFileExists(storage_path('logs/error.log'));
+        $this->assertStringContainsString('visible in both logs', $this->dailyLogContents());
+        $this->assertStringContainsString('visible in both logs', file_get_contents(storage_path('logs/error.log')));
+    }
+
+    public function test_json_channel_writes_expected_fields(): void
+    {
+        Log::channel('json')->warning('structured event', ['request_id' => 'abc-123']);
+
+        $line = trim(file_get_contents(storage_path('logs/laravel.json.log')));
+        $payload = json_decode($line, true);
+
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('timestamp', $payload);
+        $this->assertSame('WARNING', $payload['level']);
+        $this->assertSame('structured event', $payload['message']);
+        $this->assertSame(['request_id' => 'abc-123'], $payload['context']);
+    }
+
+    private function dailyLogContents(): string
+    {
+        $matches = glob(storage_path('logs/laravel-*.log')) ?: [];
+
+        $this->assertNotEmpty($matches);
+
+        return file_get_contents($matches[0]);
+    }
+}


### PR DESCRIPTION
/claim #787

## Issue
Closes #787

## Summary
- Updates the default Laravel log stack to write through `daily` and a new error-only `error` channel.
- Adds `storage/logs/error.log` for `error` level and above while keeping info/debug out of the error file.
- Keeps daily log rotation at 14 days.
- Adds a `json` channel with a structured formatter that emits `timestamp`, `level`, `message`, and `context`.
- Adds focused feature tests for stack configuration, error-only routing, daily retention, and JSON field output.

## Files changed
- `laravel/config/logging.php`
- `laravel/app/Logging/StructuredJsonFormatter.php`
- `laravel/tests/Feature/LoggingConfigurationTest.php`
- `laravel/config/_provenance.json`

## Verification
```text
PASS git diff --check
NOT RUN php/composer tests: php and composer are not installed in this local environment, and Docker is not running.
```

## Acceptance criteria
- [x] Error-level and above messages are routed to both the daily log and `error.log`
- [x] Info/debug messages remain in the daily log and do not create `error.log`
- [x] Daily rotation keeps 14 days of history
- [x] JSON channel emits valid JSON with `timestamp`, `level`, `message`, and `context`
- [x] Existing channels remain intact
- [x] PR title starts with agent name + `[ Laravel ]`
- [x] Safe `_provenance.json` included without private runtime instruction disclosure
