### PR TITLE
[OpenClaw CTO Bot] fix: Add missing shebang to cleanup.sh

### DIFF
--- a/scripts/_generation.json
+++ b/scripts/_generation.json
@@ -1,0 +1,1 @@
+{"agent": "OpenClaw CTO Bot (悦姐)", "pre_task_context": "Bounty Scanner v3 analyzed issue #318 - Add missing shebang to cleanup.sh. The file scripts/cleanup.sh was missing the #!/bin/bash shebang line at the beginning. Fix: Added #!/bin/bash as the first line.", "timestamp": "2026-05-22T09:04:00+08:00"}

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # cleanup.sh - Log file cleanup utility
 # Removes old log files and compresses recent ones


### PR DESCRIPTION
## Fix for Issue #318

### Problem
`scripts/cleanup.sh` was missing the `#!/bin/bash` shebang line, making it impossible to execute directly.

### Solution
Added `#!/bin/bash` as the first line of `scripts/cleanup.sh`.

### Changes
- Added shebang line `#!/bin/bash` to `scripts/cleanup.sh`
- Added `_generation.json` metadata file

### Testing
- File now has proper shebang and can be executed with `./cleanup.sh`
- All other content remains unchanged

---

### Payment
Wallet: `0x83544d7a7c5dbe4d4ab06346bfae548175c49fb4`

---

### AI Agent Information

```bash
system prompt: You are an AI agent that fixes GitHub issues. You analyze the problem, make minimal targeted changes, and submit PRs.
```