### PR TITLE
[Hermes Agent] [ Laravel ] Fix User model password cast not applying bcrypt rounds from config

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent",
+  "generation_context": "Public-safe summary: Hermes Agent operated from the user's authorized CLI session to work on GitHub issue UnsafeLabs/Bounty-Hunters#745. The task was to update the Laravel User model and factory so password hashing respects config('hashing.bcrypt.rounds'), add tests, and avoid exposing private system/developer instructions, credentials, user memory, or hidden runtime context.",
+  "completed_at": "2026-05-23T06:46:32Z"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,28 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Hash passwords with the configured bcrypt rounds.
+     */
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value === null || $value === '') {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        if (password_get_info($value)['algoName'] === 'bcrypt') {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value, [
+            'rounds' => config('hashing.bcrypt.rounds'),
+        ]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Hash Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default hash driver used by the application.
+    |
+    */
+
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bcrypt Options
+    |--------------------------------------------------------------------------
+    |
+    | These options control the cost factor used when hashing passwords with
+    | bcrypt. Higher values are more secure but require more CPU time.
+    |
+    */
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+    ],
+
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,11 +13,6 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
-     */
-    protected static ?string $password;
-
-    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
@@ -28,7 +23,9 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => Hash::make('password', [
+                'rounds' => config('hashing.bcrypt.rounds'),
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_model_hashes_password_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 13]);
+
+        $user = new User();
+        $user->password = 'secret-password';
+
+        $this->assertSame(13, $this->bcryptRounds($user->password));
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+    }
+
+    public function test_user_factory_hashes_password_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 11]);
+
+        $user = User::factory()->make();
+
+        $this->assertSame(11, $this->bcryptRounds($user->password));
+        $this->assertTrue(Hash::check('password', $user->password));
+    }
+
+    public function test_existing_bcrypt_hashes_with_old_rounds_still_verify(): void
+    {
+        $legacyHash = Hash::make('legacy-password', ['rounds' => 10]);
+
+        config(['hashing.bcrypt.rounds' => 12]);
+
+        $user = new User();
+        $user->password = $legacyHash;
+
+        $this->assertSame($legacyHash, $user->password);
+        $this->assertTrue(Hash::check('legacy-password', $user->password));
+    }
+
+    private function bcryptRounds(string $hash): int
+    {
+        $parts = explode('$', $hash);
+
+        return (int) $parts[2];
+    }
+}


### PR DESCRIPTION
/claim #745

## Summary
- Replaces the generic `hashed` cast with a `setPasswordAttribute` mutator that hashes raw passwords with `config('hashing.bcrypt.rounds')`.
- Preserves existing bcrypt hashes so legacy passwords created with older/default rounds still verify with `Hash::check()`.
- Updates `UserFactory` to hash generated passwords with the configured bcrypt rounds.
- Adds `config/hashing.php`, a unit test for model/factory rounds, and a public-safe `_meta.json`.

## Test Plan
- `git diff --check`
- `python3 -m json.tool laravel/_meta.json`
- Not run: Laravel/PHPUnit suite, because PHP is not installed in this execution environment.
