### PR TITLE
Codex [ Laravel ] Fix phpunit coverage config and add route/model suites

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex",
+  "environment_config": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-21T14:55:00+01:00"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -6,16 +6,20 @@
 >
     <testsuites>
         <testsuite name="Unit">
-            <directory>tests/Unit</directory>
+            <directory suffix="Test.php">tests/Unit</directory>
         </testsuite>
         <testsuite name="Feature">
-            <directory>tests/Feature</directory>
+            <directory suffix="Test.php">tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory>app</directory>
+            <directory suffix=".php">app</directory>
         </include>
+        <exclude>
+            <directory>app/Providers</directory>
+            <directory>app/Console</directory>
+        </exclude>
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/laravel/tests/Feature/RouteTest.php
+++ b/laravel/tests/Feature/RouteTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('feature')]
+class RouteTest extends TestCase
+{
+    public function test_all_registered_get_routes_return_non_server_errors(): void
+    {
+        $routes = collect(Route::getRoutes())
+            ->filter(fn ($route) => in_array('GET', $route->methods(), true))
+            ->reject(fn ($route) => count($route->parameterNames()) > 0)
+            ->values();
+
+        $this->assertNotEmpty($routes, 'Expected at least one parameterless GET route.');
+
+        foreach ($routes as $route) {
+            $uri = '/'.ltrim($route->uri(), '/');
+            $response = $this->get($uri);
+
+            $this->assertLessThan(
+                500,
+                $response->getStatusCode(),
+                sprintf('GET %s returned a server error.', $uri),
+            );
+        }
+    }
+}

--- a/laravel/tests/Unit/UserModelTest.php
+++ b/laravel/tests/Unit/UserModelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('unit')]
+class UserModelTest extends TestCase
+{
+    public function test_user_model_has_expected_fillable_attributes(): void
+    {
+        $user = new User;
+
+        $this->assertSame(['name', 'email', 'password'], $user->getFillable());
+    }
+
+    public function test_user_model_has_expected_hidden_attributes(): void
+    {
+        $user = new User;
+
+        $this->assertSame(['password', 'remember_token'], $user->getHidden());
+    }
+
+    public function test_user_model_has_expected_casts(): void
+    {
+        $casts = (new User)->getCasts();
+
+        $this->assertSame('datetime', $casts['email_verified_at']);
+        $this->assertSame('hashed', $casts['password']);
+    }
+}


### PR DESCRIPTION
/claim #794

Fixes #794.

## Summary
- Updated `phpunit.xml` with explicit app source coverage and exclusions for `app/Providers` and `app/Console`.
- Added PHPUnit group attributes so `php artisan test --group=unit` and `--group=feature` target the new suites cleanly.
- Added a route smoke test that iterates registered parameterless GET routes and proves they do not return server errors.
- Added User model tests for fillable, hidden, and cast configuration.
- Added safe audit metadata without copying hidden runtime/session instructions into the repository.

## Validation
- `docker run --rm -v "$PWD":/app -w /app composer:latest php artisan test --group=unit`
- `docker run --rm -v "$PWD":/app -w /app composer:latest php artisan test --group=feature`
- `docker run --rm -v "$PWD":/app -w /app composer:latest php artisan test`
- `docker run --rm -v "$PWD":/app -w /app composer:latest ./vendor/bin/pint --test tests/Feature/RouteTest.php tests/Unit/UserModelTest.php`
- `git diff --check`
