### PR TITLE
[ Docs ] Fix wrong package name in setup-guide.md — closes #306

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -28,7 +28,7 @@ source .venv/bin/activate
 ### Step 3: Install Dependencies
 
 ```bash
-pip install bounty-hunter
+pip install bounty-hunters
 ```
 
 This will install the core package and all required dependencies.


### PR DESCRIPTION
Fixed 'pip install bounty-hunter' → 'pip install bounty-hunters' (missing plural s).

Closes #306