### PR TITLE
Codex [ Laravel ] Add global query scope and User observer

### DIFF
--- a/laravel/app/.attribution.json
+++ b/laravel/app/.attribution.json
@@ -1,0 +1,5 @@
+{
+    "tool": "Codex",
+    "platform_config": "Unavailable: hidden platform/runtime instructions and private session context cannot be disclosed. This file intentionally contains only safe attribution metadata.",
+    "date": "2026-05-23T20:05:00Z"
+}

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class UserObserver
+{
+    public function creating(User $user): void
+    {
+        if (empty($user->uuid)) {
+            $user->uuid = (string) Str::uuid();
+        }
+    }
+
+    public function created(User $user): void
+    {
+        Log::info('User created', ['user_id' => $user->id, 'uuid' => $user->uuid]);
+    }
+
+    public function deleted(User $user): void
+    {
+        Log::info('User deleted', ['user_id' => $user->id, 'uuid' => $user->uuid]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
+        Model::preventLazyLoading(! $this->app->isProduction());
     }
 }

--- a/laravel/app/Scopes/ActiveScope.php
+++ b/laravel/app/Scopes/ActiveScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ActiveScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where($model->qualifyColumn('active'), true);
+    }
+}

--- a/laravel/database/migrations/2026_05_23_000001_add_uuid_to_users_table.php
+++ b/laravel/database/migrations/2026_05_23_000001_add_uuid_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->uuid('uuid')->nullable()->unique()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropUnique(['uuid']);
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/laravel/tests/Feature/ModelScopeObserverTest.php
+++ b/laravel/tests/Feature/ModelScopeObserverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Scopes\ActiveScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ModelScopeObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_scope_filters_active_records_and_can_be_removed(): void
+    {
+        Schema::create('active_scope_test_models', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+
+        ActiveScopeTestModel::query()->create(['name' => 'visible', 'active' => true]);
+        ActiveScopeTestModel::query()->create(['name' => 'hidden', 'active' => false]);
+
+        $this->assertSame(['visible'], ActiveScopeTestModel::query()->pluck('name')->all());
+        $this->assertSame(
+            ['visible', 'hidden'],
+            ActiveScopeTestModel::withoutGlobalScope(ActiveScope::class)
+                ->orderBy('id')
+                ->pluck('name')
+                ->all(),
+        );
+    }
+
+    public function test_user_observer_assigns_uuid_and_logs_lifecycle_events(): void
+    {
+        Log::spy();
+
+        $user = User::factory()->create();
+
+        $this->assertNotEmpty($user->uuid);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+            $user->uuid,
+        );
+        Log::shouldHaveReceived('info')
+            ->with('User created', ['user_id' => $user->id, 'uuid' => $user->uuid])
+            ->once();
+
+        $user->delete();
+
+        Log::shouldHaveReceived('info')
+            ->with('User deleted', ['user_id' => $user->id, 'uuid' => $user->uuid])
+            ->once();
+    }
+
+    public function test_lazy_loading_prevention_is_enabled_outside_production(): void
+    {
+        $this->assertTrue(Model::preventsLazyLoading());
+    }
+}
+
+class ActiveScopeTestModel extends Model
+{
+    protected $table = 'active_scope_test_models';
+
+    protected $guarded = [];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new ActiveScope);
+    }
+}


### PR DESCRIPTION
/claim #792

## Summary
- Added reusable `ActiveScope` that filters opt-in models to `active = true` while preserving `withoutGlobalScope` opt-out.
- Added `UserObserver` that assigns UUIDs before user creation and logs created/deleted lifecycle events.
- Added a users table migration for nullable unique `uuid` values.
- Registered the observer and non-production lazy-loading prevention in `AppServiceProvider`.
- Added feature tests for active scope filtering/opt-out, UUID/log observer behavior, and lazy-loading prevention.

## Verification
- `git diff --check` passed.
- PHPUnit was not run locally because this environment does not have `php` or `composer` installed.

## Metadata note
- Added safe attribution metadata. I did not paste hidden platform/runtime instructions or private session context.