### PR TITLE
[Cosmic-Game-studios] [ T3 Code ] Add persisted sidebar resize defaults

### DIFF
--- a/t3code/.provenance.json
+++ b/t3code/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex via Cosmic-Game-studios",
+  "config_snapshot": "Withheld: private system, developer, tool, and session instructions are not disclosed in repository artifacts.",
+  "created": "2026-05-20T00:00:00Z"
+}

--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, type CSSProperties, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import ThreadSidebar from "./Sidebar";
@@ -9,7 +9,9 @@ import {
 } from "../shortcutModifierState";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
-const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
+const THREAD_SIDEBAR_DEFAULT_WIDTH = 280;
+const THREAD_SIDEBAR_MIN_WIDTH = 200;
+const THREAD_SIDEBAR_MAX_WIDTH = 500;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
@@ -54,12 +56,22 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   }, [navigate]);
 
   return (
-    <SidebarProvider className="h-dvh! min-h-0!" defaultOpen>
+    <SidebarProvider
+      className="h-dvh! min-h-0!"
+      defaultOpen
+      style={
+        {
+          "--sidebar-width": `${THREAD_SIDEBAR_DEFAULT_WIDTH}px`,
+        } as CSSProperties
+      }
+    >
       <Sidebar
         side="left"
         collapsible="offcanvas"
         className="border-r border-border bg-card text-foreground"
         resizable={{
+          defaultWidth: THREAD_SIDEBAR_DEFAULT_WIDTH,
+          maxWidth: THREAD_SIDEBAR_MAX_WIDTH,
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,
           shouldAcceptWidth: ({ nextWidth, wrapper }) =>
             wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,

--- a/t3code/apps/web/src/components/ui/sidebar.test.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.test.tsx
@@ -2,10 +2,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  Sidebar,
   SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuSubButton,
   SidebarProvider,
+  SidebarRail,
 } from "./sidebar";
 
 function renderSidebarButton(className?: string) {
@@ -49,5 +51,20 @@ describe("sidebar interactive cursors", () => {
 
     expect(html).toContain('data-slot="sidebar-menu-sub-button"');
     expect(html).toContain("cursor-pointer");
+  });
+
+  it("renders the resizable rail with resize affordance and reset hint", () => {
+    const html = renderToStaticMarkup(
+      <SidebarProvider>
+        <Sidebar resizable={{ defaultWidth: 280, maxWidth: 500, minWidth: 200 }}>
+          <SidebarRail />
+        </Sidebar>
+      </SidebarProvider>,
+    );
+
+    expect(html).toContain('aria-label="Resize Sidebar"');
+    expect(html).toContain("double-click to reset");
+    expect(html).toContain("cursor-w-resize");
+    expect(html).toContain("hover:after:bg-sidebar-border");
   });
 });

--- a/t3code/apps/web/src/components/ui/sidebar.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.tsx
@@ -39,6 +39,7 @@ type SidebarContextProps = {
 };
 
 type SidebarResizableOptions = {
+  defaultWidth?: number;
   maxWidth?: number;
   minWidth?: number;
   onResize?: (width: number) => void;
@@ -54,6 +55,7 @@ type SidebarResizableOptions = {
 };
 
 type SidebarResolvedResizableOptions = {
+  defaultWidth: number;
   maxWidth: number;
   minWidth: number;
   onResize?: (width: number) => void;
@@ -191,9 +193,12 @@ function Sidebar({
     }
 
     const options = typeof resizable === "boolean" ? {} : resizable;
+    const minWidth = options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH;
+    const maxWidth = options.maxWidth ?? Number.POSITIVE_INFINITY;
     return {
-      maxWidth: options.maxWidth ?? Number.POSITIVE_INFINITY,
-      minWidth: options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
+      defaultWidth: Math.max(minWidth, Math.min(options.defaultWidth ?? minWidth, maxWidth)),
+      maxWidth,
+      minWidth,
       storageKey: options.storageKey ?? null,
       ...(options.onResize ? { onResize: options.onResize } : {}),
       ...(options.shouldAcceptWidth ? { shouldAcceptWidth: options.shouldAcceptWidth } : {}),
@@ -339,6 +344,7 @@ function SidebarRail({
   className,
   onClick,
   onPointerCancel,
+  onDoubleClick,
   onPointerDown,
   onPointerMove,
   onPointerUp,
@@ -543,6 +549,26 @@ function SidebarRail({
     [onClick, open, resolvedResizable, toggleSidebar],
   );
 
+  const handleDoubleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onDoubleClick?.(event);
+      if (event.defaultPrevented || !resolvedResizable || !open) return;
+
+      const wrapper = event.currentTarget.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
+      if (!wrapper) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      const resetWidth = clampSidebarWidth(resolvedResizable.defaultWidth, resolvedResizable);
+      wrapper.style.setProperty("--sidebar-width", `${resetWidth}px`);
+      if (resolvedResizable.storageKey && typeof window !== "undefined") {
+        setLocalStorageItem(resolvedResizable.storageKey, resetWidth, Schema.Finite);
+      }
+      resolvedResizable.onResize?.(resetWidth);
+    },
+    [onDoubleClick, open, resolvedResizable],
+  );
+
   React.useEffect(() => {
     if (!resolvedResizable?.storageKey || typeof window === "undefined") return;
     const rail = railRef.current;
@@ -554,6 +580,9 @@ function SidebarRail({
     if (storedWidth === null) return;
     const clampedWidth = clampSidebarWidth(storedWidth, resolvedResizable);
     wrapper.style.setProperty("--sidebar-width", `${clampedWidth}px`);
+    if (clampedWidth !== storedWidth) {
+      setLocalStorageItem(resolvedResizable.storageKey, clampedWidth, Schema.Finite);
+    }
     resolvedResizable.onResize?.(clampedWidth);
   }, [resolvedResizable]);
 
@@ -587,13 +616,14 @@ function SidebarRail({
       data-sidebar="rail"
       data-slot="sidebar-rail"
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onPointerCancel={handlePointerCancel}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       ref={railRef}
       tabIndex={-1}
-      title={railTitle}
+      title={canResize ? `${railTitle}; double-click to reset` : railTitle}
       type="button"
       {...props}
     />


### PR DESCRIPTION
/claim #840

## Summary
- set the T3 Code thread sidebar default width to 280px with 200px min and 500px max bounds
- keep persisted sidebar widths clamped to the active bounds, including stale stored values
- add a double-click reset on the resize rail and expose the reset affordance in the rail title
- add safe provenance without disclosing private system/developer/tool instructions

## Demo
- Video: https://github.com/Cosmic-Game-studios/Bounty-Hunters/releases/download/sidebar-resize-demo-2144/sidebar-resize-demo.webm

## Validation
- `bun fmt`
- `bun lint` (passes with existing unrelated warnings)
- `bun typecheck`
- `bun run --cwd apps/web test -- src/components/ui/sidebar.test.tsx`

## Notes
- `bun run test` was also attempted; it fails on Windows for unrelated existing environment assumptions: symlink creation in `scripts/mock-update-server.test.ts` and POSIX path expectations in desktop tests.