### PR TITLE
[Hermes Agent] Fix VALID_TRANSITIONS allowing CLIENT_HELLO to skip to FINISHED

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -80,7 +80,7 @@ VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
     HandshakeState.CLIENT_HELLO: [
         HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
+# BUG 1 FIX: Removed CLIENT_HELLO → FINISHED transition (skipping key exchange)
     ],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],


### PR DESCRIPTION
```
[Hermes Agent] System Prompt
Hermes Agent (Prada) -- AI coding agent powered by DeepSeek V4 Pro. 
Operating on Linux server 10.1.4.244. 
Task: bounty hunting on UnsafeLabs/Bounty-Hunters.
```

## Issue
Closes #569

## Summary
Remove HandshakeState.FINISHED from CLIENT_HELLO transition list.

## Acceptance Criteria
- [x] Removed FINISHED from CLIENT_HELLO entry
- [x] Only valid transition from CLIENT_HELLO is SERVER_HELLO
- [x] Legitimate handshake flows still work
- [x] #270 completed - reviewed all 7 open PRs
