### PR TITLE
Codex [ Crypto ] Fix StakingVault reentrancy

### DIFF
--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -39,31 +40,29 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 

--- a/solidity/test/StakingVault.reentrancy.test.js
+++ b/solidity/test/StakingVault.reentrancy.test.js
@@ -1,0 +1,59 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const test = require("node:test");
+const path = require("node:path");
+
+const source = readFileSync(
+  path.join(__dirname, "../contracts/StakingVault.sol"),
+  "utf8",
+);
+
+function functionBody(name) {
+  const start = source.indexOf(`function ${name}`);
+  assert.notEqual(start, -1, `${name} function should exist`);
+
+  const openingBrace = source.indexOf("{", start);
+  let depth = 0;
+
+  for (let index = openingBrace; index < source.length; index += 1) {
+    if (source[index] === "{") {
+      depth += 1;
+    } else if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(openingBrace + 1, index);
+      }
+    }
+  }
+
+  throw new Error(`Could not parse ${name} body`);
+}
+
+test("withdraw and claimRewards use ReentrancyGuard", () => {
+  assert.match(source, /import\s+"@openzeppelin\/contracts\/utils\/ReentrancyGuard\.sol";/);
+  assert.match(source, /contract\s+StakingVault\s+is\s+ReentrancyGuard/);
+  assert.match(source, /function\s+withdraw\s*\([^)]*\)\s+external\s+nonReentrant/);
+  assert.match(source, /function\s+claimRewards\s*\([^)]*\)\s+external\s+nonReentrant/);
+});
+
+test("withdraw updates stake accounting before transferring ETH", () => {
+  const body = functionBody("withdraw");
+
+  assert.ok(
+    body.indexOf("balances[msg.sender] -= amount;") < body.indexOf(".call{value: amount}"),
+    "balance must be reduced before the external ETH transfer",
+  );
+  assert.ok(
+    body.indexOf("totalStaked -= amount;") < body.indexOf(".call{value: amount}"),
+    "total staked must be reduced before the external ETH transfer",
+  );
+});
+
+test("claimRewards clears rewards before transferring ETH", () => {
+  const body = functionBody("claimRewards");
+
+  assert.ok(
+    body.indexOf("rewards[msg.sender] = 0;") < body.indexOf(".call{value: reward}"),
+    "reward balance must be cleared before the external ETH transfer",
+  );
+});


### PR DESCRIPTION
﻿/claim #911

## Summary
- Imports OpenZeppelin `ReentrancyGuard` and makes `StakingVault` inherit it.
- Applies `nonReentrant` to both `withdraw` and `claimRewards`.
- Moves stake/reward accounting before each ETH transfer so reentrant callbacks cannot observe stale balances.
- Adds a Node regression test that verifies the guard usage and checks-effects-interactions ordering for both vulnerable paths.

## Testing
- `git diff --check`
- `node --test solidity/test/StakingVault.reentrancy.test.js` -> 3 passed
- `solcjs solidity/contracts/StakingVault.sol --bin --base-path . --include-path <temp>/node_modules -o <temp>/out` using temporary `solc@0.8.20` and `@openzeppelin/contracts@5`

## Provenance note
I did not include `.provenance.json` because it requests hidden session initialization/instructions. The security fix and validation are contained in this PR.
