### PR TITLE
[Hermes Agent] [T3 Code] Add version command and --version flag to CLI

### DIFF
--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -10,13 +10,14 @@ import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { versionCommand } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, versionCommand]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/cli/.contributor.json
+++ b/t3code/apps/server/src/cli/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes Agent with gpt-5.5",
+  "initialized_with": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools.",
+  "timestamp": "2026-05-21T10:00:00Z"
+}

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,33 @@
+import * as Effect from "effect/Effect";
+import { Command } from "effect/unstable/cli";
+import packageJson from "../../package.json" with { type: "json" };
+
+const getRuntimeName = (): string => {
+  if (typeof Bun !== "undefined") return "bun";
+  return "node";
+};
+
+const getRuntimeVersion = (): string => {
+  if (typeof Bun !== "undefined") return Bun.version;
+  return process.version.replace(/^v/, "");
+};
+
+const getPlatformString = (): string => {
+  const platform = process.platform;
+  const arch = process.arch;
+  return `${platform} ${arch}`;
+};
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Show version information"),
+  Command.withHandler(() =>
+    Effect.sync(() => {
+      const runtime = getRuntimeName();
+      const runtimeVersion = getRuntimeVersion();
+      const platform = getPlatformString();
+      process.stdout.write(
+        `t3code v${packageJson.version} (${runtime} ${runtimeVersion}, ${platform})\n`,
+      );
+    }),
+  ),
+);


### PR DESCRIPTION
## Changes

### Added
- **`version` subcommand** (`t3 version`) — outputs: `t3code v0.0.24 (bun 1.x, platform arch)`
- **`--version` flag** (`t3 --version`) — already handled by Effect CLI's `Command.run` with `{ version: packageJson.version }`

### Files Changed
- `t3code/apps/server/src/cli/version.ts` — new version subcommand
- `t3code/apps/server/src/bin.ts` — imported and registered version command
- `t3code/apps/server/src/cli/.contributor.json` — contributor provenance

### Acceptance Criteria
- [x] `t3 --version` outputs version string and exits (via Effect CLI built-in)
- [x] `t3 version` outputs: `t3code v0.0.24 (bun/version, platform arch)`
- [x] Version read from package.json at build time (import assertion)
- [x] Both commands exit with code 0
- [x] Existing commands unaffected

```
Name: Hermes Agent with gpt-5.5
Timestamp: 2026-05-21T10:00:00Z
```
