### PR TITLE
[Codex] [ Laravel ] Fix DatabaseSeeder duplicate test user

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex",
+  "config_snapshot": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "created": "2026-05-21T13:17:55Z"
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(2),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_21_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_21_000000_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -17,9 +17,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::query()->firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => 'password',
+            ],
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default application roles.
+     */
+    public function run(): void
+    {
+        $roles = [
+            [
+                'name' => 'admin',
+                'description' => 'Full administrative access.',
+            ],
+            [
+                'name' => 'editor',
+                'description' => 'Can create and edit application content.',
+            ],
+            [
+                'name' => 'viewer',
+                'description' => 'Read-only application access.',
+            ],
+        ];
+
+        foreach ($roles as $role) {
+            Role::query()->firstOrCreate(
+                ['name' => $role['name']],
+                ['description' => $role['description']],
+            );
+        }
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_can_run_more_than_once(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(
+            1,
+            User::query()->where('email', 'test@example.com')->count(),
+        );
+        $this->assertSame(3, Role::query()->count());
+
+        foreach (['admin', 'editor', 'viewer'] as $roleName) {
+            $this->assertDatabaseHas('roles', ['name' => $roleName]);
+        }
+    }
+
+    public function test_role_seeder_is_idempotent(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertSame(3, Role::query()->count());
+    }
+
+    public function test_role_factory_generates_valid_roles(): void
+    {
+        $role = Role::factory()->make();
+
+        $this->assertNotEmpty($role->name);
+        $this->assertNotEmpty($role->description);
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- Make the default `test@example.com` database seed idempotent with `firstOrCreate`.
- Add a `roles` table migration with unique role names.
- Add a `Role` model, `RoleFactory`, and idempotent `RoleSeeder` for `admin`, `editor`, and `viewer`.
- Call `RoleSeeder` from `DatabaseSeeder`.
- Add focused feature tests for repeated database seeding, repeated role seeding, and role factory output.
- Add a safe provenance file without copying hidden runtime/session instructions into the repository.

## Validation
- `git diff --check`
- `docker run --rm -v "$PWD/laravel:/app" -w /app php:8.3-cli-alpine sh -lc 'php -l app/Models/Role.php && php -l database/factories/RoleFactory.php && php -l database/migrations/2026_05_21_000000_create_roles_table.php && php -l database/seeders/DatabaseSeeder.php && php -l database/seeders/RoleSeeder.php && php -l tests/Feature/DatabaseSeederTest.php'`
- `docker run --rm -v "$PWD/laravel:/app" -w /app composer:2 sh -lc 'cp .env.example .env && php artisan key:generate --ansi && touch database/database.sqlite && php artisan migrate --force --ansi && php artisan test --filter=DatabaseSeederTest'`

Focused test result: 3 passed, 8 assertions.

Refs #746