### PR TITLE
OpenAI Codex [ FastAPI ] Fix encoders.py bytes and memoryview handling

### DIFF
--- a/fastapi/_provenance.json
+++ b/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI bytes encoder change.",
+  "timestamp": "2026-05-23T10:29:11Z"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -126,6 +127,17 @@ def generate_encoders_by_class_tuples(
 encoders_by_class_tuples = generate_encoders_by_class_tuples(ENCODERS_BY_TYPE)
 
 
+def _encode_bytes(
+    value: bytes | bytearray | memoryview, bytes_encoding: str
+) -> str:
+    raw_bytes = bytes(value)
+    if bytes_encoding == "base64":
+        return base64.b64encode(raw_bytes).decode("ascii")
+    if bytes_encoding == "hex":
+        return raw_bytes.hex()
+    raise ValueError("bytes_encoding must be 'base64' or 'hex'")
+
+
 def jsonable_encoder(
     obj: Annotated[
         Any,
@@ -215,6 +227,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding to use for bytes-like values. Supported values are `base64`
+            and `hex`.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -255,6 +276,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +291,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -276,6 +299,8 @@ def jsonable_encoder(
         return str(obj)
     if isinstance(obj, (str, int, float, type(None))):
         return obj
+    if isinstance(obj, (bytes, bytearray, memoryview)):
+        return _encode_bytes(obj, bytes_encoding)
     if isinstance(obj, PydanticUndefinedType):
         return None
     if isinstance(obj, dict):
@@ -302,6 +327,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +336,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +354,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +389,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -137,6 +137,27 @@ def test_encode_unsupported():
         jsonable_encoder(unserializable)
 
 
+def test_encode_bytes_defaults_to_base64():
+    assert jsonable_encoder(b"hello") == "aGVsbG8="
+    assert jsonable_encoder({"payload": b"\x00\xff"}) == {"payload": "AP8="}
+
+
+def test_encode_memoryview_defaults_to_base64():
+    assert jsonable_encoder(memoryview(b"hello")) == "aGVsbG8="
+
+
+def test_encode_bytes_as_hex():
+    assert jsonable_encoder(b"\x00\xff", bytes_encoding="hex") == "00ff"
+    assert jsonable_encoder({"payload": memoryview(b"abc")}, bytes_encoding="hex") == {
+        "payload": "616263"
+    }
+
+
+def test_encode_bytes_rejects_unsupported_encoding():
+    with pytest.raises(ValueError, match="bytes_encoding"):
+        jsonable_encoder(b"hello", bytes_encoding="utf-8")
+
+
 def test_encode_custom_json_encoders_model_pydanticv2():
     from pydantic import field_serializer
 


### PR DESCRIPTION
## Summary
- encodes bytes-like values as base64 strings by default in jsonable_encoder
- adds bytes_encoding="hex" support for bytes and memoryview values
- covers bytes, memoryview, nested payloads, hex output, and invalid encoding with tests
- records safe, non-sensitive provenance metadata

## Validation
- uv run pytest tests/test_jsonable_encoder.py -q (29 passed, 1 skipped)
- jq empty fastapi/_provenance.json
- git diff --check

/claim #759
