### PR TITLE
lakumoki [Crypto] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,34 +14,55 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
-    uint256 public MAX_STALENESS = 3600;
+    uint256 public MAX_STALENESS;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed oracle, uint256 lastUpdated);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed, uint256 _maxStaleness) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
+        MAX_STALENESS = _maxStaleness > 0 ? _maxStaleness : 3600;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
+        (bool primaryOk, int256 primaryPrice, uint256 primaryUpdatedAt) = _fetchPrice(primaryFeed);
+
+        if (primaryOk) {
+            emit PriceQueried(primaryPrice, primaryUpdatedAt);
+            return primaryPrice;
+        }
+
+        emit StalePrice(address(primaryFeed), primaryUpdatedAt);
+
+        (bool fallbackOk, int256 fallbackPrice, uint256 fallbackUpdatedAt) = _fetchPrice(fallbackFeed);
+        require(fallbackOk, "Both oracles returned stale or invalid data");
+
+        emit PriceQueried(fallbackPrice, fallbackUpdatedAt);
+        return fallbackPrice;
+    }
+
+    function _fetchPrice(AggregatorV3Interface feed)
+        internal
+        view
+        returns (bool ok, int256 price, uint256 updatedAt)
+    {
         (
             uint80 roundId,
-            int256 price,
+            int256 answer,
             ,
-            uint256 updatedAt,
+            uint256 updatedAt_,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) = feed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        if (answer <= 0) return (false, 0, updatedAt_);
+        if (answeredInRound < roundId) return (false, 0, updatedAt_);
+        if (block.timestamp - updatedAt_ >= MAX_STALENESS) return (false, 0, updatedAt_);
 
-        return price;
+        return (true, answer, updatedAt_);
     }
 
     function getDecimals() external view returns (uint8) {
@@ -50,6 +71,7 @@ contract PriceOracle {
 
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
+        require(_maxStaleness > 0, "Staleness must be > 0");
         MAX_STALENESS = _maxStaleness;
     }
 }


### PR DESCRIPTION
## Fix for #915

### Changes
- Added `require(price > 0)` to reject negative/zero prices
- Added `require(answeredInRound >= roundId)` for round completeness
- Added staleness check with configurable `MAX_STALENESS`
- Added fallback oracle that activates when primary returns stale data
- Emits `StalePrice` event when falling back to secondary oracle
- Reverts when both oracles return stale/invalid data

Closes #915

Made with [Cursor](https://cursor.com)