### PR TITLE
[OpenAI Codex] [ FastAPI ] Fix jsonable_encoder bytes handling

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, and runtime instructions are intentionally not reproduced. This file contains only task-safe contributor metadata.",
+  "timestamp": "2026-05-25T06:32:40Z"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -81,8 +82,15 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
         return float(dec_value)
 
 
+def _encode_bytes(value: bytes, encoding: str) -> str:
+    if encoding == "base64":
+        return base64.b64encode(value).decode("ascii")
+    if encoding == "hex":
+        return value.hex()
+    raise ValueError('bytes_encoding must be either "base64" or "hex"')
+
+
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -215,6 +223,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            How to encode bytes-like values. Defaults to Base64, and can also
+            be set to ``"hex"``.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -255,6 +272,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +287,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -278,6 +297,10 @@ def jsonable_encoder(
         return obj
     if isinstance(obj, PydanticUndefinedType):
         return None
+    if isinstance(obj, bytes):
+        return _encode_bytes(obj, bytes_encoding)
+    if isinstance(obj, memoryview):
+        return _encode_bytes(obj.tobytes(), bytes_encoding)
     if isinstance(obj, dict):
         encoded_dict = {}
         allowed_keys = set(obj.keys())
@@ -302,6 +325,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +334,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +352,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +387,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -313,6 +313,31 @@ def test_encode_pydantic_undefined():
     assert jsonable_encoder(data) == {"value": None}
 
 
+def test_encode_bytes_defaults_to_base64():
+    assert jsonable_encoder(b"\x00\xffhello") == "AP9oZWxsbw=="
+
+
+def test_encode_memoryview_defaults_to_base64():
+    assert jsonable_encoder(memoryview(b"\x00\xffhello")) == "AP9oZWxsbw=="
+
+
+def test_encode_bytes_as_hex():
+    assert jsonable_encoder(b"\x00\xffhello", bytes_encoding="hex") == "00ff68656c6c6f"
+
+
+def test_encode_nested_bytes_uses_selected_encoding():
+    data = {"payload": [b"\x0f", memoryview(b"\xff")]}
+
+    assert jsonable_encoder(data, bytes_encoding="hex") == {
+        "payload": ["0f", "ff"],
+    }
+
+
+def test_encode_bytes_rejects_unknown_encoding():
+    with pytest.raises(ValueError, match="bytes_encoding"):
+        jsonable_encoder(b"payload", bytes_encoding="utf-8")
+
+
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(
     "module_path",


### PR DESCRIPTION
/claim #759

Summary:
- Encode bytes as base64 by default in jsonable_encoder.
- Encode memoryview values by converting them to bytes first.
- Add bytes_encoding="hex" support and propagate it through nested structures.
- Add focused tests for bytes, memoryview, hex encoding, nested values, and invalid encodings.
- Include safe provenance metadata without exposing private runtime instructions.

Verification:
- python3 -m py_compile fastapi/fastapi/encoders.py fastapi/tests/test_jsonable_encoder.py
- python3 -m json.tool fastapi/fastapi/_provenance.json >/dev/null
- git diff --check -- fastapi/fastapi/encoders.py fastapi/tests/test_jsonable_encoder.py fastapi/fastapi/_provenance.json

Additional verification after setting up the project with uv:
- uv run pytest tests/test_jsonable_encoder.py -q (30 passed, 1 skipped)

Acceptance criteria covered:
- bytes default to base64.
- memoryview values encode without errors.
- bytes_encoding="hex" produces hexadecimal output.
- Existing non-bytes encoder paths remain unchanged except for recursive propagation of the new option.
- Tests cover the new bytes-like behavior and encoding choices.

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-759-pr-4410-demo.mp4)


