### PR TITLE
OpenAI Codex [ Laravel ] Add database health check

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel database health endpoint change.",
+  "completed_at": "2026-05-23T11:10:49Z"
+}

--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    public function database(): JsonResponse
+    {
+        $connectionName = config('database.default');
+        $driver = config("database.connections.{$connectionName}.driver");
+        $startedAt = microtime(true);
+        $lastException = null;
+
+        for ($attempt = 1; $attempt <= 3; $attempt++) {
+            try {
+                DB::connection($connectionName)->getPdo();
+
+                return response()->json([
+                    'status' => 'ok',
+                    'driver' => $driver,
+                    'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+                    'connection_name' => $connectionName,
+                ]);
+            } catch (Throwable $exception) {
+                $lastException = $exception;
+                if ($attempt < 3) {
+                    usleep(500_000);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'error',
+            'driver' => $driver,
+            'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+            'connection_name' => $connectionName,
+            'error' => $lastException?->getMessage(),
+        ], 503);
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
+
+Route::get('/health/database', [HealthController::class, 'database']);
 
 Route::get('/', function () {
     return view('welcome');

--- a/laravel/tests/Feature/DatabaseHealthTest.php
+++ b/laravel/tests/Feature/DatabaseHealthTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class DatabaseHealthTest extends TestCase
+{
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        $response = $this->getJson('/health/database');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+            ])
+            ->assertJson(['status' => 'ok']);
+    }
+}


### PR DESCRIPTION
## Summary
- adds HealthController::database with active connection checks
- retries database connectivity up to 3 times with 500ms delay
- returns status, driver, latency_ms, and connection_name on success
- returns 503 JSON with error details after retry exhaustion
- adds GET /health/database, a feature test, and safe metadata

## Validation
- jq empty laravel/_meta.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #785
