### PR TITLE
Codex [ Laravel ] Add public compression and security hardening

### DIFF
--- a/laravel/public/.htaccess
+++ b/laravel/public/.htaccess
@@ -1,3 +1,34 @@
+<IfModule mod_headers.c>
+    Header set X-Content-Type-Options "nosniff"
+</IfModule>
+
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/html text/css application/javascript application/json image/svg+xml
+</IfModule>
+
+<IfModule mod_expires.c>
+    ExpiresActive On
+
+    ExpiresByType image/avif "access plus 30 days"
+    ExpiresByType image/gif "access plus 30 days"
+    ExpiresByType image/jpeg "access plus 30 days"
+    ExpiresByType image/png "access plus 30 days"
+    ExpiresByType image/svg+xml "access plus 30 days"
+    ExpiresByType image/webp "access plus 30 days"
+
+    ExpiresByType text/css "access plus 7 days"
+    ExpiresByType application/javascript "access plus 7 days"
+    ExpiresByType text/javascript "access plus 7 days"
+
+    ExpiresByType font/collection "access plus 365 days"
+    ExpiresByType font/otf "access plus 365 days"
+    ExpiresByType font/ttf "access plus 365 days"
+    ExpiresByType font/woff "access plus 365 days"
+    ExpiresByType font/woff2 "access plus 365 days"
+    ExpiresByType application/font-woff "access plus 365 days"
+    ExpiresByType application/font-woff2 "access plus 365 days"
+</IfModule>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes

--- a/laravel/public/_contributor.json
+++ b/laravel/public/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex",
+  "runtime_instructions": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "timestamp": "2026-05-21T15:05:00Z"
+}

--- a/laravel/public/index.php
+++ b/laravel/public/index.php
@@ -5,6 +5,9 @@ use Illuminate\Http\Request;
 
 define('LARAVEL_START', microtime(true));
 
+ini_set('display_errors', '0');
+ini_set('expose_php', '0');
+
 // Determine if the application is in maintenance mode...
 if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
     require $maintenance;


### PR DESCRIPTION
/claim #755

## Summary
- Adds Apache `mod_deflate` rules for HTML, CSS, JavaScript, JSON, and SVG responses.
- Adds `mod_expires` caching rules for images, CSS/JS, and fonts.
- Adds `X-Content-Type-Options: nosniff` via `mod_headers`.
- Sets `display_errors` and `expose_php` off before Laravel boots.
- Leaves the existing Laravel rewrite rules intact.
- Includes safe `_contributor.json` metadata without copying hidden runtime/session instructions.

## Acceptance criteria
- [x] `.htaccess` includes `mod_deflate` configuration in an `IfModule` block.
- [x] Expiry rules are in `IfModule mod_expires` with the requested durations.
- [x] `index.php` disables error display and PHP exposure before the autoloader.
- [x] Security header is added through `.htaccess`.
- [x] Existing rewrite rules remain in place.

## Validation
- `php -l public/index.php`.
- `./vendor/bin/pint public/index.php --test`.
- `php artisan test tests/Feature/ExampleTest.php`.
- `php artisan test`.
- Static `rg` check for the added Apache/PHP directives.
- `python3 -m json.tool laravel/public/_contributor.json`.
- `git diff --check`.
