### PR TITLE
[Claude Code] [ T3 Code ] Add ARIA attributes and keyboard navigation to ChatView

### DIFF
--- a/t3code/.provenance.json
+++ b/t3code/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Claude Code (DeepSeek V4 Pro) via Claude Code CLI",
+  "config_snapshot": "You are Claude, an AI assistant by Anthropic, operating as Claude Code CLI. You help users with software engineering tasks: debugging, writing and reviewing code, navigating codebases, and managing GitHub workflows. When given a bounty issue: read the full description, analyze the requirements, produce minimal and correct changes, verify with tests, and submit a clean PR with proper formatting. Follow the repository's existing code style and all acceptance criteria.",
+  "created": "2026-05-23T18:30:00Z"
+}

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -686,6 +686,12 @@ export default function ChatView(props: ChatViewProps) {
   const composerRef = useComposerHandleContext() ?? localComposerRef;
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
+  const [focusedMessageId, setFocusedMessageId] = useState<string | null>(null);
+
+  // Reset focused message when thread changes
+  useEffect(() => {
+    setFocusedMessageId(null);
+  }, [activeThreadId]);
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
   const optimisticUserMessagesRef = useRef(optimisticUserMessages);
   optimisticUserMessagesRef.current = optimisticUserMessages;
@@ -2459,11 +2465,73 @@ export default function ChatView(props: ChatViewProps) {
     terminalOpenByThreadRef.current[activeThreadKey] = current;
   }, [activeThreadKey, focusComposer, terminalState.terminalOpen]);
 
+  const navigableMessageIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const entry of timelineEntries) {
+      if (entry.kind === "message" && entry.message.role === "assistant") {
+        const messageEntry = entry as Extract<typeof entry, { kind: "message" }>;
+        ids.push(`message:${messageEntry.message.id}`);
+      }
+    }
+    return ids;
+  }, [timelineEntries]);
+
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
       if (!activeThreadId || useCommandPaletteStore.getState().open || event.defaultPrevented) {
         return;
       }
+
+      // Message keyboard navigation (Arrow keys / Enter / Escape)
+      const target = event.target;
+      const isInputFocused =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement && target.isContentEditable);
+
+      if (!isInputFocused && !isTerminalFocused()) {
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+          if (navigableMessageIds.length === 0) return;
+          event.preventDefault();
+          const currentIdx = focusedMessageId
+            ? navigableMessageIds.indexOf(focusedMessageId)
+            : -1;
+          const nextIdx =
+            event.key === "ArrowDown"
+              ? currentIdx < navigableMessageIds.length - 1
+                ? currentIdx + 1
+                : currentIdx
+              : currentIdx > 0
+                ? currentIdx - 1
+                : 0;
+          setFocusedMessageId(navigableMessageIds[nextIdx]);
+          return;
+        }
+
+        if (event.key === "Escape" && focusedMessageId) {
+          event.preventDefault();
+          setFocusedMessageId(null);
+          focusComposer();
+          return;
+        }
+
+        if (event.key === "Enter" && focusedMessageId) {
+          event.preventDefault();
+          const focusedEl = document.querySelector<HTMLElement>(
+            `[data-message-focused="true"]`,
+          );
+          if (focusedEl) {
+            const expandBtn = focusedEl.querySelector<HTMLButtonElement>(
+              'button[aria-expanded]',
+            );
+            if (expandBtn) {
+              expandBtn.click();
+            }
+          }
+          return;
+        }
+      }
+
       const shortcutContext = {
         terminalFocus: isTerminalFocused(),
         terminalOpen: Boolean(terminalState.terminalOpen),
@@ -2547,6 +2615,9 @@ export default function ChatView(props: ChatViewProps) {
     keybindings,
     onToggleDiff,
     toggleTerminalVisibility,
+    focusedMessageId,
+    focusComposer,
+    navigableMessageIds,
   ]);
 
   const onRevertToTurnCount = useCallback(
@@ -3498,6 +3569,21 @@ export default function ChatView(props: ChatViewProps) {
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
+      {/* Skip links for screen reader navigation */}
+      <div role="navigation" aria-label="Skip links">
+        <a
+          href="#chat-messages"
+          className="absolute -top-96 left-4 z-50 rounded bg-background px-3 py-1.5 text-sm opacity-0 ring-2 ring-ring focus-visible:top-2 focus-visible:opacity-100"
+        >
+          Skip to messages
+        </a>
+        <a
+          href="#chat-composer"
+          className="absolute -top-96 left-36 z-50 rounded bg-background px-3 py-1.5 text-sm opacity-0 ring-2 ring-ring focus-visible:top-2 focus-visible:opacity-100"
+        >
+          Skip to composer
+        </a>
+      </div>
       {/* Top bar */}
       <header
         className={cn(
@@ -3551,7 +3637,7 @@ export default function ChatView(props: ChatViewProps) {
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
+          <div id="chat-messages" className="relative flex min-h-0 flex-1 flex-col">
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}
@@ -3577,6 +3663,7 @@ export default function ChatView(props: ChatViewProps) {
               workspaceRoot={activeWorkspaceRoot}
               skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
               onIsAtEndChange={onIsAtEndChange}
+              focusedMessageId={focusedMessageId}
             />
 
             {/* scroll to bottom pill — shown when user has scrolled away from the bottom */}
@@ -3586,6 +3673,7 @@ export default function ChatView(props: ChatViewProps) {
                   type="button"
                   onClick={() => scrollToEnd(true)}
                   className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
+                  aria-label="Scroll to bottom"
                 >
                   <ChevronDownIcon className="size-3.5" />
                   Scroll to bottom

--- a/t3code/apps/web/src/components/chat/ChatComposer.tsx
+++ b/t3code/apps/web/src/components/chat/ChatComposer.tsx
@@ -204,6 +204,11 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
             size="sm"
             type="button"
             onClick={props.onToggleInteractionMode}
+            aria-label={
+              props.interactionMode === "plan"
+                ? "Switch to build mode"
+                : "Switch to plan mode"
+            }
             title={
               props.interactionMode === "plan"
                 ? "Plan mode — click to return to normal build mode"
@@ -1941,6 +1946,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   return (
     <form
       ref={composerFormRef}
+      id="chat-composer"
       onSubmit={submitComposer}
       className="mx-auto w-full min-w-0 max-w-208"
       data-chat-composer-form="true"

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -83,6 +83,7 @@ interface TimelineRowSharedState {
   workspaceRoot: string | undefined;
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   activeThreadEnvironmentId: EnvironmentId;
+  focusedMessageId: string | null;
   onRevertUserMessage: (messageId: MessageId) => void;
   onImageExpand: (preview: ExpandedImagePreview) => void;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
@@ -126,6 +127,7 @@ interface MessagesTimelineProps {
   workspaceRoot: string | undefined;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   onIsAtEndChange: (isAtEnd: boolean) => void;
+  focusedMessageId: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +157,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   workspaceRoot,
   skills = EMPTY_TIMELINE_SKILLS,
   onIsAtEndChange,
+  focusedMessageId,
 }: MessagesTimelineProps) {
   const rawRows = useMemo(
     () =>
@@ -217,6 +220,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       workspaceRoot,
       skills,
       activeThreadEnvironmentId,
+      focusedMessageId,
       onRevertUserMessage,
       onImageExpand,
       onOpenTurnDiff,
@@ -229,6 +233,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       workspaceRoot,
       skills,
       activeThreadEnvironmentId,
+      focusedMessageId,
       onRevertUserMessage,
       onImageExpand,
       onOpenTurnDiff,
@@ -246,7 +251,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   // from TimelineRowCtx, which propagates through LegendList's memo.
   const renderItem = useCallback(
     ({ item }: { item: MessagesTimelineRow }) => (
-      <div className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip" data-timeline-root="true">
+      <div
+        className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip"
+        role="listitem"
+        data-timeline-root="true"
+      >
         <TimelineRowContent row={item} />
       </div>
     ),
@@ -266,21 +275,28 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   return (
     <TimelineRowCtx value={sharedState}>
       <TimelineRowActivityCtx value={activityState}>
-        <LegendList<MessagesTimelineRow>
-          ref={listRef}
-          data={rows}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          estimatedItemSize={90}
-          initialScrollAtEnd
-          maintainScrollAtEnd
-          maintainScrollAtEndThreshold={0.1}
-          maintainVisibleContentPosition
-          onScroll={handleScroll}
-          className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
-          ListHeaderComponent={TIMELINE_LIST_HEADER}
-          ListFooterComponent={TIMELINE_LIST_FOOTER}
-        />
+        <div
+          role="log"
+          aria-live="polite"
+          aria-label="Chat messages"
+          className="h-full"
+        >
+          <LegendList<MessagesTimelineRow>
+            ref={listRef}
+            data={rows}
+            keyExtractor={keyExtractor}
+            renderItem={renderItem}
+            estimatedItemSize={90}
+            initialScrollAtEnd
+            maintainScrollAtEnd
+            maintainScrollAtEndThreshold={0.1}
+            maintainVisibleContentPosition
+            onScroll={handleScroll}
+            className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
+            ListHeaderComponent={TIMELINE_LIST_HEADER}
+            ListFooterComponent={TIMELINE_LIST_FOOTER}
+          />
+        </div>
       </TimelineRowActivityCtx>
     </TimelineRowCtx>
   );
@@ -300,16 +316,20 @@ type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["grouped
 type TimelineRow = MessagesTimelineRow;
 
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
+  const ctx = use(TimelineRowCtx);
+  const isFocused = row.id === ctx.focusedMessageId;
   return (
     <div
       className={cn(
         "pb-4",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
+        isFocused && "rounded-lg ring-2 ring-ring ring-offset-1",
       )}
       data-timeline-row-id={row.id}
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
       data-message-role={row.kind === "message" ? row.message.role : undefined}
+      data-message-focused={isFocused ? "true" : undefined}
     >
       {row.kind === "work" ? <WorkGroupSection groupedEntries={row.groupedEntries} /> : null}
       {row.kind === "message" && row.message.role === "user" ? <UserTimelineRow row={row} /> : null}


### PR DESCRIPTION
/claim #852

## Summary
- Add role=log, aria-live=polite, and aria-label to MessagesTimeline container
- Add role=listitem to each message row
- Add aria-labels to interaction mode toggle and scroll-to-bottom buttons
- Implement keyboard navigation: Arrow Up/Down to move between messages, Enter to expand, Escape to return to composer
- Add skip links for screen reader navigation
- Register contribution with .provenance.json

## Files changed
- apps/web/src/components/chat/MessagesTimeline.tsx
- apps/web/src/components/chat/ChatComposer.tsx
- apps/web/src/components/ChatView.tsx
- .provenance.json

Generated with [Claude Code](https://claude.com/claude-code)