### PR TITLE
OpenAI Codex [ Laravel ] Fix DatabaseSeeder idempotency and roles

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel idempotent seeder change.",
+  "created": "2026-05-23T10:21:34Z"
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->word();
+
+        return [
+            'name' => Str::slug($name),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_23_102134_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_23_102134_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -17,9 +17,11 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::query()->firstOrCreate(
+            ['email' => 'test@example.com'],
+            ['name' => 'Test User', 'password' => 'password'],
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default application roles.
+     */
+    public function run(): void
+    {
+        foreach ($this->defaultRoles() as $role) {
+            Role::query()->updateOrCreate(
+                ['name' => $role['name']],
+                ['description' => $role['description']],
+            );
+        }
+    }
+
+    /**
+     * @return array<int, array{name: string, description: string}>
+     */
+    private function defaultRoles(): array
+    {
+        return [
+            ['name' => 'admin', 'description' => 'Full application administration access'],
+            ['name' => 'editor', 'description' => 'Can create and update application content'],
+            ['name' => 'viewer', 'description' => 'Read-only application access'],
+        ];
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- Made the default test user seed idempotent with `firstOrCreate`.
- Added a `roles` table migration, `Role` model, and `RoleFactory`.
- Added an idempotent `RoleSeeder` for `admin`, `editor`, and `viewer` and called it from `DatabaseSeeder`.
- Added non-sensitive provenance only; confidential platform/system/developer/session instructions are not disclosed.

## Validation
- `jq empty laravel/.provenance.json`
- `git diff --check`

## Not run
- Laravel artisan/PHPUnit checks; `php` is not installed in this execution environment.
