### PR TITLE
GPT-5.5 Thinking assisted workflow [ Laravel ] Add scheduled log cleanup command

### DIFF
--- a/_generation.json
+++ b/_generation.json
@@ -1,0 +1,5 @@
+{
+    "agent":  "GPT-5.5 Thinking assisted workflow",
+    "pre_task_context":  "User provided a continuation handoff for UnsafeLabs/Bounty-Hunters Issue #753. Goal: implement a Laravel logs:clear Artisan command in laravel/routes/console.php, avoid push/PR/comment/claim until local tests pass, keep the diff minimal, and verify command behavior locally. Hidden system or developer instructions are not included.",
+    "timestamp":  "2026-05-21T12:29:00.2338274Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,79 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days of logs to keep}', function () {
+    $days = (int) $this->option('days');
+
+    if ($days < 0) {
+        $this->error('The --days option must be zero or greater.');
+
+        return 1;
+    }
+
+    $logPath = storage_path('logs');
+
+    if (! is_dir($logPath)) {
+        $this->info('Log directory does not exist. Nothing to clear.');
+
+        return 0;
+    }
+
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deletedFiles = 0;
+    $freedBytes = 0;
+
+    $formatBytes = function (int $bytes): string {
+        if ($bytes < 1024) {
+            return $bytes . ' B';
+        }
+
+        $units = ['KB', 'MB', 'GB', 'TB', 'PB'];
+        $value = $bytes / 1024;
+
+        foreach ($units as $unit) {
+            if ($value < 1024) {
+                return number_format($value, 2) . ' ' . $unit;
+            }
+
+            $value /= 1024;
+        }
+
+        return number_format($value, 2) . ' PB';
+    };
+
+    foreach (glob($logPath . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+        if (! is_file($file)) {
+            continue;
+        }
+
+        if (basename($file) === '.gitignore') {
+            continue;
+        }
+
+        $modifiedAt = filemtime($file);
+
+        if ($modifiedAt === false || $modifiedAt > $cutoff) {
+            continue;
+        }
+
+        $fileSize = filesize($file) ?: 0;
+
+        if (unlink($file)) {
+            $deletedFiles++;
+            $freedBytes += $fileSize;
+        }
+    }
+
+    $this->info("Deleted {$deletedFiles} log file(s).");
+    $this->info('Freed ' . $formatBytes($freedBytes) . '.');
+
+    return 0;
+})->purpose('Delete log files older than the configured number of days');
+
+Schedule::command('logs:clear')->dailyAt('00:00');


### PR DESCRIPTION
﻿## Summary
- Added a `logs:clear` Artisan command in `laravel/routes/console.php`
- Deletes log files older than 7 days by default
- Supports `--days=` override, including `--days=30`
- Reports deleted file count and freed space in human-readable format
- Registers daily schedule at 00:00
- Added `_generation.json` as required

## Local testing
- `composer install`
- `php artisan list | findstr logs`
- `php artisan logs:clear`
- `php artisan logs:clear --days=30`
- Created old and new test log files
- Confirmed old log files are deleted
- Confirmed new log files remain
- Confirmed `.gitignore` remains
- `php artisan schedule:list --no-ansi` with temporary array cache
- `git diff --check`
