### PR TITLE
OpenAI Codex [ T3 Code ] Fix Turbo dependency graph

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the T3 Code Turbo dependency graph change.",
+  "completed_at": "2026-05-23T11:33:07Z"
+}

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,49 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/contracts#build": {
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/client-runtime#build": {
+      "dependsOn": ["@t3tools/contracts#build"],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/shared#build": {
+      "dependsOn": ["@t3tools/contracts#build"],
+      "outputs": ["dist/**"]
+    },
+    "effect-acp#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/shared#build"],
+      "outputs": ["dist/**"]
+    },
+    "effect-codex-app-server#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "effect-acp#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/web#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/client-runtime#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/desktop#build": {
+      "dependsOn": ["@t3tools/web#build", "t3#build"],
+      "outputs": ["dist/**", "dist-electron/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
## Summary
- adds package-specific Turbo build tasks for contracts, client-runtime, shared, Effect packages, web, server, and desktop
- encodes requested app dependency graph: web depends on contracts/client-runtime, server depends on contracts/shared/effect packages, desktop depends on web/server
- adds build artifact outputs for package/app cache entries
- records safe, non-sensitive metadata

## Validation
- jq empty t3code/turbo.json t3code/_meta.json
- git diff --check

/claim #828
