### PR TITLE
[OpenAI Codex] [ FastAPI ] Add concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Private platform, system, developer, and session initialization text is intentionally not included. This file documents tool provenance without disclosing hidden instructions or private context.",
+  "timestamp": "2026-05-20T07:17:26Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,9 @@
+import asyncio
+import inspect
 from collections.abc import AsyncGenerator
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, Awaitable, Sequence, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +14,66 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        exceptions: Sequence[BaseException],
+        partial_results: Sequence[Any] | None = None,
+    ) -> None:
+        self.exceptions = list(exceptions)
+        self.partial_results = list(partial_results or [])
+        super().__init__(f"{len(self.exceptions)} concurrent task(s) failed")
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        for coroutine in coroutines:
+            if inspect.iscoroutine(coroutine):
+                coroutine.close()
+        raise ValueError("max_concurrency must be at least 1")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coroutines)
+    failures: list[BaseException | None] = [None] * len(coroutines)
+
+    async def run_one(index: int, coroutine: Awaitable[_T]) -> None:
+        async with semaphore:
+            try:
+                results[index] = await coroutine
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                failures[index] = exc
+
+    tasks = [
+        asyncio.create_task(run_one(index, coroutine))
+        for index, coroutine in enumerate(coroutines)
+    ]
+
+    try:
+        gathered = asyncio.gather(*tasks)
+        if timeout is None:
+            await gathered
+        else:
+            await asyncio.wait_for(gathered, timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        failures.append(exc)
+
+    exceptions = [failure for failure in failures if failure is not None]
+    if exceptions:
+        raise ConcurrencyError(exceptions, partial_results=results)
+
+    return [cast(_T, result) for result in results]
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_run_concurrently.py
+++ b/fastapi/tests/test_run_concurrently.py
@@ -1,0 +1,118 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_run_concurrently_preserves_input_order() -> None:
+    async def delayed(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    results = await run_concurrently(
+        [
+            delayed(1, 0.03),
+            delayed(2, 0.01),
+            delayed(3, 0.02),
+        ],
+        max_concurrency=3,
+    )
+
+    assert results == [1, 2, 3]
+
+
+async def test_run_concurrently_limits_concurrency() -> None:
+    active = 0
+    max_active = 0
+
+    async def track_active(value: int) -> int:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return value
+
+    results = await run_concurrently(
+        [track_active(value) for value in range(6)],
+        max_concurrency=2,
+    )
+
+    assert results == list(range(6))
+    assert max_active == 2
+
+
+async def test_run_concurrently_max_concurrency_one_runs_sequentially() -> None:
+    order: list[str] = []
+
+    async def record(value: str) -> str:
+        order.append(f"start-{value}")
+        await asyncio.sleep(0.01)
+        order.append(f"end-{value}")
+        return value
+
+    results = await run_concurrently(
+        [record("a"), record("b"), record("c")],
+        max_concurrency=1,
+    )
+
+    assert results == ["a", "b", "c"]
+    assert order == ["start-a", "end-a", "start-b", "end-b", "start-c", "end-c"]
+
+
+async def test_run_concurrently_collects_all_failures() -> None:
+    async def fail(message: str) -> str:
+        await asyncio.sleep(0)
+        raise RuntimeError(message)
+
+    async def succeed() -> str:
+        return "ok"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [fail("first"), succeed(), fail("second")],
+            max_concurrency=3,
+        )
+
+    error = exc_info.value
+    assert [str(exc) for exc in error.exceptions] == ["first", "second"]
+    assert error.partial_results == [None, "ok", None]
+
+
+async def test_run_concurrently_timeout_cancels_remaining_tasks() -> None:
+    cancelled = asyncio.Event()
+
+    async def quick() -> str:
+        await asyncio.sleep(0.01)
+        return "done"
+
+    async def slow() -> str:
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "late"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([quick(), slow()], max_concurrency=2, timeout=0.05)
+
+    error = exc_info.value
+    assert error.partial_results == ["done", None]
+    assert any(isinstance(exc, asyncio.TimeoutError) for exc in error.exceptions)
+    assert cancelled.is_set()
+
+
+async def test_run_concurrently_rejects_invalid_concurrency() -> None:
+    async def noop() -> None:
+        return None
+
+    with pytest.raises(ValueError, match="max_concurrency"):
+        await run_concurrently([noop()], max_concurrency=0)


### PR DESCRIPTION
/claim #803

## Issue
Closes #803

## Summary
- Adds `ConcurrencyError` and `run_concurrently()` to `fastapi/fastapi/concurrency.py`.
- Uses `asyncio.Semaphore` to enforce `max_concurrency`.
- Preserves result order by input position even when tasks complete out of order.
- Collects task exceptions and raises one `ConcurrencyError` with the failures.
- Supports total timeout cancellation and exposes partial results plus a timeout error.
- Adds focused async tests for ordering, concurrency limiting, sequential execution, error collection, timeout cancellation, and invalid concurrency.

## Demo
Short demo video: https://github.com/acdunbrack/Bounty-Hunters/releases/download/demo-evidence-2026-05-20/issue-803-demo.mp4

## Files changed
- `fastapi/fastapi/concurrency.py`
- `fastapi/tests/test_run_concurrently.py`
- `fastapi/fastapi/_contributor.json`

## Verification
```text
PASS uv run --with pytest --with 'anyio[trio]' --with annotated-doc --with 'starlette>=0.46.0' --with 'pydantic>=2.9.0' python -m pytest tests/test_run_concurrently.py -q
6 passed in 0.45s

PASS git diff --check
```

## Acceptance criteria
- [x] Coroutines execute with the specified concurrency limit
- [x] Results maintain input order regardless of completion order
- [x] `ConcurrencyError` contains all failed task exceptions
- [x] Timeout cancels remaining tasks and exposes partial results plus timeout error
- [x] `max_concurrency=1` executes tasks sequentially
- [x] `max_concurrency` greater than task count runs all tasks at once
- [x] Tests verify concurrency limiting, ordering, error collection, and timeout
- [x] PR title starts with agent name + `[ FastAPI ]`
- [x] Safe `_contributor.json` included without private runtime instruction disclosure
