### PR TITLE
Codex [ Laravel ] Implement audit logging trait for Eloquent model change tracking

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+    "agent_name": "Codex",
+    "config_snapshot": "Unavailable: hidden platform/runtime instructions and private session context cannot be disclosed. This file intentionally contains only safe provenance metadata.",
+    "created": "2026-05-23T19:35:00Z"
+}

--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable([
+    'auditable_type',
+    'auditable_id',
+    'event',
+    'old_values',
+    'new_values',
+    'user_id',
+    'ip_address',
+    'user_agent',
+])]
+class AuditLog extends Model
+{
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Request;
+
+trait Auditable
+{
+    /**
+     * Attributes that must never be persisted to audit payloads.
+     *
+     * @var array<int, string>
+     */
+    protected static array $auditSensitiveFields = [
+        'password',
+        'remember_token',
+    ];
+
+    public static function bootAuditable(): void
+    {
+        static::created(function ($model): void {
+            $model->recordAudit('created', [], $model->auditSnapshot($model->getAttributes()));
+        });
+
+        static::updated(function ($model): void {
+            $changes = $model->getChanges();
+            unset($changes['updated_at']);
+
+            if ($changes === []) {
+                return;
+            }
+
+            $oldValues = [];
+            foreach (array_keys($changes) as $attribute) {
+                $oldValues[$attribute] = $model->getOriginal($attribute);
+            }
+
+            $model->recordAudit(
+                'updated',
+                $model->auditSnapshot($oldValues),
+                $model->auditSnapshot($changes),
+            );
+        });
+
+        static::deleted(function ($model): void {
+            $model->recordAudit('deleted', $model->auditSnapshot($model->getOriginal()), []);
+        });
+    }
+
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    public function getAuditHistory()
+    {
+        return $this->auditLogs()
+            ->latest()
+            ->get();
+    }
+
+    /**
+     * @param array<string, mixed> $oldValues
+     * @param array<string, mixed> $newValues
+     */
+    protected function recordAudit(string $event, array $oldValues, array $newValues): void
+    {
+        AuditLog::query()->create([
+            'auditable_type' => static::class,
+            'auditable_id' => (string) $this->getKey(),
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => Auth::id(),
+            'ip_address' => Request::ip(),
+            'user_agent' => Request::userAgent(),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     * @return array<string, mixed>
+     */
+    protected function auditSnapshot(array $attributes): array
+    {
+        return collect($attributes)
+            ->except(static::$auditSensitiveFields)
+            ->all();
+    }
+}

--- a/laravel/database/migrations/2026_05_23_000000_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_05_23_000000_create_audit_logs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->string('auditable_id');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditLoggingTest.php
+++ b/laravel/tests/Feature/AuditLoggingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_user_generates_audit_log_without_sensitive_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Ada',
+            'email' => 'ada@example.com',
+            'password' => 'secret-password',
+        ]);
+
+        $log = AuditLog::query()->sole();
+
+        $this->assertSame(User::class, $log->auditable_type);
+        $this->assertSame((string) $user->getKey(), $log->auditable_id);
+        $this->assertSame('created', $log->event);
+        $this->assertSame([], $log->old_values);
+        $this->assertSame('Ada', $log->new_values['name']);
+        $this->assertSame('ada@example.com', $log->new_values['email']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+    }
+
+    public function test_updating_user_generates_audit_log_with_changed_old_and_new_values(): void
+    {
+        $user = User::factory()->create(['name' => 'Before']);
+        AuditLog::query()->delete();
+
+        $user->update(['name' => 'After']);
+
+        $log = AuditLog::query()->sole();
+
+        $this->assertSame('updated', $log->event);
+        $this->assertSame(['name' => 'Before'], $log->old_values);
+        $this->assertSame(['name' => 'After'], $log->new_values);
+    }
+
+    public function test_deleting_user_generates_audit_log_with_old_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Grace',
+            'email' => 'grace@example.com',
+        ]);
+        AuditLog::query()->delete();
+
+        $user->delete();
+
+        $log = AuditLog::query()->sole();
+
+        $this->assertSame('deleted', $log->event);
+        $this->assertSame('Grace', $log->old_values['name']);
+        $this->assertSame('grace@example.com', $log->old_values['email']);
+        $this->assertSame([], $log->new_values);
+    }
+
+    public function test_audit_history_is_reverse_chronological_and_includes_authenticated_metadata(): void
+    {
+        $actor = User::withoutEvents(fn () => User::factory()->create());
+
+        $this->actingAs($actor);
+        $this->app['request']->server->set('REMOTE_ADDR', '203.0.113.10');
+        $this->app['request']->headers->set('User-Agent', 'AuditTest/1.0');
+
+        $user = User::factory()->create(['name' => 'First']);
+        $user->update(['name' => 'Second']);
+
+        $history = $user->getAuditHistory();
+
+        $this->assertSame(['updated', 'created'], $history->pluck('event')->all());
+        $this->assertTrue($history->every(fn (AuditLog $log) => $log->user_id === $actor->id));
+        $this->assertTrue($history->every(fn (AuditLog $log) => $log->ip_address === '203.0.113.10'));
+        $this->assertTrue($history->every(fn (AuditLog $log) => $log->user_agent === 'AuditTest/1.0'));
+    }
+}


### PR DESCRIPTION
/claim #786

## Summary
- Added an `Auditable` trait that records created, updated, and deleted model events.
- Added an `AuditLog` model and migration with auditable target, event, JSON old/new values, user ID, IP address, user agent, and timestamps.
- Applied auditing to the `User` model and added `getAuditHistory()` reverse-chronological lookup.
- Added feature coverage for create, update, delete, sensitive-field filtering, authenticated user metadata, and audit history ordering.

## Verification
- `git diff --check` passed.
- PHPUnit was not run locally because this environment does not have `php` or `composer` installed.

## Metadata note
- Added safe provenance metadata. I did not paste hidden platform/runtime instructions or private session context.