### PR TITLE
[OpenAI Codex] [ Crypto ] Fix CrossChainBridge replay protection

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,54 +4,113 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "BridgeTransfer(address recipient,uint256 amount,uint256 nonce,uint256 chainId,address verifyingContract)"
+    );
+    uint256 private constant SECP256K1_HALF_ORDER =
+        0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
     IERC20 public bridgeToken;
     address public validator;
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public outboundNonces;
+    mapping(address => uint256) public nonces;
 
-    event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
+    event TransferInitiated(
+        address indexed sender,
+        uint256 amount,
+        uint256 targetChain,
+        uint256 nonce
+    );
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
 
     constructor(address _bridgeToken, address _validator) {
+        require(_bridgeToken != address(0), "Invalid token");
+        require(_validator != address(0), "Invalid validator");
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
-        bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        uint256 senderNonce = outboundNonces[msg.sender];
+        outboundNonces[msg.sender] = senderNonce + 1;
+        nonce++;
+        require(
+            bridgeToken.transferFrom(msg.sender, address(this), amount),
+            "Token transfer failed"
+        );
+        emit TransferInitiated(msg.sender, amount, targetChain, senderNonce);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
+    function domainSeparator() public view returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes("CrossChainBridge")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function transferStructHash(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        return keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce,
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function hashTransfer(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(
+            "\x19\x01",
+            domainSeparator(),
+            transferStructHash(recipient, amount, transferNonce)
+        ));
+    }
+
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(recipient != address(0), "Invalid recipient");
+        require(amount > 0, "Amount must be > 0");
+        require(transferNonce == nonces[recipient], "Invalid nonce");
 
+        bytes32 transferHash = hashTransfer(recipient, amount, transferNonce);
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
-        bridgeToken.transfer(recipient, amount);
+        nonces[recipient] = transferNonce + 1;
+        require(bridgeToken.transfer(recipient, amount), "Token transfer failed");
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
+        return recoverSigner(hash, signature) == validator;
+    }
+
+    function recoverSigner(bytes32 hash, bytes calldata signature) public pure returns (address) {
         require(signature.length == 65, "Invalid signature length");
 
         bytes32 r;
@@ -65,14 +124,18 @@ contract CrossChainBridge {
         }
 
         if (v < 27) v += 27;
+        if (v != 27 && v != 28) {
+            return address(0);
+        }
+        if (uint256(s) > SECP256K1_HALF_ORDER) {
+            return address(0);
+        }
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
-
-        // BUG: Missing require(recovered != address(0))
-        return recovered == validator;
+        address recovered = ecrecover(hash, v, r, s);
+        if (recovered == address(0)) {
+            return address(0);
+        }
+        return recovered;
     }
 
     function getPoolBalance() external view returns (uint256) {

--- a/solidity/contracts/contributor_meta.json
+++ b/solidity/contracts/contributor_meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Safe clean-room provenance only. Private system, developer, runtime, memory, and secret-handling instructions are intentionally not disclosed.",
+  "ts": "2026-05-25T10:40:57Z"
+}
+

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/crossChainBridge.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.3.0",
+    "ethers": "^6.14.4",
+    "ganache": "^7.9.2",
+    "solc": "^0.8.30"
+  }
+}
+

--- a/solidity/test/crossChainBridge.test.mjs
+++ b/solidity/test/crossChainBridge.test.mjs
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(solidityRoot, "..");
+
+const mockTokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Bridge Token", "BRG") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+`;
+
+function resolveImport(importPath) {
+  if (importPath.startsWith("@openzeppelin/")) {
+    const resolved = require.resolve(importPath, { paths: [solidityRoot] });
+    return { contents: readFileSync(resolved, "utf8") };
+  }
+
+  const localPath = path.join(repoRoot, importPath);
+  try {
+    return { contents: readFileSync(localPath, "utf8") };
+  } catch (error) {
+    return { error: `Unable to resolve ${importPath}: ${error.message}` };
+  }
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "solidity/contracts/CrossChainBridge.sol": {
+        content: readFileSync(
+          path.join(solidityRoot, "contracts", "CrossChainBridge.sol"),
+          "utf8",
+        ),
+      },
+      "test/MockToken.sol": {
+        content: mockTokenSource,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: resolveImport }));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  return {
+    bridge: output.contracts["solidity/contracts/CrossChainBridge.sol"].CrossChainBridge,
+    token: output.contracts["test/MockToken.sol"].MockToken,
+  };
+}
+
+async function deploy(contract, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    contract.abi,
+    `0x${contract.evm.bytecode.object}`,
+    signer,
+  );
+  const deployment = await factory.deploy(...args);
+  await deployment.waitForDeployment();
+  return deployment;
+}
+
+async function expectRevert(action, expectedMessage) {
+  try {
+    await action();
+  } catch (error) {
+    const message = String(error.shortMessage ?? error.message);
+    if (expectedMessage !== undefined && !message.includes(expectedMessage)) {
+      assert.match(message, /revert/i);
+    }
+    return;
+  }
+  assert.fail(`Expected revert matching ${expectedMessage}`);
+}
+
+const contracts = compileContracts();
+const ganacheProvider = ganache.provider({
+  chain: { chainId: 31_337 },
+  logging: { quiet: true },
+  wallet: { deterministic: true },
+});
+const provider = new ethers.BrowserProvider(ganacheProvider);
+const initialAccounts = Object.values(ganacheProvider.getInitialAccounts());
+const owner = await provider.getSigner(0);
+const validator = new ethers.Wallet(initialAccounts[1].secretKey);
+const recipient = await provider.getSigner(2);
+const recipientAddress = await recipient.getAddress();
+const attacker = await provider.getSigner(3);
+const attackerAddress = await attacker.getAddress();
+const chainId = 31_337n;
+
+const token = await deploy(contracts.token, owner);
+const bridge = await deploy(contracts.bridge, owner, [await token.getAddress(), validator.address]);
+await (await token.mint(await bridge.getAddress(), ethers.parseEther("1000"))).wait();
+
+const types = {
+  BridgeTransfer: [
+    { name: "recipient", type: "address" },
+    { name: "amount", type: "uint256" },
+    { name: "nonce", type: "uint256" },
+    { name: "chainId", type: "uint256" },
+    { name: "verifyingContract", type: "address" },
+  ],
+};
+
+async function signBridgeTransfer(targetBridge, recipientAddress, amount, transferNonce) {
+  const verifyingContract = await targetBridge.getAddress();
+  return validator.signTypedData(
+    {
+      name: "CrossChainBridge",
+      version: "1",
+      chainId,
+      verifyingContract,
+    },
+    types,
+    {
+      recipient: recipientAddress,
+      amount,
+      nonce: transferNonce,
+      chainId,
+      verifyingContract,
+    },
+  );
+}
+
+const transferAmount = ethers.parseEther("10");
+const firstSignature = await signBridgeTransfer(bridge, recipientAddress, transferAmount, 0);
+const bridgeAddress = await bridge.getAddress();
+const firstDigest = await bridge.hashTransfer(recipientAddress, transferAmount, 0);
+const typedDomain = {
+  name: "CrossChainBridge",
+  version: "1",
+  chainId,
+  verifyingContract: bridgeAddress,
+};
+const typedValue = {
+  recipient: recipientAddress,
+  amount: transferAmount,
+  nonce: 0,
+  chainId,
+  verifyingContract: bridgeAddress,
+};
+const ethersDigest = ethers.TypedDataEncoder.hash(typedDomain, types, typedValue);
+assert.equal(firstDigest, ethersDigest);
+assert.equal(await bridge.domainSeparator(), ethers.TypedDataEncoder.hashDomain(typedDomain));
+assert.equal(await bridge.recoverSigner(firstDigest, firstSignature), validator.address);
+const wrongChainDigest = ethers.TypedDataEncoder.hash(
+  { ...typedDomain, chainId: chainId + 1n },
+  types,
+  { ...typedValue, chainId: chainId + 1n },
+);
+assert.notEqual(ethers.recoverAddress(wrongChainDigest, firstSignature), validator.address);
+await (await bridge.connect(attacker).processTransfer(
+  recipientAddress,
+  transferAmount,
+  0,
+  firstSignature,
+)).wait();
+
+assert.equal(await token.balanceOf(recipientAddress), transferAmount);
+assert.equal(await bridge.nonces(recipientAddress), 1n);
+await expectRevert(
+  async () => {
+    const tx = await bridge.connect(attacker).processTransfer(
+      recipientAddress,
+      transferAmount,
+      0,
+      firstSignature,
+    );
+    await tx.wait();
+  },
+  "Invalid nonce",
+);
+
+const secondBridge = await deploy(contracts.bridge, owner, [
+  await token.getAddress(),
+  validator.address,
+]);
+await (await token.mint(await secondBridge.getAddress(), ethers.parseEther("1000"))).wait();
+await expectRevert(
+  async () => {
+    const tx = await secondBridge.connect(attacker).processTransfer(
+      recipientAddress,
+      transferAmount,
+      0,
+      firstSignature,
+    );
+    await tx.wait();
+  },
+  "Invalid signature",
+);
+
+const invalidSignature = `0x${"00".repeat(65)}`;
+assert.equal(
+  await bridge.verifySignature(await bridge.hashTransfer(recipientAddress, 1, 1), invalidSignature),
+  false,
+);
+await expectRevert(
+  async () => {
+    const tx = await bridge.connect(attacker).processTransfer(
+      recipientAddress,
+      1,
+      1,
+      invalidSignature,
+    );
+    await tx.wait();
+  },
+  "Invalid signature",
+);
+
+const secondSignature = await signBridgeTransfer(bridge, recipientAddress, 1, 1);
+await (await bridge.connect(attacker).processTransfer(
+  recipientAddress,
+  1,
+  1,
+  secondSignature,
+)).wait();
+assert.equal(await bridge.nonces(recipientAddress), 2n);
+
+const senderFund = ethers.parseEther("25");
+await (await token.mint(attackerAddress, senderFund)).wait();
+await (await token.connect(attacker).approve(await bridge.getAddress(), senderFund)).wait();
+await (await bridge.connect(attacker).initiateTransfer(senderFund, 42)).wait();
+assert.equal(await bridge.outboundNonces(attackerAddress), 1n);
+
+console.log("CrossChainBridge replay-protection tests passed");


### PR DESCRIPTION
/claim #920

## Summary
- Replace the packed-message signature check with EIP-712 typed transfer hashes bound to chain ID and verifying contract.
- Add inbound per-recipient nonces, outbound per-sender nonces, zero-address signature recovery handling, and low-s validation.
- Add a Solidity test harness that compiles the bridge, deploys it on Ganache, verifies the EIP-712 digest against ethers, blocks same-chain replay, blocks contract-address replay, rejects invalid signatures, and checks nonce increments.

## Verification
- npm install --no-package-lock
- npm test

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-920-pr-4428-demo.mp4)


