### PR TITLE
OpenAI Codex [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,30 @@
+import contextvars
 import logging
 
+_request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "fastapi_request_id", default=None
+)
+
+
+class RequestIDLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = _request_id.get()
+        return True
+
+
+def set_request_id(request_id: str) -> contextvars.Token:
+    return _request_id.set(request_id)
+
+
+def reset_request_id(token: contextvars.Token) -> None:
+    _request_id.reset(token)
+
+
+def get_request_id() -> str | None:
+    return _request_id.get()
+
+
 logger = logging.getLogger("fastapi")
+
+if not any(isinstance(log_filter, RequestIDLogFilter) for log_filter in logger.filters):
+    logger.addFilter(RequestIDLogFilter())

--- a/fastapi/fastapi/middleware/_provenance.json
+++ b/fastapi/fastapi/middleware/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, and runtime instructions are intentionally not copied into repository artifacts. This submission was produced by OpenAI Codex for issue #797 with a scoped request ID middleware implementation.",
+  "timestamp": "2026-05-21T15:45:28Z"
+}

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,31 @@
+import uuid
+
+from fastapi.logger import reset_request_id, set_request_id
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class RequestIDMiddleware:
+    def __init__(self, app: ASGIApp, header_name: str = "X-Request-ID") -> None:
+        self.app = app
+        self.header_name = header_name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = Headers(scope=scope).get(self.header_name) or str(uuid.uuid4())
+        scope.setdefault("state", {})["request_id"] = request_id
+        token = set_request_id(request_id)
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers[self.header_name] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            reset_request_id(token)

--- a/fastapi/tests/test_request_id_middleware.py
+++ b/fastapi/tests/test_request_id_middleware.py
@@ -1,0 +1,91 @@
+import asyncio
+import logging
+import uuid
+
+import httpx
+
+from fastapi import FastAPI, Request
+from fastapi.logger import get_request_id, logger
+from fastapi.middleware.request_id import RequestIDMiddleware
+from fastapi.testclient import TestClient
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    async def read_root(request: Request):
+        logger.info("handling request")
+        return {"request_id": request.state.request_id}
+
+    @app.get("/slow")
+    async def read_slow(request: Request):
+        await asyncio.sleep(0.01)
+        logger.info("handling slow request")
+        return {"request_id": request.state.request_id}
+
+    return app
+
+
+def test_request_id_middleware_generates_uuid_and_adds_log_context(caplog):
+    caplog.set_level(logging.INFO, logger="fastapi")
+    client = TestClient(create_app())
+
+    response = client.get("/")
+
+    request_id = response.headers["x-request-id"]
+    assert response.json() == {"request_id": request_id}
+    assert uuid.UUID(request_id).version == 4
+    assert get_request_id() is None
+
+    log_record = next(record for record in caplog.records if record.name == "fastapi")
+    assert log_record.request_id == request_id
+
+
+def test_request_id_middleware_preserves_client_request_id():
+    client = TestClient(create_app())
+
+    response = client.get("/", headers={"X-Request-ID": "client-request-123"})
+
+    assert response.headers["x-request-id"] == "client-request-123"
+    assert response.json() == {"request_id": "client-request-123"}
+    assert get_request_id() is None
+
+
+def test_request_id_middleware_does_not_leak_between_concurrent_requests():
+    async def run_requests():
+        transport = httpx.ASGITransport(app=create_app())
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            first, second = await asyncio.gather(
+                client.get("/slow", headers={"X-Request-ID": "request-one"}),
+                client.get("/slow", headers={"X-Request-ID": "request-two"}),
+            )
+            return first, second
+
+    first, second = asyncio.run(run_requests())
+
+    assert first.headers["x-request-id"] == "request-one"
+    assert first.json() == {"request_id": "request-one"}
+    assert second.headers["x-request-id"] == "request-two"
+    assert second.json() == {"request_id": "request-two"}
+    assert get_request_id() is None
+
+
+def test_logger_keeps_working_without_request_id_middleware(caplog):
+    app = FastAPI()
+
+    @app.get("/")
+    async def read_root():
+        logger.info("handling request without middleware")
+        return {"request_id": get_request_id()}
+
+    caplog.set_level(logging.INFO, logger="fastapi")
+    response = TestClient(app).get("/")
+
+    assert "x-request-id" not in response.headers
+    assert response.json() == {"request_id": None}
+    log_record = next(record for record in caplog.records if record.name == "fastapi")
+    assert log_record.request_id is None


### PR DESCRIPTION
```text
Private system, developer, and runtime instructions are not copied into this repository or PR. This implementation was produced with OpenAI Codex for the scoped FastAPI request ID middleware bounty.
```

/claim #797

## Summary

- Added `RequestIDMiddleware` for FastAPI HTTP requests.
- Preserves client-provided `X-Request-ID` or generates a UUID when absent.
- Stores the ID on `request.state.request_id`, echoes it in the response header, and exposes it to FastAPI log records through request-scoped context.
- Added focused regression tests for generated IDs, client-provided IDs, log metadata, no-middleware behavior, and concurrent request isolation.

## Verification

```bash
/Users/afvp1f17/miniforge3/envs/Bounty/bin/python -m pytest fastapi/tests/test_request_id_middleware.py
/Users/afvp1f17/miniforge3/envs/Bounty/bin/python -m py_compile fastapi/fastapi/logger.py fastapi/fastapi/middleware/request_id.py fastapi/tests/test_request_id_middleware.py
git diff --check
```

All checks passed locally.

Demo evidence: the focused test suite exercises the middleware end-to-end via `TestClient` and `httpx.ASGITransport`, including concurrent requests.
