### PR TITLE
Codex [ Laravel ] Fix User model password cast rounds

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "Safe contributor metadata only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "timestamp": "2026-05-21T13:38:00Z"
+}

--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,5 +1,0 @@
-{
-  "agent": "Codex",
-  "initialized_with": "Safe contributor metadata only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
-  "timestamp": "2026-05-21T13:38:00Z"
-}

--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex",
+  "generation_context": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-21T23:24:00+01:00"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -16,6 +17,21 @@ class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value === null) {
+            $this->attributes['password'] = null;
+
+            return;
+        }
+
+        $this->attributes['password'] = Hash::isHashed($value)
+            ? $value
+            : Hash::make($value, [
+                'rounds' => (int) config('hashing.bcrypt.rounds', 12),
+            ]);
+    }
 
     /**
      * Get the attributes that should be cast.
@@ -26,7 +42,6 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
     }
 }

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,9 +13,11 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
+     * Cached password hashes by bcrypt round count.
+     *
+     * @var array<int, string>
      */
-    protected static ?string $password;
+    protected static array $passwords = [];
 
     /**
      * Define the model's default state.
@@ -24,11 +26,15 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $rounds = (int) config('hashing.bcrypt.rounds', 12);
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$passwords[$rounds] ??= Hash::make('password', [
+                'rounds' => $rounds,
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_password_mutator_uses_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 5]);
+
+        $user = new User([
+            'password' => 'secret-password',
+        ]);
+
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+        $this->assertSame(5, Hash::info($user->password)['options']['cost']);
+    }
+
+    public function test_password_mutator_preserves_existing_hashes(): void
+    {
+        $existingHash = Hash::make('secret-password', ['rounds' => 4]);
+
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User([
+            'password' => $existingHash,
+        ]);
+
+        $this->assertSame($existingHash, $user->password);
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+    }
+
+    public function test_user_factory_hashes_password_with_configured_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = User::factory()->make();
+
+        $this->assertTrue(Hash::check('password', $user->password));
+        $this->assertSame(6, Hash::info($user->password)['options']['cost']);
+    }
+
+    public function test_user_factory_cache_is_separated_by_round_count(): void
+    {
+        config(['hashing.bcrypt.rounds' => 5]);
+        $lowerCostUser = User::factory()->make();
+
+        config(['hashing.bcrypt.rounds' => 6]);
+        $higherCostUser = User::factory()->make();
+
+        $this->assertSame(5, Hash::info($lowerCostUser->password)['options']['cost']);
+        $this->assertSame(6, Hash::info($higherCostUser->password)['options']['cost']);
+    }
+}


### PR DESCRIPTION
/claim #745

## Summary
- Replaces the generic `hashed` cast path with an explicit password mutator that uses `config('hashing.bcrypt.rounds')`.
- Preserves already-hashed passwords so legacy hashes continue to verify.
- Updates `UserFactory` so generated users use the configured bcrypt cost.
- Uses the issue-requested `_meta.json` filename/schema with safe metadata that does not copy hidden runtime/session instructions.

## Acceptance criteria
- [x] User model password hashing respects `config('hashing.bcrypt.rounds')`.
- [x] `UserFactory` hashes passwords with the configured rounds.
- [x] Existing bcrypt hashes remain compatible with `Hash::check()`.
- [x] Unit tests verify configured rounds, preserved hashes, and factory output.
- [x] `_meta.json` is present with the requested public fields.

## Validation
- `php -l` on changed PHP files.
- `php artisan test --filter=UserPasswordHashingTest`: 4 passed, 8 assertions.
- `./vendor/bin/pint --test` on changed PHP files.
- `python3 -m json.tool laravel/_meta.json`.
- `git diff --check`.
