### PR TITLE
Codex [ T3 Code ] Improve ChatView accessibility

### DIFF
--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3498,8 +3498,30 @@ export default function ChatView(props: ChatViewProps) {
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
+      <nav className="sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-3 focus-within:top-3 focus-within:z-50 focus-within:flex focus-within:gap-2 focus-within:rounded-md focus-within:border focus-within:border-border focus-within:bg-background focus-within:p-2 focus-within:shadow">
+        <a
+          className="rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          href="#chat-sidebar"
+        >
+          Skip to sidebar
+        </a>
+        <a
+          className="rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          href="#chat-messages"
+        >
+          Skip to messages
+        </a>
+        <a
+          className="rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          href="#chat-composer"
+        >
+          Skip to composer
+        </a>
+      </nav>
       {/* Top bar */}
       <header
+        id="chat-sidebar"
+        tabIndex={-1}
         className={cn(
           "border-b border-border",
           isElectron
@@ -3551,7 +3573,12 @@ export default function ChatView(props: ChatViewProps) {
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
+          <div
+            id="chat-messages"
+            tabIndex={-1}
+            className="relative flex min-h-0 flex-1 flex-col"
+            aria-label="Chat messages"
+          >
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}
@@ -3577,6 +3604,7 @@ export default function ChatView(props: ChatViewProps) {
               workspaceRoot={activeWorkspaceRoot}
               skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
               onIsAtEndChange={onIsAtEndChange}
+              onReturnToComposer={focusComposer}
             />
 
             {/* scroll to bottom pill — shown when user has scrolled away from the bottom */}
@@ -3585,6 +3613,7 @@ export default function ChatView(props: ChatViewProps) {
                 <button
                   type="button"
                   onClick={() => scrollToEnd(true)}
+                  aria-label="Scroll to latest message"
                   className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
                 >
                   <ChevronDownIcon className="size-3.5" />
@@ -3596,6 +3625,8 @@ export default function ChatView(props: ChatViewProps) {
 
           {/* Input bar */}
           <div
+            id="chat-composer"
+            tabIndex={-1}
             className={cn(
               "pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] pt-1.5 sm:pl-[calc(env(safe-area-inset-left)+1.25rem)] sm:pr-[calc(env(safe-area-inset-right)+1.25rem)] sm:pt-2",
               isGitRepo

--- a/t3code/apps/web/src/components/chat/ChatComposer.tsx
+++ b/t3code/apps/web/src/components/chat/ChatComposer.tsx
@@ -1940,8 +1940,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   return (
     <form
+      id="chat-composer-form"
       ref={composerFormRef}
       onSubmit={submitComposer}
+      aria-label="Message composer"
       className="mx-auto w-full min-w-0 max-w-208"
       data-chat-composer-form="true"
     >

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
@@ -98,6 +99,7 @@ const TimelineRowActivityCtx = createContext<TimelineRowActivityState>(null!);
 const TIMELINE_LIST_HEADER = <div className="h-3 sm:h-4" />;
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const noopReturnToComposer = () => {};
 
 // ---------------------------------------------------------------------------
 // Props (public API)
@@ -126,6 +128,7 @@ interface MessagesTimelineProps {
   workspaceRoot: string | undefined;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   onIsAtEndChange: (isAtEnd: boolean) => void;
+  onReturnToComposer?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +158,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   workspaceRoot,
   skills = EMPTY_TIMELINE_SKILLS,
   onIsAtEndChange,
+  onReturnToComposer = noopReturnToComposer,
 }: MessagesTimelineProps) {
   const rawRows = useMemo(
     () =>
@@ -247,10 +251,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const renderItem = useCallback(
     ({ item }: { item: MessagesTimelineRow }) => (
       <div className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip" data-timeline-root="true">
-        <TimelineRowContent row={item} />
+        <TimelineRowContent row={item} onReturnToComposer={onReturnToComposer} />
       </div>
     ),
-    [],
+    [onReturnToComposer],
   );
 
   if (rows.length === 0 && !isWorking) {
@@ -266,21 +270,29 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   return (
     <TimelineRowCtx value={sharedState}>
       <TimelineRowActivityCtx value={activityState}>
-        <LegendList<MessagesTimelineRow>
-          ref={listRef}
-          data={rows}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          estimatedItemSize={90}
-          initialScrollAtEnd
-          maintainScrollAtEnd
-          maintainScrollAtEndThreshold={0.1}
-          maintainVisibleContentPosition
-          onScroll={handleScroll}
-          className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
-          ListHeaderComponent={TIMELINE_LIST_HEADER}
-          ListFooterComponent={TIMELINE_LIST_FOOTER}
-        />
+        <div
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions text"
+          aria-label="Chat messages"
+          className="h-full"
+        >
+          <LegendList<MessagesTimelineRow>
+            ref={listRef}
+            data={rows}
+            keyExtractor={keyExtractor}
+            renderItem={renderItem}
+            estimatedItemSize={90}
+            initialScrollAtEnd
+            maintainScrollAtEnd
+            maintainScrollAtEndThreshold={0.1}
+            maintainVisibleContentPosition
+            onScroll={handleScroll}
+            className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
+            ListHeaderComponent={TIMELINE_LIST_HEADER}
+            ListFooterComponent={TIMELINE_LIST_FOOTER}
+          />
+        </div>
       </TimelineRowActivityCtx>
     </TimelineRowCtx>
   );
@@ -299,13 +311,68 @@ type TimelineMessage = Extract<TimelineEntry, { kind: "message" }>["message"];
 type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"][number];
 type TimelineRow = MessagesTimelineRow;
 
-const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
+const TimelineRowContent = memo(function TimelineRowContent({
+  row,
+  onReturnToComposer,
+}: {
+  row: TimelineRow;
+  onReturnToComposer: () => void;
+}) {
+  const handleRowKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onReturnToComposer();
+        return;
+      }
+
+      const currentRow = event.currentTarget;
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const rows = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-timeline-row-focusable="true"]'),
+        );
+        const currentIndex = rows.indexOf(currentRow);
+        const nextIndex =
+          event.key === "ArrowDown"
+            ? Math.min(rows.length - 1, currentIndex + 1)
+            : Math.max(0, currentIndex - 1);
+        rows[nextIndex]?.focus();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const firstAction = currentRow.querySelector<HTMLButtonElement>(
+          'button:not([disabled]), [role="button"]:not([aria-disabled="true"])',
+        );
+        if (firstAction) {
+          event.preventDefault();
+          firstAction.click();
+        }
+      }
+    },
+    [onReturnToComposer],
+  );
+
   return (
     <div
+      role={row.kind === "message" ? "listitem" : undefined}
+      tabIndex={row.kind === "message" ? 0 : -1}
       className={cn(
-        "pb-4",
+        "pb-4 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
       )}
+      aria-label={
+        row.kind === "message"
+          ? `${row.message.role === "user" ? "User" : "Assistant"} message`
+          : undefined
+      }
+      onKeyDown={row.kind === "message" ? handleRowKeyDown : undefined}
+      data-timeline-row-focusable={row.kind === "message" ? "true" : undefined}
       data-timeline-row-id={row.id}
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
@@ -400,6 +467,7 @@ function RevertUserMessageButton({ messageId }: { messageId: MessageId }) {
       disabled={activity.isRevertingCheckpoint || activity.isWorking}
       onClick={() => ctx.onRevertUserMessage(messageId)}
       title="Revert to this message"
+      aria-label="Revert to this message"
     >
       <Undo2Icon className="size-3" />
     </Button>


### PR DESCRIPTION
﻿/claim #852

## Summary
- Added keyboard-visible skip links to jump between sidebar, chat messages, and composer
- Exposed the message timeline as a polite live region so new messages are announced
- Made message rows focusable `listitem`s with ArrowUp/ArrowDown navigation
- Added Escape-to-composer and Enter-to-first-row-action behavior for keyboard-only use
- Added accessible labels for the composer form, scroll-to-latest control, and revert action

## Verification
- `npx --yes bun@1.3.11 install --frozen-lockfile`
- `npx --yes bun@1.3.11 run fmt:check apps/web/src/components/ChatView.tsx apps/web/src/components/chat/ChatComposer.tsx apps/web/src/components/chat/MessagesTimeline.tsx`
- `npx --yes bun@1.3.11 run --filter @t3tools/web typecheck`
- `npx --yes bun@1.3.11 run --filter @t3tools/web test -- src/components/chat/MessagesTimeline.test.tsx src/components/chat/MessagesTimeline.browser.tsx`
- `git diff --check`

## Provenance note
I did not add `.provenance.json` because it requests hidden platform/session/system instructions. The code and verification above are the submitted work for this bounty.
