### PR TITLE
OpenAI Codex [ Laravel ] Add scheduled log cleanup command

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel log cleanup command change.",
+  "timestamp": "2026-05-23T10:24:11Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,58 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days of logs to retain}', function () {
+    $days = max(0, (int) $this->option('days'));
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $logPath = storage_path('logs');
+    $deletedFiles = 0;
+    $freedBytes = 0;
+
+    foreach (File::files($logPath) as $file) {
+        if ($file->getMTime() >= $cutoff) {
+            continue;
+        }
+
+        $freedBytes += $file->getSize();
+        File::delete($file->getPathname());
+        $deletedFiles++;
+    }
+
+    $this->info(sprintf(
+        'Deleted %d log file%s and freed %s.',
+        $deletedFiles,
+        $deletedFiles === 1 ? '' : 's',
+        format_log_cleanup_bytes($freedBytes),
+    ));
+})->purpose('Delete log files older than the configured retention period');
+
+Schedule::command('logs:clear')->dailyAt('00:00');
+
+if (! function_exists('format_log_cleanup_bytes')) {
+    function format_log_cleanup_bytes(int $bytes): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $value = (float) $bytes;
+
+        foreach ($units as $unit) {
+            if ($value < 1024 || $unit === 'TB') {
+                return sprintf(
+                    '%s %s',
+                    rtrim(rtrim(number_format($value, 2), '0'), '.'),
+                    $unit,
+                );
+            }
+
+            $value /= 1024;
+        }
+
+        return '0 B';
+    }
+}


### PR DESCRIPTION
/claim #753

## Summary
- Added a `logs:clear` Artisan closure command with a configurable `--days` retention option.
- Deletes log files older than the retention cutoff and reports deleted file count plus freed space.
- Registered the cleanup command to run daily at `00:00`.
- Added non-sensitive generation metadata only; confidential platform/system/developer/session instructions are not disclosed.

## Validation
- `jq empty laravel/_generation.json`
- `git diff --check`

## Not run
- Laravel artisan/PHPUnit checks; `php` is not installed in this execution environment.
