### PR TITLE
Codex [ Laravel ] Fix DatabaseSeeder idempotency

### DIFF
--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(2),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_20_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_20_000000_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => Hash::make('password'),
+            ],
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the application's roles.
+     */
+    public function run(): void
+    {
+        foreach ($this->roles() as $role) {
+            Role::firstOrCreate(
+                ['name' => $role['name']],
+                ['description' => $role['description']],
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array{name: string, description: string}>
+     */
+    private function roles(): array
+    {
+        return [
+            ['name' => 'admin', 'description' => 'Full administrative access'],
+            ['name' => 'editor', 'description' => 'Can create and update content'],
+            ['name' => 'viewer', 'description' => 'Read-only application access'],
+        ];
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_is_idempotent(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertSame(3, Role::count());
+        $this->assertSame(
+            ['admin', 'editor', 'viewer'],
+            Role::query()->orderBy('name')->pluck('name')->all(),
+        );
+    }
+
+    public function test_role_seeder_is_idempotent(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertSame(3, Role::count());
+    }
+
+    public function test_role_factory_creates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertNotNull($role->id);
+        $this->assertNotSame('', $role->name);
+        $this->assertNotSame('', $role->description);
+    }
+}


### PR DESCRIPTION
﻿/claim #746

## Summary
- Makes the default `test@example.com` user seed idempotent with `firstOrCreate()`.
- Adds a `Role` model, `roles` migration, and `RoleFactory` for test generation.
- Adds `RoleSeeder` to idempotently create the default `admin`, `editor`, and `viewer` roles.
- Calls `RoleSeeder` from `DatabaseSeeder` and adds feature coverage for repeatable seeding and factory creation.

## Testing
- `git diff --check`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app php:8.4-cli sh -lc 'for file in app/Models/Role.php database/factories/RoleFactory.php database/migrations/2026_05_20_000000_create_roles_table.php database/seeders/DatabaseSeeder.php database/seeders/RoleSeeder.php tests/Feature/DatabaseSeederTest.php; do php -l "$file" || exit 1; done'`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app composer:2 ./vendor/bin/pint app/Models/Role.php database/factories/RoleFactory.php database/migrations/2026_05_20_000000_create_roles_table.php database/seeders/DatabaseSeeder.php database/seeders/RoleSeeder.php tests/Feature/DatabaseSeederTest.php`
- `docker run --rm -v "${PWD}/laravel:/app" -w /app composer:2 sh -lc 'php artisan test tests/Feature/DatabaseSeederTest.php'` -> 3 passed, 7 assertions

## Provenance note
I did not include `.provenance.json` because it requests hidden session initialization/instructions. The implementation and validation are contained in this PR.
