### PR TITLE
feat: add request ID middleware support to logger — closes #797

### DIFF
--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,31 @@
 import logging
+import uuid
+from contextvars import ContextVar
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
 
 logger = logging.getLogger("fastapi")
+
+
+def get_request_id() -> str | None:
+    """Get the current request ID from context."""
+    return request_id_var.get()
+
+
+def set_request_id(request_id: str | None = None) -> str:
+    """Set a request ID for the current context. Generates one if not provided."""
+    if request_id is None:
+        request_id = uuid.uuid4().hex[:12]
+    request_id_var.set(request_id)
+    return request_id
+
+
+class RequestIDFilter(logging.Filter):
+    """Logging filter that adds request_id to log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id() or "-"
+        return True
+
+
+logger.addFilter(RequestIDFilter())


### PR DESCRIPTION
Adds request ID tracking support to the FastAPI logger:

- request_id_var context variable for per-request isolation
- get_request_id() / set_request_id() helper functions
- RequestIDFilter that automatically adds request_id to every log record

Usage in middleware:
```python
from fastapi.logger import set_request_id

@app.middleware("http")
async def add_request_id(request: Request, call_next):
    set_request_id()
    return await call_next(request)
```

Then all log records will contain request_id field automatically.

Closes #797