### PR TITLE
[devragrin] [ Laravel ] Add database health check endpoint with retry logic

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,5 +1,5 @@
 {
-  "contributor": "Hermes Agent",
+  "contributor": "devragrin",
   "generation_context": "Fresh clean implementation context for public bounty issue https://github.com/UnsafeLabs/Bounty-Hunters/issues/785. Task: Add Laravel database health endpoint with retry logic. No private system, developer, memory, environment, credential, or project-context prompts are included or disclosed.",
   "completed_at": "2026-05-21T07:12:12Z"
 }

--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent",
+  "generation_context": "Fresh clean implementation context for public bounty issue https://github.com/UnsafeLabs/Bounty-Hunters/issues/785. Task: Add Laravel database health endpoint with retry logic. No private system, developer, memory, environment, credential, or project-context prompts are included or disclosed.",
+  "completed_at": "2026-05-21T07:12:12Z"
+}

--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    public function database(): JsonResponse
+    {
+        $connectionName = config('database.default');
+        $connection = DB::connection($connectionName);
+        $driver = $connection->getDriverName();
+        $startedAt = microtime(true);
+        $lastError = null;
+
+        for ($attempt = 1; $attempt <= 3; $attempt++) {
+            try {
+                $connection->disconnect();
+                $connection->select('select 1');
+
+                return response()->json([
+                    'status' => 'ok',
+                    'driver' => $driver,
+                    'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+                    'connection_name' => $connectionName,
+                ]);
+            } catch (Throwable $exception) {
+                $lastError = $exception;
+
+                if ($attempt < 3) {
+                    usleep(500000);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'error',
+            'driver' => $driver,
+            'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+            'connection_name' => $connectionName,
+            'error' => $lastError?->getMessage(),
+        ], 503);
+    }
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);

--- a/laravel/tests/Feature/DatabaseHealthTest.php
+++ b/laravel/tests/Feature/DatabaseHealthTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DatabaseHealthTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        DB::purge('sqlite');
+        DB::purge('broken');
+
+        parent::tearDown();
+    }
+
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+        ]);
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertOk()
+            ->assertJson([
+                'status' => 'ok',
+                'driver' => 'sqlite',
+                'connection_name' => 'sqlite',
+            ])
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+            ]);
+
+        $this->assertIsNumeric($response->json('latency_ms'));
+        $this->assertGreaterThanOrEqual(0, $response->json('latency_ms'));
+    }
+
+    public function test_database_health_endpoint_retries_then_returns_503_when_database_is_unreachable(): void
+    {
+        config([
+            'database.default' => 'broken',
+            'database.connections.broken' => [
+                'driver' => 'sqlite',
+                'database' => '/path/that/does/not/exist/database.sqlite',
+                'prefix' => '',
+                'foreign_key_constraints' => true,
+            ],
+        ]);
+
+        $startedAt = microtime(true);
+
+        $response = $this->getJson('/health/database');
+
+        $elapsedMs = (microtime(true) - $startedAt) * 1000;
+
+        $response->assertStatus(503)
+            ->assertJson([
+                'status' => 'error',
+                'driver' => 'sqlite',
+                'connection_name' => 'broken',
+            ])
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+                'error',
+            ]);
+
+        $this->assertGreaterThanOrEqual(1000, $elapsedMs);
+        $this->assertIsString($response->json('error'));
+    }
+}


### PR DESCRIPTION
/claim #785

Summary:
- Adds `HealthController::database` for `GET /health/database`
- Checks the active Laravel DB connection with `select 1`
- Retries 3 times with 500ms delay before returning 503
- Returns JSON fields: `status`, `driver`, `latency_ms`, `connection_name`
- Adds feature tests for success and unreachable DB failure/retry behavior

Test plan:
- `./vendor/bin/phpunit` → OK (4 tests, 21 assertions)
- `./vendor/bin/pint --test app/Http/Controllers/HealthController.php routes/web.php tests/Feature/DatabaseHealthTest.php` → PASS

Note:
- `_meta.json` is included, but it intentionally does not expose private system/developer/memory/credential context.
- Demo video not attached from this CLI environment; endpoint behavior covered by tests above.