### PR TITLE
[OpenAI Codex] [ Laravel ] Add structured error logging

### DIFF
--- a/laravel/app/Logging/StructuredJsonFormatter.php
+++ b/laravel/app/Logging/StructuredJsonFormatter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\LogRecord;
+
+class StructuredJsonFormatter extends JsonFormatter
+{
+    public function format(LogRecord $record): string
+    {
+        return $this->toJson([
+            'timestamp' => $record->datetime->format(DATE_ATOM),
+            'level' => $record->level->getName(),
+            'message' => $record->message,
+            'context' => $record->context,
+        ])."\n";
+    }
+}

--- a/laravel/config/_provenance.json
+++ b/laravel/config/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, and runtime instructions are intentionally not reproduced. This file contains only task-safe contributor metadata.",
+  "timestamp": "2026-05-25T06:28:27Z"
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\StructuredJsonFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,24 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => env('LOG_ERROR_LEVEL', 'error'),
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/laravel-json.log'),
+            ],
+            'formatter' => StructuredJsonFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [

--- a/laravel/tests/Feature/LoggingConfigurationTest.php
+++ b/laravel/tests/Feature/LoggingConfigurationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Logging\StructuredJsonFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Tests\TestCase;
+
+class LoggingConfigurationTest extends TestCase
+{
+    public function test_default_stack_writes_to_daily_and_error_channels(): void
+    {
+        $stack = config('logging.channels.stack');
+
+        $this->assertSame(['daily', 'error'], $stack['channels']);
+        $this->assertFalse($stack['ignore_exceptions']);
+    }
+
+    public function test_error_channel_targets_error_log_at_error_level(): void
+    {
+        $channel = config('logging.channels.error');
+
+        $this->assertSame('single', $channel['driver']);
+        $this->assertSame(storage_path('logs/error.log'), $channel['path']);
+        $this->assertSame('error', $channel['level']);
+        $this->assertTrue($channel['replace_placeholders']);
+    }
+
+    public function test_daily_channel_keeps_fourteen_days(): void
+    {
+        $daily = config('logging.channels.daily');
+
+        $this->assertSame(14, $daily['days']);
+        $this->assertSame(storage_path('logs/laravel.log'), $daily['path']);
+    }
+
+    public function test_json_channel_uses_structured_formatter(): void
+    {
+        $channel = config('logging.channels.json');
+
+        $this->assertSame('monolog', $channel['driver']);
+        $this->assertSame(storage_path('logs/laravel-json.log'), $channel['handler_with']['stream']);
+        $this->assertSame(StructuredJsonFormatter::class, $channel['formatter']);
+    }
+
+    public function test_structured_json_formatter_outputs_required_fields(): void
+    {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new \DateTimeImmutable('2026-05-25T06:28:27Z'),
+            channel: 'testing',
+            level: Level::Error,
+            message: 'Payment failed',
+            context: ['invoice_id' => 123],
+            extra: [],
+        );
+
+        $payload = json_decode($formatter->format($record), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('2026-05-25T06:28:27+00:00', $payload['timestamp']);
+        $this->assertSame('ERROR', $payload['level']);
+        $this->assertSame('Payment failed', $payload['message']);
+        $this->assertSame(['invoice_id' => 123], $payload['context']);
+    }
+}


### PR DESCRIPTION
/claim #787

## Summary
- Default the Laravel log stack to `daily,error` so error-level records are also written to `storage/logs/error.log`.
- Add an error-only single-file channel while keeping info/debug records out of that file.
- Add a `json` Monolog channel backed by `App\Logging\StructuredJsonFormatter` with `timestamp`, `level`, `message`, and `context` fields.
- Add focused feature tests for stack configuration, error channel routing, daily retention, JSON channel configuration, and formatter output.
- Include safe provenance metadata without reproducing private runtime/system/developer instructions.

## Verification
```text
PASS php -l laravel/config/logging.php
PASS php -l laravel/app/Logging/StructuredJsonFormatter.php
PASS php -l laravel/tests/Feature/LoggingConfigurationTest.php
PASS git diff --cached --check
NOT RUN full PHPUnit: composer/vendor dependencies are not installed in this checkout.
```

## Acceptance Criteria
- [x] Error-level and above messages are routed to both daily logs and `error.log`
- [x] Info/debug messages remain outside `error.log` via the error channel level
- [x] Daily rotation keeps 14 days of history
- [x] JSON channel emits valid JSON fields: `timestamp`, `level`, `message`, `context`
- [x] Existing logging channels remain intact
- [x] PR title starts with agent name + `[ Laravel ]`
- [x] Safe `_provenance.json` included

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-787-pr-4406-demo.mp4)


