### PR TITLE
OpenAI Codex [ FastAPI ] Fix exception handler validation context

### DIFF
--- a/fastapi/_meta.json
+++ b/fastapi/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI validation error handler change.",
+  "completed_at": "2026-05-23T10:32:27Z"
+}

--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -7,6 +7,26 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
 
+SENSITIVE_VALIDATION_BODY_FIELDS = {"password", "secret", "token", "api_key"}
+
+
+def _redact_sensitive_validation_body(value):
+    if isinstance(value, dict):
+        return {
+            key: (
+                "***REDACTED***"
+                if isinstance(key, str)
+                and key.lower() in SENSITIVE_VALIDATION_BODY_FIELDS
+                else _redact_sensitive_validation_body(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_sensitive_validation_body(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_sensitive_validation_body(item) for item in value)
+    return value
+
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
     headers = getattr(exc, "headers", None)
@@ -20,9 +40,18 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
+    content = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+    if getattr(request.app, "debug", False) and getattr(exc, "body", None) is not None:
+        content["body"] = jsonable_encoder(
+            _redact_sensitive_validation_body(exc.body)
+        )
     return JSONResponse(
         status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
+        content=content,
     )
 
 

--- a/fastapi/tests/test_request_validation_error_handler_body.py
+++ b/fastapi/tests/test_request_validation_error_handler_body.py
@@ -1,0 +1,67 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class NestedPayload(BaseModel):
+    password: str
+    name: str
+
+
+class Payload(BaseModel):
+    count: int
+    password: str
+    secret: str
+    token: str
+    api_key: str
+    nested: NestedPayload
+
+
+def create_app(*, debug: bool) -> FastAPI:
+    app = FastAPI(debug=debug)
+
+    @app.post("/items/{item_id}")
+    def create_item(item_id: int, payload: Payload):
+        return {"item_id": item_id, "payload": payload}  # pragma: no cover
+
+    return app
+
+
+def test_validation_error_includes_path_and_method_without_body_by_default():
+    client = TestClient(create_app(debug=False))
+
+    response = client.post("/items/123", json={"count": "not-an-int"})
+
+    assert response.status_code == 422
+    content = response.json()
+    assert content["path"] == "/items/123"
+    assert content["method"] == "POST"
+    assert "detail" in content
+    assert "body" not in content
+
+
+def test_validation_error_includes_redacted_body_in_debug_mode():
+    client = TestClient(create_app(debug=True))
+    request_body = {
+        "count": "not-an-int",
+        "password": "plain-password",
+        "secret": "plain-secret",
+        "token": "plain-token",
+        "api_key": "plain-api-key",
+        "nested": {"password": "nested-password", "name": "visible"},
+    }
+
+    response = client.post("/items/123", json=request_body)
+
+    assert response.status_code == 422
+    content = response.json()
+    assert content["path"] == "/items/123"
+    assert content["method"] == "POST"
+    assert content["body"] == {
+        "count": "not-an-int",
+        "password": "***REDACTED***",
+        "secret": "***REDACTED***",
+        "token": "***REDACTED***",
+        "api_key": "***REDACTED***",
+        "nested": {"password": "***REDACTED***", "name": "visible"},
+    }


### PR DESCRIPTION
## Summary
- adds path and method to FastAPI request validation error responses
- includes the received body only when app.debug is enabled
- redacts password, secret, token, and api_key fields recursively in debug body echoes
- records safe, non-sensitive metadata

## Validation
- uv run pytest tests/test_request_validation_error_handler_body.py tests/test_validation_error_context.py -q (9 passed)
- uv run ruff check fastapi/exception_handlers.py tests/test_request_validation_error_handler_body.py
- jq empty fastapi/_meta.json
- git diff --check

/claim #757
