### PR TITLE
[Hermes Agent] [ Laravel ] Implement API authentication controller with token-based login and registration

### DIFF
--- a/laravel/.generation_meta.json
+++ b/laravel/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes Agent",
+  "initial_directives": "Public-safe summary: Hermes Agent operated from the user's authorized CLI session to work on GitHub issue UnsafeLabs/Bounty-Hunters#752. The task was to add Laravel API authentication routes and a controller with registration, login, logout, Sanctum token generation, validation, JSON responses, tests, and public metadata. Private system/developer/tool instructions, credentials, user memory, and hidden runtime context are not disclosed.",
+  "date": "2026-05-23T07:19:51Z"
+}

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AuthController extends Controller
+{
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
+        ]);
+
+        return response()->json([
+            'user' => $user,
+            'token' => $user->createToken('api-token')->plainTextToken,
+        ], 201);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::where('email', $credentials['email'])->first();
+
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            return response()->json([
+                'message' => 'The provided credentials are incorrect.',
+            ], 401);
+        }
+
+        return response()->json([
+            'user' => $user,
+            'token' => $user->createToken('api-token')->plainTextToken,
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()?->delete();
+
+        return response()->json([
+            'message' => 'Logged out successfully.',
+        ]);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,13 +9,14 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.3",
         "laravel/framework": "^13.8",
+        "laravel/sanctum": "^5.0",
         "laravel/tinker": "^3.0"
     },
     "require-dev": {

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');

--- a/laravel/tests/Feature/ApiAuthenticationTest.php
+++ b/laravel/tests/Feature/ApiAuthenticationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ApiAuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_register_and_receive_token(): void
+    {
+        $response = $this->postJson('/api/register', [
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonStructure([
+                'user' => ['id', 'name', 'email'],
+                'token',
+            ]);
+
+        $this->assertDatabaseHas('users', ['email' => 'ada@example.com']);
+        $this->assertNotEmpty($response->json('token'));
+    }
+
+    public function test_login_returns_token_for_valid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'ada@example.com',
+            'password' => Hash::make('password123'),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'user' => ['id', 'name', 'email'],
+                'token',
+            ]);
+    }
+
+    public function test_login_returns_unauthorized_for_invalid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'ada@example.com',
+            'password' => Hash::make('password123'),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'ada@example.com',
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertStatus(401)
+            ->assertJson(['message' => 'The provided credentials are incorrect.']);
+    }
+
+    public function test_logout_revokes_current_access_token(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('api-token');
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token->plainTextToken)
+            ->postJson('/api/logout');
+
+        $response->assertOk()
+            ->assertJson(['message' => 'Logged out successfully.']);
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'id' => $token->accessToken->id,
+        ]);
+    }
+}


### PR DESCRIPTION
/claim #752

## Summary
- Adds a Laravel API `AuthController` with register, login, and logout JSON endpoints.
- Adds `/api/register`, `/api/login`, and authenticated `/api/logout` routes.
- Uses Laravel Sanctum personal access tokens for API token generation and revocation.
- Adds `HasApiTokens` to the `User` model and registers API route loading in `bootstrap/app.php`.
- Adds feature tests for registration, login, invalid credentials, and logout token revocation.
- Adds public-safe `.generation_meta.json` without exposing private runtime/system/developer instructions.

## Test Plan
- `git diff --check`
- `python3 -m json.tool laravel/composer.json`
- `python3 -m json.tool laravel/.generation_meta.json`
- Not run: Composer/PHPUnit suite, because `composer` and `php` are not installed in this execution environment.
