### PR TITLE
OpenAI Codex [ Laravel ] Fix Slack notification service

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel Slack notification service change.",
+  "timestamp": "2026-05-23T11:08:56Z"
+}

--- a/laravel/app/Services/SlackNotifier.php
+++ b/laravel/app/Services/SlackNotifier.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class SlackNotifier
+{
+    public function __construct(
+        private readonly ?string $webhookUrl = null,
+        private readonly ?string $defaultChannel = null,
+    ) {
+    }
+
+    public static function send(
+        string $text,
+        ?string $channel = null,
+        array $blocks = [],
+    ): Response {
+        return app(self::class)->sendMessage($text, $channel, $blocks);
+    }
+
+    public function sendMessage(
+        string $text,
+        ?string $channel = null,
+        array $blocks = [],
+    ): Response {
+        $webhookUrl = $this->webhookUrl ?? config('services.slack.webhook_url');
+
+        if (blank($webhookUrl)) {
+            throw new RuntimeException('Slack webhook URL is not configured.');
+        }
+
+        $payload = array_filter([
+            'text' => $text,
+            'channel' => $channel
+                ?? $this->defaultChannel
+                ?? config('services.slack.default_channel'),
+            'blocks' => $blocks ?: null,
+        ], fn ($value) => $value !== null);
+
+        $response = Http::timeout(5)->post($webhookUrl, $payload);
+
+        if ($response->serverError()) {
+            $response = Http::timeout(5)->post($webhookUrl, $payload);
+        }
+
+        return $response->throw();
+    }
+}

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -29,6 +29,8 @@ return [
     ],
 
     'slack' => [
+        'webhook_url' => env('SLACK_WEBHOOK_URL'),
+        'default_channel' => env('SLACK_DEFAULT_CHANNEL'),
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/laravel/tests/Unit/SlackNotifierTest.php
+++ b/laravel/tests/Unit/SlackNotifierTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\SlackNotifier;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SlackNotifierTest extends TestCase
+{
+    public function test_it_sends_slack_payload_with_channel_and_blocks(): void
+    {
+        Http::fake([
+            'https://hooks.slack.test/*' => Http::response(['ok' => true]),
+        ]);
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/one',
+            'services.slack.default_channel' => '#ops',
+        ]);
+
+        SlackNotifier::send('Deploy finished', blocks: [
+            ['type' => 'section', 'text' => ['type' => 'mrkdwn', 'text' => 'Done']],
+        ]);
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://hooks.slack.test/services/one'
+                && $request['text'] === 'Deploy finished'
+                && $request['channel'] === '#ops'
+                && $request['blocks'][0]['type'] === 'section';
+        });
+    }
+
+    public function test_it_retries_once_on_server_error(): void
+    {
+        Http::fakeSequence()
+            ->pushStatus(500)
+            ->push(['ok' => true], 200);
+        config(['services.slack.webhook_url' => 'https://hooks.slack.test/services/one']);
+
+        SlackNotifier::send('Retry me');
+
+        Http::assertSentCount(2);
+    }
+
+    public function test_it_does_not_retry_client_errors(): void
+    {
+        Http::fake([
+            'https://hooks.slack.test/*' => Http::response(['error' => 'bad'], 400),
+        ]);
+        config(['services.slack.webhook_url' => 'https://hooks.slack.test/services/one']);
+
+        $this->expectException(RequestException::class);
+
+        SlackNotifier::send('Fail fast');
+    }
+}


### PR DESCRIPTION
## Summary
- adds App\Services\SlackNotifier with static send convenience method
- posts Slack webhook payloads with text, channel override/default, and optional blocks
- applies a 5 second HTTP timeout, retries once on 5xx, and throws immediately on 4xx
- adds Slack webhook/default channel service config and HTTP-fake tests
- records safe, non-sensitive generation metadata

## Validation
- jq empty laravel/_generation.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #791
