### PR TITLE
fix: switch Swagger UI CDN URLs from jsdelivr to unpkg — closes #762

### DIFF
--- a/fastapi/fastapi/openapi/docs.py
+++ b/fastapi/fastapi/openapi/docs.py
@@ -76,7 +76,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+    ] = "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js",
     swagger_css_url: Annotated[
         str,
         Doc(
@@ -89,7 +89,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+    ] = "https://unpkg.com/swagger-ui-dist@5/swagger-ui.css",
     swagger_favicon_url: Annotated[
         str,
         Doc(
@@ -233,7 +233,7 @@ def get_redoc_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+    ] = "https://unpkg.com/redoc@2/bundles/redoc.standalone.js",
     redoc_favicon_url: Annotated[
         str,
         Doc(


### PR DESCRIPTION
Switches the default CDN URLs for Swagger UI and ReDoc from cdn.jsdelivr.net to unpkg.com for better reliability. Users can still override via function parameters.

Closes #762