### PR TITLE
OpenAI Codex [ FastAPI ] Add request ID middleware

### DIFF
--- a/fastapi/_provenance.json
+++ b/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI request ID middleware change.",
+  "timestamp": "2026-05-23T10:50:08Z"
+}

--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,17 @@
 import logging
+from contextvars import ContextVar
 
 logger = logging.getLogger("fastapi")
+
+request_id_context: ContextVar[str | None] = ContextVar(
+    "fastapi_request_id", default=None
+)
+
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_context.get()
+        return True
+
+
+logger.addFilter(RequestIdFilter())

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,43 @@
+import uuid
+
+from fastapi.logger import request_id_context
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class RequestIDMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        header_name: str = "X-Request-ID",
+        state_attribute: str = "request_id",
+    ) -> None:
+        self.app = app
+        self.header_name = header_name
+        self.state_attribute = state_attribute
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = self._get_request_id(scope)
+        scope.setdefault("state", {})[self.state_attribute] = request_id
+        token = request_id_context.set(request_id)
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = message.setdefault("headers", [])
+                headers.append((self.header_name.lower().encode(), request_id.encode()))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            request_id_context.reset(token)
+
+    def _get_request_id(self, scope: Scope) -> str:
+        header_name = self.header_name.lower().encode()
+        for name, value in scope.get("headers", []):
+            if name.lower() == header_name:
+                return value.decode()
+        return str(uuid.uuid4())

--- a/fastapi/tests/test_request_id_middleware.py
+++ b/fastapi/tests/test_request_id_middleware.py
@@ -1,0 +1,61 @@
+import logging
+import uuid
+
+from fastapi import FastAPI, Request
+from fastapi.logger import logger
+from fastapi.middleware.request_id import RequestIDMiddleware
+from fastapi.testclient import TestClient
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def read_root(request: Request):
+        logger.info("handling request")
+        return {"request_id": request.state.request_id}
+
+    return app
+
+
+def test_request_id_middleware_generates_uuid_header_and_state(caplog):
+    app = create_app()
+    client = TestClient(app)
+    caplog.set_level(logging.INFO, logger="fastapi")
+
+    response = client.get("/")
+
+    request_id = response.headers["x-request-id"]
+    uuid.UUID(request_id)
+    assert response.json() == {"request_id": request_id}
+    assert any(record.request_id == request_id for record in caplog.records)
+
+
+def test_request_id_middleware_preserves_client_header(caplog):
+    app = create_app()
+    client = TestClient(app)
+    caplog.set_level(logging.INFO, logger="fastapi")
+
+    response = client.get("/", headers={"X-Request-ID": "client-request-id"})
+
+    assert response.headers["x-request-id"] == "client-request-id"
+    assert response.json() == {"request_id": "client-request-id"}
+    assert any(record.request_id == "client-request-id" for record in caplog.records)
+
+
+def test_request_id_middleware_does_not_reuse_generated_ids():
+    client = TestClient(create_app())
+
+    first = client.get("/").headers["x-request-id"]
+    second = client.get("/").headers["x-request-id"]
+
+    assert first != second
+
+
+def test_fastapi_logger_works_without_request_id_context(caplog):
+    caplog.set_level(logging.INFO, logger="fastapi")
+
+    logger.info("outside request")
+
+    assert caplog.records[-1].request_id is None


### PR DESCRIPTION
## Summary
- adds RequestIDMiddleware for HTTP requests
- stores the request ID on request.state and echoes X-Request-ID
- preserves client-supplied request IDs and generates UUIDs otherwise
- exposes request_id on FastAPI log records with context-local state
- records safe, non-sensitive provenance metadata

## Validation
- uv run pytest tests/test_request_id_middleware.py -q (4 passed)
- uv run ruff check fastapi/logger.py fastapi/middleware/request_id.py tests/test_request_id_middleware.py
- jq empty fastapi/_provenance.json
- git diff --check

/claim #797
