### PR TITLE
OpenAI Codex [ FastAPI ] Add concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI concurrent runner change.",
+  "timestamp": "2026-05-23T10:52:22Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,8 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +13,60 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        failures: list[BaseException],
+        partial_results: list[Any],
+    ) -> None:
+        self.failures = failures
+        self.partial_results = partial_results
+        super().__init__(f"{len(failures)} concurrent task(s) failed")
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    *,
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be at least 1")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coroutines)
+    failures: list[BaseException] = []
+
+    async def run_one(index: int, coroutine: Awaitable[_T]) -> None:
+        async with semaphore:
+            try:
+                results[index] = await coroutine
+            except Exception as exc:
+                failures.append(exc)
+
+    tasks = [
+        asyncio.create_task(run_one(index, coroutine))
+        for index, coroutine in enumerate(coroutines)
+    ]
+
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*tasks, return_exceptions=True),
+            timeout=timeout,
+        )
+    except TimeoutError as exc:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        failures.append(exc)
+
+    if failures:
+        raise ConcurrencyError(failures=failures, partial_results=results)
+
+    return cast(list[_T], results)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_run_concurrently.py
+++ b/fastapi/tests/test_run_concurrently.py
@@ -1,0 +1,97 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_preserves_input_order():
+    async def work(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    results = await run_concurrently(
+        [work(1, 0.03), work(2, 0.01), work(3, 0.02)],
+        max_concurrency=3,
+    )
+
+    assert results == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_limits_concurrency():
+    active = 0
+    max_seen = 0
+
+    async def work() -> int:
+        nonlocal active, max_seen
+        active += 1
+        max_seen = max(max_seen, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return max_seen
+
+    await run_concurrently([work() for _ in range(6)], max_concurrency=2)
+
+    assert max_seen == 2
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_collects_failures():
+    async def fail(message: str) -> None:
+        raise RuntimeError(message)
+
+    async def succeed() -> str:
+        return "ok"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [fail("first"), succeed(), fail("second")],
+            max_concurrency=3,
+        )
+
+    assert [str(error) for error in exc_info.value.failures] == [
+        "first",
+        "second",
+    ]
+    assert exc_info.value.partial_results == [None, "ok", None]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_timeout_cancels_remaining_tasks():
+    async def fast() -> str:
+        return "done"
+
+    async def slow() -> str:
+        await asyncio.sleep(1)
+        return "late"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([fast(), slow()], max_concurrency=2, timeout=0.01)
+
+    assert exc_info.value.partial_results == ["done", None]
+    assert any(isinstance(error, TimeoutError) for error in exc_info.value.failures)
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_max_concurrency_one_runs_sequentially():
+    order: list[str] = []
+
+    async def work(name: str) -> str:
+        order.append(f"start:{name}")
+        await asyncio.sleep(0)
+        order.append(f"end:{name}")
+        return name
+
+    results = await run_concurrently(
+        [work("a"), work("b")],
+        max_concurrency=1,
+    )
+
+    assert results == ["a", "b"]
+    assert order == ["start:a", "end:a", "start:b", "end:b"]


### PR DESCRIPTION
## Summary
- adds run_concurrently with an asyncio semaphore concurrency limit
- preserves input result order and supports max_concurrency=1 sequential execution
- adds ConcurrencyError carrying failures and partial_results
- cancels outstanding work on timeout and reports TimeoutError in the aggregate failure list
- records safe, non-sensitive contributor metadata

## Validation
- uv run pytest tests/test_run_concurrently.py -q (5 passed)
- uv run ruff check fastapi/concurrency.py tests/test_run_concurrently.py
- jq empty fastapi/fastapi/_contributor.json
- git diff --check

/claim #803
