### PR TITLE
Codex [ Laravel ] Add caching layer and cache health validation

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+    "tool_name": "Codex",
+    "boot_context": "Unavailable: hidden platform/runtime instructions and private session context cannot be disclosed. This file intentionally contains only safe provenance metadata.",
+    "timestamp": "2026-05-23T19:45:00Z"
+}

--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status';
+
+    protected $description = 'Display active cache store health status';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $status = $healthCheck->check();
+
+        $this->table(
+            ['Driver', 'Available', 'Latency (ms)'],
+            [[
+                $status['driver'],
+                $status['available'] ? 'yes' : 'no',
+                number_format($status['latency_ms'], 2),
+            ]],
+        );
+
+        if (! $status['available'] && isset($status['error'])) {
+            $this->error($status['error']);
+        }
+
+        return $status['available'] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Cache;
+use Throwable;
+
+class CacheHealthCheck
+{
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float, error?: string, message?: string}
+     */
+    public function check(): array
+    {
+        $driver = (string) config('cache.default', 'array');
+
+        if (! config('cache.health_check_enabled', true)) {
+            return [
+                'available' => true,
+                'driver' => $driver,
+                'latency_ms' => 0.0,
+                'message' => 'disabled',
+            ];
+        }
+
+        $start = microtime(true);
+
+        try {
+            $store = Cache::store($driver);
+            $this->probe($store);
+
+            return [
+                'available' => true,
+                'driver' => $driver,
+                'latency_ms' => $this->latencySince($start),
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'available' => false,
+                'driver' => $driver,
+                'latency_ms' => $this->latencySince($start),
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+
+    protected function probe(Repository $store): void
+    {
+        $key = 'cache-health-check:'.bin2hex(random_bytes(8));
+        $value = bin2hex(random_bytes(8));
+
+        $store->put($key, $value, now()->addSeconds(
+            (int) config('cache.health_check_interval', 300)
+        ));
+
+        if ($store->get($key) !== $value) {
+            throw new \RuntimeException('Cache read/write verification failed');
+        }
+
+        $store->forget($key);
+    }
+
+    protected function latencySince(float $start): float
+    {
+        return round((microtime(true) - $start) * 1000, 2);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\CacheStatusCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -10,6 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        CacheStatusCommand::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -17,6 +17,10 @@ return [
 
     'default' => env('CACHE_STORE', 'database'),
 
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
     /*
     |--------------------------------------------------------------------------
     | Cache Stores

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    $status = $healthCheck->check();
+
+    return response()->json($status, $status['available'] ? 200 : 503);
 });

--- a/laravel/tests/Feature/CacheHealthCheckTest.php
+++ b/laravel/tests/Feature/CacheHealthCheckTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    public function test_cache_health_check_reports_active_store_availability(): void
+    {
+        config()->set('cache.default', 'array');
+        config()->set('cache.health_check_enabled', true);
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('array', $status['driver']);
+        $this->assertIsFloat($status['latency_ms']);
+        $this->assertGreaterThanOrEqual(0.0, $status['latency_ms']);
+    }
+
+    public function test_cache_health_check_respects_disabled_config(): void
+    {
+        config()->set('cache.default', 'array');
+        config()->set('cache.health_check_enabled', false);
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('array', $status['driver']);
+        $this->assertSame(0.0, $status['latency_ms']);
+        $this->assertSame('disabled', $status['message']);
+    }
+
+    public function test_cache_status_command_outputs_driver_and_availability(): void
+    {
+        config()->set('cache.default', 'array');
+
+        $this->artisan('cache:status')
+            ->expectsOutputToContain('Driver')
+            ->expectsOutputToContain('Available')
+            ->expectsOutputToContain('array')
+            ->expectsOutputToContain('yes')
+            ->assertExitCode(0);
+    }
+
+    public function test_cache_health_endpoint_returns_healthy_json(): void
+    {
+        config()->set('cache.default', 'array');
+
+        $this->getJson('/health/cache')
+            ->assertOk()
+            ->assertJsonPath('available', true)
+            ->assertJsonPath('driver', 'array');
+    }
+
+    public function test_cache_health_endpoint_returns_503_when_unavailable(): void
+    {
+        $this->mock(CacheHealthCheck::class, function ($mock): void {
+            $mock->shouldReceive('check')->once()->andReturn([
+                'available' => false,
+                'driver' => 'redis',
+                'latency_ms' => 0.0,
+                'error' => 'connection refused',
+            ]);
+        });
+
+        $this->getJson('/health/cache')
+            ->assertStatus(503)
+            ->assertJsonPath('available', false)
+            ->assertJsonPath('driver', 'redis')
+            ->assertJsonPath('error', 'connection refused');
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::store('array')->flush();
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
/claim #747

## Summary
- Added `App\Services\CacheHealthCheck` to probe the active Laravel cache store with read/write/delete verification and latency reporting.
- Added `cache:status` command registered in `bootstrap/app.php` with driver, availability, and latency output.
- Added `GET /health/cache`, returning 200 for healthy cache status and 503 when the health checker reports unavailable.
- Added cache health config defaults: `health_check_enabled` and `health_check_interval`.
- Added feature tests for healthy service status, disabled config, command output, healthy endpoint, and unavailable endpoint behavior.

## Verification
- `git diff --check` passed.
- PHPUnit was not run locally because this environment does not have `php` or `composer` installed.

## Metadata note
- Added safe provenance metadata. I did not paste hidden platform/runtime instructions or private session context.