### PR TITLE
ayskobtw-lil [ T3 Code ] Complete ChatMarkdown code block controls

### DIFF
--- a/t3code/apps/web/.audit.json
+++ b/t3code/apps/web/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "ayskobtw-lil",
+  "environment_config": "Not provided: hidden system, developer, runtime, account, and conversation instructions are private and cannot be copied into repository files. This contribution follows the public GitHub issue requirements and repository context.",
+  "completed_at": "2026-05-23T00:00:00Z"
+}

--- a/t3code/apps/web/src/components/ChatMarkdown.browser.tsx
+++ b/t3code/apps/web/src/components/ChatMarkdown.browser.tsx
@@ -138,4 +138,106 @@ describe("ChatMarkdown", () => {
       await screen.unmount();
     }
   });
+
+  it("auto-detects unlabeled JavaScript code fences", async () => {
+    const screen = await render(
+      <ChatMarkdown
+        text={"```\nexport function sum(a, b) {\n  return a + b;\n}\n```"}
+        cwd="/repo/project"
+      />,
+    );
+
+    try {
+      await vi.waitFor(() => {
+        expect(document.querySelector('[data-code-language="javascript"]')).not.toBeNull();
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("renders aligned line numbers for fenced code blocks", async () => {
+    const screen = await render(
+      <ChatMarkdown text={"```ts\nconst first = 1;\nconst second = 2;\n```"} cwd="/repo/project" />,
+    );
+
+    try {
+      await vi.waitFor(() => {
+        const lineNumbers = document.querySelectorAll(".chat-markdown-code-line-number");
+        expect(lineNumbers).toHaveLength(2);
+        expect(lineNumbers[0]).toHaveTextContent("1");
+        expect(lineNumbers[1]).toHaveTextContent("2");
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("collapses code blocks longer than twenty lines and expands them on request", async () => {
+    const longCode = Array.from({ length: 25 }, (_, index) => `line ${index + 1}`).join("\n");
+    const screen = await render(
+      <ChatMarkdown text={`\`\`\`text\n${longCode}\n\`\`\``} cwd="/repo/project" />,
+    );
+
+    try {
+      const codeBlock = await vi.waitFor(() => {
+        const element = document.querySelector(".chat-markdown-codeblock");
+        expect(element).not.toBeNull();
+        return element as HTMLElement;
+      });
+
+      expect(codeBlock.dataset.collapsed).toBe("true");
+      expect(document.querySelectorAll(".chat-markdown-code-line")).toHaveLength(10);
+
+      const expandButton = page.getByRole("button", { name: "Expand code block" });
+      await expandButton.click();
+
+      await vi.waitFor(() => {
+        expect(codeBlock.dataset.collapsed).toBe("false");
+        expect(document.querySelectorAll(".chat-markdown-code-line")).toHaveLength(25);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("copies the full code block even when collapsed", async () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const longCode = Array.from({ length: 25 }, (_, index) => `line ${index + 1}`).join("\n");
+    const screen = await render(
+      <ChatMarkdown text={`\`\`\`text\n${longCode}\n\`\`\``} cwd="/repo/project" />,
+    );
+
+    try {
+      await vi.waitFor(() => {
+        expect(document.querySelector(".chat-markdown-codeblock")).not.toBeNull();
+      });
+
+      await page.getByRole("button", { name: "Copy code" }).click();
+
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(`${longCode}\n`);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("does not add code-block controls to inline code", async () => {
+    const screen = await render(
+      <ChatMarkdown text={"Use `const value = 1` inline."} cwd="/repo/project" />,
+    );
+
+    try {
+      await expect.element(page.getByText("const value = 1")).toBeInTheDocument();
+      expect(document.querySelector(".chat-markdown-codeblock")).toBeNull();
+      expect(document.querySelector(".chat-markdown-code-line-number")).toBeNull();
+    } finally {
+      await screen.unmount();
+    }
+  });
 });

--- a/t3code/apps/web/src/components/ChatMarkdown.tsx
+++ b/t3code/apps/web/src/components/ChatMarkdown.tsx
@@ -1,5 +1,5 @@
 import { DiffsHighlighter, getSharedHighlighter, SupportedLanguages } from "@pierre/diffs";
-import { CheckIcon, CopyIcon } from "lucide-react";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon, CopyIcon } from "lucide-react";
 import type { ServerProviderSkill } from "@t3tools/contracts";
 import React, {
   Children,
@@ -67,6 +67,8 @@ interface ChatMarkdownProps {
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
 
 const CODE_FENCE_LANGUAGE_REGEX = /(?:^|\s)language-([^\s]+)/;
+const CODE_BLOCK_COLLAPSE_THRESHOLD_LINES = 20;
+const CODE_BLOCK_PREVIEW_LINES = 10;
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
 const MAX_HIGHLIGHT_CACHE_MEMORY_BYTES = 50 * 1024 * 1024;
 const highlightedCodeCache = new LRUCache<string>(
@@ -75,11 +77,53 @@ const highlightedCodeCache = new LRUCache<string>(
 );
 const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
 
-function extractFenceLanguage(className: string | undefined): string {
-  const match = className?.match(CODE_FENCE_LANGUAGE_REGEX);
-  const raw = match?.[1] ?? "text";
+function normalizeFenceLanguage(raw: string | undefined): string {
+  if (!raw) return "text";
   // Shiki doesn't bundle a gitignore grammar; ini is a close match (#685)
   return raw === "gitignore" ? "ini" : raw;
+}
+
+function detectFenceLanguage(code: string): string {
+  const trimmed = code.trim();
+  if (trimmed.length === 0) return "text";
+
+  if (/^(?:import|export)\s/m.test(trimmed) || /\b(?:const|let|var|function)\s+\w+/m.test(trimmed)) {
+    return /:\s*(?:string|number|boolean|unknown|Record<|\w+\[\])\b|interface\s+\w+/m.test(trimmed)
+      ? "typescript"
+      : "javascript";
+  }
+  if (/\bdef\s+\w+\(|\bclass\s+\w+[:(]|\bfrom\s+\w+\s+import\b/m.test(trimmed)) {
+    return "python";
+  }
+  if (/^(?:\$|npm|pnpm|bun|yarn|git|cd|mkdir|rm|cp|mv)\b/m.test(trimmed)) {
+    return "bash";
+  }
+  if (/^<[\w!-][\s\S]*>$/.test(trimmed)) {
+    return "html";
+  }
+  if (/^\s*[{[]/.test(trimmed)) {
+    try {
+      JSON.parse(trimmed);
+      return "json";
+    } catch {
+      // Not JSON; keep looking.
+    }
+  }
+  if (/[.#][\w-]+\s*{[\s\S]*}/.test(trimmed)) {
+    return "css";
+  }
+
+  return "text";
+}
+
+function resolveFenceLanguage(className: string | undefined, code: string): string {
+  const explicitLanguage = className?.match(CODE_FENCE_LANGUAGE_REGEX)?.[1];
+  return normalizeFenceLanguage(explicitLanguage ?? detectFenceLanguage(code));
+}
+
+function getCodeLines(code: string): string[] {
+  const withoutTrailingFenceNewline = code.endsWith("\n") ? code.slice(0, -1) : code;
+  return withoutTrailingFenceNewline.split("\n");
 }
 
 function nodeToPlainText(node: ReactNode): string {
@@ -146,9 +190,24 @@ function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
   return promise;
 }
 
-function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNode }) {
+interface MarkdownCodeBlockProps {
+  className: string | undefined;
+  code: string;
+  themeName: DiffThemeName;
+  isStreaming: boolean;
+}
+
+function MarkdownCodeBlock({ className, code, themeName, isStreaming }: MarkdownCodeBlockProps) {
+  const language = resolveFenceLanguage(className, code);
+  const allLines = useMemo(() => getCodeLines(code), [code]);
+  const isCollapsible = allLines.length > CODE_BLOCK_COLLAPSE_THRESHOLD_LINES;
+  const [isExpanded, setIsExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const visibleLines = isCollapsible && !isExpanded ? allLines.slice(0, CODE_BLOCK_PREVIEW_LINES) : allLines;
+  const visibleCode = visibleLines.join("\n");
+  const collapseButtonLabel = isExpanded ? "Collapse code block" : "Expand code block";
+
   const handleCopy = useCallback(() => {
     if (typeof navigator === "undefined" || navigator.clipboard == null) {
       return;
@@ -178,8 +237,16 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNo
     [],
   );
 
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [code]);
+
   return (
-    <div className="chat-markdown-codeblock leading-snug">
+    <div
+      className="chat-markdown-codeblock leading-snug"
+      data-code-language={language}
+      data-collapsed={isCollapsible ? String(!isExpanded) : "false"}
+    >
       <button
         type="button"
         className="chat-markdown-copy-button"
@@ -189,25 +256,68 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNo
       >
         {copied ? <CheckIcon className="size-3" /> : <CopyIcon className="size-3" />}
       </button>
-      {children}
+      <div className="chat-markdown-numbered-code">
+        <div className="chat-markdown-code-line-numbers" aria-hidden="true">
+          {visibleLines.map((_line, index) => (
+            <span className="chat-markdown-code-line" key={index}>
+              <span className="chat-markdown-code-line-number">{index + 1}</span>
+            </span>
+          ))}
+        </div>
+        <div className="chat-markdown-code-content">
+          <CodeHighlightErrorBoundary
+            fallback={
+              <pre>
+                <code>{visibleCode}</code>
+              </pre>
+            }
+          >
+            <Suspense
+              fallback={
+                <pre>
+                  <code>{visibleCode}</code>
+                </pre>
+              }
+            >
+              <SuspenseShikiCodeBlock
+                code={visibleCode}
+                language={language}
+                themeName={themeName}
+                isStreaming={isStreaming}
+              />
+            </Suspense>
+          </CodeHighlightErrorBoundary>
+        </div>
+      </div>
+      {isCollapsible ? (
+        <button
+          type="button"
+          className="chat-markdown-collapse-button"
+          onClick={() => setIsExpanded((value) => !value)}
+          aria-label={collapseButtonLabel}
+          title={collapseButtonLabel}
+        >
+          {isExpanded ? <ChevronUpIcon className="size-3.5" /> : <ChevronDownIcon className="size-3.5" />}
+          <span>{isExpanded ? "Show less" : `Show all ${allLines.length} lines`}</span>
+        </button>
+      ) : null}
     </div>
   );
 }
 
 interface SuspenseShikiCodeBlockProps {
-  className: string | undefined;
   code: string;
+  language: string;
   themeName: DiffThemeName;
   isStreaming: boolean;
 }
 
 function SuspenseShikiCodeBlock({
-  className,
   code,
+  language,
   themeName,
   isStreaming,
 }: SuspenseShikiCodeBlockProps) {
-  const language = extractFenceLanguage(className);
   const cacheKey = createHighlightCacheKey(code, language, themeName);
   const cachedHighlightedHtml = !isStreaming ? highlightedCodeCache.get(cacheKey) : null;
 
@@ -587,18 +697,12 @@ function ChatMarkdown({
         }
 
         return (
-          <MarkdownCodeBlock code={codeBlock.code}>
-            <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
-              <Suspense fallback={<pre {...props}>{children}</pre>}>
-                <SuspenseShikiCodeBlock
-                  className={codeBlock.className}
-                  code={codeBlock.code}
-                  themeName={diffThemeName}
-                  isStreaming={isStreaming}
-                />
-              </Suspense>
-            </CodeHighlightErrorBoundary>
-          </MarkdownCodeBlock>
+          <MarkdownCodeBlock
+            className={codeBlock.className}
+            code={codeBlock.code}
+            themeName={diffThemeName}
+            isStreaming={isStreaming}
+          />
         );
       },
     }),

--- a/t3code/apps/web/src/index.css
+++ b/t3code/apps/web/src/index.css
@@ -426,6 +426,7 @@ label:has(> select#reasoning-effort) select {
 
 .chat-markdown .chat-markdown-codeblock {
   --chat-markdown-codeblock-copy-button-space: 1.5rem;
+  --chat-markdown-codeblock-gutter-width: 2.75rem;
   position: relative;
   margin: 0.65rem 0;
 }
@@ -433,6 +434,56 @@ label:has(> select#reasoning-effort) select {
 .chat-markdown .chat-markdown-codeblock pre {
   margin: 0;
   padding-right: calc(0.9rem + var(--chat-markdown-codeblock-copy-button-space));
+}
+
+.chat-markdown .chat-markdown-numbered-code {
+  display: grid;
+  grid-template-columns: var(--chat-markdown-codeblock-gutter-width) minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--muted) 78%, var(--background));
+  transition: max-height 180ms ease;
+}
+
+.chat-markdown .chat-markdown-numbered-code pre {
+  border: none;
+  border-radius: 0;
+}
+
+.chat-markdown .chat-markdown-code-line-numbers {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  background: color-mix(in srgb, var(--muted) 72%, var(--background));
+  padding: 0.8rem 0.55rem;
+  color: var(--muted-foreground);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  line-height: 1.35rem;
+  user-select: none;
+}
+
+.chat-markdown .chat-markdown-code-line {
+  display: block;
+  min-height: 1.35rem;
+  text-align: right;
+}
+
+.chat-markdown .chat-markdown-code-content {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.chat-markdown .chat-markdown-code-content pre {
+  min-height: 100%;
+  background: transparent !important;
+  padding-left: 0.9rem;
+}
+
+.chat-markdown .chat-markdown-code-content code {
+  line-height: 1.35rem;
 }
 
 .chat-markdown .chat-markdown-copy-button {
@@ -467,6 +518,30 @@ label:has(> select#reasoning-effort) select {
 .chat-markdown .chat-markdown-copy-button:hover {
   color: var(--foreground);
   border-color: color-mix(in srgb, var(--border) 70%, var(--foreground));
+}
+
+.chat-markdown .chat-markdown-collapse-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--background) 84%, transparent);
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding: 0.3rem 0.5rem;
+  transition:
+    color 120ms ease,
+    border-color 120ms ease,
+    background-color 120ms ease;
+}
+
+.chat-markdown .chat-markdown-collapse-button:hover {
+  border-color: color-mix(in srgb, var(--border) 70%, var(--foreground));
+  color: var(--foreground);
 }
 
 .chat-markdown .chat-markdown-shiki .shiki {


### PR DESCRIPTION
/claim #837

## Summary

Completes ChatMarkdown code-block controls for T3 Code.

Implemented behavior:
- keeps existing Shiki highlighting and copy support
- auto-detects common unlabeled fences such as JavaScript, TypeScript, Python, Bash, JSON, HTML, and CSS
- displays a stable line-number gutter for fenced code blocks
- collapses code blocks longer than 20 lines to a 10-line preview by default
- expands and collapses long blocks with an accessible control
- copies the full source text even while a long block is visually collapsed
- leaves inline code spans untouched

## Verification

```text
npx bun@1.3.14 run --filter @t3tools/web typecheck
@t3tools/web typecheck: Exited with code 0

git diff --check
passed
```

I also attempted the focused browser test command:

```text
npx bun@1.3.14 run --filter @t3tools/web test:browser -- src/components/ChatMarkdown.browser.tsx
```

It could not run in this environment because Playwright's Chromium binary was missing, and the browser install command timed out before producing the binary. The browser tests are included in this PR for CI/reviewer execution.

## Notes

I included `t3code/apps/web/.audit.json` with safe contributor metadata, but I did not paste hidden system/developer/runtime instructions into a public repository file because those instructions are private.