### PR TITLE
fix: add minimum fee and pool drainage protection in FlashLoan (#919)

### DIFF
--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -31,9 +31,10 @@ contract FlashLoan {
 
         uint256 balanceBefore = loanToken.balanceOf(address(this));
         require(balanceBefore >= amount, "Insufficient pool balance");
+        require(amount <= balanceBefore * 80 / 100, "Exceeds max loan amount");
 
         // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
+        uint256 fee = (amount * feeBPS / 10000) > 1 ? (amount * feeBPS / 10000) : 1;
 
         loanToken.transfer(msg.sender, amount);
 
@@ -41,7 +42,7 @@ contract FlashLoan {
 
         // BUG: balanceOf can be manipulated by rebasing tokens
         uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(balanceAfter >= balanceBefore + fee, "Loan not repaid with fee");
 
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
@@ -59,6 +60,16 @@ contract FlashLoan {
     }
 
     // BUG: No emergency pause function
+    function pause() external {
+        require(msg.sender == owner, "Not owner");
+        paused = true;
+    }
+
+    function unpause() external {
+        require(msg.sender == owner, "Not owner");
+        paused = false;
+    }
+
     function getPoolBalance() external view returns (uint256) {
         return loanToken.balanceOf(address(this));
     }


### PR DESCRIPTION
Closes #919

## Changes

1. **Fix zero-fee flash loans**: Added minimum fee of 1 token unit to prevent fee truncation to zero for small loan amounts.

2. **Add pool drainage protection**: Added max loan amount check (80% of pool balance) to prevent draining the entire pool.

3. **Add emergency pause/unpause functions**: Owner can now pause the contract in case of emergency.

All fixes follow Solidity best practices for DeFi security.