### PR TITLE
fix: handle bytes/memoryview in jsonable_encoder with base64/hex enco…

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Claude Code (Claude Opus 4.7 powered by deepseek-v4-pro)",
+  "boot_context": "Fix jsonable_encoder TypeError on bytes and memoryview objects. Add base64/hex encoding support for binary data types. Issue #759 on Bounty-Hunters/FastAPI.",
+  "timestamp": "2026-05-21T17:30:00Z"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -82,7 +83,6 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -124,6 +124,14 @@ def generate_encoders_by_class_tuples(
 
 
 encoders_by_class_tuples = generate_encoders_by_class_tuples(ENCODERS_BY_TYPE)
+
+
+def _encode_bytes(data: bytes, encoding: str) -> str:
+    if encoding == "base64":
+        return base64.b64encode(data).decode("ascii")
+    if encoding == "hex":
+        return data.hex()
+    raise ValueError(f"Unsupported bytes_encoding: {encoding!r}")
 
 
 def jsonable_encoder(
@@ -215,6 +223,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            The encoding to use for ``bytes`` objects. Must be one of ``"base64"``
+            or ``"hex"``. Defaults to ``"base64"``.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -255,6 +272,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +287,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -276,6 +295,10 @@ def jsonable_encoder(
         return str(obj)
     if isinstance(obj, (str, int, float, type(None))):
         return obj
+    if isinstance(obj, memoryview):
+        return _encode_bytes(bytes(obj), bytes_encoding)
+    if isinstance(obj, bytes):
+        return _encode_bytes(obj, bytes_encoding)
     if isinstance(obj, PydanticUndefinedType):
         return None
     if isinstance(obj, dict):
@@ -302,6 +325,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +334,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +352,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +387,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -313,6 +313,66 @@ def test_encode_pydantic_undefined():
     assert jsonable_encoder(data) == {"value": None}
 
 
+def test_encode_bytes_base64():
+    data = b"hello world"
+    assert jsonable_encoder(data) == "aGVsbG8gd29ybGQ="
+
+
+def test_encode_bytes_hex():
+    data = b"hello world"
+    assert jsonable_encoder(data, bytes_encoding="hex") == "68656c6c6f20776f726c64"
+
+
+def test_encode_bytes_in_dict():
+    data = {"key": b"test"}
+    assert jsonable_encoder(data) == {"key": "dGVzdA=="}
+    assert jsonable_encoder(data, bytes_encoding="hex") == {"key": "74657374"}
+
+
+def test_encode_bytes_in_list():
+    data = [b"a", b"b"]
+    assert jsonable_encoder(data) == ["YQ==", "Yg=="]
+
+
+def test_encode_bytes_nested():
+    data = {"outer": {"inner": b"nested"}}
+    assert jsonable_encoder(data) == {"outer": {"inner": "bmVzdGVk"}}
+    assert jsonable_encoder(data, bytes_encoding="hex") == {"outer": {"inner": "6e6573746564"}}
+
+
+def test_encode_memoryview_base64():
+    data = memoryview(b"hello")
+    assert jsonable_encoder(data) == "aGVsbG8="
+
+
+def test_encode_memoryview_hex():
+    data = memoryview(b"hello")
+    assert jsonable_encoder(data, bytes_encoding="hex") == "68656c6c6f"
+
+
+def test_encode_non_utf8_bytes():
+    data = b"\xff\xfe\x00\x01"
+    assert jsonable_encoder(data) == "//4AAQ=="
+    assert jsonable_encoder(data, bytes_encoding="hex") == "fffe0001"
+
+
+def test_encode_bytes_invalid_encoding():
+    data = b"test"
+    with pytest.raises(ValueError, match="Unsupported bytes_encoding"):
+        jsonable_encoder(data, bytes_encoding="invalid")
+
+
+def test_encode_bytes_in_dataclass():
+    @dataclass
+    class BinaryItem:
+        name: str
+        content: bytes
+
+    item = BinaryItem(name="test", content=b"data")
+    result = jsonable_encoder(item)
+    assert result == {"name": "test", "content": "ZGF0YQ=="}
+
+
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(
     "module_path",


### PR DESCRIPTION
…ding

Add `_encode_bytes()` helper and `bytes_encoding` parameter to `jsonable_encoder()`, supporting "base64" (default) and "hex" encodings for `bytes` and `memoryview` objects.

Fixes #759
/claim #759