### PR TITLE
Gemini CLI [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,11 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,8 +27,8 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
+            _mint(address(0xdead), MINIMUM_LIQUIDITY);
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -38,33 +38,34 @@ contract LiquidityPool is ERC20 {
         require(lpTokens > 0, "Insufficient liquidity");
         _mint(msg.sender, lpTokens);
 
-        reserveA += amountA;
-        reserveB += amountB;
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
 
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 
         tokenA.transfer(msg.sender, amountA);
         tokenB.transfer(msg.sender, amountB);
 
-        reserveA -= amountA;
-        reserveB -= amountB;
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/contributor_meta.json
+++ b/solidity/contributor_meta.json
@@ -1,0 +1,4 @@
+{
+  "name": "Gemini CLI",
+  "description": "Fixed first-depositor price manipulation in LiquidityPool.sol."
+}

--- a/solidity/test/LiquidityPool.fix.test.js
+++ b/solidity/test/LiquidityPool.fix.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("LiquidityPool Security Fix Verification", function () {
+  let lp;
+  let tokenA;
+  let tokenB;
+  let admin;
+  let attacker;
+  let victim;
+  const MINIMUM_LIQUIDITY = 1000n;
+
+  beforeEach(async function () {
+    [admin, attacker, victim] = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("MockToken");
+    tokenA = await Token.deploy("Token A", "TKNA", ethers.parseEther("1000000"));
+    tokenB = await Token.deploy("Token B", "TKNB", ethers.parseEther("1000000"));
+    const LP = await ethers.getContractFactory("LiquidityPool");
+    lp = await LP.deploy(await tokenA.getAddress(), await tokenB.getAddress());
+    await tokenA.transfer(attacker.address, ethers.parseEther("10000"));
+    await tokenB.transfer(attacker.address, ethers.parseEther("10000"));
+    await tokenA.transfer(victim.address, ethers.parseEther("10000"));
+    await tokenB.transfer(victim.address, ethers.parseEther("10000"));
+    await tokenA.connect(attacker).approve(await lp.getAddress(), ethers.MaxUint256);
+    await tokenB.connect(attacker).approve(await lp.getAddress(), ethers.MaxUint256);
+    await tokenA.connect(victim).approve(await lp.getAddress(), ethers.MaxUint256);
+    await tokenB.connect(victim).approve(await lp.getAddress(), ethers.MaxUint256);
+  });
+
+  it("Fix: First deposit locks MINIMUM_LIQUIDITY", async function () {
+    const amount = 2000n;
+    await lp.connect(attacker).addLiquidity(amount, amount);
+    expect(await lp.totalSupply()).to.equal(2000);
+    expect(await lp.balanceOf(attacker.address)).to.equal(1000);
+    expect(await lp.balanceOf("0x000000000000000000000000000000000000dEaD")).to.equal(1000);
+  });
+
+  it("Fix: First-depositor price manipulation (Inflation) is mitigated", async function () {
+    await lp.connect(attacker).addLiquidity(2000, 2000);
+    const donation = ethers.parseEther("100");
+    await tokenA.connect(attacker).transfer(await lp.getAddress(), donation);
+    await tokenB.connect(attacker).transfer(await lp.getAddress(), donation);
+    const victimDeposit = ethers.parseEther("1");
+    await lp.connect(victim).addLiquidity(victimDeposit, victimDeposit);
+    expect(await lp.balanceOf(victim.address)).to.be.above(0);
+  });
+
+  it("Fix: removeLiquidity uses reserves and is not instantly manipulable", async function () {
+    await lp.connect(attacker).addLiquidity(ethers.parseEther("10"), ethers.parseEther("10"));
+    await lp.connect(victim).addLiquidity(ethers.parseEther("10"), ethers.parseEther("10"));
+    const attackerLP = await lp.balanceOf(attacker.address);
+    await tokenA.transfer(await lp.getAddress(), ethers.parseEther("100"));
+    const initialAttackerA = await tokenA.balanceOf(attacker.address);
+    await lp.connect(attacker).removeLiquidity(attackerLP);
+    const finalAttackerA = await tokenA.balanceOf(attacker.address);
+    expect(finalAttackerA - initialAttackerA).to.be.closeTo(ethers.parseEther("10"), ethers.parseEther("0.1"));
+  });
+
+  it("Fix: sync() function updates reserves", async function () {
+    await lp.connect(attacker).addLiquidity(ethers.parseEther("10"), ethers.parseEther("10"));
+    const donation = ethers.parseEther("5");
+    await tokenA.connect(attacker).transfer(await lp.getAddress(), donation);
+    expect(await lp.reserveA()).to.equal(ethers.parseEther("10"));
+    await expect(lp.sync())
+      .to.emit(lp, "Sync")
+      .withArgs(ethers.parseEther("15"), ethers.parseEther("10"));
+    expect(await lp.reserveA()).to.equal(ethers.parseEther("15"));
+  });
+});


### PR DESCRIPTION
## Issue
Closes #918

## Summary
Fixed a first-depositor price manipulation (inflation) vulnerability in `LiquidityPool.sol` by implementing a minimum liquidity lock and reserve-based accounting.

## Acceptance criteria
- [x] First deposit locks MINIMUM_LIQUIDITY tokens at address(0xdead)
- [x] First depositor receives LP tokens minus the locked amount
- [x] Subsequent deposits use the correct proportional formula
- [x] removeLiquidity uses internal reserves, not balanceOf
- [x] sync function updates reserves and emits a Sync event
- [x] Direct token transfers to the pool do not affect LP token pricing
- [x] Tests cover: first deposit lock, price manipulation attempt, donation attack via direct transfer, sync recovery
- [x] Include a minimal `contributor_meta.json` file

/opire try