### PR TITLE
[ Python ] Fix wrong PRF label in _derive_master_secret() when EMS is negotiated — closes #21

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -296,9 +296,8 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            # BUG 5: fixed per RFC 7627 — use "extended master secret" when EMS is negotiated
+            label = b"extended master secret"
         else:
             label = b"master secret"
 


### PR DESCRIPTION
Changed EMS branch label from b"master secret" to b"extended master secret" per RFC 7627.

Closes #21