### PR TITLE
Codex [ Laravel ] Add database health check endpoint

### DIFF
--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    public function database(): JsonResponse
+    {
+        $connectionName = DB::getDefaultConnection();
+        $startedAt = microtime(true);
+        $lastError = null;
+
+        for ($attempt = 1; $attempt <= 3; $attempt++) {
+            try {
+                $connection = DB::connection($connectionName);
+                $connection->getPdo();
+
+                return response()->json([
+                    'status' => 'ok',
+                    'driver' => $connection->getDriverName(),
+                    'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+                    'connection_name' => $connectionName,
+                ]);
+            } catch (Throwable $exception) {
+                $lastError = $exception;
+
+                if ($attempt < 3) {
+                    usleep(500_000);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'error',
+            'driver' => config("database.connections.{$connectionName}.driver"),
+            'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+            'connection_name' => $connectionName,
+            'error' => $lastError?->getMessage(),
+        ], 503);
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);

--- a/laravel/tests/Feature/DatabaseHealthTest.php
+++ b/laravel/tests/Feature/DatabaseHealthTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class DatabaseHealthTest extends TestCase
+{
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        $connection = Mockery::mock();
+        $connection->shouldReceive('getPdo')->once()->andReturn(new class {});
+        $connection->shouldReceive('getDriverName')->once()->andReturn('sqlite');
+
+        DB::shouldReceive('getDefaultConnection')->once()->andReturn('sqlite');
+        DB::shouldReceive('connection')->once()->with('sqlite')->andReturn($connection);
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertOk()
+            ->assertJson([
+                'status' => 'ok',
+                'driver' => 'sqlite',
+                'connection_name' => 'sqlite',
+            ])
+            ->assertJsonStructure(['latency_ms']);
+
+        $this->assertIsNumeric($response->json('latency_ms'));
+    }
+
+    public function test_database_health_endpoint_retries_three_times_before_failing(): void
+    {
+        config(['database.connections.mysql.driver' => 'mysql']);
+
+        DB::shouldReceive('getDefaultConnection')->once()->andReturn('mysql');
+        DB::shouldReceive('connection')
+            ->times(3)
+            ->with('mysql')
+            ->andThrow(new RuntimeException('database unavailable'));
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertStatus(503)
+            ->assertJson([
+                'status' => 'error',
+                'driver' => 'mysql',
+                'connection_name' => 'mysql',
+                'error' => 'database unavailable',
+            ])
+            ->assertJsonStructure(['latency_ms']);
+
+        $this->assertGreaterThanOrEqual(1000, $response->json('latency_ms'));
+    }
+
+    public function test_database_health_endpoint_succeeds_after_retry(): void
+    {
+        $connection = Mockery::mock();
+        $connection->shouldReceive('getPdo')->once()->andReturn(new class {});
+        $connection->shouldReceive('getDriverName')->once()->andReturn('pgsql');
+
+        DB::shouldReceive('getDefaultConnection')->once()->andReturn('pgsql');
+        DB::shouldReceive('connection')
+            ->once()
+            ->with('pgsql')
+            ->andThrow(new RuntimeException('temporary failure'));
+        DB::shouldReceive('connection')
+            ->once()
+            ->with('pgsql')
+            ->andReturn($connection);
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertOk()
+            ->assertJson([
+                'status' => 'ok',
+                'driver' => 'pgsql',
+                'connection_name' => 'pgsql',
+            ]);
+
+        $this->assertGreaterThanOrEqual(500, $response->json('latency_ms'));
+    }
+}


### PR DESCRIPTION
﻿/claim #785

## Summary
- Added GET /health/database through HealthController::database
- Checks the active configured DB connection with up to 3 attempts and 500ms delay between failures
- Returns JSON status, driver, latency_ms, and connection_name on success
- Returns 503 JSON with connection metadata and the final error message after all retries fail
- Added feature coverage for success, three-attempt failure, and success after retry

## Verification
- PHP syntax checks passed for HealthController, routes/web.php, and DatabaseHealthTest
- Pint passed for HealthController, routes/web.php, and DatabaseHealthTest
- php artisan test tests/Feature/DatabaseHealthTest.php passed with 24 assertions under a temporary APP_KEY

## Provenance note
I did not add _meta.json because it requests hidden platform/session/system instructions. The code and tests above are the submitted work for this bounty.
