### PR TITLE
fix: handle bytes/memoryview in jsonable_encoder via base64 encoding

### DIFF
--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -82,7 +83,8 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
+    bytes: lambda o: base64.b64encode(o).decode("ascii"),
+    memoryview: lambda o: base64.b64encode(bytes(o)).decode("ascii"),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -308,6 +308,42 @@ def test_encode_deque_encodes_child_models():
     assert jsonable_encoder(dq)[0]["test"] == "test"
 
 
+def test_encode_bytes_base64():
+    data = b"hello world"
+    assert jsonable_encoder(data) == "aGVsbG8gd29ybGQ="
+
+
+def test_encode_bytes_in_dict():
+    assert jsonable_encoder({"key": b"test"}) == {"key": "dGVzdA=="}
+
+
+def test_encode_bytes_in_list():
+    assert jsonable_encoder([b"a", b"b"]) == ["YQ==", "Yg=="]
+
+
+def test_encode_bytes_nested():
+    data = {"outer": {"inner": b"nested"}}
+    assert jsonable_encoder(data) == {"outer": {"inner": "bmVzdGVk"}}
+
+
+def test_encode_memoryview_base64():
+    assert jsonable_encoder(memoryview(b"hello")) == "aGVsbG8="
+
+
+def test_encode_non_utf8_bytes():
+    assert jsonable_encoder(b"\xff\xfe\x00\x01") == "//4AAQ=="
+
+
+def test_encode_bytes_in_dataclass():
+    @dataclass
+    class BinaryItem:
+        name: str
+        content: bytes
+
+    item = BinaryItem(name="test", content=b"data")
+    assert jsonable_encoder(item) == {"name": "test", "content": "ZGF0YQ=="}
+
+
 def test_encode_pydantic_undefined():
     data = {"value": Undefined}
     assert jsonable_encoder(data) == {"value": None}

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -308,30 +308,18 @@ def test_encode_deque_encodes_child_models():
     assert jsonable_encoder(dq)[0]["test"] == "test"
 
 
-def test_encode_bytes_base64():
-    data = b"hello world"
-    assert jsonable_encoder(data) == "aGVsbG8gd29ybGQ="
-
-
-def test_encode_bytes_in_dict():
-    assert jsonable_encoder({"key": b"test"}) == {"key": "dGVzdA=="}
-
-
-def test_encode_bytes_in_list():
-    assert jsonable_encoder([b"a", b"b"]) == ["YQ==", "Yg=="]
-
-
-def test_encode_bytes_nested():
-    data = {"outer": {"inner": b"nested"}}
-    assert jsonable_encoder(data) == {"outer": {"inner": "bmVzdGVk"}}
-
-
-def test_encode_memoryview_base64():
-    assert jsonable_encoder(memoryview(b"hello")) == "aGVsbG8="
-
-
-def test_encode_non_utf8_bytes():
+def test_encode_bytes():
+    assert jsonable_encoder(b"hello world") == "aGVsbG8gd29ybGQ="
     assert jsonable_encoder(b"\xff\xfe\x00\x01") == "//4AAQ=="
+    assert jsonable_encoder({"key": b"test"}) == {"key": "dGVzdA=="}
+    assert jsonable_encoder([b"a", b"b"]) == ["YQ==", "Yg=="]
+    assert jsonable_encoder({"outer": {"inner": b"nested"}}) == {
+        "outer": {"inner": "bmVzdGVk"}
+    }
+
+
+def test_encode_memoryview():
+    assert jsonable_encoder(memoryview(b"hello")) == "aGVsbG8="
 
 
 def test_encode_bytes_in_dataclass():


### PR DESCRIPTION
Replace the broken bytes.decode() default encoder with base64 encoding for both bytes and memoryview objects.

Fixes #759
/claim #759