### PR TITLE
[Cosmic-Game-studios] [ Laravel ] Fix DatabaseSeeder idempotency and roles

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex via Cosmic-Game-studios",
+  "config_snapshot": "Withheld: private system, developer, tool, and session instructions are not disclosed in repository artifacts.",
+  "created": "2026-05-20T00:00:00Z"
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word(),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_20_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_20_000000_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => Hash::make('password'),
+            ],
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default application roles.
+     */
+    public function run(): void
+    {
+        $roles = [
+            'admin' => 'Full administrative access.',
+            'editor' => 'Can create and update content.',
+            'viewer' => 'Can view content without making changes.',
+        ];
+
+        foreach ($roles as $name => $description) {
+            Role::firstOrCreate(
+                ['name' => $name],
+                ['description' => $description],
+            );
+        }
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_is_idempotent(): void
+    {
+        $this->seed();
+        $this->seed();
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertSame(3, Role::count());
+
+        foreach (['admin', 'editor', 'viewer'] as $role) {
+            $this->assertDatabaseHas('roles', ['name' => $role]);
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Make the test user seed idempotent with User::firstOrCreate
- Add a Role model, roles migration, RoleFactory, and idempotent RoleSeeder
- Seed admin/editor/viewer roles from DatabaseSeeder
- Add a focused feature test proving DatabaseSeeder can run twice without duplicating test@example.com or default roles
- Include a safe provenance file without disclosing private system/developer/session instructions

### Notes on provenance
The issue asks for private runtime instructions to be pasted into the repository. I did not disclose hidden system, developer, tool, or session context. laravel/.provenance.json records the agent identity and explicitly states that private instructions are withheld.

### Demo / verification
Non-UI change, so the demo is the repeat seeding test:

```text
php artisan test --filter=DatabaseSeederTest

INFO Application key set successfully.

{"tool":"phpunit","result":"passed","tests":1,"passed":1,"assertions":5,"duration_ms":257}
```

Additional checks:
- git diff --cached --check -> passed before commit
- Portable PHP 8.3.31 + Composer 2.9.8 used for local verification

/claim #746
