### PR TITLE
fix: lock minimum liquidity and fix reserve calculation in LiquidityPool (#918)

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -27,8 +27,10 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
             lpTokens = sqrt(amountA * amountB);
+            require(lpTokens >= MINIMUM_LIQUIDITY, "Insufficient liquidity to provide");
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -49,12 +51,8 @@ contract LiquidityPool is ERC20 {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 


### PR DESCRIPTION
Closes #918

## Changes

1. **Lock MINIMUM_LIQUIDITY to address(0)**: On the first deposit, MINIMUM_LIQUIDITY (1000) LP tokens are minted to address(0) and permanently locked. This prevents first-depositor price manipulation attacks.

2. **Fix removeLiquidity to use internal reserves**: Changed from using `balanceOf` (which can be manipulated by direct token transfers) to using the internal `reserveA`/`reserveB` tracking variables.

Both fixes follow Uniswap V2 style security patterns.