### PR TITLE
Codex [ Laravel ] Fix Slack notification service

### DIFF
--- a/laravel/app/Services/SlackNotifier.php
+++ b/laravel/app/Services/SlackNotifier.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+
+class SlackNotifier
+{
+    /**
+     * Send a Slack webhook message.
+     *
+     * @param  array<int, array<string, mixed>>  $blocks
+     */
+    public static function send(string $text, ?string $channel = null, array $blocks = []): Response
+    {
+        return app(self::class)->sendMessage($text, $channel, $blocks);
+    }
+
+    /**
+     * Send a Slack webhook message using configured defaults.
+     *
+     * @param  array<int, array<string, mixed>>  $blocks
+     */
+    public function sendMessage(string $text, ?string $channel = null, array $blocks = []): Response
+    {
+        $webhookUrl = config('services.slack.webhook_url');
+
+        if (! is_string($webhookUrl) || $webhookUrl === '') {
+            throw new InvalidArgumentException('Slack webhook URL is not configured.');
+        }
+
+        $payload = array_filter([
+            'text' => $text,
+            'channel' => $channel ?? config('services.slack.default_channel'),
+            'blocks' => $blocks === [] ? null : $blocks,
+        ], fn (mixed $value): bool => $value !== null && $value !== '');
+
+        return $this->postWithServerErrorRetry($webhookUrl, $payload);
+    }
+
+    /**
+     * Post to Slack, retrying once for 5xx responses and never retrying 4xx responses.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function postWithServerErrorRetry(string $webhookUrl, array $payload): Response
+    {
+        $response = Http::timeout(5)->post($webhookUrl, $payload);
+
+        if ($response->serverError()) {
+            $response = Http::timeout(5)->post($webhookUrl, $payload);
+        }
+
+        return $response->throw();
+    }
+}

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -29,6 +29,9 @@ return [
     ],
 
     'slack' => [
+        'webhook_url' => env('SLACK_WEBHOOK_URL'),
+        'default_channel' => env('SLACK_DEFAULT_CHANNEL', env('SLACK_BOT_USER_DEFAULT_CHANNEL')),
+
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/laravel/tests/Feature/SlackNotifierTest.php
+++ b/laravel/tests/Feature/SlackNotifierTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SlackNotifier;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class SlackNotifierTest extends TestCase
+{
+    public function test_it_sends_a_slack_webhook_payload_from_config(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/default',
+            'services.slack.default_channel' => '#alerts',
+        ]);
+        Http::fake([
+            'hooks.slack.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        SlackNotifier::send('Deploy complete');
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://hooks.slack.test/services/default'
+                && $request['text'] === 'Deploy complete'
+                && $request['channel'] === '#alerts';
+        });
+    }
+
+    public function test_channel_override_and_blocks_are_sent_when_provided(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/override',
+            'services.slack.default_channel' => '#alerts',
+        ]);
+        Http::fake([
+            'hooks.slack.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        SlackNotifier::send('Build failed', '#deploys', [
+            [
+                'type' => 'section',
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => '*Build failed*',
+                ],
+            ],
+        ]);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request['channel'] === '#deploys'
+                && $request['blocks'][0]['type'] === 'section'
+                && $request['blocks'][0]['text']['text'] === '*Build failed*';
+        });
+    }
+
+    public function test_server_errors_are_retried_once_before_succeeding(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/retry',
+            'services.slack.default_channel' => '#alerts',
+        ]);
+        Http::fake([
+            'hooks.slack.test/*' => Http::sequence()
+                ->push(['error' => 'temporary'], 500)
+                ->push(['ok' => true], 200),
+        ]);
+
+        $response = SlackNotifier::send('Retry me');
+
+        $this->assertTrue($response->successful());
+        Http::assertSentCount(2);
+    }
+
+    public function test_client_errors_throw_without_retrying(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/client-error',
+            'services.slack.default_channel' => '#alerts',
+        ]);
+        Http::fake([
+            'hooks.slack.test/*' => Http::response(['error' => 'bad request'], 400),
+        ]);
+
+        $this->expectException(RequestException::class);
+
+        try {
+            SlackNotifier::send('Bad request');
+        } finally {
+            Http::assertSentCount(1);
+        }
+    }
+
+    public function test_missing_webhook_url_throws_configuration_exception(): void
+    {
+        config([
+            'services.slack.webhook_url' => null,
+            'services.slack.default_channel' => '#alerts',
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        SlackNotifier::send('No webhook configured');
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SlackNotifier` service with config-driven webhook URL/default channel and a facade-style `SlackNotifier::send(...)` convenience method.
- Send Slack webhook payloads with text, optional channel override, and optional block attachments.
- Use a 5 second HTTP timeout, retry once for 5xx responses, and fail immediately for 4xx responses.
- Add HTTP fake coverage for payload structure, channel/block overrides, one retry on 5xx, immediate 4xx failure, and missing webhook configuration.

/claim #791

## Validation
- Added focused HTTP fake coverage for the Slack notification behavior described above.
- `git diff --check` passed.

## Note
- I did not add the requested generation metadata file because it asks for private session context. The implementation and tests are in the diff.