### PR TITLE
OpenAI Codex [ Laravel ] Add public performance and security rules

### DIFF
--- a/laravel/_contributor.json
+++ b/laravel/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel public performance/security change.",
+  "timestamp": "2026-05-23T10:25:34Z"
+}

--- a/laravel/public/.htaccess
+++ b/laravel/public/.htaccess
@@ -1,3 +1,26 @@
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/html text/css application/javascript application/json image/svg+xml
+</IfModule>
+
+<IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType image/gif "access plus 30 days"
+    ExpiresByType image/jpeg "access plus 30 days"
+    ExpiresByType image/png "access plus 30 days"
+    ExpiresByType image/svg+xml "access plus 30 days"
+    ExpiresByType image/webp "access plus 30 days"
+    ExpiresByType text/css "access plus 7 days"
+    ExpiresByType application/javascript "access plus 7 days"
+    ExpiresByType font/otf "access plus 365 days"
+    ExpiresByType font/ttf "access plus 365 days"
+    ExpiresByType font/woff "access plus 365 days"
+    ExpiresByType font/woff2 "access plus 365 days"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header set X-Content-Type-Options "nosniff"
+</IfModule>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes

--- a/laravel/public/index.php
+++ b/laravel/public/index.php
@@ -5,6 +5,9 @@ use Illuminate\Http\Request;
 
 define('LARAVEL_START', microtime(true));
 
+ini_set('display_errors', '0');
+ini_set('expose_php', '0');
+
 // Determine if the application is in maintenance mode...
 if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
     require $maintenance;


### PR DESCRIPTION
## Summary
- adds Apache compression, cache expiry, and content-sniffing protections for Laravel public assets
- disables PHP display_errors and expose_php at the public entrypoint before bootstrapping
- records safe, non-sensitive contributor provenance

## Validation
- jq empty laravel/_contributor.json
- git diff --check
- Not run: PHP/Laravel tests because php is not installed in this workspace.

/claim #755
