### PR TITLE
[Hermes Agent] [ T3 Code ] Add runtime validation for provider configuration schemas

### DIFF
--- a/t3code/packages/contracts/.attribution.json
+++ b/t3code/packages/contracts/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Hermes Agent",
+  "platform_config": "User requested to add runtime validation for provider configuration schemas in T3 Code monorepo. Task: add Effect Schema refinements for API key validation (non-empty, min 10 chars), HTTPS URL validation (must be valid https://... URL), validateProviderConfig function, ProviderConfigError tagged error type, collect all validation errors at once. AGENTS.md guidelines: bun fmt, bun lint, bun typecheck must pass. Effect v4 beta 59, @effect/vitest testing framework. T3 Code is a minimal web GUI for coding agents.",
+  "date": "2026-05-21T23:31:00+08:00"
+}

--- a/t3code/packages/contracts/src/providerConfig.test.ts
+++ b/t3code/packages/contracts/src/providerConfig.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import {
+  ApiKey,
+  HttpsUrl,
+  validateApiKey,
+  validateHttpsUrl,
+  validateAll,
+  validateProviderConfig,
+  ProviderConfigError,
+} from "./providerConfig.ts";
+
+// ─── ApiKey Schema Tests ─────────────────────────────────────────
+describe("ApiKey", () => {
+  it.effect("accepts valid API key", () =>
+    Effect.gen(function* () {
+      const result = yield* Schema.decodeUnknownEffect(ApiKey)("sk-abc123def456ghi789");
+      assert.strictEqual(result, "sk-abc123def456ghi789");
+    }),
+  );
+
+  it.effect("accepts API key exactly 10 chars", () =>
+    Effect.gen(function* () {
+      const result = yield* Schema.decodeUnknownEffect(ApiKey)("1234567890");
+      assert.strictEqual(result, "1234567890");
+    }),
+  );
+
+  it.effect("rejects empty string", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(Schema.decodeUnknownEffect(ApiKey)(""));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+
+  it.effect("rejects short string (less than 10 chars)", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(Schema.decodeUnknownEffect(ApiKey)("short"));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+
+  it.effect("accepts long API key (512 chars)", () =>
+    Effect.gen(function* () {
+      const long = "k".repeat(512);
+      const result = yield* Schema.decodeUnknownEffect(ApiKey)(long);
+      assert.strictEqual(result, long);
+    }),
+  );
+});
+
+// ─── HttpsUrl Schema Tests ───────────────────────────────────────
+describe("HttpsUrl", () => {
+  it.effect("accepts valid HTTPS URL", () =>
+    Effect.gen(function* () {
+      const result = yield* Schema.decodeUnknownEffect(HttpsUrl)("https://api.openai.com/v1");
+      assert.strictEqual(result, "https://api.openai.com/v1");
+    }),
+  );
+
+  it.effect("accepts HTTPS URL with port", () =>
+    Effect.gen(function* () {
+      const result = yield* Schema.decodeUnknownEffect(HttpsUrl)("https://localhost:8443/api");
+      assert.strictEqual(result, "https://localhost:8443/api");
+    }),
+  );
+
+  it.effect("rejects HTTP URL", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(Schema.decodeUnknownEffect(HttpsUrl)("http://api.example.com"));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+
+  it.effect("rejects empty string", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(Schema.decodeUnknownEffect(HttpsUrl)(""));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+
+  it.effect("rejects malformed URL", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(Schema.decodeUnknownEffect(HttpsUrl)("not-a-url"));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+
+  it.effect("rejects FTP URL", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(Schema.decodeUnknownEffect(HttpsUrl)("ftp://files.example.com"));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+});
+
+// ─── ProviderConfigError Tests ───────────────────────────────────
+describe("ProviderConfigError", () => {
+  it("is a tagged error with expected shape", () => {
+    const err = new ProviderConfigError({
+      field: "apiKey",
+      value: "short",
+      expected: "API key (min 10 chars)",
+    });
+    assert.strictEqual(err._tag, "ProviderConfigError");
+    assert.strictEqual(err.field, "apiKey");
+    assert.strictEqual(err.value, "short");
+    assert.strictEqual(err.expected, "API key (min 10 chars)");
+  });
+});
+
+// ─── validateApiKey Tests ────────────────────────────────────────
+describe("validateApiKey", () => {
+  it.effect("succeeds for valid key", () =>
+    Effect.gen(function* () {
+      const result = yield* validateApiKey("apiKey", "abcdef1234567890");
+      assert.strictEqual(result, undefined);
+    }),
+  );
+
+  it.effect("fails for short key", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(validateApiKey("apiKey", "short"));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+});
+
+// ─── validateHttpsUrl Tests ──────────────────────────────────────
+describe("validateHttpsUrl", () => {
+  it.effect("succeeds for valid HTTPS URL", () =>
+    Effect.gen(function* () {
+      const result = yield* validateHttpsUrl("endpoint", "https://api.example.com");
+      assert.strictEqual(result, undefined);
+    }),
+  );
+
+  it.effect("fails for HTTP URL", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(validateHttpsUrl("endpoint", "http://api.example.com"));
+      assert.ok(exit._tag === "Failure");
+    }),
+  );
+});
+
+// ─── validateAll Tests ───────────────────────────────────────────
+describe("validateAll", () => {
+  it.effect("returns valid=true when all pass", () =>
+    Effect.gen(function* () {
+      const result = yield* validateAll([
+        validateApiKey("key1", "abcdef1234567890"),
+        validateHttpsUrl("url1", "https://example.com"),
+      ]);
+      assert.ok(result.valid);
+      assert.strictEqual(result.errors.length, 0);
+    }),
+  );
+
+  it.effect("collects multiple errors", () =>
+    Effect.gen(function* () {
+      const result = yield* validateAll([
+        validateApiKey("key1", "short"),
+        validateHttpsUrl("url1", "http://bad.com"),
+        validateApiKey("key2", "ok123456789012345"),
+      ]);
+      assert.ok(!result.valid);
+      assert.strictEqual(result.errors.length, 2);
+      assert.strictEqual(result.errors[0].field, "key1");
+      assert.strictEqual(result.errors[1].field, "url1");
+    }),
+  );
+
+  it.effect("returns empty errors for no validations", () =>
+    Effect.gen(function* () {
+      const result = yield* validateAll([]);
+      assert.ok(result.valid);
+      assert.strictEqual(result.errors.length, 0);
+    }),
+  );
+});
+
+// ─── validateProviderConfig Tests ────────────────────────────────
+describe("validateProviderConfig", () => {
+  it.effect("passes valid config", () =>
+    Effect.gen(function* () {
+      const result = yield* validateProviderConfig({
+        apiKey: "sk-abcdef1234567890",
+        endpoint: "https://api.openai.com/v1",
+      });
+      assert.ok(result.valid);
+    }),
+  );
+
+  it.effect("detects empty API key", () =>
+    Effect.gen(function* () {
+      const result = yield* validateProviderConfig({
+        apiKey: "",
+        endpoint: "https://api.example.com",
+      });
+      assert.ok(!result.valid);
+      assert.ok(result.errors.some((e) => e.field === "apiKey"));
+    }),
+  );
+
+  it.effect("detects HTTP URL", () =>
+    Effect.gen(function* () {
+      const result = yield* validateProviderConfig({
+        apiKey: "abcdef1234567890",
+        endpoint: "http://api.example.com",
+      });
+      assert.ok(!result.valid);
+      assert.ok(result.errors.some((e) => e.field === "endpoint"));
+    }),
+  );
+
+  it.effect("detects malformed URL", () =>
+    Effect.gen(function* () {
+      const result = yield* validateProviderConfig({
+        apiKey: "abcdef1234567890",
+        host: "not-a-url",
+      });
+      assert.ok(!result.valid);
+      assert.ok(result.errors.some((e) => e.field === "host"));
+    }),
+  );
+
+  it.effect("returns multiple errors at once", () =>
+    Effect.gen(function* () {
+      const result = yield* validateProviderConfig({
+        apiKey: "",
+        endpoint: "",
+        host: "http://bad.com",
+      });
+      assert.ok(!result.valid);
+      assert.ok(result.errors.length >= 2);
+    }),
+  );
+
+  it.effect("passes config with no API/URL fields", () =>
+    Effect.gen(function* () {
+      const result = yield* validateProviderConfig({
+        model: "gpt-4",
+        temperature: "0.7",
+      });
+      assert.ok(result.valid);
+    }),
+  );
+
+  it.effect("handles token field as API key", () =>
+    Effect.gen(function* () {
+      const result = yield* validateProviderConfig({
+        accessToken: "abc",
+        url: "https://example.com",
+      });
+      assert.ok(!result.valid);
+      assert.ok(result.errors.some((e) => e.field === "accessToken"));
+    }),
+  );
+});

--- a/t3code/packages/contracts/src/providerConfig.ts
+++ b/t3code/packages/contracts/src/providerConfig.ts
@@ -1,0 +1,153 @@
+import * as Schema from "effect/Schema";
+import * as Effect from "effect/Effect";
+
+// ─── Refined schemas ─────────────────────────────────────────────
+
+/**
+ * An API key that must be at least 10 characters and non-empty.
+ */
+export const ApiKey = Schema.String
+  .check(Schema.isNonEmpty())
+  .check(Schema.isMaxLength(512))
+  .check(Schema.isMinLength(10));
+export type ApiKey = typeof ApiKey.Type;
+
+/**
+ * An HTTPS URL with a valid hostname.
+ * Rejects empty strings, non-URL strings, and non-HTTPS protocols.
+ */
+export const HttpsUrl = Schema.String
+  .check(Schema.isNonEmpty())
+  .check(Schema.isPattern(/^https:\/\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*(:[0-9]+)?(\/.*)?$/));
+export type HttpsUrl = typeof HttpsUrl.Type;
+
+// ─── Error types ─────────────────────────────────────────────────
+
+/**
+ * Tagged error for provider configuration validation failures.
+ */
+export class ProviderConfigError extends Schema.TaggedErrorClass<ProviderConfigError>()("ProviderConfigError", {
+  field: Schema.String,
+  value: Schema.Unknown,
+  expected: Schema.String,
+}) {}
+
+// ─── Validation helpers ──────────────────────────────────────────
+
+export interface ValidationError {
+  readonly field: string;
+  readonly value: unknown;
+  readonly expected: string;
+}
+
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly errors: ReadonlyArray<ValidationError>;
+}
+
+/**
+ * Validate that a value conforms to the `ApiKey` schema.
+ */
+export const validateApiKey = (
+  field: string,
+  value: string,
+): Effect.Effect<void, ProviderConfigError> =>
+  Effect.matchEffect(
+    Schema.decodeUnknownEffect(ApiKey)(value),
+    {
+      onSuccess: () => Effect.succeed(undefined as void),
+      onFailure: () =>
+        Effect.fail(
+          new ProviderConfigError({
+            field: field,
+            value: value,
+            expected: "API key (non-empty, min 10 characters, max 512)",
+          }),
+        ),
+    },
+  );
+
+/**
+ * Validate that a value conforms to the `HttpsUrl` schema.
+ */
+export const validateHttpsUrl = (
+  field: string,
+  value: string,
+): Effect.Effect<void, ProviderConfigError> =>
+  Effect.matchEffect(
+    Schema.decodeUnknownEffect(HttpsUrl)(value),
+    {
+      onSuccess: () => Effect.succeed(undefined as void),
+      onFailure: () =>
+        Effect.fail(
+          new ProviderConfigError({
+            field: field,
+            value: value,
+            expected: "Valid HTTPS URL (https://...)",
+          }),
+        ),
+    },
+  );
+
+/**
+ * Run multiple validations and collect all errors.
+ * Returns a `ValidationResult` with all errors, not just the first one.
+ */
+export const validateAll = (
+  validations: ReadonlyArray<Effect.Effect<void, ProviderConfigError>>,
+): Effect.Effect<ValidationResult> =>
+  Effect.forEach(validations, (v) =>
+    Effect.matchEffect(v, {
+      onSuccess: () => Effect.succeed(null as null),
+      onFailure: (err) => Effect.succeed(err),
+    }),
+  ).pipe(
+    Effect.map((results) => {
+      const errors = results.filter(
+        (r): r is ProviderConfigError => r !== null,
+      );
+      return {
+        valid: errors.length === 0,
+        errors: errors.map((e) => ({
+          field: e.field,
+          value: e.value,
+          expected: e.expected,
+        })),
+      };
+    }),
+  );
+
+/**
+ * Validate a provider configuration with API keys and endpoint URLs.
+ *
+ * @param config - Object with field names as keys and values to validate.
+ *   Fields starting with "api" or "key" or "token" are validated as API keys.
+ *   Fields starting with "url" or "endpoint" or "host" are validated as HTTPS URLs.
+ * @returns A `ValidationResult` with all errors collected.
+ */
+export const validateProviderConfig = (
+  config: Record<string, string>,
+): Effect.Effect<ValidationResult> => {
+  const validations: Array<Effect.Effect<void, ProviderConfigError>> = [];
+
+  for (const [field, value] of Object.entries(config)) {
+    const lowerField = field.toLowerCase();
+    if (
+      lowerField.includes("api") ||
+      lowerField.includes("key") ||
+      lowerField.includes("token") ||
+      lowerField.includes("secret")
+    ) {
+      validations.push(validateApiKey(field, value));
+    }
+    if (
+      lowerField.includes("url") ||
+      lowerField.includes("endpoint") ||
+      lowerField.includes("host")
+    ) {
+      validations.push(validateHttpsUrl(field, value));
+    }
+  }
+
+  return validateAll(validations);
+};


### PR DESCRIPTION
/claim #825

## Changes

- **ApiKey schema**: Refined  with checks for non-empty, min 10 chars, max 512 chars
- **HttpsUrl schema**: Refined  with HTTPS URL regex pattern validation
- **ProviderConfigError**: Tagged error type with field, value, and expected format fields
- **validateApiKey / validateHttpsUrl**: Individual validation functions returning typed Effects
- **validateAll**: Collects all validation errors at once (not short-circuit)
- **validateProviderConfig**: Auto-detects API key/URL fields by name pattern and validates them
- **26 tests**: cover valid configs, empty API keys, HTTP URLs, malformed URLs, multiple errors, non-matching field names
- All 168 tests pass (10 test files, +26 new)

Closes #825