### PR TITLE
[OpenAI Codex] [ Crypto ] Fix SimpleSwap slippage controls

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract SimpleSwap {
+    uint256 private constant BPS_DENOMINATOR = 10_000;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
     uint256 public reserveA;
@@ -13,39 +15,54 @@ contract SimpleSwap {
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_tokenA != address(0), "Invalid tokenA");
+        require(_tokenB != address(0), "Invalid tokenB");
+        require(_tokenA != _tokenB, "Duplicate tokens");
+        require(_fee <= BPS_DENOMINATOR, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(amountA > 0 && amountB > 0, "Invalid liquidity");
+        require(
+            tokenA.transferFrom(msg.sender, address(this), amountA),
+            "TokenA transfer failed"
+        );
+        require(
+            tokenB.transferFrom(msg.sender, address(this), amountB),
+            "TokenB transfer failed"
+        );
         reserveA += amountA;
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
+        require(block.timestamp <= deadline, "Deadline expired");
 
         bool isTokenA = tokenIn == address(tokenA);
         (IERC20 inputToken, IERC20 outputToken, uint256 reserveIn, uint256 reserveOut) = isTokenA
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
-        inputToken.transferFrom(msg.sender, address(this), amountIn);
+        amountOut = _quoteAmountOut(amountIn, reserveIn, reserveOut);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+        require(amountOut < reserveOut, "Insufficient liquidity");
 
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
+        require(
+            inputToken.transferFrom(msg.sender, address(this), amountIn),
+            "Input transfer failed"
+        );
 
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
-        outputToken.transfer(msg.sender, amountOut);
+        require(outputToken.transfer(msg.sender, amountOut), "Output transfer failed");
 
         if (isTokenA) {
             reserveA += amountIn;
@@ -59,11 +76,34 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
+        require(amountIn > 0, "Amount must be > 0");
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
+        return _quoteAmountOut(amountIn, reserveIn, reserveOut);
+    }
+
+    function _quoteAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) private view returns (uint256) {
+        require(reserveIn > 0 && reserveOut > 0, "Insufficient liquidity");
+        uint256 feeAmount = _mulDivUp(amountIn, fee, BPS_DENOMINATOR);
+        require(feeAmount <= amountIn, "Fee exceeds input");
         uint256 amountInAfterFee = amountIn - feeAmount;
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+    }
+
+    function _mulDivUp(
+        uint256 value,
+        uint256 numerator,
+        uint256 denominator
+    ) private pure returns (uint256) {
+        if (value == 0 || numerator == 0) {
+            return 0;
+        }
+        return (value * numerator - 1) / denominator + 1;
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,6 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Safe clean-room provenance only. Private system, developer, runtime, memory, and secret-handling instructions are intentionally not disclosed.",
+  "completed_at": "2026-05-25T10:40:57Z"
+}
+

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/simpleSwap.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.3.0",
+    "ethers": "^6.14.4",
+    "ganache": "^7.9.2",
+    "solc": "^0.8.30"
+  }
+}
+

--- a/solidity/test/simpleSwap.test.mjs
+++ b/solidity/test/simpleSwap.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(solidityRoot, "..");
+
+const mockTokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+`;
+
+function resolveImport(importPath) {
+  if (importPath.startsWith("@openzeppelin/")) {
+    const resolved = require.resolve(importPath, { paths: [solidityRoot] });
+    return { contents: readFileSync(resolved, "utf8") };
+  }
+
+  const localPath = path.join(repoRoot, importPath);
+  try {
+    return { contents: readFileSync(localPath, "utf8") };
+  } catch (error) {
+    return { error: `Unable to resolve ${importPath}: ${error.message}` };
+  }
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "solidity/contracts/SimpleSwap.sol": {
+        content: readFileSync(path.join(solidityRoot, "contracts", "SimpleSwap.sol"), "utf8"),
+      },
+      "test/MockToken.sol": {
+        content: mockTokenSource,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: resolveImport }));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  return {
+    swap: output.contracts["solidity/contracts/SimpleSwap.sol"].SimpleSwap,
+    token: output.contracts["test/MockToken.sol"].MockToken,
+  };
+}
+
+async function deploy(contract, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    contract.abi,
+    `0x${contract.evm.bytecode.object}`,
+    signer,
+  );
+  const deployment = await factory.deploy(...args);
+  await deployment.waitForDeployment();
+  return deployment;
+}
+
+async function expectRevert(action) {
+  try {
+    await action();
+  } catch (error) {
+    assert.match(String(error.shortMessage ?? error.message), /revert/i);
+    return;
+  }
+  assert.fail("Expected revert");
+}
+
+function expectedOut(amountIn, reserveIn, reserveOut, feeBps) {
+  const feeAmount = feeBps === 0n ? 0n : ((amountIn * feeBps - 1n) / 10_000n) + 1n;
+  const amountInAfterFee = amountIn - feeAmount;
+  return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+}
+
+const contracts = compileContracts();
+const ganacheProvider = ganache.provider({
+  chain: { chainId: 31_337 },
+  logging: { quiet: true },
+  wallet: { deterministic: true },
+});
+const provider = new ethers.BrowserProvider(ganacheProvider);
+const owner = await provider.getSigner(0);
+const trader = await provider.getSigner(1);
+const traderAddress = await trader.getAddress();
+
+const tokenA = await deploy(contracts.token, owner, ["Token A", "TKA"]);
+const tokenB = await deploy(contracts.token, owner, ["Token B", "TKB"]);
+const swap = await deploy(contracts.swap, owner, [
+  await tokenA.getAddress(),
+  await tokenB.getAddress(),
+  30,
+]);
+
+const reserveA = ethers.parseEther("1000");
+const reserveB = ethers.parseEther("1000");
+await (await tokenA.mint(await owner.getAddress(), reserveA)).wait();
+await (await tokenB.mint(await owner.getAddress(), reserveB)).wait();
+await (await tokenA.approve(await swap.getAddress(), reserveA)).wait();
+await (await tokenB.approve(await swap.getAddress(), reserveB)).wait();
+await (await swap.addLiquidity(reserveA, reserveB)).wait();
+
+const amountIn = ethers.parseEther("10");
+await (await tokenA.mint(traderAddress, amountIn * 2n)).wait();
+await (await tokenA.connect(trader).approve(await swap.getAddress(), amountIn * 2n)).wait();
+const deadline = BigInt((await provider.getBlock("latest")).timestamp + 60);
+const quote = await swap.getAmountOut(await tokenA.getAddress(), amountIn);
+assert.equal(quote, expectedOut(amountIn, reserveA, reserveB, 30n));
+
+await expectRevert(async () => {
+  const tx = await swap.connect(trader).swap(
+    await tokenA.getAddress(),
+    amountIn,
+    quote + 1n,
+    deadline,
+  );
+  await tx.wait();
+});
+
+await expectRevert(async () => {
+  const tx = await swap.connect(trader).swap(
+    await tokenA.getAddress(),
+    amountIn,
+    0,
+    deadline - 61n,
+  );
+  await tx.wait();
+});
+
+await (await swap.connect(trader).swap(
+  await tokenA.getAddress(),
+  amountIn,
+  quote,
+  deadline,
+)).wait();
+assert.equal(await tokenB.balanceOf(traderAddress), quote);
+
+const tinyIn = 100n;
+const tinyQuote = await swap.getAmountOut(await tokenA.getAddress(), tinyIn);
+assert.equal(tinyQuote, expectedOut(tinyIn, reserveA + amountIn, reserveB - quote, 30n));
+assert.equal(tinyQuote > 0n, true);
+
+console.log("SimpleSwap slippage and deadline tests passed");


### PR DESCRIPTION
/claim #913

## Summary
- Require minAmountOut and deadline on swaps so users can bound slippage and stale execution.
- Round basis-point fees up for non-zero fees instead of silently truncating small trades to a zero fee.
- Add a Solidity runtime test that verifies exact-output swaps, slippage rejection, expired-deadline rejection, and small-amount fee precision.

## Verification
- npm install --no-package-lock
- npm test

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-913-pr-4432-demo.mp4)


