### PR TITLE
OpenAI Codex [ Laravel ] Fix User model password hashing rounds

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel password hashing change.",
+  "completed_at": "2026-05-23T10:18:38Z"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,18 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Hash plain-text passwords with the configured bcrypt cost.
+     */
+    public function setPasswordAttribute(string $value): void
+    {
+        $this->attributes['password'] = Hash::isHashed($value)
+            ? $value
+            : Hash::make($value, [
+                'rounds' => config('hashing.bcrypt.rounds'),
+            ]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
+        'limit' => env('BCRYPT_LIMIT', null),
+    ],
+
+    'argon' => [
+        'memory' => env('ARGON_MEMORY', 65536),
+        'threads' => env('ARGON_THREADS', 1),
+        'time' => env('ARGON_TIME', 4),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,11 +13,6 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
-     */
-    protected static ?string $password;
-
-    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
@@ -28,7 +23,9 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => Hash::make('password', [
+                'rounds' => config('hashing.bcrypt.rounds'),
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_password_mutator_respects_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User();
+        $user->password = 'secret-password';
+
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+        $this->assertSame(6, password_get_info($user->password)['options']['cost']);
+    }
+
+    public function test_factory_password_respects_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 5]);
+
+        $password = User::factory()->make()->password;
+
+        $this->assertTrue(Hash::check('password', $password));
+        $this->assertSame(5, password_get_info($password)['options']['cost']);
+    }
+
+    public function test_existing_bcrypt_hashes_are_not_rehashed(): void
+    {
+        $existingHash = Hash::make('legacy-password', ['rounds' => 4]);
+
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User();
+        $user->password = $existingHash;
+
+        $this->assertSame($existingHash, $user->password);
+        $this->assertTrue(Hash::check('legacy-password', $user->password));
+    }
+}


### PR DESCRIPTION
/claim #745

## Summary
- Replaced the generic password `hashed` cast with an explicit `setPasswordAttribute` mutator that hashes plain-text passwords using `config('hashing.bcrypt.rounds')`.
- Added `config/hashing.php` so bcrypt rounds are configurable through `BCRYPT_ROUNDS`.
- Updated `UserFactory` to hash generated passwords with the configured bcrypt rounds.
- Added unit coverage for configured bcrypt costs and preserving existing bcrypt hashes.
- Added non-sensitive metadata only; confidential platform/system/developer/session instructions are not disclosed.

## Validation
- `jq empty laravel/_meta.json`
- `git diff --check`

## Not run
- Laravel PHPUnit tests; `php` is not installed in this execution environment.
