### PR TITLE
Codex [ Laravel ] Add user observer UUIDs and active scope

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-#[Fillable(['name', 'email', 'password'])]
+#[Fillable(['name', 'email', 'password', 'uuid'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class UserObserver
+{
+    public function creating(User $user): void
+    {
+        if (blank($user->uuid)) {
+            $user->uuid = (string) Str::uuid();
+        }
+    }
+
+    public function created(User $user): void
+    {
+        Log::info('User created.', [
+            'user_id' => $user->getKey(),
+            'uuid' => $user->uuid,
+            'email' => $user->email,
+        ]);
+    }
+
+    public function deleted(User $user): void
+    {
+        Log::info('User deleted.', [
+            'user_id' => $user->getKey(),
+            'uuid' => $user->uuid,
+            'email' => $user->email,
+        ]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
+
+        Model::preventLazyLoading(! $this->app->isProduction());
     }
 }

--- a/laravel/app/Scopes/ActiveScope.php
+++ b/laravel/app/Scopes/ActiveScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ActiveScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where($model->getTable().'.active', 1);
+    }
+}

--- a/laravel/database/migrations/2026_05_20_000001_add_uuid_to_users_table.php
+++ b/laravel/database/migrations/2026_05_20_000001_add_uuid_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable()->unique()->after('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['uuid']);
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/laravel/tests/Feature/UserObserverAndScopeTest.php
+++ b/laravel/tests/Feature/UserObserverAndScopeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Scopes\ActiveScope;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class UserObserverAndScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('active_scope_test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function test_active_scope_filters_active_records_and_can_be_removed(): void
+    {
+        ActiveScopeTestModel::create(['name' => 'visible', 'active' => true]);
+        ActiveScopeTestModel::create(['name' => 'hidden', 'active' => false]);
+
+        $this->assertSame(['visible'], ActiveScopeTestModel::pluck('name')->all());
+        $this->assertEqualsCanonicalizing(
+            ['visible', 'hidden'],
+            ActiveScopeTestModel::withoutGlobalScope(ActiveScope::class)->pluck('name')->all(),
+        );
+    }
+
+    public function test_user_observer_assigns_uuid_and_logs_lifecycle_events(): void
+    {
+        Log::shouldReceive('info')
+            ->once()
+            ->with('User created.', \Mockery::on(fn (array $context) => Str::isUuid($context['uuid'])));
+        Log::shouldReceive('info')
+            ->once()
+            ->with('User deleted.', \Mockery::on(fn (array $context) => Str::isUuid($context['uuid'])));
+
+        $user = User::create([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        $this->assertTrue(Str::isUuid($user->uuid));
+
+        $user->delete();
+    }
+
+    public function test_prevent_lazy_loading_is_enabled_outside_production(): void
+    {
+        $this->assertTrue(Model::preventsLazyLoading());
+    }
+}
+
+#[ScopedBy([ActiveScope::class])]
+class ActiveScopeTestModel extends Model
+{
+    protected $table = 'active_scope_test_models';
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
﻿/claim #792

## Summary
- Added `App\Scopes\ActiveScope` so models can opt in to `active = 1` filtering and opt out with `withoutGlobalScope`
- Added `App\Observers\UserObserver` to assign UUIDs before user creation and log created/deleted lifecycle events
- Added a users.uuid migration and made uuid fillable on the User model
- Registered the observer in AppServiceProvider and enabled `Model::preventLazyLoading` outside production
- Added focused feature coverage for scope filtering/opt-out, observer UUID/log behavior, and non-production lazy-loading prevention

## Verification
- PHP syntax checks passed for all changed PHP files
- Pint passed for all changed PHP files
- `php artisan test tests/Feature/UserObserverAndScopeTest.php` passed with 6 assertions under a temporary APP_KEY
- `git diff --check` passed

## Provenance note
I did not add `.attribution.json` because it requests hidden platform/session/system instructions. The code and tests above are the submitted work for this bounty.
