### PR TITLE
[ Python ] Fix VALID_TRANSITIONS state machine bypass bug — closes #16

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -80,7 +80,7 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
+        # HandshakeState.FINISHED removed to prevent state machine bypass
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
Removed HandshakeState.FINISHED from CLIENT_HELLO transitions to prevent state machine bypass.

Closes #16