### PR TITLE
OpenAI Codex [ Laravel ] Add User observer UUID and ActiveScope

### DIFF
--- a/laravel/.attribution.json
+++ b/laravel/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive attribution for the Laravel observer, scope, UUID, and lazy-loading change.",
+  "date": "2026-05-23T11:15:00Z"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-#[Fillable(['name', 'email', 'password'])]
+#[Fillable(['name', 'email', 'password', 'uuid'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class UserObserver
+{
+    public function creating(User $user): void
+    {
+        if (blank($user->uuid)) {
+            $user->uuid = (string) Str::uuid();
+        }
+    }
+
+    public function created(User $user): void
+    {
+        Log::info('User created', [
+            'user_id' => $user->getKey(),
+            'uuid' => $user->uuid,
+        ]);
+    }
+
+    public function deleted(User $user): void
+    {
+        Log::info('User deleted', [
+            'user_id' => $user->getKey(),
+            'uuid' => $user->uuid,
+        ]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
+
+        Model::preventLazyLoading($this->app->environment(['local', 'testing']));
     }
 }

--- a/laravel/app/Scopes/ActiveScope.php
+++ b/laravel/app/Scopes/ActiveScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ActiveScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where($model->qualifyColumn('active'), 1);
+    }
+}

--- a/laravel/database/migrations/2026_05_23_111500_add_uuid_to_users_table.php
+++ b/laravel/database/migrations/2026_05_23_111500_add_uuid_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable()->unique()->after('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['uuid']);
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/laravel/tests/Unit/UserObserverScopeTest.php
+++ b/laravel/tests/Unit/UserObserverScopeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class UserObserverScopeTest extends TestCase
+{
+    public function test_user_observer_generates_uuid_on_create(): void
+    {
+        $user = User::factory()->create(['uuid' => null]);
+
+        $this->assertTrue(Str::isUuid($user->uuid));
+    }
+
+    public function test_lazy_loading_prevention_is_enabled_in_testing(): void
+    {
+        $this->assertTrue(Model::preventsLazyLoading());
+    }
+}


### PR DESCRIPTION
## Summary
- adds reusable ActiveScope filtering active records
- adds UserObserver for UUID generation plus create/delete logging
- adds nullable unique users.uuid migration and makes uuid fillable
- registers the observer and enables lazy-loading prevention for local/testing
- records safe, non-sensitive attribution metadata

## Validation
- jq empty laravel/.attribution.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #792
