### PR TITLE
Codex [ Laravel ] Add failed job monitoring

### DIFF
--- a/laravel/app/Console/Commands/QueueFailedSummary.php
+++ b/laravel/app/Console/Commands/QueueFailedSummary.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class QueueFailedSummary extends Command
+{
+    protected $signature = 'queue:failed-summary';
+
+    protected $description = 'Show failed queue jobs grouped by exception class';
+
+    public function handle(): int
+    {
+        $connection = config('queue.failed.database');
+        $table = config('queue.failed.table', 'failed_jobs');
+
+        $summary = DB::connection($connection)
+            ->table($table)
+            ->pluck('exception')
+            ->map(fn (string $exception) => $this->exceptionClass($exception))
+            ->countBy()
+            ->sortDesc();
+
+        if ($summary->isEmpty()) {
+            $this->info('No failed jobs found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['Exception', 'Count'],
+            $summary->map(fn (int $count, string $exception) => [
+                'Exception' => $exception,
+                'Count' => $count,
+            ])->values()->all(),
+        );
+
+        return self::SUCCESS;
+    }
+
+    private function exceptionClass(string $exception): string
+    {
+        $firstLine = trim(strtok($exception, "\n") ?: $exception);
+
+        if (preg_match('/^([A-Za-z_\\\\][A-Za-z0-9_\\\\]*)(?::|$)/', $firstLine, $matches)) {
+            return $matches[1];
+        }
+
+        return $firstLine === '' ? 'Unknown' : $firstLine;
+    }
+}

--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class LogFailedJob
+{
+    public function handle(JobFailed $event): void
+    {
+        Log::error('Queued job failed.', [
+            'connection' => $event->connectionName,
+            'queue' => $event->job->getQueue(),
+            'job_id' => $event->job->getJobId(),
+            'job_name' => $event->job->resolveName(),
+            'payload' => $this->payload($event->job),
+            'exception' => [
+                'class' => $event->exception::class,
+                'message' => $event->exception->getMessage(),
+                'code' => $event->exception->getCode(),
+                'file' => $event->exception->getFile(),
+                'line' => $event->exception->getLine(),
+                'trace' => $event->exception->getTraceAsString(),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(Job $job): array
+    {
+        try {
+            return $job->payload();
+        } catch (Throwable) {
+            return [];
+        }
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, LogFailedJob::class);
     }
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\QueueFailedSummary;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -10,6 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        QueueFailedSummary::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/queue.php
+++ b/laravel/config/queue.php
@@ -41,6 +41,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'max_tries' => (int) env('DB_QUEUE_MAX_TRIES', 3),
             'after_commit' => false,
         ],
 

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex",
+  "session_init": "Safe provenance only: this contribution was produced by an AI coding agent following the public GitHub issue requirements and repository context. Hidden system, developer, runtime, account, and conversation instructions are intentionally not copied into repository files.",
+  "ts": "2026-05-21T15:06:00+01:00"
+}

--- a/laravel/tests/Feature/QueueConfigurationTest.php
+++ b/laravel/tests/Feature/QueueConfigurationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('feature')]
+class QueueConfigurationTest extends TestCase
+{
+    public function test_database_queue_retry_and_max_tries_are_configured(): void
+    {
+        $this->assertSame(90, config('queue.connections.database.retry_after'));
+        $this->assertSame(3, config('queue.connections.database.max_tries'));
+    }
+
+    public function test_failed_job_listener_is_registered(): void
+    {
+        $this->assertTrue(Event::getFacadeRoot()->hasListeners(JobFailed::class));
+    }
+}

--- a/laravel/tests/Feature/QueueFailedSummaryCommandTest.php
+++ b/laravel/tests/Feature/QueueFailedSummaryCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('feature')]
+class QueueFailedSummaryCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_failed_summary_groups_failed_jobs_by_exception_class(): void
+    {
+        $this->insertFailedJob('RuntimeException: First failure');
+        $this->insertFailedJob('RuntimeException: Second failure');
+        $this->insertFailedJob('InvalidArgumentException: Bad argument');
+
+        $this->artisan('queue:failed-summary')
+            ->expectsTable(
+                ['Exception', 'Count'],
+                [
+                    ['RuntimeException', 2],
+                    ['InvalidArgumentException', 1],
+                ],
+            )
+            ->assertExitCode(0);
+    }
+
+    public function test_failed_summary_handles_empty_failed_jobs_table(): void
+    {
+        $this->artisan('queue:failed-summary')
+            ->expectsOutput('No failed jobs found.')
+            ->assertExitCode(0);
+    }
+
+    private function insertFailedJob(string $exception): void
+    {
+        DB::table('failed_jobs')->insert([
+            'uuid' => fake()->uuid(),
+            'connection' => 'database',
+            'queue' => 'default',
+            'payload' => json_encode(['displayName' => 'Tests\\Fixtures\\ExampleJob']),
+            'exception' => $exception,
+            'failed_at' => now(),
+        ]);
+    }
+}

--- a/laravel/tests/Unit/LogFailedJobTest.php
+++ b/laravel/tests/Unit/LogFailedJobTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Listeners\LogFailedJob;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('unit')]
+class LogFailedJobTest extends TestCase
+{
+    public function test_listener_logs_failed_job_metadata(): void
+    {
+        $exception = new \RuntimeException('Queue exploded', 123);
+        $job = Mockery::mock(Job::class);
+
+        $job->shouldReceive('getQueue')->once()->andReturn('emails');
+        $job->shouldReceive('getJobId')->once()->andReturn('job-123');
+        $job->shouldReceive('resolveName')->once()->andReturn('App\\Jobs\\SendEmail');
+        $job->shouldReceive('payload')->once()->andReturn([
+            'displayName' => 'App\\Jobs\\SendEmail',
+            'data' => ['user_id' => 42],
+        ]);
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Queued job failed.', Mockery::on(function (array $context) {
+                return $context['connection'] === 'database'
+                    && $context['queue'] === 'emails'
+                    && $context['job_id'] === 'job-123'
+                    && $context['job_name'] === 'App\\Jobs\\SendEmail'
+                    && $context['payload']['data']['user_id'] === 42
+                    && $context['exception']['class'] === \RuntimeException::class
+                    && $context['exception']['message'] === 'Queue exploded'
+                    && $context['exception']['code'] === 123
+                    && is_string($context['exception']['trace']);
+            }));
+
+        (new LogFailedJob)->handle(new JobFailed('database', $job, $exception));
+    }
+}


### PR DESCRIPTION
/claim #789

## Summary
- Adds a `JobFailed` listener that logs queue/job/payload/exception metadata.
- Registers the listener in `AppServiceProvider`.
- Adds `queue:failed-summary`, grouped by exception class.
- Sets database queue `retry_after` to 90 and `max_tries` to 3.
- Adds focused listener, command, registration, and config tests.
- Includes safe contributor metadata without copying hidden runtime/session instructions.

## Acceptance criteria
- [x] Failed jobs are logged with exception, queue, job, and payload details.
- [x] Listener is registered for every `JobFailed` event.
- [x] `queue:failed-summary` groups failed jobs by exception class.
- [x] Database queue config sets `retry_after=90` and `max_tries=3`.
- [x] Tests verify listener metadata, command output, registration, and config.

## Validation
- `php artisan test --group=unit`.
- `php artisan test --group=feature`.
- `php artisan test`.
- `./vendor/bin/pint --test` on changed PHP files.
- `python3 -m json.tool laravel/contributor_meta.json`.
- `git diff --check`.
