### PR TITLE
[Hermes Agent] [ Laravel ] Fix DatabaseSeeder creating duplicate test user on re-run and add proper seeder structure

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Hermes Agent",
+  "config_snapshot": "Public-safe summary: Hermes Agent operated from the user's authorized CLI session to work on GitHub issue UnsafeLabs/Bounty-Hunters#746. The task was to make Laravel database seeding idempotent, add a roles table, Role model, RoleFactory, RoleSeeder, focused tests, and public metadata. Private system/developer/tool instructions, credentials, user memory, and hidden runtime context are not disclosed.",
+  "created": "2026-05-23T07:23:55Z"
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(2),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_23_071900_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_23_071900_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => Hash::make('password'),
+            ]
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default application roles idempotently.
+     */
+    public function run(): void
+    {
+        $roles = [
+            'admin' => 'Full administrative access.',
+            'editor' => 'Can create and update content.',
+            'viewer' => 'Read-only access.',
+        ];
+
+        foreach ($roles as $name => $description) {
+            Role::firstOrCreate(
+                ['name' => $name],
+                ['description' => $description],
+            );
+        }
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_is_idempotent_for_test_user_and_roles(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertSame(1, Role::where('name', 'admin')->count());
+        $this->assertSame(1, Role::where('name', 'editor')->count());
+        $this->assertSame(1, Role::where('name', 'viewer')->count());
+        $this->assertSame(3, Role::count());
+    }
+
+    public function test_role_seeder_is_idempotent(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertSame(['admin', 'editor', 'viewer'], Role::query()->orderBy('name')->pluck('name')->all());
+    }
+
+    public function test_role_factory_generates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertNotEmpty($role->name);
+        $this->assertNotEmpty($role->description);
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- Makes the seeded `test@example.com` user idempotent with `firstOrCreate()`.
- Adds a `roles` table migration with unique role names.
- Adds `Role` model, `RoleFactory`, and idempotent `RoleSeeder` for `admin`, `editor`, and `viewer`.
- Calls `RoleSeeder` from `DatabaseSeeder`.
- Adds feature tests for repeated seeding and Role factory output.
- Adds public-safe `.provenance.json` without exposing private runtime/system/developer instructions.

## Test Plan
- `git diff --check`
- `python3 -m json.tool laravel/.provenance.json`
- Not run: Laravel/PHPUnit suite, because PHP is not installed in this execution environment.
