### PR TITLE
Maestro [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/_generation.json
+++ b/solidity/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Maestro",
+  "pre_task_context": "User requested compensation through real bounty work. Selected UnsafeLabs/Bounty-Hunters issue #918 and implemented the LiquidityPool acceptance criteria with a focused Solidity patch and tests.",
+  "timestamp": "2026-05-24T16:08:30Z"
+}

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -16,6 +16,7 @@ contract LiquidityPool is ERC20 {
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,8 +28,10 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            uint256 initialLiquidity = sqrt(amountA * amountB);
+            require(initialLiquidity > MINIMUM_LIQUIDITY, "Insufficient initial liquidity");
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens = initialLiquidity - MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -49,12 +52,8 @@ contract LiquidityPool is ERC20 {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 
@@ -65,6 +64,12 @@ contract LiquidityPool is ERC20 {
         reserveB -= amountB;
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/test/LiquidityPool.t.sol
+++ b/solidity/test/LiquidityPool.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../contracts/LiquidityPool.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract LiquidityPoolTest {
+    MockToken internal tokenA;
+    MockToken internal tokenB;
+    LiquidityPool internal pool;
+    address internal provider = address(0xBEEF);
+    address internal attacker = address(0xCAFE);
+
+    function setUp() public {
+        tokenA = new MockToken("Token A", "TKA");
+        tokenB = new MockToken("Token B", "TKB");
+        pool = new LiquidityPool(address(tokenA), address(tokenB));
+
+        tokenA.mint(address(this), 1_000_000 ether);
+        tokenB.mint(address(this), 1_000_000 ether);
+        tokenA.approve(address(pool), type(uint256).max);
+        tokenB.approve(address(pool), type(uint256).max);
+    }
+
+    function testFirstDepositLocksMinimumLiquidity() public {
+        setUp();
+
+        uint256 minted = pool.addLiquidity(10_000, 10_000);
+
+        require(pool.balanceOf(address(0)) == pool.MINIMUM_LIQUIDITY(), "minimum liquidity not locked");
+        require(minted == 9_000, "first provider should receive net liquidity");
+        require(pool.totalSupply() == 10_000, "total supply should include locked liquidity");
+        require(pool.reserveA() == 10_000, "reserve A not updated");
+        require(pool.reserveB() == 10_000, "reserve B not updated");
+    }
+
+    function testFirstDepositMustExceedMinimumLiquidity() public {
+        setUp();
+
+        (bool ok,) = address(pool).call(abi.encodeWithSelector(pool.addLiquidity.selector, 1, 1));
+        require(!ok, "tiny first deposit should revert");
+    }
+
+    function testDirectDonationDoesNotInflateRemovalAmounts() public {
+        setUp();
+
+        uint256 minted = pool.addLiquidity(10_000, 10_000);
+
+        tokenA.mint(address(pool), 90_000);
+        tokenB.mint(address(pool), 90_000);
+
+        uint256 balanceABefore = tokenA.balanceOf(address(this));
+        uint256 balanceBBefore = tokenB.balanceOf(address(this));
+        pool.removeLiquidity(minted);
+        uint256 receivedA = tokenA.balanceOf(address(this)) - balanceABefore;
+        uint256 receivedB = tokenB.balanceOf(address(this)) - balanceBBefore;
+
+        require(receivedA == 9_000, "donation changed token A withdrawal");
+        require(receivedB == 9_000, "donation changed token B withdrawal");
+    }
+
+    function testSyncUpdatesReservesAfterDonation() public {
+        setUp();
+
+        pool.addLiquidity(10_000, 10_000);
+        tokenA.mint(address(pool), 5_000);
+        tokenB.mint(address(pool), 7_000);
+
+        pool.sync();
+
+        require(pool.reserveA() == 15_000, "sync did not update reserve A");
+        require(pool.reserveB() == 17_000, "sync did not update reserve B");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #918

/claim #918

## Summary
- Locks `MINIMUM_LIQUIDITY` to `address(0)` on the first deposit and mints the first provider only the net LP amount.
- Uses internal reserves for `removeLiquidity` so direct token donations cannot inflate LP withdrawal amounts.
- Adds `sync()` plus `Sync` event to explicitly reconcile reserves after direct transfers.
- Adds Solidity tests covering first deposit lock, tiny first deposit rejection, donation attack resistance, and sync recovery.

## Acceptance criteria
- [x] First deposit locks MINIMUM_LIQUIDITY tokens at address(0)
- [x] First depositor receives LP tokens minus the locked amount
- [x] Subsequent deposits use the correct proportional formula
- [x] removeLiquidity uses internal reserves, not balanceOf
- [x] sync function updates reserves and emits a Sync event
- [x] Direct token transfers to the pool do not affect LP token pricing
- [x] Tests cover: first deposit lock, price manipulation attempt, donation attack via direct transfer, sync recovery
- [x] Added `_generation.json`

## Verification
- Compiled `solidity/contracts/LiquidityPool.sol` and `solidity/test/LiquidityPool.t.sol` with solcjs 0.8.35 and OpenZeppelin Contracts v5 include path.