### PR TITLE
[Hermes Agent] [T3 Code] Fix ProviderModelPicker not persisting selection across reloads

### DIFF
--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -3,9 +3,9 @@ import {
   type ProviderDriverKind,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
-import { ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon, RotateCcwIcon } from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -19,6 +19,13 @@ import {
 } from "./providerIconUtils";
 import { setModelPickerOpen } from "../../modelPickerOpenState";
 import type { ProviderInstanceEntry } from "../../providerInstances";
+
+const PERSISTENCE_KEY = "t3code:provider-model-preference";
+
+interface PersistedPreference {
+  instanceId: ProviderInstanceId;
+  model: string;
+}
 
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   /**
@@ -45,6 +52,106 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
 }) {
   const [uncontrolledIsMenuOpen, setUncontrolledIsMenuOpen] = useState(false);
   const isMenuOpen = props.open ?? uncontrolledIsMenuOpen;
+
+  // Track whether we've already attempted to restore from localStorage on mount.
+  // We use a ref so it persists across re-renders but resets on unmount/remount.
+  const hasRestoredRef = useRef(false);
+
+  // Restore persisted provider/model selection on mount.
+  useEffect(() => {
+    if (hasRestoredRef.current) return;
+    hasRestoredRef.current = true;
+
+    try {
+      const raw = localStorage.getItem(PERSISTENCE_KEY);
+      if (!raw) return;
+      const pref: PersistedPreference = JSON.parse(raw);
+      if (!pref.instanceId || !pref.model) return;
+
+      // Only restore if the persisted instance still exists in the available entries.
+      const exists = props.instanceEntries.some(
+        (entry) => entry.instanceId === pref.instanceId,
+      );
+      if (!exists) {
+        // Stale preference — clear it and fall back to default.
+        localStorage.removeItem(PERSISTENCE_KEY);
+        return;
+      }
+
+      // Only restore if it differs from the current selection to avoid
+      // an unnecessary re-render loop.
+      if (
+        pref.instanceId !== props.activeInstanceId ||
+        pref.model !== props.model
+      ) {
+        props.onInstanceModelChange(pref.instanceId, pref.model);
+      }
+    } catch {
+      // Corrupted data — clear it.
+      localStorage.removeItem(PERSISTENCE_KEY);
+    }
+    // We only want this to fire on mount — don't re-run when props change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist selection to localStorage whenever it changes.
+  const prevSelectionRef = useRef<{ instanceId: string; model: string } | null>(null);
+  useEffect(() => {
+    const current = { instanceId: props.activeInstanceId, model: props.model };
+    if (
+      prevSelectionRef.current?.instanceId === current.instanceId &&
+      prevSelectionRef.current?.model === current.model
+    ) {
+      return;
+    }
+    prevSelectionRef.current = current;
+    try {
+      localStorage.setItem(PERSISTENCE_KEY, JSON.stringify(current));
+    } catch {
+      // localStorage may be full or unavailable — silently ignore.
+    }
+  }, [props.activeInstanceId, props.model]);
+
+  // Sync persisted preference across browser tabs via the storage event.
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key !== PERSISTENCE_KEY || !e.newValue) return;
+      try {
+        const pref: PersistedPreference = JSON.parse(e.newValue);
+        if (!pref.instanceId || !pref.model) return;
+
+        const exists = props.instanceEntries.some(
+          (entry) => entry.instanceId === pref.instanceId,
+        );
+        if (!exists) return;
+
+        if (
+          pref.instanceId !== props.activeInstanceId ||
+          pref.model !== props.model
+        ) {
+          props.onInstanceModelChange(pref.instanceId, pref.model);
+        }
+      } catch {
+        // Ignore parse errors from other tabs.
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [props.activeInstanceId, props.model, props.instanceEntries, props.onInstanceModelChange]);
+
+  // Clear persisted preference and reset to the first available provider/model.
+  const handleResetToDefault = useCallback(() => {
+    localStorage.removeItem(PERSISTENCE_KEY);
+    const firstEntry = props.instanceEntries[0];
+    if (firstEntry) {
+      const firstModel =
+        props.modelOptionsByInstance.get(firstEntry.instanceId)?.[0];
+      if (firstModel) {
+        props.onInstanceModelChange(firstEntry.instanceId, firstModel.slug);
+      }
+    }
+    setIsMenuOpen(false);
+  }, [props.instanceEntries, props.modelOptionsByInstance, props.onInstanceModelChange]);
 
   // Resolve the active instance entry by exact routing key. The composer
   // resolves fallbacks before rendering this component; if the selected
@@ -181,6 +288,16 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           onRequestClose={() => setIsMenuOpen(false)}
           onInstanceModelChange={handleInstanceModelChange}
         />
+        <div className="border-t border-border px-3 py-1.5">
+          <button
+            type="button"
+            onClick={handleResetToDefault}
+            className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs text-muted-foreground/60 hover:bg-accent hover:text-muted-foreground transition-colors"
+          >
+            <RotateCcwIcon className="size-3" />
+            Reset to default
+          </button>
+        </div>
       </PopoverPopup>
     </Popover>
   );

--- a/t3code/apps/web/src/components/chat/_generation.json
+++ b/t3code/apps/web/src/components/chat/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes Agent with gpt-5.5",
+  "pre_task_context": "User asked to find and fix a bounty issue. Selected Issue #834: Add localStorage persistence to ProviderModelPicker in T3 Code project. The component is a controlled React component at t3code/apps/web/src/components/chat/ProviderModelPicker.tsx that uses Popover/ModelPickerContent for provider/model selection.",
+  "timestamp": "2026-05-21T10:30:00Z"
+}


### PR DESCRIPTION
## Summary

Fixes #834 by adding localStorage persistence to `ProviderModelPicker` so the selected provider and model survive page reloads.

## Changes

### `t3code/apps/web/src/components/chat/ProviderModelPicker.tsx`

- **Restore on mount**: On component mount, reads persisted preference from `localStorage` under the namespaced key `t3code:provider-model-preference` and restores the selection via `onInstanceModelChange`.
- **Persist on change**: Whenever the active instance or model changes, writes the new selection to `localStorage`.
- **Graceful fallback**: If the persisted provider is no longer in the available entries, clears the stale preference and falls back to default.
- **Cross-tab sync**: Listens for `StorageEvent` to sync provider/model selection across multiple browser tabs.
- **Reset to default**: Adds a "Reset to default" button at the bottom of the picker popover that clears `localStorage` and reverts to the first available provider/model.
- **Error handling**: Catches and recovers from corrupted `localStorage` entries (JSON parse errors, missing values).

### `_generation.json`

Added contributor meta file as required by the issue template.

## Acceptance Criteria

- [x] Selected provider and model persist across page reloads
- [x] Invalid persisted values fall back gracefully to first available option
- [x] Reset option clears localStorage keys and reverts to default selection
- [x] Multiple browser tabs share the same persisted preference via storage event
- [x] localStorage keys are namespaced to avoid conflicts
- [x] Existing picker behavior is unchanged when localStorage is empty
- [x] PR title follows `[Agent Name] [T3 Code]` format
- [x] `_generation.json` included with required fields

---

**Agent**: Hermes Agent with gpt-5.5
**Issue**: #834