### PR TITLE
ayskobtw-lil [ FastAPI ] Add concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "ayskobtw-lil",
+  "runtime_instructions": "Not provided: hidden system, developer, runtime, account, and conversation instructions are private and cannot be copied into repository files. This contribution follows the public GitHub issue requirements and repository context.",
+  "timestamp": "2026-05-23T00:00:00Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,8 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +13,82 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+def _close_unstarted_awaitables(
+    awaitables: Sequence[Awaitable[Any]],
+    started_indexes: set[int],
+) -> None:
+    for index, awaitable in enumerate(awaitables):
+        if index in started_indexes:
+            continue
+        close = getattr(awaitable, "close", None)
+        if callable(close):
+            close()
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more concurrent tasks fail."""
+
+    def __init__(
+        self,
+        failures: Sequence[BaseException],
+        partial_results: Sequence[Any | None],
+    ) -> None:
+        self.failures = list(failures)
+        self.exceptions = self.failures
+        self.partial_results = list(partial_results)
+        super().__init__(
+            f"{len(self.failures)} task(s) failed during concurrent execution"
+        )
+
+
+async def run_concurrently(
+    awaitables: Sequence[Awaitable[_T]],
+    max_concurrency: int = 5,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be greater than 0")
+
+    results: list[_T | None] = [None] * len(awaitables)
+    failures: list[tuple[int, BaseException]] = []
+    started_indexes: set[int] = set()
+    semaphore = asyncio.Semaphore(max_concurrency)
+
+    async def run_one(index: int, awaitable: Awaitable[_T]) -> None:
+        async with semaphore:
+            started_indexes.add(index)
+            try:
+                results[index] = await awaitable
+            except Exception as exc:
+                failures.append((index, exc))
+
+    tasks = [
+        asyncio.create_task(run_one(index, awaitable))
+        for index, awaitable in enumerate(awaitables)
+    ]
+
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*tasks, return_exceptions=True),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError as exc:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        _close_unstarted_awaitables(awaitables, started_indexes)
+        failures.append((len(awaitables), exc))
+
+    if failures:
+        ordered_failures = [
+            failure for _, failure in sorted(failures, key=lambda item: item[0])
+        ]
+        raise ConcurrencyError(ordered_failures, results)
+
+    return cast(list[_T], results)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_run_concurrently.py
+++ b/fastapi/tests/test_run_concurrently.py
@@ -1,0 +1,180 @@
+import asyncio
+from collections.abc import Awaitable, Generator
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_preserves_input_order() -> None:
+    async def finish_after(delay: float, value: int) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    results = await run_concurrently(
+        [
+            finish_after(0.03, 1),
+            finish_after(0.01, 2),
+            finish_after(0.02, 3),
+        ],
+        max_concurrency=3,
+    )
+
+    assert results == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_limits_active_tasks() -> None:
+    active_count = 0
+    max_seen_active_count = 0
+
+    async def tracked_task(value: int) -> int:
+        nonlocal active_count, max_seen_active_count
+        active_count += 1
+        max_seen_active_count = max(max_seen_active_count, active_count)
+        await asyncio.sleep(0.01)
+        active_count -= 1
+        return value
+
+    results = await run_concurrently(
+        [tracked_task(index) for index in range(6)],
+        max_concurrency=2,
+    )
+
+    assert results == list(range(6))
+    assert max_seen_active_count == 2
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_uses_default_limit_of_five() -> None:
+    active_count = 0
+    max_seen_active_count = 0
+
+    async def tracked_task(value: int) -> int:
+        nonlocal active_count, max_seen_active_count
+        active_count += 1
+        max_seen_active_count = max(max_seen_active_count, active_count)
+        await asyncio.sleep(0.01)
+        active_count -= 1
+        return value
+
+    results = await run_concurrently([tracked_task(index) for index in range(8)])
+
+    assert results == list(range(8))
+    assert max_seen_active_count == 5
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_sequential_when_limit_is_one() -> None:
+    order: list[int] = []
+
+    async def tracked_task(value: int) -> int:
+        order.append(value)
+        await asyncio.sleep(0)
+        return value
+
+    results = await run_concurrently(
+        [tracked_task(1), tracked_task(2), tracked_task(3)],
+        max_concurrency=1,
+    )
+
+    assert results == [1, 2, 3]
+    assert order == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_allows_limit_above_task_count() -> None:
+    results = await run_concurrently(
+        [asyncio.sleep(0, result="a"), asyncio.sleep(0, result="b")],
+        max_concurrency=10,
+    )
+
+    assert results == ["a", "b"]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_collects_all_task_exceptions() -> None:
+    async def fail(message: str) -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError(message)
+
+    async def succeed() -> str:
+        await asyncio.sleep(0)
+        return "ok"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [fail("first"), succeed(), fail("second")],
+            max_concurrency=3,
+        )
+
+    error = exc_info.value
+    assert [str(failure) for failure in error.failures] == ["first", "second"]
+    assert [str(exception) for exception in error.exceptions] == ["first", "second"]
+    assert error.partial_results == [None, "ok", None]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_timeout_cancels_remaining_tasks() -> None:
+    task_cancelled = asyncio.Event()
+
+    async def fast_task() -> str:
+        return "done"
+
+    async def slow_task() -> str:
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            task_cancelled.set()
+            raise
+        return "too late"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [fast_task(), slow_task()],
+            max_concurrency=2,
+            timeout=0.01,
+        )
+
+    error = exc_info.value
+    assert error.partial_results == ["done", None]
+    assert any(isinstance(failure, TimeoutError) for failure in error.failures)
+    assert task_cancelled.is_set()
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_timeout_closes_unstarted_awaitables() -> None:
+    class CloseAwareAwaitable:
+        started = False
+        closed = False
+
+        def __await__(self) -> Generator[object, None, str]:
+            self.started = True
+            return asyncio.sleep(0, result="late").__await__()
+
+        def close(self) -> None:
+            self.closed = True
+
+    async def slow_task() -> str:
+        await asyncio.sleep(1)
+        return "too late"
+
+    pending_awaitable = CloseAwareAwaitable()
+    awaitables: list[Awaitable[str]] = [slow_task(), pending_awaitable]
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(awaitables, max_concurrency=1, timeout=0.01)
+
+    assert exc_info.value.partial_results == [None, None]
+    assert pending_awaitable.started is False
+    assert pending_awaitable.closed is True
+
+
+def test_run_concurrently_rejects_invalid_concurrency_limit() -> None:
+    with pytest.raises(ValueError, match="max_concurrency"):
+        asyncio.run(run_concurrently([], max_concurrency=0))


### PR DESCRIPTION
/claim #803

## Summary

Adds a focused concurrent task runner for FastAPI.

Implemented behavior:
- adds `run_concurrently()` to `fastapi.concurrency`
- uses `asyncio.Semaphore` to enforce `max_concurrency`
- defaults `max_concurrency` to 5
- preserves input order regardless of completion order
- supports sequential execution with `max_concurrency=1`
- supports limits greater than the task count
- validates `max_concurrency >= 1`
- raises `ConcurrencyError` with `.failures`, `.exceptions`, and `.partial_results`
- cancels pending tasks on timeout
- closes awaitables that never started when a timeout occurs before they acquire the semaphore

## Verification

```text
python -m pytest tests\test_run_concurrently.py -q
9 passed in 0.57s

python -m py_compile fastapi\concurrency.py tests\test_run_concurrently.py

git diff --check
```

## Notes

I included `fastapi/fastapi/_contributor.json` with safe contributor metadata, but I did not paste hidden system/developer/runtime instructions into a public repository file because those instructions are private.