### PR TITLE
OpenAI Codex [ FastAPI ] Add UploadFile validation

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI UploadFile validation change.",
+  "ts": "2026-05-23T10:35:14Z"
+}

--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -1,4 +1,5 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import (
     Annotated,
     Any,
@@ -16,6 +17,14 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+from starlette.exceptions import HTTPException
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    is_valid: bool
+    file_size: int
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +71,58 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+    max_size: Annotated[
+        int | None, Doc("The maximum allowed file size in bytes.")
+    ]
+    allowed_content_types: Annotated[
+        Sequence[str] | None, Doc("Allowed MIME types for the uploaded file.")
+    ]
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(file, size=size, filename=filename, headers=headers)
+        self.max_size = max_size
+        self.allowed_content_types = allowed_content_types
+
+    def _get_file_size(self) -> int:
+        if self.size is not None:
+            return self.size
+        current_position = self.file.tell()
+        self.file.seek(0, 2)
+        file_size = self.file.tell()
+        self.file.seek(current_position)
+        self.size = file_size
+        return file_size
+
+    async def validate(self) -> ValidationResult:
+        """
+        Validate file size and content type constraints for this upload.
+        """
+        file_size = self._get_file_size()
+        content_type = self.content_type
+
+        if self.max_size is not None and file_size > self.max_size:
+            raise HTTPException(status_code=413, detail="File exceeds maximum size")
+        if (
+            self.allowed_content_types is not None
+            and content_type not in self.allowed_content_types
+        ):
+            raise HTTPException(
+                status_code=415, detail="File content type is not allowed"
+            )
+        return ValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=content_type,
+        )
 
     async def write(
         self,

--- a/fastapi/tests/test_datastructures.py
+++ b/fastapi/tests/test_datastructures.py
@@ -5,6 +5,8 @@ import pytest
 from fastapi import FastAPI, UploadFile
 from fastapi.datastructures import Default
 from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
+from starlette.exceptions import HTTPException
 
 
 def test_upload_file_invalid_pydantic_v2():
@@ -63,3 +65,74 @@ async def test_upload_file():
     await file.seek(0)
     assert await file.read() == b"data and more data!"
     await file.close()
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_returns_metadata():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(
+        filename="file",
+        file=stream,
+        size=4,
+        headers=Headers({"content-type": "text/plain"}),
+        max_size=10,
+        allowed_content_types=["text/plain"],
+    )
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 4
+    assert result.content_type == "text/plain"
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_calculates_missing_size_without_moving_cursor():
+    stream = io.BytesIO(b"data")
+    stream.seek(2)
+    file = UploadFile(filename="file", file=stream)
+
+    result = await file.validate()
+
+    assert result.file_size == 4
+    assert stream.tell() == 2
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_large_files():
+    stream = io.BytesIO(b"large")
+    file = UploadFile(filename="file", file=stream, size=5, max_size=4)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_disallowed_content_type():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(
+        filename="file",
+        file=stream,
+        size=4,
+        headers=Headers({"content-type": "image/png"}),
+        allowed_content_types=["text/plain"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_skips_unset_constraints():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(filename="file", file=stream)
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 4
+    assert result.content_type is None


### PR DESCRIPTION
## Summary
- adds optional max_size and allowed_content_types constraints to FastAPI UploadFile
- adds async validate() returning ValidationResult metadata
- raises 413 for oversized files and 415 for disallowed content types
- preserves existing UploadFile construction when new parameters are omitted
- records safe, non-sensitive contributor metadata

## Validation
- uv run pytest tests/test_datastructures.py -q (16 passed)
- uv run ruff check fastapi/datastructures.py tests/test_datastructures.py
- jq empty fastapi/contributor_meta.json
- git diff --check

/claim #761
