### PR TITLE
OpenAI Codex [ Laravel ] Add failed job monitoring

### DIFF
--- a/laravel/app/Console/Commands/FailedJobSummary.php
+++ b/laravel/app/Console/Commands/FailedJobSummary.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class FailedJobSummary extends Command
+{
+    protected $signature = 'queue:failed-summary';
+
+    protected $description = 'Show failed jobs grouped by exception class';
+
+    public function handle(): int
+    {
+        $table = config('queue.failed.table', 'failed_jobs');
+        $rows = DB::table($table)->select('exception')->get();
+
+        if ($rows->isEmpty()) {
+            $this->info('No failed jobs found.');
+
+            return self::SUCCESS;
+        }
+
+        $summary = $rows
+            ->map(fn ($row) => $this->exceptionClass((string) $row->exception))
+            ->countBy()
+            ->sortDesc()
+            ->map(fn ($count, $exception) => [
+                'Exception' => $exception,
+                'Count' => $count,
+            ])
+            ->values()
+            ->all();
+
+        $this->table(['Exception', 'Count'], $summary);
+
+        return self::SUCCESS;
+    }
+
+    private function exceptionClass(string $exception): string
+    {
+        if (preg_match('/^([A-Za-z0-9_\\\\]+)(:|\\s)/', $exception, $matches)) {
+            return $matches[1];
+        }
+
+        return 'Unknown';
+    }
+}

--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+
+class LogFailedJob
+{
+    public function handle(JobFailed $event): void
+    {
+        $payload = method_exists($event->job, 'payload')
+            ? $event->job->payload()
+            : [];
+
+        Log::error('Queue job failed', [
+            'connection' => $event->connectionName,
+            'queue' => method_exists($event->job, 'getQueue')
+                ? $event->job->getQueue()
+                : null,
+            'job' => method_exists($event->job, 'resolveName')
+                ? $event->job->resolveName()
+                : get_class($event->job),
+            'payload' => $payload,
+            'exception' => get_class($event->exception),
+            'message' => $event->exception->getMessage(),
+            'trace' => $event->exception->getTraceAsString(),
+        ]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, LogFailedJob::class);
     }
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -10,6 +10,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        App\Console\Commands\FailedJobSummary::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/queue.php
+++ b/laravel/config/queue.php
@@ -41,6 +41,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'max_tries' => (int) env('DB_QUEUE_MAX_TRIES', 3),
             'after_commit' => false,
         ],
 

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel failed job monitoring change.",
+  "ts": "2026-05-23T11:06:21Z"
+}


### PR DESCRIPTION
## Summary
- adds LogFailedJob listener for JobFailed events with queue, payload, and exception context
- registers the listener in AppServiceProvider
- adds queue:failed-summary command grouped by exception class
- adds database queue max_tries=3 while preserving retry_after=90
- records safe, non-sensitive contributor metadata

## Validation
- jq empty laravel/contributor_meta.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #789
