### PR TITLE
OpenAI Codex [ FastAPI ] Add FastAPITestClient helpers

### DIFF
--- a/fastapi/.audit.json
+++ b/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the FastAPI test client helper change.",
+  "completed_at": "2026-05-23T11:02:16Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,53 @@
+import base64
+from collections.abc import Sequence
+from typing import Any
+
+from httpx import Response
 from starlette.testclient import TestClient as TestClient  # noqa
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> "FastAPITestClient":
+        self.headers["Authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(
+        self, username: str, password: str
+    ) -> "FastAPITestClient":
+        credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+        self.headers["Authorization"] = f"Basic {credentials}"
+        return self
+
+    def reset_auth(self) -> "FastAPITestClient":
+        self.headers.pop("Authorization", None)
+        return self
+
+    def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: Sequence[str] | None = None,
+        **kwargs: Any,
+    ):
+        return self.websocket_connect(
+            url,
+            headers=headers,
+            subprotocols=subprotocols,
+            **kwargs,
+        )
+
+    def assert_status(
+        self,
+        method: str,
+        url: str,
+        expected_status: int,
+        **kwargs: Any,
+    ) -> Response:
+        response = self.request(method, url, **kwargs)
+        if response.status_code != expected_status:
+            raise AssertionError(
+                f"Expected status {expected_status}, got {response.status_code}: "
+                f"{response.text}"
+            )
+        return response

--- a/fastapi/tests/test_fastapi_testclient_helpers.py
+++ b/fastapi/tests/test_fastapi_testclient_helpers.py
@@ -1,0 +1,88 @@
+from fastapi import FastAPI, Header, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+
+
+def test_existing_testclient_export_is_unchanged():
+    assert TestClient is not FastAPITestClient
+
+
+def test_fastapi_testclient_authenticate_sets_bearer_token():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root(authorization: str = Header()):
+        return {"authorization": authorization}
+
+    client = FastAPITestClient(app)
+    client.authenticate("first")
+    assert client.get("/").json() == {"authorization": "Bearer first"}
+
+    client.authenticate("second")
+    assert client.get("/").json() == {"authorization": "Bearer second"}
+
+
+def test_fastapi_testclient_authenticate_basic_and_reset_auth():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root(authorization: str | None = Header(default=None)):
+        return {"authorization": authorization}
+
+    client = FastAPITestClient(app)
+    client.authenticate_basic("alice", "secret")
+    assert client.get("/").json() == {"authorization": "Basic YWxpY2U6c2VjcmV0"}
+
+    client.reset_auth()
+    assert client.get("/").json() == {"authorization": None}
+
+
+def test_fastapi_testclient_ws_connect_supports_headers_and_subprotocols():
+    app = FastAPI()
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(websocket: WebSocket):
+        await websocket.accept(subprotocol=websocket.scope["subprotocols"][0])
+        await websocket.send_json(
+            {
+                "x-token": websocket.headers["x-token"],
+                "subprotocol": websocket.scope["subprotocols"][0],
+            }
+        )
+        await websocket.close()
+
+    client = FastAPITestClient(app)
+
+    with client.ws_connect(
+        "/ws",
+        headers={"x-token": "abc"},
+        subprotocols=["chat"],
+    ) as websocket:
+        assert websocket.accepted_subprotocol == "chat"
+        assert websocket.receive_json() == {"x-token": "abc", "subprotocol": "chat"}
+
+
+def test_fastapi_testclient_assert_status_returns_response():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    response = FastAPITestClient(app).assert_status("GET", "/", 200)
+
+    assert response.json() == {"ok": True}
+
+
+def test_fastapi_testclient_assert_status_raises_helpful_error():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    try:
+        FastAPITestClient(app).assert_status("GET", "/", 201)
+    except AssertionError as exc:
+        assert "Expected status 201, got 200" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected assert_status to fail")


### PR DESCRIPTION
## Summary
- adds opt-in FastAPITestClient while preserving the existing TestClient export
- adds bearer/basic auth helpers plus reset_auth
- adds ws_connect convenience wrapper with headers and subprotocols
- adds assert_status helper with a useful assertion message
- records safe, non-sensitive audit metadata

## Validation
- uv run pytest tests/test_fastapi_testclient_helpers.py -q (6 passed)
- uv run ruff check fastapi/testclient.py tests/test_fastapi_testclient_helpers.py
- jq empty fastapi/.audit.json
- git diff --check

/claim #804
