### PR TITLE
Codex [ T3 Code ] Improve ChatView accessibility

### DIFF
--- a/t3code/apps/web/.contributor.json
+++ b/t3code/apps/web/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initialized_with": "Safe contributor metadata only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "timestamp": "2026-05-21T13:42:28Z"
+}

--- a/t3code/apps/web/.contributor.json
+++ b/t3code/apps/web/.contributor.json
@@ -1,5 +1,0 @@
-{
-  "agent": "Codex",
-  "initialized_with": "Safe contributor metadata only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
-  "timestamp": "2026-05-21T13:42:28Z"
-}

--- a/t3code/apps/web/.provenance.json
+++ b/t3code/apps/web/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex",
+  "config_snapshot": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "created": "2026-05-21T23:25:00+01:00"
+}

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3550,8 +3550,31 @@ export default function ChatView(props: ChatViewProps) {
       <div className="flex min-h-0 min-w-0 flex-1">
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="sr-only focus-within:not-sr-only">
+            <a
+              href="#chat-messages"
+              className="absolute left-3 top-3 z-50 rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              Skip to messages
+            </a>
+            <a
+              href="#chat-composer"
+              className="absolute left-3 top-14 z-50 rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              Skip to composer
+            </a>
+          </div>
+
           {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
+          <div
+            id="chat-messages"
+            className="relative flex min-h-0 flex-1 flex-col"
+            role="log"
+            aria-label="Conversation messages"
+            aria-live="polite"
+            aria-relevant="additions text"
+            data-chat-messages-region="true"
+          >
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}
@@ -3596,6 +3619,7 @@ export default function ChatView(props: ChatViewProps) {
 
           {/* Input bar */}
           <div
+            id="chat-composer"
             className={cn(
               "pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] pt-1.5 sm:pl-[calc(env(safe-area-inset-left)+1.25rem)] sm:pr-[calc(env(safe-area-inset-right)+1.25rem)] sm:pt-2",
               isGitRepo

--- a/t3code/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/t3code/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1614,7 +1614,9 @@ function ComposerPromptEditorInner({
                 "block max-h-50 min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap wrap-break-word bg-transparent text-[16px] leading-relaxed text-foreground focus:outline-none sm:text-[14px]",
                 className,
               )}
+              data-chat-composer-editor="true"
               data-testid="composer-editor"
+              aria-label="Message composer"
               aria-placeholder={placeholder}
               placeholder={<span />}
               onPaste={onPaste}

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentId, MessageId } from "@t3tools/contracts";
-import { createRef, type ReactNode, type Ref } from "react";
+import { createRef, type HTMLAttributes, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { LegendListRef } from "@legendapp/list/react";
@@ -7,20 +7,38 @@ import type { LegendListRef } from "@legendapp/list/react";
 vi.mock("@legendapp/list/react", async () => {
   const legendListTestId = "legend-list";
 
-  const LegendList = (props: {
+  const LegendList = ({
+    data,
+    keyExtractor,
+    renderItem,
+    estimatedItemSize: _estimatedItemSize,
+    initialScrollAtEnd: _initialScrollAtEnd,
+    maintainScrollAtEnd: _maintainScrollAtEnd,
+    maintainScrollAtEndThreshold: _maintainScrollAtEndThreshold,
+    maintainVisibleContentPosition: _maintainVisibleContentPosition,
+    ListHeaderComponent,
+    ListFooterComponent,
+    ref: _ref,
+    ...rest
+  }: {
     data: Array<{ id: string }>;
     keyExtractor: (item: { id: string }) => string;
     renderItem: (args: { item: { id: string } }) => ReactNode;
+    estimatedItemSize?: number;
+    initialScrollAtEnd?: boolean;
+    maintainScrollAtEnd?: boolean;
+    maintainScrollAtEndThreshold?: number;
+    maintainVisibleContentPosition?: boolean;
     ListHeaderComponent?: ReactNode;
     ListFooterComponent?: ReactNode;
     ref?: Ref<LegendListRef>;
-  }) => (
-    <div data-testid={legendListTestId}>
-      {props.ListHeaderComponent}
-      {props.data.map((item) => (
-        <div key={props.keyExtractor(item)}>{props.renderItem({ item })}</div>
+  } & HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid={legendListTestId} {...rest}>
+      {ListHeaderComponent}
+      {data.map((item) => (
+        <div key={keyExtractor(item)}>{renderItem({ item })}</div>
       ))}
-      {props.ListFooterComponent}
+      {ListFooterComponent}
     </div>
   );
 
@@ -185,6 +203,23 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Copy link"');
     expect(markup).toContain('data-user-message-collapsed="true"');
     expect(markup).toContain('data-user-message-footer="true"');
+  });
+
+  it("marks message rows as keyboard-focusable list items", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[buildUserTimelineEntry("Keyboard reachable prompt.")]}
+      />,
+    );
+
+    expect(markup).toContain('role="list"');
+    expect(markup).toContain('aria-label="Conversation timeline"');
+    expect(markup).toContain('role="listitem"');
+    expect(markup).toContain('tabindex="0"');
+    expect(markup).toContain('aria-label="User message"');
+    expect(markup).toContain('data-timeline-row-focusable="true"');
   });
 
   it("renders context compaction entries in the normal work log", async () => {

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
@@ -98,6 +99,8 @@ const TimelineRowActivityCtx = createContext<TimelineRowActivityState>(null!);
 const TIMELINE_LIST_HEADER = <div className="h-3 sm:h-4" />;
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const TIMELINE_FOCUSABLE_ROW_SELECTOR = '[data-timeline-row-focusable="true"]';
+const COMPOSER_EDITOR_SELECTOR = '[data-chat-composer-editor="true"]';
 
 // ---------------------------------------------------------------------------
 // Props (public API)
@@ -277,6 +280,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           maintainScrollAtEndThreshold={0.1}
           maintainVisibleContentPosition
           onScroll={handleScroll}
+          role="list"
+          aria-label="Conversation timeline"
           className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
           ListHeaderComponent={TIMELINE_LIST_HEADER}
           ListFooterComponent={TIMELINE_LIST_FOOTER}
@@ -300,14 +305,50 @@ type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["grouped
 type TimelineRow = MessagesTimelineRow;
 
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
+  const isMessageRow = row.kind === "message";
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!isMessageRow) {
+        return;
+      }
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        focusAdjacentTimelineRow(event.currentTarget, event.key === "ArrowDown" ? 1 : -1);
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        focusComposerEditor(event.currentTarget);
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const firstAction = event.currentTarget.querySelector<HTMLElement>(
+          'button:not(:disabled), a[href], [role="button"]:not([aria-disabled="true"])',
+        );
+        firstAction?.click();
+      }
+    },
+    [isMessageRow],
+  );
+
   return (
     <div
       className={cn(
         "pb-4",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
       )}
+      role={isMessageRow ? "listitem" : undefined}
+      tabIndex={isMessageRow ? 0 : undefined}
+      aria-label={
+        isMessageRow ? `${row.message.role === "user" ? "User" : "Assistant"} message` : undefined
+      }
+      onKeyDown={isMessageRow ? handleKeyDown : undefined}
       data-timeline-row-id={row.id}
       data-timeline-row-kind={row.kind}
+      data-timeline-row-focusable={isMessageRow ? "true" : undefined}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
       data-message-role={row.kind === "message" ? row.message.role : undefined}
     >
@@ -321,6 +362,22 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
     </div>
   );
 });
+
+function focusAdjacentTimelineRow(currentRow: HTMLElement, direction: 1 | -1): void {
+  const root = currentRow.closest('[data-chat-messages-region="true"]');
+  const rows = Array.from(
+    (root ?? currentRow.ownerDocument).querySelectorAll<HTMLElement>(
+      TIMELINE_FOCUSABLE_ROW_SELECTOR,
+    ),
+  );
+  const currentIndex = rows.indexOf(currentRow);
+  const nextRow = rows[currentIndex + direction];
+  nextRow?.focus();
+}
+
+function focusComposerEditor(currentRow: HTMLElement): void {
+  currentRow.ownerDocument.querySelector<HTMLElement>(COMPOSER_EDITOR_SELECTOR)?.focus();
+}
 
 function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);


### PR DESCRIPTION
/claim #852

## Summary
- Adds skip links from the chat view to messages and composer.
- Exposes the messages region as a polite `role="log"` area and the virtualised timeline as a labelled list.
- Makes message rows focusable list items with Arrow Up/Down navigation, Escape back to the composer, and Enter activation of row actions.
- Adds a composer editor label and focused tests for the timeline/list-item accessibility contract.
- Uses the issue-requested `.provenance.json` filename/schema with safe metadata that does not copy hidden runtime/session instructions.

## Acceptance criteria
- [x] Messages region uses `role="log"` and `aria-live="polite"`.
- [x] Message rows are keyboard-focusable `role="listitem"` entries.
- [x] Existing composer/send/remove controls remain labelled; composer editor now has an explicit label.
- [x] Arrow Up/Down moves between message rows.
- [x] Escape returns focus to the composer.
- [x] Skip links work by keyboard and are visually hidden until focused.
- [x] Existing mouse/touch interactions are left intact.
- [x] Focused markup tests cover the list/listitem contract.

## Validation
- `bun run fmt:check` on changed files.
- `bun --filter @t3tools/web test src/components/chat/MessagesTimeline.test.tsx`: 7 passed.
- `bun --filter @t3tools/web typecheck`.
- `bun run lint` on changed files; only existing `composerRef.current` hook dependency warnings were reported.
- `python3 -m json.tool t3code/apps/web/.provenance.json`.
- `git diff --check`.
