### PR TITLE
feat: add ProviderCache with Effect.Cache for provider API response c…

### DIFF
--- a/t3code/apps/server/src/services/ProviderCache.test.ts
+++ b/t3code/apps/server/src/services/ProviderCache.test.ts
@@ -1,0 +1,237 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import { makeProviderCache, type CacheMetrics } from "./ProviderCache.ts";
+import type { ProviderInstanceId } from "@t3tools/contracts";
+import type { ProviderAdapterCapabilities } from "../provider/Services/ProviderAdapter.ts";
+import type { ServerProviderModel } from "@t3tools/contracts";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+const makeId = (n: number): ProviderInstanceId =>
+  `provider-${n}` as ProviderInstanceId;
+
+const sampleModels: ReadonlyArray<ServerProviderModel> = [
+  { id: "gpt-4o" } as ServerProviderModel,
+];
+
+const sampleCapabilities: ProviderAdapterCapabilities = {
+  streaming: true,
+  functionCalling: true,
+} as unknown as ProviderAdapterCapabilities;
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                             */
+/* ------------------------------------------------------------------ */
+
+describe("ProviderCache", () => {
+  describe("getModels", () => {
+    it.effect("should return cached models on repeated calls", () =>
+      Effect.gen(function* () {
+        let callCount = 0;
+        const cache = yield* makeProviderCache({
+          fetchModels: () =>
+            Effect.sync(() => {
+              callCount++;
+              return sampleModels;
+            }),
+          fetchCapabilities: () => Effect.succeed(sampleCapabilities),
+          modelListTTL: Duration.minutes(5),
+        });
+
+        const r1 = yield* cache.getModels(makeId(1));
+        assert.deepStrictEqual(r1, sampleModels);
+        assert.strictEqual(callCount, 1);
+
+        const r2 = yield* cache.getModels(makeId(1));
+        assert.deepStrictEqual(r2, sampleModels);
+        assert.strictEqual(callCount, 1);
+      }),
+    );
+
+    it.effect("should call fetch again after TTL expiry", () =>
+      Effect.gen(function* () {
+        let callCount = 0;
+        const cache = yield* makeProviderCache({
+          fetchModels: () =>
+            Effect.sync(() => {
+              callCount++;
+              return sampleModels;
+            }),
+          fetchCapabilities: () => Effect.succeed(sampleCapabilities),
+          modelListTTL: Duration.minutes(5),
+        });
+
+        yield* cache.getModels(makeId(1));
+        assert.strictEqual(callCount, 1);
+
+        yield* TestClock.adjust(Duration.minutes(6));
+        yield* cache.getModels(makeId(1));
+        assert.strictEqual(callCount, 2);
+      }),
+    );
+
+    it.effect("should cache different provider IDs separately", () =>
+      Effect.gen(function* () {
+        let callCount = 0;
+        const cache = yield* makeProviderCache({
+          fetchModels: (id) =>
+            Effect.sync(() => {
+              callCount++;
+              return [{ id: `model-${id}` }] as unknown as ServerProviderModel[];
+            }),
+          fetchCapabilities: () => Effect.succeed(sampleCapabilities),
+        });
+
+        yield* cache.getModels(makeId(1));
+        yield* cache.getModels(makeId(2));
+        assert.strictEqual(callCount, 2);
+
+        yield* cache.getModels(makeId(1));
+        yield* cache.getModels(makeId(2));
+        assert.strictEqual(callCount, 2);
+      }),
+    );
+  });
+
+  describe("getCapabilities", () => {
+    it.effect("should cache capabilities and respect TTL", () =>
+      Effect.gen(function* () {
+        let callCount = 0;
+        const cache = yield* makeProviderCache({
+          fetchModels: () => Effect.succeed(sampleModels),
+          fetchCapabilities: () =>
+            Effect.sync(() => {
+              callCount++;
+              return sampleCapabilities;
+            }),
+          capabilityTTL: Duration.minutes(10),
+        });
+
+        yield* cache.getCapabilities(makeId(1));
+        assert.strictEqual(callCount, 1);
+
+        yield* cache.getCapabilities(makeId(1));
+        assert.strictEqual(callCount, 1);
+
+        yield* TestClock.adjust(Duration.minutes(11));
+        yield* cache.getCapabilities(makeId(1));
+        assert.strictEqual(callCount, 2);
+      }),
+    );
+  });
+
+  describe("invalidateProvider", () => {
+    it.effect("should clear both caches for a given provider", () =>
+      Effect.gen(function* () {
+        let modelCalls = 0;
+        let capCalls = 0;
+        const cache = yield* makeProviderCache({
+          fetchModels: () =>
+            Effect.sync(() => {
+              modelCalls++;
+              return sampleModels;
+            }),
+          fetchCapabilities: () =>
+            Effect.sync(() => {
+              capCalls++;
+              return sampleCapabilities;
+            }),
+        });
+
+        yield* cache.getModels(makeId(1));
+        yield* cache.getCapabilities(makeId(1));
+        assert.strictEqual(modelCalls, 1);
+        assert.strictEqual(capCalls, 1);
+
+        yield* cache.invalidateProvider(makeId(1));
+
+        yield* cache.getModels(makeId(1));
+        yield* cache.getCapabilities(makeId(1));
+        assert.strictEqual(modelCalls, 2);
+        assert.strictEqual(capCalls, 2);
+      }),
+    );
+
+    it.effect("should not invalidate other providers", () =>
+      Effect.gen(function* () {
+        let callCount = 0;
+        const cache = yield* makeProviderCache({
+          fetchModels: () =>
+            Effect.sync(() => {
+              callCount++;
+              return sampleModels;
+            }),
+          fetchCapabilities: () => Effect.succeed(sampleCapabilities),
+        });
+
+        yield* cache.getModels(makeId(1));
+        yield* cache.getModels(makeId(2));
+        assert.strictEqual(callCount, 2);
+
+        yield* cache.invalidateProvider(makeId(1));
+
+        yield* cache.getModels(makeId(2));
+        assert.strictEqual(callCount, 2);
+
+        yield* cache.getModels(makeId(1));
+        assert.strictEqual(callCount, 3);
+      }),
+    );
+  });
+
+  describe("invalidateAll", () => {
+    it.effect("should clear all cached entries", () =>
+      Effect.gen(function* () {
+        let callCount = 0;
+        const cache = yield* makeProviderCache({
+          fetchModels: () =>
+            Effect.sync(() => {
+              callCount++;
+              return sampleModels;
+            }),
+          fetchCapabilities: () => Effect.succeed(sampleCapabilities),
+        });
+
+        yield* cache.getModels(makeId(1));
+        yield* cache.getModels(makeId(2));
+        assert.strictEqual(callCount, 2);
+
+        yield* cache.invalidateAll;
+
+        yield* cache.getModels(makeId(1));
+        yield* cache.getModels(makeId(2));
+        assert.strictEqual(callCount, 4);
+      }),
+    );
+  });
+
+  describe("getMetrics", () => {
+    it.effect("should report cache hits and misses", () =>
+      Effect.gen(function* () {
+        const cache = yield* makeProviderCache({
+          fetchModels: () => Effect.succeed(sampleModels),
+          fetchCapabilities: () => Effect.succeed(sampleCapabilities),
+        });
+
+        // miss + set
+        yield* cache.getModels(makeId(1));
+        let m = yield* cache.getMetrics;
+        assert.deepStrictEqual(m, { hits: 0, misses: 1 } satisfies CacheMetrics);
+
+        // hit
+        yield* cache.getModels(makeId(1));
+        m = yield* cache.getMetrics;
+        assert.deepStrictEqual(m, { hits: 1, misses: 1 } satisfies CacheMetrics);
+
+        // miss for a new provider
+        yield* cache.getModels(makeId(2));
+        m = yield* cache.getMetrics;
+        assert.deepStrictEqual(m, { hits: 1, misses: 2 } satisfies CacheMetrics);
+      }),
+    );
+  });
+});

--- a/t3code/apps/server/src/services/ProviderCache.ts
+++ b/t3code/apps/server/src/services/ProviderCache.ts
@@ -1,37 +1,17 @@
-/**
- * ProviderCache — configurable in-memory cache for provider API responses.
- *
- * Uses `Effect.Cache` for bounded, TTL-expiring storage with built-in
- * concurrent-request deduplication.  Cache hit/miss counters are exposed
- * through Effect Metrics.
- *
- * @module services/ProviderCache
- */
-import type {
-  ProviderInstanceId,
-  ServerProviderModel,
-} from "@t3tools/contracts";
+import type { ProviderInstanceId, ServerProviderModel } from "@t3tools/contracts";
 import type { ProviderAdapterCapabilities } from "../provider/Services/ProviderAdapter.ts";
 import * as Cache from "effect/Cache";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Metric from "effect/Metric";
-
-/* ------------------------------------------------------------------ */
-/*  Metrics                                                           */
-/* ------------------------------------------------------------------ */
+import * as Option from "effect/Option";
 
 const cacheHitsTotal = Metric.counter("t3_provider_cache_hits_total", {
   description: "Total provider cache hits.",
 });
-
 const cacheMissesTotal = Metric.counter("t3_provider_cache_misses_total", {
   description: "Total provider cache misses.",
 });
-
-/* ------------------------------------------------------------------ */
-/*  Public types                                                      */
-/* ------------------------------------------------------------------ */
 
 export interface CacheMetrics {
   readonly hits: number;
@@ -39,127 +19,53 @@ export interface CacheMetrics {
 }
 
 export interface ProviderCache {
-  readonly getModels: (
-    instanceId: ProviderInstanceId,
-  ) => Effect.Effect<ReadonlyArray<ServerProviderModel>>;
-  readonly getCapabilities: (
-    instanceId: ProviderInstanceId,
-  ) => Effect.Effect<ProviderAdapterCapabilities>;
-  readonly invalidateProvider: (
-    instanceId: ProviderInstanceId,
-  ) => Effect.Effect<void>;
+  readonly getModels: (instanceId: ProviderInstanceId) => Effect.Effect<ReadonlyArray<ServerProviderModel>>;
+  readonly getCapabilities: (instanceId: ProviderInstanceId) => Effect.Effect<ProviderAdapterCapabilities>;
+  readonly invalidateProvider: (instanceId: ProviderInstanceId) => Effect.Effect<void>;
   readonly invalidateAll: Effect.Effect<void>;
   readonly getMetrics: Effect.Effect<CacheMetrics>;
 }
 
-export interface ProviderCacheOptions {
-  readonly modelListTTL: Duration.Duration;
-  readonly capabilityTTL: Duration.Duration;
-  readonly maxEntries: number;
-}
-
-const DEFAULT_OPTIONS: ProviderCacheOptions = {
-  modelListTTL: Duration.minutes(5),
-  capabilityTTL: Duration.minutes(15),
-  maxEntries: 100,
-};
-
-/* ------------------------------------------------------------------ */
-/*  Factory                                                           */
-/* ------------------------------------------------------------------ */
-
 export const makeProviderCache = (options: {
-  readonly fetchModels: (
-    instanceId: ProviderInstanceId,
-  ) => Effect.Effect<ReadonlyArray<ServerProviderModel>>;
-  readonly fetchCapabilities: (
-    instanceId: ProviderInstanceId,
-  ) => Effect.Effect<ProviderAdapterCapabilities>;
+  readonly fetchModels: (instanceId: ProviderInstanceId) => Effect.Effect<ReadonlyArray<ServerProviderModel>>;
+  readonly fetchCapabilities: (instanceId: ProviderInstanceId) => Effect.Effect<ProviderAdapterCapabilities>;
   readonly modelListTTL?: Duration.Duration;
   readonly capabilityTTL?: Duration.Duration;
   readonly maxEntries?: number;
 }): Effect.Effect<ProviderCache> =>
   Effect.gen(function* () {
-    const opts: ProviderCacheOptions = {
-      ...DEFAULT_OPTIONS,
-      modelListTTL: options.modelListTTL ?? DEFAULT_OPTIONS.modelListTTL,
-      capabilityTTL:
-        options.capabilityTTL ?? DEFAULT_OPTIONS.capabilityTTL,
-      maxEntries: options.maxEntries ?? DEFAULT_OPTIONS.maxEntries,
-    };
-
-    const modelCache = yield* Cache.make<
-      ProviderInstanceId,
-      ReadonlyArray<ServerProviderModel>
-    >({
-      capacity: opts.maxEntries,
-      timeToLive: opts.modelListTTL,
+    const modelCache = yield* Cache.make<ProviderInstanceId, ReadonlyArray<ServerProviderModel>>({
+      capacity: options.maxEntries ?? 100,
+      timeToLive: options.modelListTTL ?? Duration.minutes(5),
       lookup: options.fetchModels,
     });
-
-    const capabilityCache = yield* Cache.make<
-      ProviderInstanceId,
-      ProviderAdapterCapabilities
-    >({
-      capacity: opts.maxEntries,
-      timeToLive: opts.capabilityTTL,
+    const capabilityCache = yield* Cache.make<ProviderInstanceId, ProviderAdapterCapabilities>({
+      capacity: options.maxEntries ?? 100,
+      timeToLive: options.capabilityTTL ?? Duration.minutes(15),
       lookup: options.fetchCapabilities,
     });
 
     let hits = 0;
     let misses = 0;
 
-    const getWithMetrics = <A>(
-      cache: Cache.Cache<ProviderInstanceId, A>,
-      instanceId: ProviderInstanceId,
-    ): Effect.Effect<A> =>
-      Cache.has(cache, instanceId).pipe(
-        Effect.flatMap((cached) =>
-          cached
-            ? Cache.get(cache, instanceId).pipe(
-                Effect.tap(() => Effect.sync(() => hits++)),
-                Effect.tap(() => Metric.update(cacheHitsTotal, 1)),
-              )
-            : Cache.get(cache, instanceId).pipe(
-                Effect.tap(() => Effect.sync(() => misses++)),
-                Effect.tap(() => Metric.update(cacheMissesTotal, 1)),
-              ),
+    const recordHit = Effect.andThen(Metric.update(cacheHitsTotal, 1), Effect.sync(() => hits++));
+    const recordMiss = Effect.andThen(Metric.update(cacheMissesTotal, 1), Effect.sync(() => misses++));
+
+    const getWithMetrics = <A>(cache: Cache.Cache<ProviderInstanceId, A>, id: ProviderInstanceId): Effect.Effect<A> =>
+      Cache.getOption(cache, id).pipe(
+        Effect.flatMap((option) =>
+          Option.isSome(option)
+            ? Effect.succeed(option.value).pipe(Effect.tap(() => recordHit))
+            : Cache.get(cache, id).pipe(Effect.tap(() => recordMiss)),
         ),
       );
 
-    const getModels = (
-      instanceId: ProviderInstanceId,
-    ): Effect.Effect<ReadonlyArray<ServerProviderModel>> =>
-      getWithMetrics(modelCache, instanceId);
+    const getModels = (id: ProviderInstanceId) => getWithMetrics(modelCache, id);
+    const getCapabilities = (id: ProviderInstanceId) => getWithMetrics(capabilityCache, id);
+    const invalidateProvider = (id: ProviderInstanceId) =>
+      Effect.andThen(Cache.invalidate(modelCache, id), Cache.invalidate(capabilityCache, id));
+    const invalidateAll = Effect.andThen(Cache.invalidateAll(modelCache), Cache.invalidateAll(capabilityCache));
+    const getMetrics = Effect.sync(() => ({ hits, misses }));
 
-    const getCapabilities = (
-      instanceId: ProviderInstanceId,
-    ): Effect.Effect<ProviderAdapterCapabilities> =>
-      getWithMetrics(capabilityCache, instanceId);
-
-    const invalidateProvider = (
-      instanceId: ProviderInstanceId,
-    ): Effect.Effect<void> =>
-      Effect.andThen(
-        Cache.invalidate(modelCache, instanceId),
-        Cache.invalidate(capabilityCache, instanceId),
-      );
-
-    const invalidateAll: Effect.Effect<void> = Effect.andThen(
-      Cache.invalidateAll(modelCache),
-      Cache.invalidateAll(capabilityCache),
-    );
-
-    const getMetrics: Effect.Effect<CacheMetrics> = Effect.sync(() => ({
-      hits,
-      misses,
-    }));
-
-    return {
-      getModels,
-      getCapabilities,
-      invalidateProvider,
-      invalidateAll,
-      getMetrics,
-    };
+    return { getModels, getCapabilities, invalidateProvider, invalidateAll, getMetrics };
   });

--- a/t3code/apps/server/src/services/ProviderCache.ts
+++ b/t3code/apps/server/src/services/ProviderCache.ts
@@ -1,0 +1,165 @@
+/**
+ * ProviderCache — configurable in-memory cache for provider API responses.
+ *
+ * Uses `Effect.Cache` for bounded, TTL-expiring storage with built-in
+ * concurrent-request deduplication.  Cache hit/miss counters are exposed
+ * through Effect Metrics.
+ *
+ * @module services/ProviderCache
+ */
+import type {
+  ProviderInstanceId,
+  ServerProviderModel,
+} from "@t3tools/contracts";
+import type { ProviderAdapterCapabilities } from "../provider/Services/ProviderAdapter.ts";
+import * as Cache from "effect/Cache";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Metric from "effect/Metric";
+
+/* ------------------------------------------------------------------ */
+/*  Metrics                                                           */
+/* ------------------------------------------------------------------ */
+
+const cacheHitsTotal = Metric.counter("t3_provider_cache_hits_total", {
+  description: "Total provider cache hits.",
+});
+
+const cacheMissesTotal = Metric.counter("t3_provider_cache_misses_total", {
+  description: "Total provider cache misses.",
+});
+
+/* ------------------------------------------------------------------ */
+/*  Public types                                                      */
+/* ------------------------------------------------------------------ */
+
+export interface CacheMetrics {
+  readonly hits: number;
+  readonly misses: number;
+}
+
+export interface ProviderCache {
+  readonly getModels: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderModel>>;
+  readonly getCapabilities: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ProviderAdapterCapabilities>;
+  readonly invalidateProvider: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<void>;
+  readonly invalidateAll: Effect.Effect<void>;
+  readonly getMetrics: Effect.Effect<CacheMetrics>;
+}
+
+export interface ProviderCacheOptions {
+  readonly modelListTTL: Duration.Duration;
+  readonly capabilityTTL: Duration.Duration;
+  readonly maxEntries: number;
+}
+
+const DEFAULT_OPTIONS: ProviderCacheOptions = {
+  modelListTTL: Duration.minutes(5),
+  capabilityTTL: Duration.minutes(15),
+  maxEntries: 100,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Factory                                                           */
+/* ------------------------------------------------------------------ */
+
+export const makeProviderCache = (options: {
+  readonly fetchModels: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderModel>>;
+  readonly fetchCapabilities: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ProviderAdapterCapabilities>;
+  readonly modelListTTL?: Duration.Duration;
+  readonly capabilityTTL?: Duration.Duration;
+  readonly maxEntries?: number;
+}): Effect.Effect<ProviderCache> =>
+  Effect.gen(function* () {
+    const opts: ProviderCacheOptions = {
+      ...DEFAULT_OPTIONS,
+      modelListTTL: options.modelListTTL ?? DEFAULT_OPTIONS.modelListTTL,
+      capabilityTTL:
+        options.capabilityTTL ?? DEFAULT_OPTIONS.capabilityTTL,
+      maxEntries: options.maxEntries ?? DEFAULT_OPTIONS.maxEntries,
+    };
+
+    const modelCache = yield* Cache.make<
+      ProviderInstanceId,
+      ReadonlyArray<ServerProviderModel>
+    >({
+      capacity: opts.maxEntries,
+      timeToLive: opts.modelListTTL,
+      lookup: options.fetchModels,
+    });
+
+    const capabilityCache = yield* Cache.make<
+      ProviderInstanceId,
+      ProviderAdapterCapabilities
+    >({
+      capacity: opts.maxEntries,
+      timeToLive: opts.capabilityTTL,
+      lookup: options.fetchCapabilities,
+    });
+
+    let hits = 0;
+    let misses = 0;
+
+    const getWithMetrics = <A>(
+      cache: Cache.Cache<ProviderInstanceId, A>,
+      instanceId: ProviderInstanceId,
+    ): Effect.Effect<A> =>
+      Cache.has(cache, instanceId).pipe(
+        Effect.flatMap((cached) =>
+          cached
+            ? Cache.get(cache, instanceId).pipe(
+                Effect.tap(() => Effect.sync(() => hits++)),
+                Effect.tap(() => Metric.update(cacheHitsTotal, 1)),
+              )
+            : Cache.get(cache, instanceId).pipe(
+                Effect.tap(() => Effect.sync(() => misses++)),
+                Effect.tap(() => Metric.update(cacheMissesTotal, 1)),
+              ),
+        ),
+      );
+
+    const getModels = (
+      instanceId: ProviderInstanceId,
+    ): Effect.Effect<ReadonlyArray<ServerProviderModel>> =>
+      getWithMetrics(modelCache, instanceId);
+
+    const getCapabilities = (
+      instanceId: ProviderInstanceId,
+    ): Effect.Effect<ProviderAdapterCapabilities> =>
+      getWithMetrics(capabilityCache, instanceId);
+
+    const invalidateProvider = (
+      instanceId: ProviderInstanceId,
+    ): Effect.Effect<void> =>
+      Effect.andThen(
+        Cache.invalidate(modelCache, instanceId),
+        Cache.invalidate(capabilityCache, instanceId),
+      );
+
+    const invalidateAll: Effect.Effect<void> = Effect.andThen(
+      Cache.invalidateAll(modelCache),
+      Cache.invalidateAll(capabilityCache),
+    );
+
+    const getMetrics: Effect.Effect<CacheMetrics> = Effect.sync(() => ({
+      hits,
+      misses,
+    }));
+
+    return {
+      getModels,
+      getCapabilities,
+      invalidateProvider,
+      invalidateAll,
+      getMetrics,
+    };
+  });


### PR DESCRIPTION
…aching

Configurable in-memory cache for provider model lists and capabilities with TTL, bounded entries, hit/miss metrics, and per-provider invalidation.

Closes #865