### PR TITLE
OpenAI Codex [ Laravel ] Add web rate limiting and session fallback

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel web rate limiting and session fallback change.",
+  "timestamp": "2026-05-23T10:41:44Z"
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,7 +2,13 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
+use Throwable;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +25,50 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('web', function (Request $request) {
+            return Limit::perMinute(60)->by(
+                (string) ($request->user()?->getAuthIdentifier() ?: $request->ip())
+            );
+        });
+
+        $this->configureSessionFallback();
+    }
+
+    private function configureSessionFallback(): void
+    {
+        $driver = config('session.driver');
+        $fallback = config('session.fallback', 'file');
+
+        if ($driver === $fallback || $driver === 'file') {
+            return;
+        }
+
+        if (! $this->sessionDriverIsAvailable($driver)) {
+            config(['session.driver' => $fallback]);
+        }
+    }
+
+    private function sessionDriverIsAvailable(?string $driver): bool
+    {
+        try {
+            return match ($driver) {
+                'database' => $this->databaseSessionDriverIsAvailable(),
+                'redis' => ! empty(config('database.redis.default')),
+                'memcached' => class_exists('Memcached'),
+                'dynamodb' => class_exists('Aws\DynamoDb\DynamoDbClient'),
+                default => true,
+            };
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function databaseSessionDriverIsAvailable(): bool
+    {
+        $connection = config('session.connection');
+
+        DB::connection($connection)->getPdo();
+
+        return Schema::connection($connection)->hasTable(config('session.table'));
     }
 }

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -20,6 +20,8 @@ return [
 
     'driver' => env('SESSION_DRIVER', 'database'),
 
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
+
     /*
     |--------------------------------------------------------------------------
     | Session Lifetime

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,24 @@
 <?php
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware(['throttle:web', 'throttle:60,1'])->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/rate-limit/debug', function (Request $request) {
+        $key = (string) ($request->user()?->getAuthIdentifier() ?: $request->ip());
+
+        return response()->json([
+            'key' => $key,
+            'headers' => [
+                'X-RateLimit-Limit' => 60,
+                'X-RateLimit-Remaining' => RateLimiter::remaining($key, 60),
+                'Retry-After' => RateLimiter::availableIn($key),
+            ],
+        ]);
+    });
 });


### PR DESCRIPTION
## Summary
- applies web route throttling with the custom web limiter and throttle:60,1 middleware
- registers a web RateLimiter that keys by authenticated user id or guest IP
- adds a rate-limit debug route returning current limit/remaining/retry headers
- adds session fallback configuration and switches to the fallback driver when the selected backing driver is unavailable
- records safe, non-sensitive contributor metadata

## Validation
- jq empty laravel/.contributor.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #749
