### PR TITLE
Codex [ FastAPI ] Fix dependency caching request scope

### DIFF
--- a/fastapi/fastapi/dependencies/utils.py
+++ b/fastapi/fastapi/dependencies/utils.py
@@ -89,6 +89,17 @@ multipart_incorrect_install_error = (
     'And then install "python-multipart" with: \n\n'
     "pip install python-multipart\n"
 )
+request_dependency_cache_attr = "_fastapi_dependency_cache"
+
+
+def _get_request_dependency_cache(
+    request: Request | WebSocket,
+) -> dict[DependencyCacheKey, Any]:
+    cache = getattr(request.state, request_dependency_cache_attr, None)
+    if cache is None:
+        cache = {}
+        setattr(request.state, request_dependency_cache_attr, cache)
+    return cache
 
 
 def ensure_multipart_is_installed() -> None:
@@ -130,6 +141,7 @@ def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> De
     return get_dependant(
         path=path,
         call=depends.dependency,
+        use_cache=depends.use_cache,
         scope=depends.scope,
         own_oauth_scopes=own_oauth_scopes,
     )
@@ -624,7 +636,7 @@ async def solve_dependencies(
         del response.headers["content-length"]
         response.status_code = None  # type: ignore
     if dependency_cache is None:
-        dependency_cache = {}
+        dependency_cache = _get_request_dependency_cache(request)
     for sub_dependant in dependant.dependencies:
         sub_dependant.call = cast(Callable[..., Any], sub_dependant.call)
         call = sub_dependant.call
@@ -680,7 +692,7 @@ async def solve_dependencies(
             solved = await run_in_threadpool(call, **solved_result.values)
         if sub_dependant.name is not None:
             values[sub_dependant.name] = solved
-        if sub_dependant.cache_key not in dependency_cache:
+        if sub_dependant.use_cache and sub_dependant.cache_key not in dependency_cache:
             dependency_cache[sub_dependant.cache_key] = solved
     path_values, path_errors = request_params_to_args(
         dependant.path_params, request.path_params

--- a/fastapi/tests/test_dependency_cache.py
+++ b/fastapi/tests/test_dependency_cache.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI, Security
+from fastapi import Depends, FastAPI, Request, Security
 from fastapi.testclient import TestClient
 
 app = FastAPI()
@@ -11,6 +11,11 @@ async def dep_counter():
     return counter_holder["counter"]
 
 
+def sync_dep_counter():
+    counter_holder["counter"] += 1
+    return counter_holder["counter"]
+
+
 async def super_dep(count: int = Depends(dep_counter)):
     return count
 
@@ -18,6 +23,14 @@ async def super_dep(count: int = Depends(dep_counter)):
 @app.get("/counter/")
 async def get_counter(count: int = Depends(dep_counter)):
     return {"counter": count}
+
+
+@app.get("/sync-counter/")
+async def get_sync_counter(
+    first: int = Depends(sync_dep_counter),
+    second: int = Depends(sync_dep_counter),
+):
+    return {"first": first, "second": second}
 
 
 @app.get("/sub-counter/")
@@ -33,6 +46,35 @@ async def get_sub_counter_no_cache(
     count: int = Depends(dep_counter, use_cache=False),
 ):
     return {"counter": count, "subcounter": subcount}
+
+
+@app.get("/sub-counter-no-cache-first/")
+async def get_sub_counter_no_cache_first(
+    count: int = Depends(dep_counter, use_cache=False),
+    subcount: int = Depends(super_dep),
+):
+    return {"counter": count, "subcounter": subcount}
+
+
+@app.get(
+    "/decorator-dependency-no-cache/",
+    dependencies=[
+        Depends(dep_counter, use_cache=False),
+        Depends(dep_counter, use_cache=False),
+    ],
+)
+async def get_decorator_dependency_no_cache():
+    return {"counter": counter_holder["counter"]}
+
+
+@app.get("/request-state-cache/")
+async def get_request_state_cache(
+    request: Request,
+    first: int = Depends(dep_counter),
+    second: int = Depends(dep_counter),
+):
+    cache = getattr(request.state, "_fastapi_dependency_cache", {})
+    return {"first": first, "second": second, "cache_size": len(cache)}
 
 
 @app.get("/scope-counter")
@@ -61,6 +103,16 @@ def test_normal_counter():
     assert response.json() == {"counter": 2}
 
 
+def test_sync_counter():
+    counter_holder["counter"] = 0
+    response = client.get("/sync-counter/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"first": 1, "second": 1}
+    response = client.get("/sync-counter/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"first": 2, "second": 2}
+
+
 def test_sub_counter():
     counter_holder["counter"] = 0
     response = client.get("/sub-counter/")
@@ -79,6 +131,36 @@ def test_sub_counter_no_cache():
     response = client.get("/sub-counter-no-cache/")
     assert response.status_code == 200, response.text
     assert response.json() == {"counter": 4, "subcounter": 3}
+
+
+def test_sub_counter_no_cache_first():
+    counter_holder["counter"] = 0
+    response = client.get("/sub-counter-no-cache-first/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 1, "subcounter": 2}
+    response = client.get("/sub-counter-no-cache-first/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 3, "subcounter": 4}
+
+
+def test_decorator_dependency_no_cache():
+    counter_holder["counter"] = 0
+    response = client.get("/decorator-dependency-no-cache/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 2}
+    response = client.get("/decorator-dependency-no-cache/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"counter": 4}
+
+
+def test_request_state_cache_is_scoped_per_request():
+    counter_holder["counter"] = 0
+    response = client.get("/request-state-cache/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"first": 1, "second": 1, "cache_size": 1}
+    response = client.get("/request-state-cache/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"first": 2, "second": 2, "cache_size": 1}
 
 
 def test_security_cache():


### PR DESCRIPTION
/claim #795

## Summary
- Preserve `Depends(..., use_cache=False)` for parameterless/decorator dependencies.
- Back the default dependency cache with request state so it stays scoped to the active request.
- Avoid letting `use_cache=False` dependency resolutions seed later cached injections.
- Add coverage for sync cache hits, no-cache miss ordering, decorator dependencies, and request isolation.

## Validation
- `uv run pytest tests/test_dependency_cache.py -q`
- `uv run pytest tests/test_dependency_cache.py tests/test_dependencies_utils.py tests/test_dependency_overrides.py tests/test_dependency_yield_scope.py tests/test_ws_dependencies.py -q`
- `uv run ruff check fastapi/dependencies/utils.py tests/test_dependency_cache.py`
- `uv run ruff format --check fastapi/dependencies/utils.py tests/test_dependency_cache.py`
- `git diff --check`

## Note
- I did not add the requested metadata file because it asks for private session context. The implementation and tests are in the diff.