### PR TITLE
[codex] add T3 Code Playwright E2E tests

### DIFF
--- a/t3code/.gitignore
+++ b/t3code/.gitignore
@@ -17,6 +17,7 @@ release-mock/
 .idea/
 apps/web/.playwright
 apps/web/playwright-report
+apps/web/test-results
 apps/web/src/components/__screenshots__
 .vitest-*
 __screenshots__/

--- a/t3code/apps/web/playwright.config.ts
+++ b/t3code/apps/web/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "playwright/test";
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `VITE_HOSTED_APP_CHANNEL=latest bun run dev --host 127.0.0.1 --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/t3code/apps/web/tests/e2e/app-shell.spec.ts
+++ b/t3code/apps/web/tests/e2e/app-shell.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "playwright/test";
+
+test("loads the hosted-static app shell", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveTitle(/T3 Code \(Latest\)/);
+  await expect(page.getByText("Connect an environment to get started")).toBeVisible();
+  await expect(page.getByTestId("command-palette-trigger")).toBeVisible();
+});

--- a/t3code/apps/web/tests/e2e/command-palette.spec.ts
+++ b/t3code/apps/web/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "playwright/test";
+
+test("opens the command palette and filters actions", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByTestId("command-palette-trigger").click();
+
+  const palette = page.getByTestId("command-palette");
+  await expect(palette).toBeVisible();
+
+  const searchInput = page.getByPlaceholder("Search commands, projects, and threads...");
+  await expect(searchInput).toBeFocused();
+
+  await searchInput.fill("settings");
+  await expect(palette.getByText("Open settings")).toBeVisible();
+});

--- a/t3code/apps/web/tests/e2e/sidebar-navigation.spec.ts
+++ b/t3code/apps/web/tests/e2e/sidebar-navigation.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "playwright/test";
+
+test("navigates from the sidebar to settings", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Settings" }).click();
+
+  await expect(page).toHaveURL(/\/settings\/general$/);
+  await expect(page.getByRole("main").getByRole("heading", { name: "General" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "General" })).toBeVisible();
+});

--- a/t3code/package.json
+++ b/t3code/package.json
@@ -44,6 +44,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "oxlint --report-unused-disable-directives",
     "test": "turbo run test",
+    "test:e2e": "bun run --cwd apps/web playwright test",
     "test:desktop-smoke": "turbo run smoke-test --filter=@t3tools/desktop",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",


### PR DESCRIPTION
/claim #847

## Summary
- Add a Playwright config for the T3 Code web app that starts Vite in hosted-static mode.
- Add E2E coverage for app shell loading, command palette filtering, and sidebar settings navigation.
- Ignore Playwright test result artifacts so local E2E runs do not dirty the worktree.

## Validation
- `bun run test:e2e` (3 passed)
- `bun run --cwd apps/web typecheck`
- `bun run fmt:check apps/web/playwright.config.ts apps/web/tests/e2e/app-shell.spec.ts apps/web/tests/e2e/command-palette.spec.ts apps/web/tests/e2e/sidebar-navigation.spec.ts package.json .gitignore`
