### PR TITLE
[OpenAI Codex] [ Laravel ] Add scheduled log cleanup command

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Public task context for GitHub issue #753 in UnsafeLabs/Bounty-Hunters: add a Laravel console closure command that clears storage/logs files older than seven days by default, supports a --days override, reports deleted file count and freed space in human-readable form, schedules the cleanup daily at midnight, and keep private system, developer, runtime, memory, credential, or hidden session instructions out of repository files and PR text.",
+  "timestamp": "2026-05-25T06:42:51Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,77 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
+use Symfony\Component\Console\Command\Command;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days of logs to retain}', function () {
+    $days = (int) $this->option('days');
+
+    if ($days < 1) {
+        $this->error('The --days option must be at least 1.');
+
+        return Command::FAILURE;
+    }
+
+    $logsPath = storage_path('logs');
+
+    if (! File::isDirectory($logsPath)) {
+        $this->info('No log directory found; deleted 0 files and freed 0 B.');
+
+        return Command::SUCCESS;
+    }
+
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deletedFiles = 0;
+    $freedBytes = 0;
+
+    foreach (File::files($logsPath) as $file) {
+        if ($file->getMTime() >= $cutoff) {
+            continue;
+        }
+
+        $fileSize = $file->getSize();
+
+        if (File::delete($file->getPathname())) {
+            $deletedFiles++;
+            $freedBytes += $fileSize;
+        }
+    }
+
+    $formatBytes = static function (int $bytes): string {
+        if ($bytes === 0) {
+            return '0 B';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $value = (float) $bytes;
+        $unitIndex = 0;
+
+        while ($value >= 1024 && $unitIndex < count($units) - 1) {
+            $value /= 1024;
+            $unitIndex++;
+        }
+
+        if ($unitIndex === 0) {
+            return sprintf('%d %s', $bytes, $units[$unitIndex]);
+        }
+
+        return rtrim(rtrim(number_format($value, 2, '.', ''), '0'), '.') . ' ' . $units[$unitIndex];
+    };
+
+    $this->info(sprintf(
+        'Deleted %d log %s and freed %s.',
+        $deletedFiles,
+        $deletedFiles === 1 ? 'file' : 'files',
+        $formatBytes($freedBytes),
+    ));
+
+    return Command::SUCCESS;
+})->purpose('Delete log files older than the configured retention window');
+
+Schedule::command('logs:clear')->dailyAt('00:00');


### PR DESCRIPTION
/claim #753

Summary:
- Added a `logs:clear` Artisan closure command in `laravel/routes/console.php`.
- Default retention is 7 days, with `--days=` override support.
- Reports deleted file count and freed space in human-readable units.
- Registered `logs:clear` to run daily at `00:00`.
- Added safe generation metadata without exposing private runtime instructions.

Verification:
- php -l laravel/routes/console.php
- python3 -m json.tool laravel/_generation.json >/dev/null
- git diff --check -- laravel/routes/console.php laravel/_generation.json

Not run:
- Full Laravel test suite (Composer/vendor dependencies are not installed in this checkout).

Acceptance criteria covered:
- Default command deletes logs older than 7 days.
- `--days=30` overrides retention.
- Output includes deleted file count and freed space.
- Schedule entry runs daily at midnight.

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-753-pr-4413-demo.mp4)


