### PR TITLE
Codex [ FastAPI ] add validation error request context

### DIFF
--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -8,6 +8,25 @@ from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
 
 
+SENSITIVE_BODY_FIELDS = {"password", "secret", "token", "api_key"}
+REDACTED_VALUE = "***REDACTED***"
+
+
+def _redact_sensitive_body_fields(value):
+    if isinstance(value, dict):
+        return {
+            key: (
+                REDACTED_VALUE
+                if isinstance(key, str) and key.lower() in SENSITIVE_BODY_FIELDS
+                else _redact_sensitive_body_fields(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_sensitive_body_fields(item) for item in value]
+    return value
+
+
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
     headers = getattr(exc, "headers", None)
     if not is_body_allowed_for_status_code(exc.status_code):
@@ -20,9 +39,18 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
+    content = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+    if getattr(request.app, "debug", False):
+        content["body"] = jsonable_encoder(
+            _redact_sensitive_body_fields(getattr(exc, "body", None))
+        )
     return JSONResponse(
         status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
+        content=content,
     )
 
 

--- a/fastapi/tests/test_request_validation_context.py
+++ b/fastapi/tests/test_request_validation_context.py
@@ -1,0 +1,72 @@
+from fastapi import Body, FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class LoginPayload(BaseModel):
+    username: str
+    password: str
+    age: int
+    profile: dict
+    sessions: list[dict]
+
+
+def create_app(debug: bool) -> FastAPI:
+    app = FastAPI(debug=debug)
+
+    @app.post("/login/{tenant}")
+    def login(tenant: str, payload: LoginPayload = Body()):
+        return {"tenant": tenant, "username": payload.username}
+
+    return app
+
+
+def test_validation_error_includes_request_path_and_method():
+    client = TestClient(create_app(debug=False))
+
+    response = client.post("/login/acme", json={"username": "alice"})
+
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/login/acme"
+    assert data["method"] == "POST"
+    assert "body" not in data
+
+
+def test_debug_validation_error_includes_redacted_nested_body():
+    client = TestClient(create_app(debug=True))
+
+    response = client.post(
+        "/login/acme",
+        json={
+            "username": "alice",
+            "password": "plain-text",
+            "age": "not-an-int",
+            "profile": {
+                "secret": "inner-secret",
+                "nested": {"token": "inner-token", "safe": "kept"},
+            },
+            "sessions": [
+                {"api_key": "first-key", "label": "prod"},
+                {"password": "second-password"},
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/login/acme"
+    assert data["method"] == "POST"
+    assert data["body"] == {
+        "username": "alice",
+        "password": "***REDACTED***",
+        "age": "not-an-int",
+        "profile": {
+            "secret": "***REDACTED***",
+            "nested": {"token": "***REDACTED***", "safe": "kept"},
+        },
+        "sessions": [
+            {"api_key": "***REDACTED***", "label": "prod"},
+            {"password": "***REDACTED***"},
+        ],
+    }


### PR DESCRIPTION
﻿/claim #757

## Summary
- Adds request `path` and HTTP `method` to the default `RequestValidationError` JSON response.
- Includes the received validation body only when the FastAPI app is running in debug mode.
- Recursively redacts sensitive fields named `password`, `secret`, `token`, or `api_key` in nested dictionaries/lists before echoing the body.
- Adds focused TestClient coverage for non-debug omission and debug nested redaction.

## Testing
- `git diff --check`
- `py -m py_compile fastapi\exception_handlers.py tests\test_request_validation_context.py`
- `PYTHONPATH=. py -m pytest tests\test_request_validation_context.py` -> 2 passed
- `PYTHONPATH=. py -m pytest tests\test_exception_handlers.py` -> 5 passed

## Provenance note
I did not include `_meta.json` because it requests hidden session initialization/instructions. The implementation and validation are contained in this PR.
