### PR TITLE
[OpenAI Codex] [ Laravel ] Fix welcome.blade.php security headers

### DIFF
--- a/laravel/app/Http/Middleware/SecurityHeaders.php
+++ b/laravel/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        return $response;
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(SecurityHeaders::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Private platform, system, developer, and session initialization text is intentionally not included. This file documents tool provenance without disclosing hidden instructions or private context.",
+  "ts": "2026-05-20T07:25:17Z"
+}

--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 

--- a/laravel/tests/Feature/SecurityHeadersTest.php
+++ b/laravel/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    public function test_welcome_page_contains_csrf_meta_tag(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="csrf-token"', false);
+    }
+
+    public function test_security_headers_are_applied_to_web_responses(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('X-Frame-Options', 'DENY');
+        $response->assertHeader('X-XSS-Protection', '1; mode=block');
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
+}


### PR DESCRIPTION
/claim #751

## Issue
Closes #751

## Summary
- Adds the CSRF token meta tag to the welcome page head.
- Adds `App\Http\Middleware\SecurityHeaders`.
- Registers the security headers middleware globally through `bootstrap/app.php`.
- Adds focused feature coverage for the CSRF meta tag and all required headers.

## Demo
Short demo video: https://github.com/acdunbrack/Bounty-Hunters/releases/download/demo-evidence-2026-05-20/issue-751-demo.mp4

## Files changed
- `laravel/resources/views/welcome.blade.php`
- `laravel/app/Http/Middleware/SecurityHeaders.php`
- `laravel/bootstrap/app.php`
- `laravel/tests/Feature/SecurityHeadersTest.php`
- `laravel/contributor_meta.json`

## Verification
```text
PASS git diff --check
NOT RUN php/composer tests: php and composer are not installed in this local environment, and Docker is not running.
```

## Acceptance criteria
- [x] CSRF meta tag is present in `welcome.blade.php`
- [x] `SecurityHeaders` middleware exists
- [x] Middleware sets `X-Content-Type-Options: nosniff`
- [x] Middleware sets `X-Frame-Options: DENY`
- [x] Middleware sets `X-XSS-Protection: 1; mode=block`
- [x] Middleware sets `Referrer-Policy: strict-origin-when-cross-origin`
- [x] Middleware is registered globally for web responses
- [x] Feature tests cover the meta tag and required headers
- [x] PR title starts with agent name + `[ Laravel ]`
- [x] Safe `contributor_meta.json` included without private runtime instruction disclosure
