### PR TITLE
OpenAI Codex [ Laravel ] Implement audit logging trait

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the Laravel audit logging change.",
+  "created": "2026-05-23T11:31:02Z"
+}

--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class AuditLog extends Model
+{
+    protected $guarded = [];
+
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+trait Auditable
+{
+    protected static array $auditHidden = ['password', 'remember_token'];
+
+    public static function bootAuditable(): void
+    {
+        static::created(fn ($model) => $model->writeAuditLog('created'));
+        static::updated(fn ($model) => $model->writeAuditLog('updated'));
+        static::deleted(fn ($model) => $model->writeAuditLog('deleted'));
+    }
+
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    public function getAuditHistory()
+    {
+        return $this->auditLogs()->latest()->get();
+    }
+
+    protected function writeAuditLog(string $event): void
+    {
+        $oldValues = [];
+        $newValues = [];
+
+        if ($event === 'created') {
+            $newValues = $this->auditValues($this->getAttributes());
+        } elseif ($event === 'updated') {
+            $dirty = array_keys($this->getChanges());
+            $oldValues = $this->auditValues($this->getOriginal(), $dirty);
+            $newValues = $this->auditValues($this->getAttributes(), $dirty);
+        } elseif ($event === 'deleted') {
+            $oldValues = $this->auditValues($this->getOriginal());
+        }
+
+        $this->auditLogs()->create([
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => auth()->id(),
+            'ip_address' => request()?->ip(),
+            'user_agent' => request()?->userAgent(),
+        ]);
+    }
+
+    protected function auditValues(array $values, ?array $only = null): array
+    {
+        if ($only !== null) {
+            $values = array_intersect_key($values, array_flip($only));
+        }
+
+        return collect($values)
+            ->except(static::$auditHidden)
+            ->all();
+    }
+}

--- a/laravel/database/migrations/2026_05_23_113102_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_05_23_113102_create_audit_logs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('auditable');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('ip_address')->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditLogTest.php
+++ b/laravel/tests/Feature/AuditLogTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_create_update_and_delete_are_audited(): void
+    {
+        $user = User::factory()->create(['name' => 'Alice']);
+        $this->assertSame('created', AuditLog::first()->event);
+        $this->assertSame('Alice', AuditLog::first()->new_values['name']);
+        $this->assertArrayNotHasKey('password', AuditLog::first()->new_values);
+
+        $user->update(['name' => 'Bob']);
+        $updated = AuditLog::where('event', 'updated')->first();
+        $this->assertSame('Alice', $updated->old_values['name']);
+        $this->assertSame('Bob', $updated->new_values['name']);
+
+        $user->delete();
+        $this->assertDatabaseHas('audit_logs', ['event' => 'deleted']);
+        $this->assertCount(3, $user->getAuditHistory());
+    }
+}


### PR DESCRIPTION
## Summary
- adds AuditLog model and audit_logs migration
- adds Auditable trait for created, updated, and deleted model events
- excludes sensitive fields such as password and remember_token from snapshots
- stores request/user metadata and exposes getAuditHistory ordered newest first
- applies the trait to User and adds a feature test

## Validation
- jq empty laravel/.provenance.json
- git diff --check
- Not run: php -l or Laravel tests because php is not installed in this workspace.

/claim #786
