### PR TITLE
fix: add memoryview support to jsonable_encoder — closes #759

### DIFF
--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -83,6 +83,7 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
     bytes: lambda o: o.decode(),
+    memoryview: lambda o: o.tobytes().decode(),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,


### PR DESCRIPTION
Adds memoryview to ENCODERS_BY_TYPE so that jsonable_encoder handles memoryview objects (bytes-like views).

Currently, passing a memoryview to jsonable_encoder raises a ValueError because it falls through to dict(obj) which fails on memoryview objects. This fix decodes memoryview as bytes, matching the existing bytes handler.

Closes #759