### PR TITLE
OpenAI Codex [ Laravel ] Fix PHPUnit coverage and test suites

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel PHPUnit coverage and grouped test change.",
+  "completed_at": "2026-05-23T11:12:48Z"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -16,6 +16,10 @@
         <include>
             <directory>app</directory>
         </include>
+        <exclude>
+            <directory>app/Providers</directory>
+            <directory>app/Console</directory>
+        </exclude>
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/laravel/tests/Feature/RouteTest.php
+++ b/laravel/tests/Feature/RouteTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('feature')]
+class RouteTest extends TestCase
+{
+    public function test_registered_get_routes_do_not_return_server_errors(): void
+    {
+        foreach (Route::getRoutes() as $route) {
+            if (! in_array('GET', $route->methods(), true)) {
+                continue;
+            }
+
+            if (str_contains($route->uri(), '{')) {
+                continue;
+            }
+
+            $response = $this->get($route->uri());
+
+            $this->assertLessThan(
+                500,
+                $response->getStatusCode(),
+                "GET /{$route->uri()} returned a server error"
+            );
+        }
+    }
+}

--- a/laravel/tests/Unit/UserModelTest.php
+++ b/laravel/tests/Unit/UserModelTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('unit')]
+class UserModelTest extends TestCase
+{
+    public function test_user_model_configuration(): void
+    {
+        $user = new User();
+
+        $this->assertSame(['name', 'email', 'password'], $user->getFillable());
+        $this->assertSame(['password', 'remember_token'], $user->getHidden());
+        $this->assertSame('datetime', $user->getCasts()['email_verified_at']);
+        $this->assertSame('hashed', $user->getCasts()['password']);
+    }
+}


### PR DESCRIPTION
## Summary
- adds PHPUnit source exclusions for app/Providers and app/Console under app coverage
- adds feature/unit groups via PHPUnit attributes
- adds a GET route smoke test for non-parameterized registered routes
- adds User model fillable/hidden/cast configuration coverage
- records safe, non-sensitive audit metadata

## Validation
- jq empty laravel/.audit.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #794
