### PR TITLE
ayskobtw-lil [ FastAPI ] Add concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "ayskobtw-lil",
+  "runtime_instructions": "Not provided: hidden system/developer/runtime instructions are private and cannot be copied into repository files.",
+  "timestamp": "2026-05-22T23:35:00Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,6 +1,10 @@
+import asyncio
 from collections.abc import AsyncGenerator
+from collections.abc import Awaitable
+from collections.abc import Iterable
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
+from typing import Generic
 from typing import TypeVar
 
 import anyio.to_thread
@@ -12,6 +16,65 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception, Generic[_T]):
+    """Raised when one or more concurrent tasks fail or time out."""
+
+    def __init__(
+        self,
+        exceptions: list[BaseException],
+        partial_results: list[_T | None] | None = None,
+    ) -> None:
+        self.exceptions = exceptions
+        self.partial_results = partial_results or []
+        super().__init__(f"{len(exceptions)} concurrent task(s) failed")
+
+
+async def run_concurrently(
+    awaitables: Iterable[Awaitable[_T]],
+    *,
+    max_concurrency: int = 5,
+    timeout: float | None = None,
+) -> list[_T]:
+    """Run awaitables with a concurrency limit and preserve input order."""
+
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be at least 1")
+
+    awaitable_list = list(awaitables)
+    if not awaitable_list:
+        return []
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[_T | None] = [None] * len(awaitable_list)
+    exceptions: list[BaseException] = []
+
+    async def run_one(index: int, awaitable: Awaitable[_T]) -> None:
+        async with semaphore:
+            try:
+                results[index] = await awaitable
+            except BaseException as exc:
+                exceptions.append(exc)
+
+    tasks = [
+        asyncio.create_task(run_one(index, awaitable))
+        for index, awaitable in enumerate(awaitable_list)
+    ]
+
+    done, pending = await asyncio.wait(tasks, timeout=timeout)
+    if pending:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        exceptions.append(TimeoutError("concurrent tasks timed out"))
+    if done:
+        await asyncio.gather(*done, return_exceptions=True)
+
+    if exceptions:
+        raise ConcurrencyError(exceptions, results)
+
+    return [result for result in results]
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency_runner.py
+++ b/fastapi/tests/test_concurrency_runner.py
@@ -1,0 +1,134 @@
+import asyncio
+
+import pytest
+
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_preserves_input_order() -> None:
+    async def delayed(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    results = await run_concurrently(
+        [
+            delayed(1, 0.03),
+            delayed(2, 0.01),
+            delayed(3, 0.02),
+        ],
+        max_concurrency=3,
+    )
+
+    assert results == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_limits_active_tasks() -> None:
+    active = 0
+    peak_active = 0
+
+    async def worker(value: int) -> int:
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return value
+
+    results = await run_concurrently(
+        [worker(value) for value in range(6)],
+        max_concurrency=2,
+    )
+
+    assert results == [0, 1, 2, 3, 4, 5]
+    assert peak_active == 2
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_supports_sequential_execution() -> None:
+    order: list[str] = []
+
+    async def worker(value: str) -> str:
+        order.append(f"start:{value}")
+        await asyncio.sleep(0)
+        order.append(f"end:{value}")
+        return value
+
+    results = await run_concurrently(
+        [worker("a"), worker("b"), worker("c")],
+        max_concurrency=1,
+    )
+
+    assert results == ["a", "b", "c"]
+    assert order == ["start:a", "end:a", "start:b", "end:b", "start:c", "end:c"]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_collects_all_failures() -> None:
+    async def fail(message: str) -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError(message)
+
+    async def succeed() -> str:
+        await asyncio.sleep(0)
+        return "ok"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [fail("first"), succeed(), fail("second")],
+            max_concurrency=3,
+        )
+
+    error = exc_info.value
+    assert [str(exc) for exc in error.exceptions] == ["first", "second"]
+    assert error.partial_results == [None, "ok", None]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_timeout_cancels_pending_tasks() -> None:
+    cancelled = asyncio.Event()
+
+    async def fast() -> str:
+        await asyncio.sleep(0.01)
+        return "done"
+
+    async def slow() -> str:
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "too late"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([fast(), slow()], max_concurrency=2, timeout=0.05)
+
+    error = exc_info.value
+    assert any(isinstance(exc, TimeoutError) for exc in error.exceptions)
+    assert error.partial_results == ["done", None]
+    assert cancelled.is_set()
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_allows_concurrency_above_task_count() -> None:
+    async def worker(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    results = await run_concurrently([worker(1), worker(2)], max_concurrency=10)
+
+    assert results == [1, 2]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_rejects_invalid_concurrency() -> None:
+    async def worker() -> str:
+        return "unused"
+
+    coroutine = worker()
+    try:
+        with pytest.raises(ValueError, match="max_concurrency"):
+            await run_concurrently([coroutine], max_concurrency=0)
+    finally:
+        coroutine.close()


### PR DESCRIPTION
/claim #803

## Summary

Adds a focused `run_concurrently()` helper to `fastapi.concurrency` plus a `ConcurrencyError` aggregate exception.

Implemented behavior:
- limits active coroutine execution with `asyncio.Semaphore`
- preserves result order regardless of completion order
- supports `max_concurrency=1` sequential execution
- supports `max_concurrency` greater than the task count
- validates `max_concurrency >= 1`
- collects task failures into `ConcurrencyError.exceptions`
- raises `ConcurrencyError` on timeout with completed partial results and cancels pending tasks

## Verification

```text
python -m pytest fastapi\tests\test_concurrency_runner.py -q
7 passed in 1.90s

python -m py_compile fastapi\fastapi\concurrency.py fastapi\tests\test_concurrency_runner.py

git diff --check
```

## Notes

I added `fastapi/fastapi/_contributor.json`, but I did not paste hidden system/developer/runtime instructions into the repository. That content is private and cannot be copied into a public PR. The field states that limitation directly.

I cannot provide a fabricated demo video from this environment; the focused test run above is the demo evidence for the change.