### PR TITLE
[ Config ] Fix trailing comma in app.json — closes #308

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -22,6 +22,6 @@
   "features": {
     "rate_limiting": true,
     "cors": true,
-    "allowed_origins": ["https://app.example.com", "https://admin.example.com"],
+    "allowed_origins": ["https://app.example.com", "https://admin.example.com"]
   }
 }


### PR DESCRIPTION
Removed trailing comma after allowed_origins array in features object.

Closes #308