### PR TITLE
OpenAI Codex [ FastAPI ] Fix default operation ID generation

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive attribution for the FastAPI operation ID generation change.",
+  "date": "2026-05-23T10:37:38Z"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -233,6 +233,17 @@ def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:
     return route.name.replace("_", " ").title()
 
 
+def get_unique_operation_id(operation_id: str, operation_ids: set[str]) -> str:
+    if operation_id not in operation_ids:
+        return operation_id
+    suffix = 2
+    unique_operation_id = f"{operation_id}_{suffix}"
+    while unique_operation_id in operation_ids:
+        suffix += 1
+        unique_operation_id = f"{operation_id}_{suffix}"
+    return unique_operation_id
+
+
 def get_openapi_operation_metadata(
     *, route: routing.APIRoute, method: str, operation_ids: set[str]
 ) -> dict[str, Any]:
@@ -243,15 +254,16 @@ def get_openapi_operation_metadata(
     if route.description:
         operation["description"] = route.description
     operation_id = route.operation_id or route.unique_id
-    if operation_id in operation_ids:
+    unique_operation_id = get_unique_operation_id(operation_id, operation_ids)
+    if unique_operation_id != operation_id:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
         file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
-    operation_ids.add(operation_id)
-    operation["operationId"] = operation_id
+    operation_ids.add(unique_operation_id)
+    operation["operationId"] = unique_operation_id
     if route.deprecated:
         operation["deprecated"] = route.deprecated
     return operation

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -93,11 +93,12 @@ def generate_operation_id_for_path(
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0].lower()
+    operation_id = f"{method}_{route.path_format}_{route.name}"
+    operation_id = re.sub(r"[^0-9a-zA-Z]+", "_", operation_id)
+    operation_id = re.sub(r"_+", "_", operation_id).strip("_")
+    return operation_id.lower()
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_default_generate_unique_id.py
+++ b/fastapi/tests/test_default_generate_unique_id.py
@@ -1,0 +1,59 @@
+import re
+import warnings
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_default_generate_unique_id_includes_method_and_sanitized_path():
+    app = FastAPI()
+    api_v1 = APIRouter(prefix="/api/v1")
+    api_v2 = APIRouter(prefix="/api-v2")
+
+    @api_v1.get("/users/{user_id}", name="list_users")
+    def list_users_v1(user_id: int):
+        return {"user_id": user_id}  # pragma: no cover
+
+    @api_v2.get("/users/{user_id}", name="list_users")
+    def list_users_v2(user_id: int):
+        return {"user_id": user_id}  # pragma: no cover
+
+    app.include_router(api_v1)
+    app.include_router(api_v2)
+
+    openapi = TestClient(app).get("/openapi.json").json()
+    operation_ids = [
+        openapi["paths"]["/api/v1/users/{user_id}"]["get"]["operationId"],
+        openapi["paths"]["/api-v2/users/{user_id}"]["get"]["operationId"],
+    ]
+
+    assert operation_ids == [
+        "get_api_v1_users_user_id_list_users",
+        "get_api_v2_users_user_id_list_users",
+    ]
+    assert all(re.fullmatch(r"[a-z0-9_]+", item) for item in operation_ids)
+
+
+def test_default_generate_unique_id_appends_suffix_for_sanitized_collisions():
+    app = FastAPI()
+
+    @app.get("/items-alpha", name="list_items")
+    def list_items_hyphen():
+        return []  # pragma: no cover
+
+    @app.get("/items_alpha", name="list_items")
+    def list_items_underscore():
+        return []  # pragma: no cover
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        openapi = TestClient(app).get("/openapi.json").json()
+
+    assert (
+        openapi["paths"]["/items-alpha"]["get"]["operationId"]
+        == "get_items_alpha_list_items"
+    )
+    assert (
+        openapi["paths"]["/items_alpha"]["get"]["operationId"]
+        == "get_items_alpha_list_items_2"
+    )


### PR DESCRIPTION
## Summary
- changes FastAPI default operation IDs to method + sanitized path + route name
- lowercases operation IDs and keeps only alphanumeric characters and underscores
- appends numeric suffixes during OpenAPI generation when sanitized IDs collide
- adds tests for router/path uniqueness and suffix handling
- records safe, non-sensitive attribution metadata

## Validation
- uv run pytest tests/test_default_generate_unique_id.py -q (2 passed)
- uv run pytest tests/test_generate_unique_id_function.py -q (8 passed)
- uv run ruff check fastapi/utils.py fastapi/openapi/utils.py tests/test_default_generate_unique_id.py
- jq empty fastapi/fastapi/.attribution.json
- git diff --check

/claim #764
