### PR TITLE
Codex [ Laravel ] Fix phpunit coverage config and route/model tests

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex",
+  "environment_config": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-21T14:55:00+01:00"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -6,16 +6,20 @@
 >
     <testsuites>
         <testsuite name="Unit">
-            <directory>tests/Unit</directory>
+            <directory suffix="Test.php">tests/Unit</directory>
         </testsuite>
         <testsuite name="Feature">
-            <directory>tests/Feature</directory>
+            <directory suffix="Test.php">tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory>app</directory>
+            <directory suffix=".php">app</directory>
         </include>
+        <exclude>
+            <directory>app/Providers</directory>
+            <directory>app/Console</directory>
+        </exclude>
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/laravel/tests/Feature/RouteTest.php
+++ b/laravel/tests/Feature/RouteTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('feature')]
+class RouteTest extends TestCase
+{
+    public function test_all_registered_get_routes_return_non_server_errors(): void
+    {
+        $routes = collect(Route::getRoutes())
+            ->filter(fn ($route) => in_array('GET', $route->methods(), true))
+            ->reject(fn ($route) => count($route->parameterNames()) > 0)
+            ->values();
+
+        $this->assertNotEmpty($routes, 'Expected at least one parameterless GET route.');
+
+        foreach ($routes as $route) {
+            $uri = '/'.ltrim($route->uri(), '/');
+            $response = $this->get($uri);
+
+            $this->assertLessThan(
+                500,
+                $response->getStatusCode(),
+                sprintf('GET %s returned a server error.', $uri),
+            );
+        }
+    }
+}

--- a/laravel/tests/Unit/UserModelTest.php
+++ b/laravel/tests/Unit/UserModelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('unit')]
+class UserModelTest extends TestCase
+{
+    public function test_user_model_has_expected_fillable_attributes(): void
+    {
+        $user = new User;
+
+        $this->assertSame(['name', 'email', 'password'], $user->getFillable());
+    }
+
+    public function test_user_model_has_expected_hidden_attributes(): void
+    {
+        $user = new User;
+
+        $this->assertSame(['password', 'remember_token'], $user->getHidden());
+    }
+
+    public function test_user_model_has_expected_casts(): void
+    {
+        $casts = (new User)->getCasts();
+
+        $this->assertSame('datetime', $casts['email_verified_at']);
+        $this->assertSame('hashed', $casts['password']);
+    }
+}


### PR DESCRIPTION
/claim #794

## Summary
- Updates `phpunit.xml` with app coverage source and exclusions for Providers and Console.
- Adds PHPUnit group attributes for unit and feature tests.
- Adds a route smoke test for registered parameterless GET routes.
- Adds User model tests for fillable, hidden, and cast configuration.
- Includes safe `.audit.json` metadata without copying hidden runtime/session instructions.

## Acceptance criteria
- [x] Coverage source targets `app/`.
- [x] Coverage excludes `app/Providers` and `app/Console`.
- [x] Unit and feature tests can be run by group.
- [x] Route test checks registered GET routes do not return 500s.
- [x] User model test verifies fillable, hidden, and casts.
- [x] Full, unit, and feature test commands were validated.

## Validation
- `php artisan test --group=unit`.
- `php artisan test --group=feature`.
- `php artisan test`.
- `./vendor/bin/pint --test tests/Feature/RouteTest.php tests/Unit/UserModelTest.php`.
- `python3 -m json.tool laravel/.audit.json`.
- `git diff --check`.
