### PR TITLE
[ Docs ] Fix broken markdown table in api-reference.md — closes #303

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+|  /bounties/:id/claims | POST | 5 req/min     |
 
 ## Error Codes
 


### PR DESCRIPTION
Fixed missing leading pipe character on last row of Rate Limits table.

Closes #303