### PR TITLE
Claude Code [ T3 Code ] Fix ProviderModelPicker not persisting selection across reloads

### DIFF
--- a/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -82,6 +82,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   terminalOpen: boolean;
   onRequestClose?: () => void;
   onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
+  onResetToDefault?: () => void;
 }) {
   const {
     keybindings: providedKeybindings,
@@ -605,6 +606,19 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                 size="sm"
               />
             </div>
+
+            {/* Reset to default */}
+            {props.onResetToDefault && (
+              <div className="border-b px-3 py-1">
+                <button
+                  type="button"
+                  onClick={props.onResetToDefault}
+                  className="text-[11px] text-muted-foreground/50 hover:text-muted-foreground/80 transition-colors"
+                >
+                  Reset to default
+                </button>
+              </div>
+            )}
 
             {/* Model list */}
             <div

--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -3,7 +3,7 @@ import {
   type ProviderDriverKind,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
@@ -19,6 +19,8 @@ import {
 } from "./providerIconUtils";
 import { setModelPickerOpen } from "../../modelPickerOpenState";
 import type { ProviderInstanceEntry } from "../../providerInstances";
+
+const LAST_SELECTION_KEY = "t3code:last-model-picker-selection:v1";
 
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   /**
@@ -45,6 +47,54 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
 }) {
   const [uncontrolledIsMenuOpen, setUncontrolledIsMenuOpen] = useState(false);
   const isMenuOpen = props.open ?? uncontrolledIsMenuOpen;
+
+  // Restore persisted selection on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(LAST_SELECTION_KEY);
+      if (!stored) return;
+      const parsed = JSON.parse(stored) as { instanceId: string; model: string };
+      const instanceId = parsed.instanceId as ProviderInstanceId;
+      if (!instanceId || !parsed.model) return;
+      const entry = props.instanceEntries.find((e) => e.instanceId === instanceId && e.enabled);
+      if (!entry) {
+        localStorage.removeItem(LAST_SELECTION_KEY);
+        return;
+      }
+      const options = props.modelOptionsByInstance.get(instanceId);
+      if (!options?.some((o) => o.slug === parsed.model)) return;
+      if (instanceId !== props.activeInstanceId || parsed.model !== props.model) {
+        props.onInstanceModelChange(instanceId, parsed.model);
+      }
+    } catch {
+      localStorage.removeItem(LAST_SELECTION_KEY);
+    }
+    // Only on mount — deps intentionally empty
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Cross-tab sync via storage event
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== LAST_SELECTION_KEY || !e.newValue) return;
+      try {
+        const parsed = JSON.parse(e.newValue) as { instanceId: string; model: string };
+        const instanceId = parsed.instanceId as ProviderInstanceId;
+        if (!instanceId || !parsed.model) return;
+        const entry = props.instanceEntries.find((e) => e.instanceId === instanceId && e.enabled);
+        if (!entry) return;
+        const options = props.modelOptionsByInstance.get(instanceId);
+        if (!options?.some((o) => o.slug === parsed.model)) return;
+        if (instanceId !== props.activeInstanceId || parsed.model !== props.model) {
+          props.onInstanceModelChange(instanceId, parsed.model);
+        }
+      } catch {
+        // Ignore parse errors from other tabs
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [props.activeInstanceId, props.model, props.instanceEntries, props.modelOptionsByInstance, props.onInstanceModelChange]);
 
   // Resolve the active instance entry by exact routing key. The composer
   // resolves fallbacks before rendering this component; if the selected
@@ -88,9 +138,26 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
 
   const handleInstanceModelChange = (instanceId: ProviderInstanceId, model: string) => {
     if (props.disabled) return;
+    try {
+      localStorage.setItem(LAST_SELECTION_KEY, JSON.stringify({ instanceId, model }));
+    } catch {
+      // Ignore storage quota errors
+    }
     props.onInstanceModelChange(instanceId, model);
     setIsMenuOpen(false);
   };
+
+  const handleResetToDefault = useCallback(() => {
+    localStorage.removeItem(LAST_SELECTION_KEY);
+    const firstEntry = props.instanceEntries[0];
+    if (firstEntry) {
+      const options = props.modelOptionsByInstance.get(firstEntry.instanceId);
+      if (options?.[0]) {
+        props.onInstanceModelChange(firstEntry.instanceId, options[0].slug);
+      }
+    }
+    setIsMenuOpen(false);
+  }, [props.instanceEntries, props.modelOptionsByInstance, props.onInstanceModelChange]);
 
   return (
     <Popover
@@ -180,6 +247,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           terminalOpen={props.terminalOpen ?? false}
           onRequestClose={() => setIsMenuOpen(false)}
           onInstanceModelChange={handleInstanceModelChange}
+          onResetToDefault={handleResetToDefault}
         />
       </PopoverPopup>
     </Popover>

--- a/t3code/apps/web/src/components/chat/_generation.json
+++ b/t3code/apps/web/src/components/chat/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Claude Code (Claude Opus 4.7 via DeepSeek V4 Pro backend)",
+  "pre_task_context": "Session start: Read CLAUDE.md, session_handoff.md, agent_safety_rules.md. Previous task: PR #4098 (ARIA + keyboard nav for ChatView, #852) submitted and still open. User (鹿潇) selected next bounty #834: Fix ProviderModelPicker not persisting selection across reloads ($40). Acceptance criteria: persist provider/model to localStorage, restore on mount, fallback gracefully if persisted provider unavailable, reset to default option, cross-tab sync via storage event, localStorage keys namespaced.",
+  "timestamp": "2026-05-25T03:15:00+08:00"
+}


### PR DESCRIPTION
## Summary

- Persist selected provider ID and model ID to localStorage on selection
- Restore persisted selection on mount, with graceful fallback if provider is unavailable
- Add "Reset to default" option in the picker popup
- Cross-tab sync via `window.storage` event
- localStorage key namespaced as `t3code:last-model-picker-selection:v1`

## Changes

- `ProviderModelPicker.tsx` — localStorage write in `handleInstanceModelChange`, restore on mount, storage event listener, `handleResetToDefault` callback
- `ModelPickerContent.tsx` — optional `onResetToDefault` prop, subtle "Reset to default" button below search bar

## Test plan

- [x] `bun run typecheck` — 13/13 passed
- [x] No behavior change when localStorage is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)