### PR TITLE
Codex [ Laravel ] Fix .htaccess compression and public runtime settings

### DIFF
--- a/laravel/public/.htaccess
+++ b/laravel/public/.htaccess
@@ -1,3 +1,28 @@
+<IfModule mod_headers.c>
+    Header set X-Content-Type-Options "nosniff"
+</IfModule>
+
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/html text/css application/javascript application/json image/svg+xml
+</IfModule>
+
+<IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType image/jpeg "access plus 30 days"
+    ExpiresByType image/png "access plus 30 days"
+    ExpiresByType image/gif "access plus 30 days"
+    ExpiresByType image/webp "access plus 30 days"
+    ExpiresByType image/svg+xml "access plus 30 days"
+    ExpiresByType image/x-icon "access plus 30 days"
+    ExpiresByType text/css "access plus 7 days"
+    ExpiresByType application/javascript "access plus 7 days"
+    ExpiresByType font/woff "access plus 365 days"
+    ExpiresByType font/woff2 "access plus 365 days"
+    ExpiresByType application/vnd.ms-fontobject "access plus 365 days"
+    ExpiresByType font/ttf "access plus 365 days"
+    ExpiresByType font/otf "access plus 365 days"
+</IfModule>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes

--- a/laravel/public/index.php
+++ b/laravel/public/index.php
@@ -5,6 +5,9 @@ use Illuminate\Http\Request;
 
 define('LARAVEL_START', microtime(true));
 
+ini_set('display_errors', '0');
+ini_set('expose_php', '0');
+
 // Determine if the application is in maintenance mode...
 if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
     require $maintenance;


### PR DESCRIPTION
﻿/claim #755

## Summary
- Added Apache mod_deflate rules for text/html, text/css, application/javascript, application/json, and image/svg+xml
- Added mod_expires cache lifetimes for images, CSS/JS, and fonts without changing the existing rewrite rules
- Added X-Content-Type-Options: nosniff through mod_headers
- Disabled display_errors and expose_php before Laravel loads the Composer autoloader

## Verification
- php -l public/index.php passed in php:8.4-cli Docker
- git diff --check passed
- Static assertions verified the requested compression, expiry, security header, and ini_set directives are present

## Provenance note
I did not add _contributor.json because it requests hidden platform/session/system instructions. The code above is the submitted work for this bounty.
