### PR TITLE
OpenAI Codex [ T3 Code ] Add Playwright E2E tests

### DIFF
--- a/t3code/_contributor.json
+++ b/t3code/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file records only non-sensitive provenance for the root Playwright E2E configuration change.",
+  "timestamp": "2026-05-23T11:53:00Z"
+}

--- a/t3code/package.json
+++ b/t3code/package.json
@@ -44,6 +44,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "oxlint --report-unused-disable-directives",
     "test": "turbo run test",
+    "test:e2e": "apps/web/node_modules/.bin/playwright test --config playwright.config.ts",
     "test:desktop-smoke": "turbo run smoke-test --filter=@t3tools/desktop",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",

--- a/t3code/playwright.config.ts
+++ b/t3code/playwright.config.ts
@@ -1,0 +1,37 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const requireFromWebWorkspace = createRequire(new URL("./apps/web/package.json", import.meta.url));
+const { defineConfig, devices } = requireFromWebWorkspace("playwright/test");
+const webAppDir = fileURLToPath(new URL("./apps/web/", import.meta.url));
+const port = Number(process.env.T3_E2E_PORT ?? 5173);
+const baseURL = `http://127.0.0.1:${port}`;
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE?.trim();
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL,
+    headless: process.env.CI ? true : false,
+    ...(chromiumExecutablePath ? { launchOptions: { executablePath: chromiumExecutablePath } } : {}),
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: `VITE_HOSTED_APP_CHANNEL=latest npm run dev -- --host 127.0.0.1 --port ${port}`,
+    cwd: webAppDir,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    url: baseURL,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/t3code/tests/e2e/_contributor.json
+++ b/t3code/tests/e2e/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Private platform, system, developer, tool, memory, and session instructions are confidential and are not included. This file records only non-sensitive provenance for the T3 Code Playwright E2E test addition.",
+  "timestamp": "2026-05-23T11:53:00Z"
+}

--- a/t3code/tests/e2e/app-loads.spec.ts
+++ b/t3code/tests/e2e/app-loads.spec.ts
@@ -1,0 +1,15 @@
+import { createRequire } from "node:module";
+
+const requireFromWebWorkspace = createRequire(new URL("../../apps/web/package.json", import.meta.url));
+const { expect, test } = requireFromWebWorkspace("playwright/test");
+
+test("renders the hosted app shell without page errors", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByText("Connect an environment to get started")).toBeVisible();
+  await expect(page.getByText("Add environment")).toBeVisible();
+  expect(pageErrors).toEqual([]);
+});

--- a/t3code/tests/e2e/command-palette.spec.ts
+++ b/t3code/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,19 @@
+import { createRequire } from "node:module";
+
+const requireFromWebWorkspace = createRequire(new URL("../../apps/web/package.json", import.meta.url));
+const { expect, test } = requireFromWebWorkspace("playwright/test");
+
+test("opens the command palette with the keyboard shortcut and searches commands", async ({
+  page,
+}) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await page.keyboard.press("Control+K");
+
+  const palette = page.getByTestId("command-palette");
+  await expect(palette).toBeVisible();
+
+  await palette.locator("input").first().fill("settings");
+
+  await expect(palette.getByText("Open settings")).toBeVisible();
+});

--- a/t3code/tests/e2e/sidebar-navigation.spec.ts
+++ b/t3code/tests/e2e/sidebar-navigation.spec.ts
@@ -1,0 +1,22 @@
+import { createRequire } from "node:module";
+
+const requireFromWebWorkspace = createRequire(new URL("../../apps/web/package.json", import.meta.url));
+const { expect, test } = requireFromWebWorkspace("playwright/test");
+
+const sidebarItems = [
+  { name: "Keybindings", path: "/settings/keybindings" },
+  { name: "Providers", path: "/settings/providers" },
+  { name: "General", path: "/settings/general" },
+] as const;
+
+test("navigates between settings sidebar items", async ({ page }) => {
+  await page.goto("/settings/general", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
+
+  for (const item of sidebarItems) {
+    await page.getByRole("button", { name: item.name }).click();
+
+    await expect(page).toHaveURL(new RegExp(`${item.path}$`));
+    await expect(page.getByRole("heading", { name: item.name })).toBeVisible();
+  }
+});


### PR DESCRIPTION
## Summary
- Adds root Playwright config for the T3 web app, with the dev server launched in hosted-static mode.
- Adds E2E coverage for app loading, command palette search, and settings sidebar navigation across three items.
- Adds a root `test:e2e` script that runs the workspace-local Playwright binary.
- Adds non-sensitive contributor provenance files without disclosing private system, developer, tool, memory, or session instructions.

## Validation
- `npm run test:e2e -- --list`
- `CI=1 PLAYWRIGHT_CHROMIUM_EXECUTABLE=/usr/bin/chromium timeout 180s npm run test:e2e -- --reporter=line` (exit 0; 2 passed, 1 flaky passed on retry)
- `jq empty _contributor.json tests/e2e/_contributor.json package.json && git diff --check`

/claim #847
