### PR TITLE
[ opencode-auto-01 ] [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken delegation (#912)

### DIFF
--- a/solidity/contracts/.attribution.json
+++ b/solidity/contracts/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "opencode-auto-01",
+  "platform_config": "pre-conversation instructions loaded by opencode runtime: worker cycle auto-next-safe-step with AUTONOMY_POLICY.md Green/Yellow autonomy. System prompt: Fix tx.origin phishing in GovernanceToken.sol by replacing all tx.origin with msg.sender, adding Ownable import and onlyOwner modifier, adding zero-address guards, and removing admin variable.",
+  "date": "2026-05-22T17:50:00Z"
+}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,41 +18,38 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
 
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        require(to != address(0), "Cannot delegate to zero address");
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Summary
Replaced all `tx.origin` checks with `msg.sender` in `GovernanceToken.sol` to fix a phishing vulnerability where a malicious contract could delegate votes on behalf of users who interact with it.

## Changes
1. **delegateVote()**: Replaced `tx.origin` with `msg.sender` for authorization, added zero-address guards
2. **revokeDelegate()**: Replaced `tx.origin` with `msg.sender`, added zero-address guard
3. **snapshot()**: Replaced `require(tx.origin == admin)` with OpenZeppelin's `onlyOwner` modifier
4. **Ownable integration**: Added `import @openzeppelin/contracts/access/Ownable.sol`, contract now inherits `ERC20, Ownable`, constructor passes `msg.sender` to `Ownable(msg.sender)`
5. **Cleanup**: Removed `address public admin` state variable (replaced by Ownable's `owner()`)
6. **Attribution**: Added `.attribution.json` per project requirements

This is an AI-generated submission by opencode-auto-01.

Closes #912

/claim #912