### PR TITLE
Codex [ Laravel ] Add email verification flow

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+    "contributor": "Codex",
+    "environment_config": "Unavailable: hidden platform/runtime instructions and private session context cannot be disclosed. This file intentionally contains only safe audit metadata.",
+    "completed_at": "2026-05-23T19:55:00Z"
+}

--- a/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
+++ b/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureEmailIsVerified
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail()) {
+            return redirect()->route('verification.notice');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,8 +2,9 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Notifications\CustomVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,10 +13,15 @@ use Illuminate\Notifications\Notifiable;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify(new CustomVerifyEmail);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Notifications/CustomVerifyEmail.php
+++ b/laravel/app/Notifications/CustomVerifyEmail.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomVerifyEmail extends VerifyEmail
+{
+    public function toMail($notifiable): MailMessage
+    {
+        $verificationUrl = $this->verificationUrl($notifiable);
+
+        return (new MailMessage)
+            ->subject('Verify your Laravel account email')
+            ->view('emails.verify-email', [
+                'url' => $verificationUrl,
+                'user' => $notifiable,
+            ]);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureEmailIsVerified;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'verified' => EnsureEmailIsVerified::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/config/mail.php
+++ b/laravel/config/mail.php
@@ -16,6 +16,8 @@ return [
 
     'default' => env('MAIL_MAILER', 'log'),
 
+    'fallback_mailer' => env('MAIL_FALLBACK_MAILER', 'log'),
+
     /*
     |--------------------------------------------------------------------------
     | Mailer Configurations
@@ -82,8 +84,8 @@ return [
         'failover' => [
             'transport' => 'failover',
             'mailers' => [
-                'smtp',
-                'log',
+                env('MAIL_PRIMARY_MAILER', 'smtp'),
+                env('MAIL_FALLBACK_MAILER', 'log'),
             ],
             'retry_after' => 60,
         ],

--- a/laravel/resources/views/auth/verify-email.blade.php
+++ b/laravel/resources/views/auth/verify-email.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Verify Email</title>
+</head>
+<body>
+    <h1>Verify your email address</h1>
+    <p>Please check your inbox for a verification link before continuing.</p>
+
+    @if (session('status') === 'verification-link-sent')
+        <p>A new verification link has been sent to your email address.</p>
+    @endif
+</body>
+</html>

--- a/laravel/resources/views/emails/verify-email.blade.php
+++ b/laravel/resources/views/emails/verify-email.blade.php
@@ -1,0 +1,11 @@
+<h1>Welcome to Laravel</h1>
+
+<p>Hello {{ $user->name ?? 'there' }},</p>
+
+<p>Please verify your email address to finish setting up your account.</p>
+
+<p>
+    <a href="{{ $url }}">Verify email address</a>
+</p>
+
+<p>If you did not create this account, no further action is required.</p>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,36 @@
 <?php
 
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/email/verify', function () {
+    return view('auth.verify-email');
+})->middleware('auth')->name('verification.notice');
+
+Route::get('/email/verify/{id}/{hash}', function (EmailVerificationRequest $request) {
+    if ($request->user()->hasVerifiedEmail()) {
+        return redirect('/');
+    }
+
+    if ($request->user()->markEmailAsVerified()) {
+        event(new Verified($request->user()));
+    }
+
+    return redirect('/');
+})->middleware(['auth', 'signed'])->name('verification.verify');
+
+Route::post('/email/verification-notification', function (Request $request) {
+    if ($request->user()->hasVerifiedEmail()) {
+        return redirect('/');
+    }
+
+    $request->user()->sendEmailVerificationNotification();
+
+    return back()->with('status', 'verification-link-sent');
+})->middleware(['auth', 'throttle:1,1'])->name('verification.send');

--- a/laravel/tests/Feature/EmailVerificationTest.php
+++ b/laravel/tests/Feature/EmailVerificationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\CustomVerifyEmail;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class EmailVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_signed_verification_link_marks_user_verified(): void
+    {
+        Event::fake([Verified::class]);
+        $user = User::factory()->unverified()->create();
+
+        $url = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->getEmailForVerification())],
+        );
+
+        $this->actingAs($user)->get($url)
+            ->assertRedirect('/');
+
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
+        Event::assertDispatched(Verified::class);
+    }
+
+    public function test_resend_endpoint_sends_custom_verification_notification(): void
+    {
+        Notification::fake();
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertRedirect()
+            ->assertSessionHas('status', 'verification-link-sent');
+
+        Notification::assertSentTo($user, CustomVerifyEmail::class);
+    }
+
+    public function test_verified_users_do_not_receive_duplicate_verification_notification(): void
+    {
+        Notification::fake();
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertRedirect('/');
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_unverified_users_are_redirected_from_verified_routes(): void
+    {
+        Route::middleware(['web', 'verified'])->get('/verified-only-test', fn () => 'ok');
+
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)
+            ->get('/verified-only-test')
+            ->assertRedirect('/email/verify');
+    }
+
+    public function test_mail_fallback_configuration_is_available(): void
+    {
+        config()->set('mail.fallback_mailer', 'log');
+
+        $this->assertSame('log', config('mail.fallback_mailer'));
+        $this->assertContains(config('mail.fallback_mailer'), config('mail.mailers.failover.mailers'));
+    }
+}


### PR DESCRIPTION
/claim #756

## Summary
- Enabled `MustVerifyEmail` on `User` and routed verification notifications through `CustomVerifyEmail`.
- Added signed email verification and throttled resend routes.
- Added `EnsureEmailIsVerified` middleware alias plus a verification notice page.
- Added branded verification email Blade template.
- Added `fallback_mailer` config and failover mailer wiring using `MAIL_PRIMARY_MAILER` + `MAIL_FALLBACK_MAILER`.
- Added feature tests covering signed verification, resend notification, duplicate resend skip for verified users, verified middleware redirect, and fallback mail config.

## Verification
- `git diff --check` passed.
- PHPUnit was not run locally because this environment does not have `php` or `composer` installed.

## Metadata note
- Added safe audit metadata. I did not paste hidden platform/runtime instructions or private session context.