### PR TITLE
[Hermes Agent] [ T3 Code ] Fix turbo.json missing dependency graph for incremental builds

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent",
+  "generation_context": "User requested to fix turbo.json dependency graph for T3 Code monorepo. Task: add proper dependsOn relationships between build tasks, change dev task to depend on all upstream builds (^build), add no-op build scripts to source-only packages for cache tracking. Issue #828: Fix turbo.json missing dependency graph for incremental builds. Acceptance criteria: Changing only packages/contracts triggers rebuild of dependent apps; build cache works correctly; full build order respects dependency graph; no circular dependencies; existing build commands still work.",
+  "completed_at": "2026-05-21T23:30:00+08:00"
+}

--- a/t3code/packages/client-runtime/package.json
+++ b/t3code/packages/client-runtime/package.json
@@ -9,6 +9,7 @@
     }
   },
   "scripts": {
+    "build": "true",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/t3code/packages/contracts/package.json
+++ b/t3code/packages/contracts/package.json
@@ -17,6 +17,7 @@
     }
   },
   "scripts": {
+    "build": "true",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/t3code/packages/effect-acp/package.json
+++ b/t3code/packages/effect-acp/package.json
@@ -33,6 +33,7 @@
     }
   },
   "scripts": {
+    "build": "true",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "generate": "bun run scripts/generate.ts"

--- a/t3code/packages/effect-codex-app-server/package.json
+++ b/t3code/packages/effect-codex-app-server/package.json
@@ -25,6 +25,7 @@
     }
   },
   "scripts": {
+    "build": "true",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "generate": "bun run scripts/generate.ts",

--- a/t3code/packages/shared/package.json
+++ b/t3code/packages/shared/package.json
@@ -93,6 +93,7 @@
     }
   },
   "scripts": {
+    "build": "true",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/t3code/packages/ssh/package.json
+++ b/t3code/packages/ssh/package.json
@@ -25,6 +25,7 @@
     }
   },
   "scripts": {
+    "build": "true",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/t3code/packages/tailscale/package.json
+++ b/t3code/packages/tailscale/package.json
@@ -9,6 +9,7 @@
     }
   },
   "scripts": {
+    "build": "true",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,8 +34,20 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/web#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/client-runtime#build"],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/shared#build", "effect-acp#build", "effect-codex-app-server#build"],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/desktop#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/shared#build", "@t3tools/ssh#build", "@t3tools/tailscale#build"],
+      "outputs": ["dist/**", "dist-electron/**"]
+    },
     "dev": {
-      "dependsOn": ["@t3tools/contracts#build"],
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
/claim #828

## Changes

- **dev task**: Changed  from  →  so all upstream packages build before dev mode starts
- **Per-app build edges**: Added explicit  for web, server, and desktop builds in root turbo.json
- **Package build scripts**: Added no-op  to source-only packages (contracts, shared, client-runtime, ssh, tailscale, effect-acp, effect-codex-app-server) for Turbo cache tracking
- **Incremental builds**: Proper dependency graph ensures changing only  triggers rebuild of dependent apps without touching unrelated packages
- **No circular dependencies**: All edges are DAG-valid
- **Existing commands unchanged**: , ,  all work as before

Closes #828