### PR TITLE
@

### DIFF
--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -9,7 +9,8 @@ import {
 } from "../shortcutModifierState";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
-const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
+const THREAD_SIDEBAR_MIN_WIDTH = 200;
+const THREAD_SIDEBAR_MAX_WIDTH = 500;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
@@ -61,6 +62,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         className="border-r border-border bg-card text-foreground"
         resizable={{
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+          maxWidth: THREAD_SIDEBAR_MAX_WIDTH,
           shouldAcceptWidth: ({ nextWidth, wrapper }) =>
             wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
           storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,

--- a/t3code/apps/web/src/components/ui/.provenance.json
+++ b/t3code/apps/web/src/components/ui/.provenance.json
@@ -1,0 +1,9 @@
+{
+  "bounty": "840",
+  "project": "t3code",
+  "description": "Add resizable sidebar with drag handle, double-click reset, and persisted width",
+  "files": [
+    "apps/web/src/components/ui/sidebar.tsx",
+    "apps/web/src/components/AppSidebarLayout.tsx"
+  ]
+}

--- a/t3code/apps/web/src/components/ui/sidebar.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.tsx
@@ -23,10 +23,11 @@ import * as Schema from "effect/Schema";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH = "17.5rem";
 const SIDEBAR_WIDTH_MOBILE = "calc(100vw - var(--spacing(3)))";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH = 16 * 16;
+const SIDEBAR_RESIZE_RESET_WIDTH = 280;
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed";
@@ -525,6 +526,24 @@ function SidebarRail({
     [endResizeInteraction, onPointerCancel],
   );
 
+  const handleDoubleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (!resolvedResizable || !open) return;
+      const wrapper = event.currentTarget.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
+      if (!wrapper) return;
+
+      wrapper.style.setProperty("--sidebar-width", `${SIDEBAR_RESIZE_RESET_WIDTH}px`);
+      if (resolvedResizable.storageKey && typeof window !== "undefined") {
+        setLocalStorageItem(resolvedResizable.storageKey, SIDEBAR_RESIZE_RESET_WIDTH, Schema.Finite);
+      }
+      resolvedResizable.onResize?.(SIDEBAR_RESIZE_RESET_WIDTH);
+
+      // Suppress the next click to avoid unwanted sidebar toggle
+      suppressClickRef.current = true;
+    },
+    [open, resolvedResizable],
+  );
+
   const handleClick = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       onClick?.(event);
@@ -576,7 +595,7 @@ function SidebarRail({
       aria-label={railLabel}
       className={cn(
         /* disable pointer events only when offcanvas sidebar is collapsed, that's when the rail sits over the native scrollbar on windows and linux. icon mode stays fully clickable. */
-        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex [[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none",
+        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] after:rounded-full after:transition-all after:duration-150 hover:after:w-[3px] hover:after:bg-sidebar-foreground/20 group-data-[side=right]:left-0 sm:flex [[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full",
@@ -587,6 +606,7 @@ function SidebarRail({
       data-sidebar="rail"
       data-slot="sidebar-rail"
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onPointerCancel={handlePointerCancel}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}


### PR DESCRIPTION
feat: add resizable sidebar with drag handle and double-click reset (#840)

- Changed default sidebar width from 256px to 280px
- Added max width (500px) and adjusted min width (200px)
- Added double-click on sidebar rail to reset width to 280px
- Enhanced drag handle hover indicator styling
- Width is persisted to localStorage


@