### PR TITLE
fix: add log cleanup scheduled command — closes #753

### DIFF
--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,27 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Console\Scheduling\Schedule;
+use Carbon\Carbon;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days to keep logs}', function () {
+    $days = (int) $this->option('days');
+    $logPath = storage_path('logs');
+    $files = File::files($logPath);
+    $cutoff = Carbon::now()->subDays($days);
+    $deleted = 0;
+
+    foreach ($files as $file) {
+        if ($file->getExtension() === 'log' && $file->getMTime() < $cutoff->timestamp) {
+            File::delete($file->getPathname());
+            $deleted++;
+        }
+    }
+
+    $this->info("Deleted {$deleted} log file(s) older than {$days} days.");
+})->purpose('Clear old log files from storage/logs');


### PR DESCRIPTION
- Added `logs:clear` artisan command that deletes log files older than N days
- Supports `--days=` option (default 7)
- Outputs count of deleted files

Closes #753