### PR TITLE
OpenAI Codex [ T3 Code ] Add CLI version command

### DIFF
--- a/t3code/apps/server/.contributor.json
+++ b/t3code/apps/server/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file intentionally records only non-sensitive provenance for the T3 Code CLI version command change.",
+  "timestamp": "2026-05-23T11:34:45Z"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -17,6 +17,7 @@ import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
 import { cli } from "./bin.ts";
+import packageJson from "../package.json" with { type: "json" };
 import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "./config.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
@@ -36,7 +37,8 @@ import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
-const runCli = (args: ReadonlyArray<string>) => Command.runWith(cli, { version: "0.0.0" })(args);
+const runCli = (args: ReadonlyArray<string>) =>
+  Command.runWith(cli, { version: packageJson.version })(args);
 const runCliWithRuntime = (args: ReadonlyArray<string>) =>
   runCli(args).pipe(Effect.provide(CliRuntimeLayer));
 
@@ -150,6 +152,24 @@ const withLiveProjectCliServer = <A, E, R>(baseDir: string, run: () => Effect.Ef
   });
 
 it.layer(NodeServices.layer)("bin cli parsing", (it) => {
+  it.effect("prints the package version with --version", () =>
+    Effect.gen(function* () {
+      const versionOutput = yield* captureStdout(runCli(["--version"]));
+
+      assert.equal(versionOutput.output, `t3 v${packageJson.version}`);
+    }),
+  );
+
+  it.effect("prints detailed runtime information with the version subcommand", () =>
+    Effect.gen(function* () {
+      const versionOutput = yield* captureStdout(runCli(["version"]));
+
+      assert.equal(versionOutput.output.includes(`t3code v${packageJson.version}`), true);
+      assert.equal(versionOutput.output.includes(process.platform), true);
+      assert.equal(versionOutput.output.includes(process.arch), true);
+    }),
+  );
+
   it.effect("accepts the built-in lowercase log-level flag values", () =>
     runCliWithRuntime(["--log-level", "debug", "--version"]),
   );

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -1,5 +1,6 @@
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Command } from "effect/unstable/cli";
@@ -13,10 +14,31 @@ import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
+const bunRuntime = (
+  globalThis as typeof globalThis & { readonly Bun?: { readonly version: string } }
+).Bun;
+const runtimeName = bunRuntime === undefined ? "node" : "bun";
+const runtimeVersion =
+  bunRuntime === undefined ? process.versions.node : bunRuntime.version;
+
+const formatVersion = () =>
+  `t3code v${packageJson.version} (${runtimeName} ${runtimeVersion}, ${process.platform} ${process.arch})`;
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print T3 Code version and runtime information."),
+  Command.withHandler(() => Console.log(formatVersion())),
+);
+
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    versionCommand,
+  ]),
 );
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary
- Adds a `t3 version` subcommand that prints the package version plus runtime, platform, and architecture.
- Keeps the existing Effect CLI built-in `--version` path wired to package.json and adds focused assertions for both outputs.
- Adds non-sensitive contributor provenance without disclosing private system, developer, tool, memory, or session instructions.

## Validation
- `timeout 120s npm run --workspace t3 test -- src/bin.test.ts -t version`
- `jq empty apps/server/.contributor.json && git diff --check`
- `npm run --workspace t3 typecheck` was attempted separately but the local `tsc --noEmit` process produced no output for several minutes and was killed before this PR.

/claim #821
