### PR TITLE
[OpenAI Codex] [ Crypto ] Fix PriceOracle validation and fallback

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,6 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Safe clean-room provenance only. Private system, developer, runtime, memory, and secret-handling instructions are intentionally not disclosed.",
+  "date": "2026-05-25T10:40:57Z"
+}
+

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,79 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed feed, uint256 updatedAt);
+    event FallbackFeedUpdated(address indexed fallbackFeed);
 
-    constructor(address _primaryFeed) {
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    constructor(address _primaryFeed, address _fallbackFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
+        (int256 primaryPrice, uint256 primaryUpdatedAt) = _validatedPrice(primaryFeed);
+        if (_isFresh(primaryUpdatedAt)) {
+            emit PriceQueried(primaryPrice, primaryUpdatedAt);
+            return primaryPrice;
+        }
+
+        emit StalePrice(address(primaryFeed), primaryUpdatedAt);
+
+        (int256 fallbackPrice, uint256 fallbackUpdatedAt) = _validatedPrice(fallbackFeed);
+        require(_isFresh(fallbackUpdatedAt), "Stale price");
+        emit PriceQueried(fallbackPrice, fallbackUpdatedAt);
+        return fallbackPrice;
+    }
+
+    function _validatedPrice(
+        AggregatorV3Interface feed
+    ) private view returns (int256 price, uint256 updatedAt) {
         (
             uint80 roundId,
-            int256 price,
+            int256 answer,
             ,
-            uint256 updatedAt,
+            uint256 feedUpdatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) = feed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        require(answer > 0, "Invalid price");
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(feedUpdatedAt > 0, "Invalid timestamp");
 
-        return price;
+        return (answer, feedUpdatedAt);
+    }
+
+    function _isFresh(uint256 updatedAt) private view returns (bool) {
+        if (updatedAt > block.timestamp) {
+            return false;
+        }
+        return block.timestamp - updatedAt < MAX_STALENESS;
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        emit FallbackFeedUpdated(_fallbackFeed);
+    }
+
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        require(_maxStaleness > 0, "Invalid staleness");
         MAX_STALENESS = _maxStaleness;
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/priceOracle.test.mjs"
+  },
+  "devDependencies": {
+    "ethers": "^6.14.4",
+    "ganache": "^7.9.2",
+    "solc": "^0.8.30"
+  }
+}
+

--- a/solidity/test/priceOracle.test.mjs
+++ b/solidity/test/priceOracle.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+
+const mockAggregatorSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockAggregator {
+    uint80 public roundId = 1;
+    int256 public answer;
+    uint256 public startedAt;
+    uint256 public updatedAt;
+    uint80 public answeredInRound = 1;
+    uint8 public decimals = 8;
+
+    constructor(int256 initialAnswer, uint256 initialUpdatedAt) {
+        answer = initialAnswer;
+        startedAt = initialUpdatedAt;
+        updatedAt = initialUpdatedAt;
+    }
+
+    function setRound(
+        uint80 nextRoundId,
+        int256 nextAnswer,
+        uint256 nextUpdatedAt,
+        uint80 nextAnsweredInRound
+    ) external {
+        roundId = nextRoundId;
+        answer = nextAnswer;
+        startedAt = nextUpdatedAt;
+        updatedAt = nextUpdatedAt;
+        answeredInRound = nextAnsweredInRound;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+}
+`;
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "solidity/contracts/PriceOracle.sol": {
+        content: readFileSync(path.join(solidityRoot, "contracts", "PriceOracle.sol"), "utf8"),
+      },
+      "test/MockAggregator.sol": {
+        content: mockAggregatorSource,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  return {
+    oracle: output.contracts["solidity/contracts/PriceOracle.sol"].PriceOracle,
+    aggregator: output.contracts["test/MockAggregator.sol"].MockAggregator,
+  };
+}
+
+async function deploy(contract, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    contract.abi,
+    `0x${contract.evm.bytecode.object}`,
+    signer,
+  );
+  const deployment = await factory.deploy(...args);
+  await deployment.waitForDeployment();
+  return deployment;
+}
+
+async function expectRevert(action) {
+  try {
+    await action();
+  } catch (error) {
+    assert.match(String(error.shortMessage ?? error.message), /revert/i);
+    return;
+  }
+  assert.fail("Expected revert");
+}
+
+const contracts = compileContracts();
+const ganacheProvider = ganache.provider({
+  chain: { chainId: 31_337 },
+  logging: { quiet: true },
+  wallet: { deterministic: true },
+});
+const provider = new ethers.BrowserProvider(ganacheProvider);
+const owner = await provider.getSigner(0);
+const other = await provider.getSigner(1);
+const now = BigInt((await provider.getBlock("latest")).timestamp);
+
+const primary = await deploy(contracts.aggregator, owner, [200_00000000n, now]);
+const fallback = await deploy(contracts.aggregator, owner, [199_00000000n, now]);
+const oracle = await deploy(contracts.oracle, owner, [
+  await primary.getAddress(),
+  await fallback.getAddress(),
+]);
+
+assert.equal(await oracle.getLatestPrice.staticCall(), 200_00000000n);
+assert.equal(await oracle.getDecimals(), 8n);
+
+await (await primary.setRound(2, 200_00000000n, now - 3_700n, 2)).wait();
+assert.equal(await oracle.getLatestPrice.staticCall(), 199_00000000n);
+const staleReceipt = await (await oracle.getLatestPrice()).wait();
+const staleTopic = oracle.interface.getEvent("StalePrice").topicHash;
+assert.equal(staleReceipt.logs.some((log) => log.topics[0] === staleTopic), true);
+
+await (await fallback.setRound(2, 199_00000000n, now - 3_700n, 2)).wait();
+await expectRevert(async () => {
+  const tx = await oracle.getLatestPrice();
+  await tx.wait();
+});
+
+await (await primary.setRound(3, -1n, now, 3)).wait();
+await expectRevert(async () => {
+  const tx = await oracle.getLatestPrice();
+  await tx.wait();
+});
+
+await (await primary.setRound(4, 200_00000000n, now, 3)).wait();
+await expectRevert(async () => {
+  const tx = await oracle.getLatestPrice();
+  await tx.wait();
+});
+
+await expectRevert(async () => {
+  const tx = await oracle.connect(other).setMaxStaleness(7200);
+  await tx.wait();
+});
+await (await oracle.setMaxStaleness(7200)).wait();
+assert.equal(await oracle.MAX_STALENESS(), 7200n);
+
+const replacementFallback = await deploy(contracts.aggregator, owner, [198_00000000n, now]);
+await (await oracle.setFallbackFeed(await replacementFallback.getAddress())).wait();
+assert.equal(await oracle.fallbackFeed(), await replacementFallback.getAddress());
+
+console.log("PriceOracle validation and fallback tests passed");


### PR DESCRIPTION
/claim #915

## Summary
- Validate Chainlink round completeness, positive prices, and nonzero timestamps before returning a price.
- Add stale-price fallback support with owner-configurable staleness and fallback feed updates.
- Emit StalePrice when the primary feed is stale and add a Solidity runtime test for valid, stale fallback, both stale, negative, incomplete, and owner-only configuration paths.

## Verification
- npm install --no-package-lock
- npm test

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-915-pr-4434-demo.mp4)


