### PR TITLE
OpenAI Codex [ FastAPI ] Add HTTPBasic brute force protection

### DIFF
--- a/fastapi/fastapi/security/.generation_meta.json
+++ b/fastapi/fastapi/security/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI HTTP Basic protection change.",
+  "date": "2026-05-23T10:59:22Z"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,4 +1,7 @@
 import binascii
+import hashlib
+import hmac
+import time
 from base64 import b64decode
 from typing import Annotated
 
@@ -10,7 +13,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -217,6 +220,105 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    def __init__(
+        self,
+        *,
+        password_hash: str | None = None,
+        max_attempts: int = 5,
+        window_seconds: float = 60,
+        scheme_name: str | None = None,
+        realm: str | None = None,
+        description: str | None = None,
+        auto_error: bool = True,
+    ):
+        super().__init__(
+            scheme_name=scheme_name,
+            realm=realm,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.password_hash = password_hash
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self._failed_attempts: dict[str, tuple[int, float, float | None]] = {}
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        self._raise_if_locked(request)
+        credentials = await super().__call__(request)
+        if credentials is None or self.password_hash is None:
+            return credentials
+        if self.verify_password(credentials.password, self.password_hash):
+            self.reset_attempts(request)
+            return credentials
+        self.record_failed_attempt(request)
+        raise self.make_not_authenticated_error()
+
+    @staticmethod
+    def hash_password(password: str) -> str:
+        return f"sha256${hashlib.sha256(password.encode()).hexdigest()}"
+
+    @staticmethod
+    def verify_password(password: str, password_hash: str) -> bool:
+        if password_hash.startswith("sha256$"):
+            expected = password_hash.removeprefix("sha256$")
+            candidate = hashlib.sha256(password.encode()).hexdigest()
+            return hmac.compare_digest(candidate, expected)
+        return hmac.compare_digest(password, password_hash)
+
+    def record_failed_attempt(self, request: Request) -> None:
+        client_key = self._client_key(request)
+        now = time.monotonic()
+        count, first_failure, locked_until = self._failed_attempts.get(
+            client_key, (0, now, None)
+        )
+        if now - first_failure > self.window_seconds:
+            count = 0
+            first_failure = now
+            locked_until = None
+        count += 1
+        if count >= self.max_attempts:
+            locked_until = now + self.window_seconds
+        self._failed_attempts[client_key] = (count, first_failure, locked_until)
+        self._raise_if_locked(request)
+
+    def reset_attempts(self, request: Request) -> None:
+        self._failed_attempts.pop(self._client_key(request), None)
+
+    def _raise_if_locked(self, request: Request) -> None:
+        client_key = self._client_key(request)
+        now = time.monotonic()
+        attempt = self._failed_attempts.get(client_key)
+        if attempt is None:
+            return
+        count, first_failure, locked_until = attempt
+        if now - first_failure > self.window_seconds:
+            self._failed_attempts.pop(client_key, None)
+            return
+        if locked_until is not None and locked_until > now:
+            retry_after = max(1, int(locked_until - now))
+            raise HTTPException(
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many authentication attempts",
+                headers={"Retry-After": str(retry_after)},
+            )
+        if count >= self.max_attempts:
+            locked_until = now + self.window_seconds
+            self._failed_attempts[client_key] = (count, first_failure, locked_until)
+            raise HTTPException(
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many authentication attempts",
+                headers={"Retry-After": str(int(self.window_seconds))},
+            )
+
+    def _client_key(self, request: Request) -> str:
+        if request.client is None:
+            return "unknown"
+        return request.client.host
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_security_http_basic_protection.py
+++ b/fastapi/tests/test_security_http_basic_protection.py
@@ -1,0 +1,63 @@
+import base64
+
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+
+def basic_auth(username: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def create_client(max_attempts: int = 2) -> TestClient:
+    app = FastAPI()
+    security = HTTPBasicWithProtection(
+        password_hash=HTTPBasicWithProtection.hash_password("secret"),
+        max_attempts=max_attempts,
+        window_seconds=60,
+    )
+
+    @app.get("/users/me")
+    def read_current_user(
+        credentials: HTTPBasicCredentials = Security(security),
+    ):
+        return {"username": credentials.username}
+
+    return TestClient(app)
+
+
+def test_http_basic_with_protection_allows_valid_password():
+    response = create_client().get("/users/me", headers=basic_auth("alice", "secret"))
+
+    assert response.status_code == 200
+    assert response.json() == {"username": "alice"}
+
+
+def test_http_basic_with_protection_locks_after_max_failed_attempts():
+    client = create_client(max_attempts=2)
+
+    first = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    second = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+
+    assert first.status_code == 401
+    assert second.status_code == 429
+    assert int(second.headers["retry-after"]) > 0
+
+
+def test_http_basic_with_protection_success_resets_failed_attempts():
+    client = create_client(max_attempts=2)
+
+    assert client.get("/users/me", headers=basic_auth("alice", "wrong")).status_code == 401
+    assert (
+        client.get("/users/me", headers=basic_auth("alice", "secret")).status_code
+        == 200
+    )
+    assert client.get("/users/me", headers=basic_auth("alice", "wrong")).status_code == 401
+
+
+def test_http_basic_with_protection_verify_password_constant_time_hash():
+    password_hash = HTTPBasicWithProtection.hash_password("secret")
+
+    assert HTTPBasicWithProtection.verify_password("secret", password_hash)
+    assert not HTTPBasicWithProtection.verify_password("wrong", password_hash)


### PR DESCRIPTION
## Summary
- adds HTTPBasicWithProtection without changing existing HTTPBasic behavior
- supports sha256 password hashing and constant-time verification helpers
- tracks failed authentication attempts per client IP and returns 429 with Retry-After after lockout
- resets failed attempts after successful authentication
- records safe, non-sensitive generation metadata

## Validation
- uv run pytest tests/test_security_http_basic_protection.py tests/test_security_http_basic_realm.py -q (9 passed)
- uv run ruff check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py
- jq empty fastapi/fastapi/security/.generation_meta.json
- git diff --check

/claim #800
