### PR TITLE
Codex [ Laravel ] Implement audit logging trait

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+#[Fillable([
+    'auditable_type',
+    'auditable_id',
+    'event',
+    'old_values',
+    'new_values',
+    'user_id',
+    'ip_address',
+    'user_agent',
+])]
+class AuditLog extends Model
+{
+    /**
+     * Get the audited model instance.
+     */
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Get the authenticated user that caused the audited change.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+
+trait Auditable
+{
+    /**
+     * Fields that should never be persisted in audit payloads.
+     *
+     * @var array<int, string>
+     */
+    protected static array $defaultAuditHidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * Register model event hooks for audit logging.
+     */
+    protected static function bootAuditable(): void
+    {
+        static::created(function (Model $model): void {
+            $model->writeAuditLog('created', [], $model->auditValues($model->getAttributes()));
+        });
+
+        static::updated(function (Model $model): void {
+            $changed = $model->auditValues($model->getChanges());
+
+            if ($changed === []) {
+                return;
+            }
+
+            $oldValues = $model->auditValues(
+                Arr::only($model->getOriginal(), array_keys($changed))
+            );
+
+            $model->writeAuditLog('updated', $oldValues, $changed);
+        });
+
+        static::deleted(function (Model $model): void {
+            $model->writeAuditLog('deleted', $model->auditValues($model->getOriginal()), []);
+        });
+    }
+
+    /**
+     * Get all audit log entries for this model in reverse chronological order.
+     */
+    public function getAuditHistory(): Collection
+    {
+        return $this->auditLogs()
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    /**
+     * Get the audit logs for this model.
+     */
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    /**
+     * Create a persisted audit log entry for this model.
+     *
+     * @param  array<string, mixed>  $oldValues
+     * @param  array<string, mixed>  $newValues
+     */
+    protected function writeAuditLog(string $event, array $oldValues, array $newValues): void
+    {
+        $request = app()->bound('request') ? request() : null;
+
+        $this->auditLogs()->create([
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => Auth::id(),
+            'ip_address' => $request?->ip(),
+            'user_agent' => $request?->userAgent(),
+        ]);
+    }
+
+    /**
+     * Filter out sensitive and non-business attributes before storing audit data.
+     *
+     * @param  array<string, mixed>  $values
+     * @return array<string, mixed>
+     */
+    protected function auditValues(array $values): array
+    {
+        $hidden = array_unique(array_merge(
+            static::$defaultAuditHidden,
+            method_exists($this, 'getHidden') ? $this->getHidden() : []
+        ));
+
+        return Arr::except($values, array_merge($hidden, [
+            'created_at',
+            'updated_at',
+        ]));
+    }
+}

--- a/laravel/database/migrations/2026_05_22_040000_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_05_22_040000_create_audit_logs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('auditable');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditableTest.php
+++ b/laravel/tests/Feature/AuditableTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_a_user_writes_an_audit_log_without_sensitive_values(): void
+    {
+        $actor = User::withoutEvents(fn () => User::factory()->create());
+
+        $this->actingAs($actor);
+        request()->server->set('REMOTE_ADDR', '203.0.113.10');
+        request()->headers->set('User-Agent', 'AuditTest/1.0');
+
+        $user = User::factory()->create([
+            'name' => 'Audited User',
+            'email' => 'audited@example.com',
+        ]);
+
+        $log = AuditLog::query()->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame(User::class, $log->auditable_type);
+        $this->assertSame($user->id, $log->auditable_id);
+        $this->assertSame('created', $log->event);
+        $this->assertSame([], $log->old_values);
+        $this->assertSame('Audited User', $log->new_values['name']);
+        $this->assertSame('audited@example.com', $log->new_values['email']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+        $this->assertArrayNotHasKey('remember_token', $log->new_values);
+        $this->assertSame($actor->id, $log->user_id);
+        $this->assertSame('203.0.113.10', $log->ip_address);
+        $this->assertSame('AuditTest/1.0', $log->user_agent);
+    }
+
+    public function test_updating_a_user_writes_old_and_new_changed_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Old Name',
+            'email' => 'old@example.com',
+        ]);
+        AuditLog::query()->delete();
+
+        $user->update([
+            'name' => 'New Name',
+            'password' => 'new-password',
+        ]);
+
+        $log = AuditLog::query()->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('updated', $log->event);
+        $this->assertSame(['name' => 'Old Name'], $log->old_values);
+        $this->assertSame(['name' => 'New Name'], $log->new_values);
+        $this->assertArrayNotHasKey('password', $log->old_values);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+    }
+
+    public function test_deleting_a_user_writes_an_audit_log_with_old_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Deleted User',
+            'email' => 'deleted@example.com',
+        ]);
+        AuditLog::query()->delete();
+
+        $user->delete();
+
+        $log = AuditLog::query()->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame('deleted', $log->event);
+        $this->assertSame('Deleted User', $log->old_values['name']);
+        $this->assertSame('deleted@example.com', $log->old_values['email']);
+        $this->assertSame([], $log->new_values);
+        $this->assertArrayNotHasKey('password', $log->old_values);
+    }
+
+    public function test_get_audit_history_returns_logs_in_reverse_chronological_order(): void
+    {
+        $user = User::factory()->create(['name' => 'First Name']);
+        $user->update(['name' => 'Second Name']);
+        $user->update(['name' => 'Third Name']);
+
+        $history = $user->getAuditHistory();
+
+        $this->assertCount(3, $history);
+        $this->assertSame('updated', $history[0]->event);
+        $this->assertSame(['name' => 'Third Name'], $history[0]->new_values);
+        $this->assertGreaterThan($history[1]->id, $history[0]->id);
+        $this->assertSame('created', $history[2]->event);
+    }
+}


### PR DESCRIPTION
## Summary
- Add an `Auditable` trait that records created, updated, and deleted Eloquent model events.
- Add an `AuditLog` model and migration with auditable target, event payloads, nullable user metadata, request IP/user-agent metadata, and timestamps.
- Apply the trait to `User` and add feature tests for create/update/delete events, sensitive-field filtering, reverse chronological history, and authenticated user metadata.

/claim #786

## Validation
- Added focused feature coverage for the audit log behavior described above.
- `git diff --check` passed.

## Note
- I did not add the requested provenance file because it asks for private session context. The implementation and tests are in the diff.