### PR TITLE
Codex [ FastAPI ] Fix duplicate operation IDs across routers

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex",
+  "platform_config": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "date": "2026-05-21T14:47:00+01:00"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -33,6 +33,8 @@ from fastapi.types import ModelNameMap
 from fastapi.utils import (
     deep_dict_update,
     generate_operation_id_for_path,
+    generate_unique_id,
+    generate_unique_id_for_method,
     is_body_allowed_for_status_code,
 )
 from pydantic import BaseModel
@@ -242,7 +244,12 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
+    if route.operation_id:
+        operation_id = route.operation_id
+    elif route.generate_unique_id_function is generate_unique_id:
+        operation_id = generate_unique_id_for_method(route=route, method=method)
+    else:
+        operation_id = route.unique_id
     if operation_id in operation_ids:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
@@ -250,6 +257,12 @@ def get_openapi_operation_metadata(
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        suffix = 2
+        suffixed_operation_id = f"{operation_id}_{suffix}"
+        while suffixed_operation_id in operation_ids:
+            suffix += 1
+            suffixed_operation_id = f"{operation_id}_{suffix}"
+        operation_id = suffixed_operation_id
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -92,12 +92,23 @@ def generate_operation_id_for_path(
     return operation_id
 
 
+def _normalise_operation_id_part(value: str) -> str:
+    return re.sub(r"\W+", "_", value).strip("_").lower()
+
+
+def generate_unique_id_for_method(*, route: "APIRoute", method: str) -> str:
+    operation_id_parts = [
+        _normalise_operation_id_part(method),
+        _normalise_operation_id_part(route.path_format),
+        _normalise_operation_id_part(route.name),
+    ]
+    return "_".join(part for part in operation_id_parts if part)
+
+
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0]
+    return generate_unique_id_for_method(route=route, method=method)
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_unique_operation_ids.py
+++ b/fastapi/tests/test_unique_operation_ids.py
@@ -1,0 +1,58 @@
+import re
+import warnings
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_default_operation_ids_include_method_prefix_and_route_path():
+    app = FastAPI()
+    users_router = APIRouter(prefix="/users")
+    admin_router = APIRouter(prefix="/admin/users")
+
+    def make_list_users_endpoint():
+        def list_users():
+            return []  # pragma: nocover
+
+        return list_users
+
+    users_router.get("/")(make_list_users_endpoint())
+    admin_router.get("/")(make_list_users_endpoint())
+
+    app.include_router(users_router)
+    app.include_router(admin_router)
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    user_operation_id = schema["paths"]["/users/"]["get"]["operationId"]
+    admin_operation_id = schema["paths"]["/admin/users/"]["get"]["operationId"]
+
+    assert user_operation_id == "get_users_list_users"
+    assert admin_operation_id == "get_admin_users_list_users"
+    assert user_operation_id != admin_operation_id
+    assert re.fullmatch(r"[a-z0-9_]+", user_operation_id)
+    assert re.fullmatch(r"[a-z0-9_]+", admin_operation_id)
+
+
+def test_duplicate_operation_ids_receive_numeric_suffix():
+    app = FastAPI()
+
+    def read_item():
+        return {"ok": True}  # pragma: nocover
+
+    app.get("/items/foo-bar")(read_item)
+    app.get("/items/foo_bar")(read_item)
+
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        warnings.simplefilter("always")
+        schema = TestClient(app).get("/openapi.json").json()
+
+    first_operation_id = schema["paths"]["/items/foo-bar"]["get"]["operationId"]
+    second_operation_id = schema["paths"]["/items/foo_bar"]["get"]["operationId"]
+
+    assert first_operation_id == "get_items_foo_bar_read_item"
+    assert second_operation_id == "get_items_foo_bar_read_item_2"
+    assert any(
+        "Duplicate Operation ID get_items_foo_bar_read_item" in str(warning.message)
+        for warning in recorded_warnings
+    )


### PR DESCRIPTION
/claim #764

Fixes #764.

## Summary
- Changed default FastAPI operation IDs to use a method-first, path-aware format such as `get_users_list_users`.
- Normalised generated IDs to lowercase alphanumeric/underscore tokens.
- Resolved remaining OpenAPI operation ID collisions by appending a numeric suffix instead of leaving duplicate IDs in the schema.
- Preserved custom `generate_unique_id_function` behaviour and explicit `operation_id` values.
- Added safe attribution metadata without copying hidden runtime/session instructions into the repository.

## Validation
- `/tmp/fastapi803-venv/bin/python -m pytest fastapi/tests/test_unique_operation_ids.py fastapi/tests/test_generate_unique_id_function.py::test_top_level_generate_unique_id`
- `/tmp/fastapi803-venv/bin/python -m ruff check fastapi/fastapi/utils.py fastapi/fastapi/openapi/utils.py fastapi/tests/test_unique_operation_ids.py`
- `git diff --check`
