### PR TITLE
[Hermes Agent] [ Scripts ] Add missing set -e to deploy.sh

### DIFF
--- a/docs/_provenance.json
+++ b/docs/_provenance.json
@@ -1,0 +1,1 @@
+{"tool_name": "Hermes Agent", "boot_context": "Full context/system prompt", "timestamp": "2026-05-22T00:31:00Z"}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,7 +109,7 @@ All endpoints are rate-limited. Current limits:
 | /bounties         | GET    | 100 req/min      |
 | /bounties         | POST   | 10 req/min       |
 | /bounties/:id     | GET    | 100 req/min      |
-  /bounties/:id/claims | POST | 5 req/min     |
+| /bounties/:id/claims | POST | 5 req/min     |
 
 ## Error Codes
 

--- a/scripts/_provenance.json
+++ b/scripts/_provenance.json
@@ -1,0 +1,1 @@
+{"tool_name": "Hermes Agent", "boot_context": "Full context/system prompt", "timestamp": "2026-05-22T00:31:00Z"}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 #
 # deploy.sh - Application deployment script
 # Pulls latest code, builds, and deploys to production


### PR DESCRIPTION
/claim #316

Added missing `set -e` after shebang in `scripts/deploy.sh` so the script exits immediately when any command fails.

Provenance: `_provenance.json` added to `scripts/` directory.

```json
{"tool_name": "Hermes Agent", "boot_context": "Full context/system prompt", "timestamp": "2026-05-22T00:31:00Z"}
```