### PR TITLE
[Argus] [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken delegation

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,30 +28,31 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // FIX: Replace tx.origin with msg.sender to prevent phishing attacks.
+    // tx.origin can be exploited via intermediary contracts to impersonate the true caller.
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    // FIX: Replace tx.origin with msg.sender
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
+    // FIX: Replace tx.origin with msg.sender for admin check
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        require(msg.sender == admin, "Not admin");
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Fixes: UnsafeLabs/Bounty-Hunters#912

### Problem
The `GovernanceToken` contract uses `tx.origin` in three functions: `delegateVote()`, `revokeDelegate()`, and `snapshot()`. `tx.origin` refers to the original EOA that started the transaction chain — not the immediate caller. This enables phishing attacks where:

1. Attacker deploys a malicious contract
2. User interacts with the malicious contract (e.g., a dApp UI)
3. The malicious contract calls `delegateVote()` targeting the attacker's address
4. `tx.origin` resolves to the user (bypassing the contract check `require(tx.origin != to)`)
5. User unknowingly delegates their governance power to the attacker

### Fix
Replace all `tx.origin` references with `msg.sender`:

- `delegateVote()`: `tx.origin` → `msg.sender` for both the delegate check and storage updates
- `revokeDelegate()`: `tx.origin` → `msg.sender` for storage reads and writes  
- `snapshot()`: `tx.origin == admin` → `msg.sender == admin`

`msg.sender` is the correct reference because it always points to the immediate caller (whether EOA or contract), which is the entity authorizing the action.

### Acceptance Criteria Met
- [x] `delegateVote()` uses `msg.sender` — attacker cannot phish via intermediary contract
- [x] `revokeDelegate()` uses `msg.sender` — prevents unauthorized revocation via phishing
- [x] `snapshot()` uses `msg.sender` for admin check — prevents `tx.origin` bypass
- [x] Event emissions use `msg.sender` for correct caller attribution
- [x] All storage mutations use `msg.sender` consistently
- [x] Existing `vote()` and `createProposal()` already used `msg.sender` correctly

### /claim #912