### PR TITLE
[ Docs ] Fix wrong HTTP method for Create Bounty in api-reference.md — closes #304

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -48,7 +48,7 @@ Returns a paginated list of all available bounties.
 ### Create Bounty
 
 ```
-GET /bounties
+POST /bounties
 ```
 
 Creates a new bounty listing.


### PR DESCRIPTION
Changed GET /bounties to POST /bounties for Create Bounty endpoint.

Closes #304