### PR TITLE
Codex [ Laravel ] Implement notification preferences

### DIFF
--- a/laravel/app/Http/Controllers/NotificationPreferenceController.php
+++ b/laravel/app/Http/Controllers/NotificationPreferenceController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NotificationPreferenceController extends Controller
+{
+    /**
+     * List notification preferences for the authenticated user.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $preferences = $request->user()
+            ->notificationPreferences()
+            ->orderBy('event_type')
+            ->orderBy('channel')
+            ->get();
+
+        return response()->json([
+            'data' => $preferences,
+        ]);
+    }
+
+    /**
+     * Toggle a single notification preference.
+     */
+    public function update(Request $request, NotificationPreference $preference): JsonResponse
+    {
+        abort_unless($preference->user_id === $request->user()->id, 404);
+
+        $validated = $request->validate([
+            'enabled' => ['required', 'boolean'],
+        ]);
+
+        $preference->update($validated);
+
+        return response()->json([
+            'data' => $preference->refresh(),
+        ]);
+    }
+
+    /**
+     * Toggle several notification preferences in one request.
+     */
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'preferences' => ['required', 'array'],
+            'preferences.*.id' => ['required', 'integer'],
+            'preferences.*.enabled' => ['required', 'boolean'],
+        ]);
+
+        $preferencesById = $request->user()
+            ->notificationPreferences()
+            ->whereIn('id', collect($validated['preferences'])->pluck('id'))
+            ->get()
+            ->keyBy('id');
+
+        foreach ($validated['preferences'] as $preferenceData) {
+            $preference = $preferencesById->get($preferenceData['id']);
+
+            if ($preference === null) {
+                continue;
+            }
+
+            $preference->update([
+                'enabled' => $preferenceData['enabled'],
+            ]);
+        }
+
+        return response()->json([
+            'data' => $request->user()
+                ->notificationPreferences()
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get(),
+        ]);
+    }
+}

--- a/laravel/app/Models/NotificationPreference.php
+++ b/laravel/app/Models/NotificationPreference.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'user_id',
+    'channel',
+    'event_type',
+    'enabled',
+])]
+class NotificationPreference extends Model
+{
+    public const CHANNELS = [
+        'mail',
+        'slack',
+        'database',
+    ];
+
+    public const DEFAULT_EVENT_TYPES = [
+        'account.updated',
+        'security.alert',
+        'weekly.digest',
+    ];
+
+    /**
+     * Seed default notification preferences for a user.
+     */
+    public static function seedDefaultsFor(User $user): void
+    {
+        foreach (self::DEFAULT_EVENT_TYPES as $eventType) {
+            foreach (self::CHANNELS as $channel) {
+                self::query()->firstOrCreate([
+                    'user_id' => $user->id,
+                    'channel' => $channel,
+                    'event_type' => $eventType,
+                ], [
+                    'enabled' => true,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Get the user that owns the preference.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,6 +7,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -16,6 +17,14 @@ class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    /**
+     * Get the notification preferences configured for the user.
+     */
+    public function notificationPreferences(): HasMany
+    {
+        return $this->hasMany(NotificationPreference::class);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Notifications/RoutedNotification.php
+++ b/laravel/app/Notifications/RoutedNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+class RoutedNotification extends Notification
+{
+    /**
+     * @param  array<int, string>  $channels
+     */
+    public function __construct(
+        public readonly Notification $notification,
+        private readonly array $channels,
+    ) {}
+
+    /**
+     * Get the filtered delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return $this->channels;
+    }
+
+    /**
+     * Forward channel-specific formatting methods to the wrapped notification.
+     *
+     * @param  array<int, mixed>  $parameters
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        return $this->notification->{$method}(...$parameters);
+    }
+}

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+
+class UserObserver
+{
+    /**
+     * Seed notification preferences when a user is created.
+     */
+    public function created(User $user): void
+    {
+        NotificationPreference::seedDefaultsFor($user);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 }

--- a/laravel/app/Services/NotificationRouter.php
+++ b/laravel/app/Services/NotificationRouter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Notifications\RoutedNotification;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+class NotificationRouter
+{
+    /**
+     * Return only channels enabled by the user for the given event type.
+     *
+     * @param  array<int, string>|null  $channels
+     * @return array<int, string>
+     */
+    public function enabledChannels(User $user, string $eventType, ?array $channels = null): array
+    {
+        $candidateChannels = $channels ?? NotificationPreference::CHANNELS;
+
+        return $user->notificationPreferences()
+            ->where('event_type', $eventType)
+            ->where('enabled', true)
+            ->whereIn('channel', $candidateChannels)
+            ->orderByRaw("case channel when 'mail' then 1 when 'slack' then 2 when 'database' then 3 else 4 end")
+            ->pluck('channel')
+            ->all();
+    }
+
+    /**
+     * Determine whether a channel is enabled for an event type.
+     */
+    public function shouldSend(User $user, string $eventType, string $channel): bool
+    {
+        return in_array($channel, $this->enabledChannels($user, $eventType, [$channel]), true);
+    }
+
+    /**
+     * Dispatch a notification only through channels enabled for the event type.
+     *
+     * @param  array<int, string>|null  $channels
+     * @return array<int, string> The channels used for dispatch.
+     */
+    public function send(User $user, string $eventType, Notification $notification, ?array $channels = null): array
+    {
+        $candidateChannels = $channels ?? $notification->via($user);
+        $enabledChannels = $this->enabledChannels($user, $eventType, $candidateChannels);
+
+        if ($enabledChannels !== []) {
+            NotificationFacade::send($user, new RoutedNotification($notification, $enabledChannels));
+        }
+
+        return $enabledChannels;
+    }
+}

--- a/laravel/database/migrations/2026_05_22_043000_create_notification_preferences_table.php
+++ b/laravel/database/migrations/2026_05_22_043000_create_notification_preferences_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('channel');
+            $table->string('event_type');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'channel', 'event_type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Http\Controllers\NotificationPreferenceController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::middleware('auth')->group(function (): void {
+    Route::get('/notifications/preferences', [NotificationPreferenceController::class, 'index']);
+    Route::put('/notifications/preferences/{preference}', [NotificationPreferenceController::class, 'update']);
+    Route::post('/notifications/preferences/bulk', [NotificationPreferenceController::class, 'bulkUpdate']);
 });

--- a/laravel/tests/Feature/NotificationPreferenceTest.php
+++ b/laravel/tests/Feature/NotificationPreferenceTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Notifications\RoutedNotification;
+use App\Services\NotificationRouter;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+use Tests\TestCase;
+
+class NotificationPreferenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_new_users_receive_default_notification_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertCount(9, $user->notificationPreferences);
+        $this->assertTrue(
+            $user->notificationPreferences
+                ->where('event_type', 'security.alert')
+                ->where('channel', 'mail')
+                ->first()
+                ->enabled
+        );
+    }
+
+    public function test_users_can_list_their_notification_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->getJson('/notifications/preferences');
+
+        $response->assertOk()
+            ->assertJsonCount(9, 'data')
+            ->assertJsonPath('data.0.event_type', 'account.updated');
+    }
+
+    public function test_users_can_update_one_notification_preference(): void
+    {
+        $user = User::factory()->create();
+        $preference = $user->notificationPreferences()->first();
+
+        $response = $this->actingAs($user)
+            ->putJson("/notifications/preferences/{$preference->id}", [
+                'enabled' => false,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.enabled', false);
+
+        $this->assertFalse($preference->refresh()->enabled);
+    }
+
+    public function test_users_cannot_update_another_users_preference(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $preference = $otherUser->notificationPreferences()->first();
+
+        $this->actingAs($user)
+            ->putJson("/notifications/preferences/{$preference->id}", [
+                'enabled' => false,
+            ])
+            ->assertNotFound();
+    }
+
+    public function test_users_can_bulk_update_their_notification_preferences(): void
+    {
+        $user = User::factory()->create();
+        $preferences = $user->notificationPreferences()->take(2)->get();
+
+        $response = $this->actingAs($user)
+            ->postJson('/notifications/preferences/bulk', [
+                'preferences' => $preferences->map(fn (NotificationPreference $preference): array => [
+                    'id' => $preference->id,
+                    'enabled' => false,
+                ])->all(),
+            ]);
+
+        $response->assertOk()
+            ->assertJsonCount(9, 'data');
+
+        $this->assertSame(0, NotificationPreference::query()
+            ->whereIn('id', $preferences->pluck('id'))
+            ->where('enabled', true)
+            ->count());
+    }
+
+    public function test_notification_router_filters_disabled_channels(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notificationPreferences()
+            ->where('event_type', 'security.alert')
+            ->where('channel', 'mail')
+            ->update(['enabled' => false]);
+
+        $channels = app(NotificationRouter::class)->enabledChannels(
+            $user,
+            'security.alert',
+            ['mail', 'slack', 'database']
+        );
+
+        $this->assertSame(['slack', 'database'], $channels);
+        $this->assertFalse(app(NotificationRouter::class)->shouldSend($user, 'security.alert', 'mail'));
+        $this->assertTrue(app(NotificationRouter::class)->shouldSend($user, 'security.alert', 'slack'));
+    }
+
+    public function test_notification_router_sends_only_to_enabled_channels(): void
+    {
+        NotificationFacade::fake();
+
+        $user = User::factory()->create();
+        $user->notificationPreferences()
+            ->where('event_type', 'security.alert')
+            ->where('channel', 'mail')
+            ->update(['enabled' => false]);
+
+        $usedChannels = app(NotificationRouter::class)->send(
+            $user,
+            'security.alert',
+            new class extends Notification
+            {
+                /**
+                 * @return array<int, string>
+                 */
+                public function via(object $notifiable): array
+                {
+                    return ['mail', 'slack', 'database'];
+                }
+            }
+        );
+
+        $this->assertSame(['slack', 'database'], $usedChannels);
+
+        NotificationFacade::assertSentTo(
+            $user,
+            RoutedNotification::class,
+            fn (RoutedNotification $notification): bool => $notification->via($user) === ['slack', 'database']
+        );
+    }
+
+    public function test_duplicate_notification_preferences_are_rejected(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $user = User::factory()->create();
+        NotificationPreference::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'security.alert',
+            'enabled' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `NotificationPreference` model and migration with user/channel/event uniqueness and default preference seeding.
- Add authenticated listing, single update, and bulk update endpoints for user notification preferences.
- Add a `NotificationRouter` service plus routed notification wrapper so dispatch only uses channels enabled for the event type.
- Register a `UserObserver` to seed default preferences for new users and add feature coverage for listing, toggling, bulk update, router filtering, routed dispatch, and uniqueness.

/claim #793

## Validation
- Added focused feature coverage for the notification preference and routing behavior described above.
- `git diff --check` passed.

## Note
- I did not add the requested contributor metadata file because it asks for private session context. The implementation and tests are in the diff.