### PR TITLE
Codex [ Laravel ] Add database health check endpoint

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex",
+  "generation_context": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-21T14:55:00Z"
+}

--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    private const MAX_ATTEMPTS = 3;
+
+    private const RETRY_DELAY_MICROSECONDS = 500_000;
+
+    public function database(): JsonResponse
+    {
+        $connectionName = config('database.default');
+        $driver = config("database.connections.{$connectionName}.driver");
+        $startedAt = hrtime(true);
+        $lastError = null;
+
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+            try {
+                $connection = DB::connection($connectionName);
+                $connection->getPdo();
+
+                return response()->json([
+                    'status' => 'ok',
+                    'driver' => $connection->getDriverName(),
+                    'latency_ms' => $this->elapsedMilliseconds($startedAt),
+                    'connection_name' => $connectionName,
+                    'attempts' => $attempt,
+                ]);
+            } catch (Throwable $exception) {
+                $lastError = $exception;
+                DB::purge($connectionName);
+
+                if ($attempt < self::MAX_ATTEMPTS) {
+                    usleep(self::RETRY_DELAY_MICROSECONDS);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'error',
+            'driver' => $driver,
+            'latency_ms' => $this->elapsedMilliseconds($startedAt),
+            'connection_name' => $connectionName,
+            'attempts' => self::MAX_ATTEMPTS,
+            'error' => $lastError?->getMessage() ?? 'Database connection failed.',
+        ], 503);
+    }
+
+    private function elapsedMilliseconds(int $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000, 2);
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);

--- a/laravel/tests/Feature/DatabaseHealthTest.php
+++ b/laravel/tests/Feature/DatabaseHealthTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DatabaseHealthTest extends TestCase
+{
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        $response = $this->getJson('/health/database');
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'status' => 'ok',
+                'driver' => 'sqlite',
+                'connection_name' => 'sqlite',
+                'attempts' => 1,
+            ])
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+                'attempts',
+            ]);
+
+        $this->assertIsNumeric($response->json('latency_ms'));
+        $this->assertGreaterThanOrEqual(0, $response->json('latency_ms'));
+    }
+
+    public function test_database_health_endpoint_returns_service_unavailable_after_retries(): void
+    {
+        config(['database.connections.sqlite.database' => database_path('missing/database.sqlite')]);
+        DB::purge('sqlite');
+
+        $response = $this->getJson('/health/database');
+
+        $response
+            ->assertStatus(503)
+            ->assertJson([
+                'status' => 'error',
+                'driver' => 'sqlite',
+                'connection_name' => 'sqlite',
+                'attempts' => 3,
+            ])
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+                'attempts',
+                'error',
+            ]);
+
+        $this->assertNotEmpty($response->json('error'));
+        $this->assertIsNumeric($response->json('latency_ms'));
+    }
+
+    protected function tearDown(): void
+    {
+        DB::purge('sqlite');
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
/claim #785

## Summary

Adds `GET /health/database` for Laravel database readiness checks.

## What changed

- Added `HealthController::database()` with active connection metadata and measured latency.
- Retries failed database connection checks 3 times with a 500ms delay before returning 503.
- Registers the `/health/database` web route.
- Adds feature tests for reachable and unreachable database states.
- Adds safe contributor metadata without copying private runtime instructions.

## Validation

- `docker run --rm -v "$PWD":/app -w /app composer:latest sh -lc 'php -l app/Http/Controllers/HealthController.php && php -l routes/web.php && php -l tests/Feature/DatabaseHealthTest.php && php -r "json_decode(file_get_contents(\"_meta.json\")); exit(json_last_error() === JSON_ERROR_NONE ? 0 : 1);"'`
- `docker run --rm -v "$PWD":/app -w /app composer:latest sh -lc 'cp .env.example .env && php artisan key:generate --ansi && php artisan test --filter=DatabaseHealthTest'`
- `docker run --rm -v "$PWD":/app -w /app composer:latest sh -lc './vendor/bin/pint app/Http/Controllers/HealthController.php routes/web.php tests/Feature/DatabaseHealthTest.php --test'`
- `docker run --rm -v "$PWD":/app -w /app composer:latest sh -lc 'php artisan test'`
- `git diff --check`
