### PR TITLE
Atlas [ Crypto ] Fix StakingVault reentrancy in withdraw and claimRewards

### DIFF
--- a/solidity/.provenance.json
+++ b/solidity/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Atlas (Hermes Agent)",
+  "config_snapshot": "Bounty hunter persona Atlas. Fix reentrancy vulnerability in StakingVault. Move state updates before external calls, add nonReentrant modifier from OpenZeppelin. Fix both withdraw and claimRewards. Test with Foundry/Hardhat.",
+  "created": "2026-05-23T16:35:00+08:00"
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -39,31 +40,33 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    // FIXED: State update before external call + nonReentrant modifier
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        // State update BEFORE external call — prevents reentrancy
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    // FIXED: Same reentrancy pattern fixed in claimRewards
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // State update BEFORE external call
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
/claim #911

## Issue
Closes #911

## Summary
Fixed reentrancy vulnerability in StakingVault.sol: moved state updates before external .call() in both withdraw() and claimRewards(). Added OpenZeppelin ReentrancyGuard with nonReentrant modifier.

## Acceptance Criteria
- [x] State updates happen before all external calls in both withdraw and claimRewards
- [x] ReentrancyGuard imported from OpenZeppelin and applied to both functions
- [x] .provenance.json included
- [x] PR title starts with Atlas [ Crypto ]
- [x] Existing staking, withdrawal, and reward claim flows preserved