### PR TITLE
fix(fastapi): allow customizing Swagger UI and ReDoc asset URLs

### DIFF
--- a/.generation_meta.json
+++ b/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Antigravity",
+  "initial_directives": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide.",
+  "date": "2026-05-21T13:30:00Z"
+}

--- a/fastapi/fastapi/applications.py
+++ b/fastapi/fastapi/applications.py
@@ -859,6 +859,46 @@ class FastAPI(Starlette):
                 """
             ),
         ] = True,
+        swagger_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI JavaScript.
+                """
+            ),
+        ] = None,
+        swagger_css_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI CSS.
+                """
+            ),
+        ] = None,
+        swagger_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the Swagger UI favicon.
+                """
+            ),
+        ] = None,
+        redoc_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the ReDoc JavaScript.
+                """
+            ),
+        ] = None,
+        redoc_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the ReDoc favicon.
+                """
+            ),
+        ] = None,
         **extra: Annotated[
             Any,
             Doc(
@@ -888,6 +928,11 @@ class FastAPI(Starlette):
         self.servers = servers or []
         self.separate_input_output_schemas = separate_input_output_schemas
         self.openapi_external_docs = openapi_external_docs
+        self.swagger_js_url = swagger_js_url
+        self.swagger_css_url = swagger_css_url
+        self.swagger_favicon_url = swagger_favicon_url
+        self.redoc_js_url = redoc_js_url
+        self.redoc_favicon_url = redoc_favicon_url
         self.extra = extra
         self.openapi_version: Annotated[
             str,
@@ -1122,12 +1167,20 @@ class FastAPI(Starlette):
                 oauth2_redirect_url = self.swagger_ui_oauth2_redirect_url
                 if oauth2_redirect_url:
                     oauth2_redirect_url = root_path + oauth2_redirect_url
+                swagger_kwargs = {}
+                if self.swagger_js_url is not None:
+                    swagger_kwargs["swagger_js_url"] = self.swagger_js_url
+                if self.swagger_css_url is not None:
+                    swagger_kwargs["swagger_css_url"] = self.swagger_css_url
+                if self.swagger_favicon_url is not None:
+                    swagger_kwargs["swagger_favicon_url"] = self.swagger_favicon_url
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=f"{self.title} - Swagger UI",
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                     swagger_ui_parameters=self.swagger_ui_parameters,
+                    **swagger_kwargs,
                 )
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
@@ -1147,8 +1200,15 @@ class FastAPI(Starlette):
             async def redoc_html(req: Request) -> HTMLResponse:
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
+                redoc_kwargs = {}
+                if self.redoc_js_url is not None:
+                    redoc_kwargs["redoc_js_url"] = self.redoc_js_url
+                if self.redoc_favicon_url is not None:
+                    redoc_kwargs["redoc_favicon_url"] = self.redoc_favicon_url
                 return get_redoc_html(
-                    openapi_url=openapi_url, title=f"{self.title} - ReDoc"
+                    openapi_url=openapi_url,
+                    title=f"{self.title} - ReDoc",
+                    **redoc_kwargs,
                 )
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)

--- a/fastapi/fastapi/applications.py
+++ b/fastapi/fastapi/applications.py
@@ -891,6 +891,14 @@ class FastAPI(Starlette):
                 """
             ),
         ] = None,
+        redoc_css_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the ReDoc CSS.
+                """
+            ),
+        ] = None,
         redoc_favicon_url: Annotated[
             str | None,
             Doc(
@@ -932,6 +940,7 @@ class FastAPI(Starlette):
         self.swagger_css_url = swagger_css_url
         self.swagger_favicon_url = swagger_favicon_url
         self.redoc_js_url = redoc_js_url
+        self.redoc_css_url = redoc_css_url
         self.redoc_favicon_url = redoc_favicon_url
         self.extra = extra
         self.openapi_version: Annotated[
@@ -1203,6 +1212,8 @@ class FastAPI(Starlette):
                 redoc_kwargs = {}
                 if self.redoc_js_url is not None:
                     redoc_kwargs["redoc_js_url"] = self.redoc_js_url
+                if self.redoc_css_url is not None:
+                    redoc_kwargs["redoc_css_url"] = self.redoc_css_url
                 if self.redoc_favicon_url is not None:
                     redoc_kwargs["redoc_favicon_url"] = self.redoc_favicon_url
                 return get_redoc_html(

--- a/fastapi/fastapi/openapi/docs.py
+++ b/fastapi/fastapi/openapi/docs.py
@@ -234,6 +234,14 @@ def get_redoc_html(
             """
         ),
     ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+    redoc_css_url: Annotated[
+        str | None,
+        Doc(
+            """
+            The URL to use to load the ReDoc CSS.
+            """
+        ),
+    ] = None,
     redoc_favicon_url: Annotated[
         str,
         Doc(
@@ -273,6 +281,10 @@ def get_redoc_html(
     if with_google_fonts:
         html += """
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    """
+    if redoc_css_url:
+        html += f"""
+    <link type="text/css" rel="stylesheet" href="{redoc_css_url}">
     """
     html += f"""
     <link rel="shortcut icon" href="{redoc_favicon_url}">

--- a/fastapi/tests/test_local_docs.py
+++ b/fastapi/tests/test_local_docs.py
@@ -1,6 +1,8 @@
 import inspect
 
+from fastapi import FastAPI
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.testclient import TestClient
 
 
 def test_strings_in_generated_swagger():
@@ -65,3 +67,27 @@ def test_google_fonts_in_generated_redoc():
         openapi_url="/docs", title="title", with_google_fonts=False
     ).body.decode()
     assert "fonts.googleapis.com" not in body_without_google_fonts
+
+
+def test_fastapi_custom_docs_urls():
+    app = FastAPI(
+        swagger_js_url="https://example.com/swagger.js",
+        swagger_css_url="https://example.com/swagger.css",
+        swagger_favicon_url="https://example.com/swagger-favicon.png",
+        redoc_js_url="https://example.com/redoc.js",
+        redoc_favicon_url="https://example.com/redoc-favicon.png",
+    )
+    client = TestClient(app)
+
+    response = client.get("/docs")
+    assert response.status_code == 200
+    html = response.text
+    assert "https://example.com/swagger.js" in html
+    assert "https://example.com/swagger.css" in html
+    assert "https://example.com/swagger-favicon.png" in html
+
+    response_redoc = client.get("/redoc")
+    assert response_redoc.status_code == 200
+    html_redoc = response_redoc.text
+    assert "https://example.com/redoc.js" in html_redoc
+    assert "https://example.com/redoc-favicon.png" in html_redoc

--- a/fastapi/tests/test_local_docs.py
+++ b/fastapi/tests/test_local_docs.py
@@ -46,15 +46,18 @@ def test_strings_in_generated_redoc():
 
 def test_strings_in_custom_redoc():
     redoc_js_url = "fake_redoc_file.js"
+    redoc_css_url = "fake_redoc_file.css"
     redoc_favicon_url = "fake_redoc_file.png"
     html = get_redoc_html(
         openapi_url="/docs",
         title="title",
         redoc_js_url=redoc_js_url,
+        redoc_css_url=redoc_css_url,
         redoc_favicon_url=redoc_favicon_url,
     )
     body_content = html.body.decode()
     assert redoc_js_url in body_content
+    assert redoc_css_url in body_content
     assert redoc_favicon_url in body_content
 
 
@@ -75,6 +78,7 @@ def test_fastapi_custom_docs_urls():
         swagger_css_url="https://example.com/swagger.css",
         swagger_favicon_url="https://example.com/swagger-favicon.png",
         redoc_js_url="https://example.com/redoc.js",
+        redoc_css_url="https://example.com/redoc.css",
         redoc_favicon_url="https://example.com/redoc-favicon.png",
     )
     client = TestClient(app)
@@ -90,4 +94,5 @@ def test_fastapi_custom_docs_urls():
     assert response_redoc.status_code == 200
     html_redoc = response_redoc.text
     assert "https://example.com/redoc.js" in html_redoc
+    assert "https://example.com/redoc.css" in html_redoc
     assert "https://example.com/redoc-favicon.png" in html_redoc


### PR DESCRIPTION
/claim #762

## Issue
Closes #762

## Summary
Added keyword-only initialization parameters to the `FastAPI` class to allow customizing the default CDN asset URLs (JS, CSS, favicon) for Swagger UI and ReDoc HTML generation, replacing the previous hardcoded defaults.

## Acceptance criteria
- [x] Customize Swagger UI JS, CSS, and favicon URLs globally on FastAPI app initialization.
- [x] Customize ReDoc JS and favicon URLs globally on FastAPI app initialization.
- [x] Add a unit test validating that the custom URLs override the defaults.
- [x] All existing tests still pass.

## Demo Video

https://github.com/user-attachments/assets/40edacfb-ddb3-4855-ac69-4b012525c3f4

