### PR TITLE
[devragrin] [ FastAPI ] Implement dynamic CORS origin validation

### DIFF
--- a/_generation.json
+++ b/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "devragrin",
+  "pre_task_context": "Public bounty task context only: implement GitHub issue #763 in UnsafeLabs/Bounty-Hunters. Private system/developer prompts, memory, credentials, and hidden runtime context are intentionally not disclosed.",
+  "timestamp": "2026-05-21T08:26:56Z"
+}

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,145 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+AllowOriginFunc = Callable[[str], bool | Awaitable[bool]]
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        allow_origins: Sequence[str] = (),
+        allow_methods: Sequence[str] = ("GET",),
+        allow_headers: Sequence[str] = (),
+        allow_credentials: bool = False,
+        allow_origin_regex: str | None = None,
+        expose_headers: Sequence[str] = (),
+        max_age: int = 600,
+        allow_origin_func: AllowOriginFunc | None = None,
+        cors_max_age: int | None = None,
+    ) -> None:
+        super().__init__(
+            app=app,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=allow_origin_regex,
+            expose_headers=expose_headers,
+            max_age=cors_max_age if cors_max_age is not None else max_age,
+        )
+        self.allow_origin_func = allow_origin_func
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.allow_origin_func is None:
+            await super().__call__(scope, receive, send)
+            return
+
+        if scope["type"] != "http":  # pragma: no cover
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+
+        if origin is None:
+            await self.app(scope, receive, send)
+            return
+
+        is_allowed = await self.is_allowed_origin_dynamic(origin)
+
+        if method == "OPTIONS" and "access-control-request-method" in headers:
+            response = self.preflight_response_for_origin(
+                request_headers=headers,
+                is_allowed_origin=is_allowed,
+            )
+            await response(scope, receive, send)
+            return
+
+        await self.simple_response_for_origin(
+            scope,
+            receive,
+            send,
+            request_headers=headers,
+            is_allowed_origin=is_allowed,
+        )
+
+    async def is_allowed_origin_dynamic(self, origin: str) -> bool:
+        if self.allow_origin_func is None:
+            return self.is_allowed_origin(origin)
+
+        result = self.allow_origin_func(origin)
+        if inspect.isawaitable(result):
+            result = await result
+        return bool(result)
+
+    def preflight_response_for_origin(
+        self,
+        request_headers: Headers,
+        is_allowed_origin: bool,
+    ) -> PlainTextResponse:
+        requested_origin = request_headers["origin"]
+        requested_method = request_headers["access-control-request-method"]
+        requested_headers = request_headers.get("access-control-request-headers")
+
+        headers = dict(self.preflight_headers)
+        failures = []
+
+        if is_allowed_origin:
+            if self.preflight_explicit_allow_origin:
+                headers["Access-Control-Allow-Origin"] = requested_origin
+        else:
+            failures.append("origin")
+
+        if requested_method not in self.allow_methods:
+            failures.append("method")
+
+        if self.allow_all_headers and requested_headers is not None:
+            headers["Access-Control-Allow-Headers"] = requested_headers
+        elif requested_headers is not None:
+            for header in [h.lower() for h in requested_headers.split(",")]:
+                if header.strip() not in self.allow_headers:
+                    failures.append("headers")
+                    break
+
+        if failures:
+            failure_text = "Disallowed CORS " + ", ".join(failures)
+            return PlainTextResponse(failure_text, status_code=400, headers=headers)
+
+        return PlainTextResponse("OK", status_code=200, headers=headers)
+
+    async def simple_response_for_origin(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        request_headers: Headers,
+        is_allowed_origin: bool,
+    ) -> None:
+        async def send_with_dynamic_origin(message: Message) -> None:
+            if message["type"] != "http.response.start":
+                await send(message)
+                return
+
+            message.setdefault("headers", [])
+            headers = MutableHeaders(scope=message)
+            headers.update(self.simple_headers)
+            origin = request_headers["Origin"]
+            has_cookie = "cookie" in request_headers
+
+            if self.allow_all_origins and has_cookie:
+                self.allow_explicit_origin(headers, origin)
+            elif not self.allow_all_origins and is_allowed_origin:
+                self.allow_explicit_origin(headers, origin)
+
+            await send(message)
+
+        await self.app(scope, receive, send_with_dynamic_origin)

--- a/fastapi/tests/test_dynamic_cors.py
+++ b/fastapi/tests/test_dynamic_cors.py
@@ -1,0 +1,136 @@
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware, DynamicCORSMiddleware
+from fastapi.testclient import TestClient
+
+
+def create_app(
+    middleware_class: type[Any] = DynamicCORSMiddleware,
+    **middleware_kwargs: Any,
+) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root() -> dict[str, str]:
+        return {"message": "ok"}
+
+    app.add_middleware(middleware_class, **middleware_kwargs)  # type: ignore[arg-type]
+    return app
+
+
+def test_existing_cors_middleware_export_is_unchanged() -> None:
+    app = create_app(
+        middleware_class=CORSMiddleware,
+        allow_origins=["https://allowed.example"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Origin": "https://allowed.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://allowed.example"
+
+
+def test_dynamic_cors_allows_origin_with_sync_callback() -> None:
+    seen_origins = []
+
+    def allow_origin(origin: str) -> bool:
+        seen_origins.append(origin)
+        return origin == "https://allowed.example"
+
+    app = create_app(allow_origin_func=allow_origin)
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Origin": "https://allowed.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://allowed.example"
+    assert response.headers["vary"] == "Origin"
+    assert seen_origins == ["https://allowed.example"]
+
+
+def test_dynamic_cors_denies_origin_with_sync_callback() -> None:
+    def allow_origin(origin: str) -> bool:
+        return False
+
+    app = create_app(allow_origin_func=allow_origin)
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Origin": "https://blocked.example"})
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_dynamic_cors_supports_async_callback() -> None:
+    async def allow_origin(origin: str) -> bool:
+        return origin.endswith(".example")
+
+    app = create_app(allow_origin_func=allow_origin)
+    client = TestClient(app)
+
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://api.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://api.example"
+
+
+def test_dynamic_cors_falls_back_to_static_origins_without_callback() -> None:
+    app = create_app(allow_origins=["https://static.example"])
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Origin": "https://static.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://static.example"
+
+
+def test_dynamic_cors_preflight_uses_cors_max_age() -> None:
+    def allow_origin(origin: str) -> bool:
+        return origin == "https://allowed.example"
+
+    app = create_app(
+        allow_origin_func=allow_origin,
+        allow_methods=["GET", "POST"],
+        cors_max_age=3600,
+    )
+    client = TestClient(app)
+
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://allowed.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://allowed.example"
+    assert response.headers["access-control-max-age"] == "3600"
+
+
+def test_dynamic_cors_preflight_denies_origin() -> None:
+    def allow_origin(origin: str) -> bool:
+        return False
+
+    app = create_app(allow_origin_func=allow_origin)
+    client = TestClient(app)
+
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://blocked.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
/claim #763

## Summary
- Add `DynamicCORSMiddleware` while preserving the existing `CORSMiddleware` re-export.
- Support sync and async `allow_origin_func(origin)` callbacks for per-request origin decisions.
- Add `cors_max_age` support for preflight `Access-Control-Max-Age`.
- Fall back to static Starlette CORS behavior when no callback is provided.
- Add focused tests for dynamic allow/deny, async callbacks, static fallback, max-age, and existing export behavior.

## Test Plan
- `python3.12 -m ruff check fastapi/middleware/cors.py tests/test_dynamic_cors.py`
- `python3.12 -m ruff format --check fastapi/middleware/cors.py tests/test_dynamic_cors.py`
- `python3.12 -m pytest tests/test_dynamic_cors.py -q`
- `python3.12 -m mypy fastapi/middleware/cors.py tests/test_dynamic_cors.py --config-file pyproject.toml`

## Metadata note
`_generation.json` is included with safe public task context only. Private system/developer prompts, memory, credentials, and hidden runtime context are intentionally not disclosed.

Demo video: https://github.com/user-attachments/assets/10954502-7971-4399-a828-d1ac7430254f
