### PR TITLE
OpenAI Codex [ Laravel ] Add cache health validation

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel cache health check change.",
+  "timestamp": "2026-05-23T11:28:38Z"
+}

--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status {store?}';
+
+    protected $description = 'Show cache store health status';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $status = $healthCheck->check($this->argument('store'));
+
+        $this->table(
+            ['Driver', 'Available', 'Latency (ms)'],
+            [[
+                $status['driver'],
+                $status['available'] ? 'yes' : 'no',
+                $status['latency_ms'],
+            ]]
+        );
+
+        if (! $status['available'] && isset($status['error'])) {
+            $this->error($status['error']);
+        }
+
+        return $status['available'] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Throwable;
+
+class CacheHealthCheck
+{
+    public function check(?string $store = null): array
+    {
+        $store ??= config('cache.default');
+        $driver = config("cache.stores.{$store}.driver", $store);
+        $key = 'cache-health:'.uniqid('', true);
+        $startedAt = microtime(true);
+
+        try {
+            $cache = Cache::store($store);
+            $cache->put($key, 'ok', 5);
+            $available = $cache->get($key) === 'ok';
+            $cache->forget($key);
+
+            return [
+                'available' => $available,
+                'driver' => $driver,
+                'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'available' => false,
+                'driver' => $driver,
+                'latency_ms' => round((microtime(true) - $startedAt) * 1000, 2),
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -10,6 +10,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        App\Console\Commands\CacheStatusCommand::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -17,6 +17,10 @@ return [
 
     'default' => env('CACHE_STORE', 'database'),
 
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => (int) env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
     /*
     |--------------------------------------------------------------------------
     | Cache Stores

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,6 +1,13 @@
 <?php
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\Facades\Route;
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    $status = $healthCheck->check();
+
+    return response()->json($status, $status['available'] ? 200 : 503);
+});
 
 Route::get('/', function () {
     return view('welcome');

--- a/laravel/tests/Feature/CacheStatusCommandTest.php
+++ b/laravel/tests/Feature/CacheStatusCommandTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class CacheStatusCommandTest extends TestCase
+{
+    public function test_cache_status_command_outputs_health_table(): void
+    {
+        config(['cache.default' => 'array']);
+
+        $this->artisan('cache:status')
+            ->assertExitCode(0);
+    }
+}

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    public function test_array_cache_store_reports_available(): void
+    {
+        config(['cache.default' => 'array']);
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('array', $status['driver']);
+        $this->assertArrayHasKey('latency_ms', $status);
+    }
+}


### PR DESCRIPTION
## Summary
- adds CacheHealthCheck service that probes active cache store availability and latency
- adds cache:status artisan command and registers it with the app bootstrap
- adds cache health config switches and interval settings
- exposes GET /health/cache with 200/503 based on availability
- adds service/command tests and safe provenance metadata

## Validation
- jq empty laravel/_provenance.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #747
