### PR TITLE
OpenAI Codex [ FastAPI ] Add StreamingCSVResponse

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI StreamingCSVResponse change.",
+  "ts": "2026-05-23T10:56:08Z"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,4 +1,7 @@
+import csv
 import importlib
+import io
+from collections.abc import AsyncIterable, Mapping, Sequence
 from typing import Any, Protocol, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
@@ -11,6 +14,8 @@ from starlette.responses import RedirectResponse as RedirectResponse  # noqa
 from starlette.responses import Response as Response  # noqa
 from starlette.responses import StreamingResponse as StreamingResponse  # noqa
 from typing_extensions import deprecated
+
+CSVRow = Sequence[Any] | Mapping[str, Any]
 
 
 class _UjsonModule(Protocol):
@@ -34,6 +39,52 @@ try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
 except ModuleNotFoundError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
+
+
+class StreamingCSVResponse(StreamingResponse):
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        content: AsyncIterable[CSVRow],
+        *,
+        headers: Sequence[str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        response_headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self.csv_headers = list(headers) if headers is not None else None
+        self.delimiter = delimiter
+        http_headers = dict(response_headers or {})
+        http_headers.setdefault(
+            "Content-Disposition", f'attachment; filename="{filename}"'
+        )
+        super().__init__(
+            self._stream_csv(content),
+            status_code=status_code,
+            headers=http_headers,
+            media_type=self.media_type,
+        )
+
+    async def _stream_csv(self, content: AsyncIterable[CSVRow]):
+        if self.csv_headers is not None:
+            yield self._render_csv_row(self.csv_headers)
+        async for row in content:
+            yield self._render_csv_row(self._normalize_row(row))
+
+    def _normalize_row(self, row: CSVRow) -> Sequence[Any]:
+        if isinstance(row, Mapping):
+            if self.csv_headers is not None:
+                return [row.get(header, "") for header in self.csv_headers]
+            return list(row.values())
+        return row
+
+    def _render_csv_row(self, row: Sequence[Any]) -> str:
+        buffer = io.StringIO()
+        writer = csv.writer(buffer, delimiter=self.delimiter)
+        writer.writerow(row)
+        return buffer.getvalue()
 
 
 @deprecated(

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,71 @@
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+
+async def row_stream() -> AsyncIterator[dict[str, str]]:
+    yield {"name": "Alice", "note": "hello, world"}
+    yield {"name": "Bob", "note": 'quote "here"'}
+    yield {"name": "Carol", "note": "two\nlines"}
+
+
+def test_streaming_csv_response_headers_filename_and_escaping():
+    app = FastAPI()
+
+    @app.get("/export")
+    def export():
+        return StreamingCSVResponse(
+            row_stream(),
+            headers=["name", "note"],
+            filename="users.csv",
+        )
+
+    response = TestClient(app).get("/export")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="users.csv"'
+    )
+    assert response.text == (
+        "name,note\r\n"
+        'Alice,"hello, world"\r\n'
+        'Bob,"quote ""here"""\r\n'
+        'Carol,"two\nlines"\r\n'
+    )
+
+
+def test_streaming_csv_response_custom_delimiter():
+    app = FastAPI()
+
+    async def rows() -> AsyncIterator[list[str]]:
+        yield ["alpha", "one;two"]
+
+    @app.get("/export")
+    def export():
+        return StreamingCSVResponse(
+            rows(),
+            headers=["name", "value"],
+            delimiter=";",
+        )
+
+    response = TestClient(app).get("/export")
+
+    assert response.text == 'name;value\r\nalpha;"one;two"\r\n'
+
+
+def test_streaming_csv_response_without_headers_uses_row_values():
+    app = FastAPI()
+
+    async def rows() -> AsyncIterator[dict[str, str]]:
+        yield {"name": "Alice", "note": "hello"}
+
+    @app.get("/export")
+    def export():
+        return StreamingCSVResponse(rows())
+
+    response = TestClient(app).get("/export")
+
+    assert response.text == "Alice,hello\r\n"


### PR DESCRIPTION
## Summary
- adds StreamingCSVResponse for async row streams
- writes optional CSV headers first and maps dict rows by header order
- supports RFC 4180 escaping through csv.writer and configurable delimiters
- sets text/csv and configurable attachment filename
- records safe, non-sensitive contributor metadata

## Validation
- uv run pytest tests/test_streaming_csv_response.py -q (3 passed)
- uv run ruff check fastapi/responses.py tests/test_streaming_csv_response.py
- jq empty fastapi/contributor_meta.json
- git diff --check

/claim #799
