### PR TITLE
OpenAI Codex [ Laravel ] Fix logging channels and JSON formatting

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel logging configuration change.",
+  "timestamp": "2026-05-23T11:04:12Z"
+}

--- a/laravel/app/Logging/JsonLogFormatter.php
+++ b/laravel/app/Logging/JsonLogFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Logger;
+
+class JsonLogFormatter
+{
+    public function __invoke(Logger $logger): void
+    {
+        foreach ($logger->getHandlers() as $handler) {
+            $handler->setFormatter(
+                new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, true)
+            );
+        }
+    }
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -54,7 +54,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -69,7 +69,24 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
-            'days' => env('LOG_DAILY_DAYS', 14),
+            'days' => 14,
+            'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'days' => 14,
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/structured.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 14,
+            'tap' => [App\Logging\JsonLogFormatter::class],
             'replace_placeholders' => true,
         ],
 


### PR DESCRIPTION
## Summary
- adds an error-only daily log channel writing to storage/logs/error.log
- updates the default stack to include daily and error logs
- sets daily/error/json retention to 14 days
- adds a json channel using a Monolog JsonFormatter tap
- records safe, non-sensitive provenance metadata

## Validation
- jq empty laravel/_provenance.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #787
