### PR TITLE
H4ck3r-netizen [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken delegation

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,31 +28,27 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
-        // snapshot logic placeholder
+        require(msg.sender == admin, "Not admin");
     }
 
     function getVotingPower(address account) public view returns (uint256) {
@@ -76,10 +72,8 @@ contract GovernanceToken is ERC20 {
         Proposal storage proposal = proposals[proposalId];
         require(block.timestamp < proposal.endTime, "Voting ended");
         require(!hasVoted[proposalId][msg.sender], "Already voted");
-
         uint256 power = getVotingPower(msg.sender);
         require(power > 0, "No voting power");
-
         hasVoted[proposalId][msg.sender] = true;
         if (support) {
             proposal.forVotes += power;


### PR DESCRIPTION
## Summary
Fixes #912 — tx.origin phishing vulnerability in GovernanceToken

## Changes
- delegateVote(): tx.origin → msg.sender — prevents malicious contracts from redirecting delegation
- revokeDelegate(): tx.origin → msg.sender — prevents phishing via intermediate contract
- snapshot(): tx.origin → msg.sender — prevents tx.origin spoofing for admin check

## Why this matters
tx.origin returns the original transaction sender (EOA), while msg.sender returns the immediate caller. Using tx.origin for authorization allows an attacker to trick a user into calling a malicious contract which calls GovernanceToken, and tx.origin would be the user's address.

## Bounty
$700