### PR TITLE
Codex [ FastAPI ] Add UploadFile validation constraints

### DIFF
--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import (
     Annotated,
     Any,
@@ -16,6 +17,15 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+
+from .exceptions import HTTPException
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    is_valid: bool
+    file_size: int | None
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +72,25 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+    max_size: Annotated[int | None, Doc("The maximum allowed file size in bytes.")]
+    allowed_content_types: Annotated[
+        list[str] | None,
+        Doc("The allowed content types for the uploaded file."),
+    ]
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: list[str] | None = None,
+    ) -> None:
+        super().__init__(file=file, size=size, filename=filename, headers=headers)
+        self.max_size = max_size
+        self.allowed_content_types = allowed_content_types
 
     async def write(
         self,
@@ -83,6 +112,35 @@ class UploadFile(StarletteUploadFile):
         """
         return await super().write(data)
 
+    async def validate(self) -> ValidationResult:
+        """
+        Validate the uploaded file size and content type.
+        """
+        file_size = self.size if self.size is not None else self._measure_file_size()
+        content_type = self.content_type
+
+        if (
+            self.max_size is not None
+            and file_size is not None
+            and file_size > self.max_size
+        ):
+            raise HTTPException(status_code=413, detail="Uploaded file is too large")
+
+        if (
+            self.allowed_content_types is not None
+            and content_type not in self.allowed_content_types
+        ):
+            raise HTTPException(
+                status_code=415,
+                detail="Uploaded file content type is not allowed",
+            )
+
+        return ValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=content_type,
+        )
+
     async def read(
         self,
         size: Annotated[
@@ -99,6 +157,7 @@ class UploadFile(StarletteUploadFile):
 
         To be awaitable, compatible with async, this is run in threadpool.
         """
+        await self.validate()
         return await super().read(size)
 
     async def seek(
@@ -148,6 +207,16 @@ class UploadFile(StarletteUploadFile):
         from ._compat.v2 import with_info_plain_validator_function
 
         return with_info_plain_validator_function(cls._validate)
+
+    def _measure_file_size(self) -> int | None:
+        try:
+            position = self.file.tell()
+            self.file.seek(0, 2)
+            file_size = self.file.tell()
+            self.file.seek(position)
+            return file_size
+        except (OSError, AttributeError):
+            return None
 
 
 class DefaultPlaceholder:

--- a/fastapi/tests/test_datastructures.py
+++ b/fastapi/tests/test_datastructures.py
@@ -2,9 +2,10 @@ import io
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI, UploadFile
+from fastapi import FastAPI, HTTPException, UploadFile
 from fastapi.datastructures import Default
 from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
 
 
 def test_upload_file_invalid_pydantic_v2():
@@ -63,3 +64,76 @@ async def test_upload_file():
     await file.seek(0)
     assert await file.read() == b"data and more data!"
     await file.close()
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_returns_metadata():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(
+        filename="file.txt",
+        file=stream,
+        headers=Headers({"content-type": "text/plain"}),
+        max_size=10,
+        allowed_content_types=["text/plain"],
+    )
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 4
+    assert result.content_type == "text/plain"
+    assert await file.read() == b"data"
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_skips_optional_constraints():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(
+        filename="file.bin",
+        file=stream,
+        headers=Headers({"content-type": "application/octet-stream"}),
+    )
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 4
+    assert result.content_type == "application/octet-stream"
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_oversized_file():
+    stream = io.BytesIO(b"large data")
+    file = UploadFile(filename="file", file=stream, max_size=4)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_upload_file_read_rejects_oversized_file_before_processing():
+    stream = io.BytesIO(b"large data")
+    file = UploadFile(filename="file", file=stream, size=10, max_size=4)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.read()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_disallowed_content_type():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(
+        filename="file.json",
+        file=stream,
+        headers=Headers({"content-type": "application/json"}),
+        allowed_content_types=["text/plain"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 415


### PR DESCRIPTION
## Summary
- Add optional `max_size` and `allowed_content_types` parameters to FastAPI `UploadFile`.
- Add `validate()` returning `ValidationResult` with `is_valid`, `file_size`, and `content_type` metadata.
- Raise `HTTPException` 413 for oversized files and 415 for disallowed content types when constraints are configured.
- Keep existing default UploadFile behavior unchanged when validation constraints are omitted.
- Add focused tests for metadata, optional-constraint skips, size rejection, read-time size rejection, and content-type rejection.

/claim #761

## Validation
- `uv run pytest tests/test_datastructures.py -q` -> 16 passed
- `uv run ruff check fastapi/datastructures.py tests/test_datastructures.py` -> passed
- `git diff --check` -> passed

## Note
- I did not add the requested contributor metadata file because it asks for private session context. The implementation and tests are in the diff.