### PR TITLE
Codex [ FastAPI ] Add StreamingCSVResponse for large dataset exports

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex",
+  "session_init": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "ts": "2026-05-21T14:40:00+01:00"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,4 +1,7 @@
+import csv
 import importlib
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+from io import StringIO
 from typing import Any, Protocol, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
@@ -11,6 +14,85 @@ from starlette.responses import RedirectResponse as RedirectResponse  # noqa
 from starlette.responses import Response as Response  # noqa
 from starlette.responses import StreamingResponse as StreamingResponse  # noqa
 from typing_extensions import deprecated
+
+CSVRow = Mapping[str, Any] | Sequence[Any]
+
+
+def _quote_content_disposition_filename(filename: str) -> str:
+    return filename.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _normalise_csv_row(row: CSVRow, headers: Sequence[str] | None) -> Sequence[Any]:
+    if isinstance(row, Mapping):
+        if headers is not None:
+            return [row.get(header, "") for header in headers]
+        return list(row.values())
+    if isinstance(row, str | bytes):
+        return [row]
+    return row
+
+
+def _render_csv_row(
+    row: CSVRow,
+    *,
+    headers: Sequence[str] | None,
+    delimiter: str,
+) -> str:
+    output = StringIO()
+    writer = csv.writer(output, delimiter=delimiter)
+    writer.writerow(_normalise_csv_row(row, headers))
+    return output.getvalue()
+
+
+async def _iterate_csv_rows(
+    content: AsyncIterable[CSVRow] | Iterable[CSVRow],
+    *,
+    headers: Sequence[str] | None,
+    delimiter: str,
+) -> AsyncIterable[str]:
+    if headers is not None:
+        yield _render_csv_row(headers, headers=None, delimiter=delimiter)
+
+    if isinstance(content, AsyncIterable):
+        async for row in content:
+            yield _render_csv_row(row, headers=headers, delimiter=delimiter)
+    else:
+        for row in content:
+            yield _render_csv_row(row, headers=headers, delimiter=delimiter)
+
+
+class StreamingCSVResponse(StreamingResponse):
+    """Stream CSV rows without materialising the full export in memory."""
+
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        content: AsyncIterable[CSVRow] | Iterable[CSVRow],
+        status_code: int = 200,
+        headers: Sequence[str] | None = None,
+        response_headers: Mapping[str, str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        background: Any = None,
+    ) -> None:
+        rendered_rows = _iterate_csv_rows(
+            content,
+            headers=headers,
+            delimiter=delimiter,
+        )
+        http_headers = dict(response_headers or {})
+        http_headers.setdefault(
+            "Content-Disposition",
+            f'attachment; filename="{_quote_content_disposition_filename(filename)}"',
+        )
+        super().__init__(
+            rendered_rows,
+            status_code=status_code,
+            headers=http_headers,
+            media_type=self.media_type,
+            background=background,
+        )
 
 
 class _UjsonModule(Protocol):

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,81 @@
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+
+async def user_rows() -> AsyncIterator[dict[str, object]]:
+    yield {"id": 1, "name": "Alice", "note": "plain"}
+    yield {"id": 2, "name": "Bob, Jr.", "note": 'quote "inside"'}
+    yield {"id": 3, "name": "Charlie", "note": "line\nbreak"}
+
+
+app = FastAPI()
+
+
+@app.get("/users.csv")
+async def users_csv():
+    return StreamingCSVResponse(
+        user_rows(),
+        headers=["id", "name", "note"],
+        filename="users.csv",
+    )
+
+
+@app.get("/users-semicolon.csv")
+async def users_semicolon_csv():
+    return StreamingCSVResponse(
+        [{"id": 1, "name": "Alice; admin"}],
+        headers=["id", "name"],
+        filename="users-semicolon.csv",
+        delimiter=";",
+    )
+
+
+client = TestClient(app)
+
+
+def test_streaming_csv_response_writes_headers_and_escapes_values():
+    response = client.get("/users.csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert response.headers["content-disposition"] == 'attachment; filename="users.csv"'
+    assert response.text == (
+        "id,name,note\r\n"
+        "1,Alice,plain\r\n"
+        '2,"Bob, Jr.","quote ""inside"""\r\n'
+        '3,Charlie,"line\nbreak"\r\n'
+    )
+
+
+def test_streaming_csv_response_supports_custom_delimiter():
+    response = client.get("/users-semicolon.csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="users-semicolon.csv"'
+    )
+    assert response.text == 'id;name\r\n1;"Alice; admin"\r\n'
+
+
+def test_streaming_csv_response_consumes_iterable_lazily():
+    consumed: list[int] = []
+
+    async def rows() -> AsyncIterator[list[int]]:
+        for item in [1, 2, 3]:
+            consumed.append(item)
+            yield [item]
+
+    response = StreamingCSVResponse(rows())
+
+    assert consumed == []
+
+    client = TestClient(FastAPI())
+    client.app.get("/lazy.csv")(lambda: response)
+
+    result = client.get("/lazy.csv")
+
+    assert result.text == "1\r\n2\r\n3\r\n"
+    assert consumed == [1, 2, 3]


### PR DESCRIPTION
/claim #799

Fixes #799.

## Summary
- Added `StreamingCSVResponse` built on `StreamingResponse` so CSV rows are yielded incrementally instead of materialised up front.
- Used Python's `csv.writer` for RFC-style escaping of commas, quotes, and embedded newlines.
- Added optional column headers, configurable download filename, custom delimiter support, and focused tests.
- Added safe contributor metadata without copying hidden runtime/session instructions into the repository.

## Validation
- `/tmp/fastapi803-venv/bin/python -m pytest fastapi/tests/test_streaming_csv_response.py`
- `/tmp/fastapi803-venv/bin/python -m ruff check fastapi/fastapi/responses.py fastapi/tests/test_streaming_csv_response.py`
- `git diff --check`
