### PR TITLE
[OpenAI Codex] [ Crypto ] Fix StakingVault reentrancy

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/solidity/contracts/.provenance.json
+++ b/solidity/contracts/.provenance.json
@@ -1,0 +1,6 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe clean-room provenance only. Private system, developer, runtime, memory, and secret-handling instructions are intentionally not disclosed.",
+  "created": "2026-05-25T10:40:57Z"
+}
+

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -17,13 +18,17 @@ contract StakingVault {
     event RewardClaimed(address indexed user, uint256 amount);
 
     constructor(address _stakingToken, uint256 _rewardRate) {
+        require(_stakingToken != address(0), "Invalid staking token");
         stakingToken = IERC20(_stakingToken);
         rewardRate = _rewardRate;
     }
 
     function stake(uint256 amount) external {
         require(amount > 0, "Cannot stake 0");
-        stakingToken.transferFrom(msg.sender, address(this), amount);
+        require(
+            stakingToken.transferFrom(msg.sender, address(this), amount),
+            "Stake transfer failed"
+        );
         _updateReward(msg.sender);
         balances[msg.sender] += amount;
         totalStaked += amount;
@@ -39,31 +44,29 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/stakingVault.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.3.0",
+    "ethers": "^6.14.4",
+    "ganache": "^7.9.2",
+    "solc": "^0.8.30"
+  }
+}
+

--- a/solidity/test/stakingVault.test.mjs
+++ b/solidity/test/stakingVault.test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(solidityRoot, "..");
+
+const testContractsSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IStakingVault {
+    function stake(uint256 amount) external;
+    function withdraw(uint256 amount) external;
+    function claimRewards() external;
+}
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Stake Token", "STK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract ReenteringStaker {
+    IStakingVault public vault;
+    IERC20 public token;
+    bool public attackWithdraw;
+    bool public attackRewards;
+    bool public tolerateReentryFailure;
+    bool public reentryBlocked;
+    uint256 public reentryCount;
+
+    constructor(address vaultAddress, address tokenAddress) {
+        vault = IStakingVault(vaultAddress);
+        token = IERC20(tokenAddress);
+    }
+
+    function stakeAndApprove(uint256 amount) external {
+        token.approve(address(vault), amount);
+        vault.stake(amount);
+    }
+
+    function withdrawAttack(uint256 amount) external {
+        attackWithdraw = true;
+        tolerateReentryFailure = false;
+        vault.withdraw(amount);
+        attackWithdraw = false;
+    }
+
+    function withdrawProbe(uint256 amount) external {
+        attackWithdraw = true;
+        tolerateReentryFailure = true;
+        vault.withdraw(amount);
+        attackWithdraw = false;
+    }
+
+    function rewardAttack() external {
+        attackRewards = true;
+        tolerateReentryFailure = false;
+        vault.claimRewards();
+        attackRewards = false;
+    }
+
+    function rewardProbe() external {
+        attackRewards = true;
+        tolerateReentryFailure = true;
+        vault.claimRewards();
+        attackRewards = false;
+    }
+
+    receive() external payable {
+        if (attackWithdraw && reentryCount == 0) {
+            reentryCount++;
+            if (tolerateReentryFailure) {
+                (bool ok, ) = address(vault).call(
+                    abi.encodeWithSelector(IStakingVault.withdraw.selector, msg.value)
+                );
+                reentryBlocked = !ok;
+            } else {
+                vault.withdraw(msg.value);
+            }
+        }
+        if (attackRewards && reentryCount == 0) {
+            reentryCount++;
+            if (tolerateReentryFailure) {
+                (bool ok, ) = address(vault).call(
+                    abi.encodeWithSelector(IStakingVault.claimRewards.selector)
+                );
+                reentryBlocked = !ok;
+            } else {
+                vault.claimRewards();
+            }
+        }
+    }
+}
+`;
+
+function resolveImport(importPath) {
+  if (importPath.startsWith("@openzeppelin/")) {
+    const resolved = require.resolve(importPath, { paths: [solidityRoot] });
+    return { contents: readFileSync(resolved, "utf8") };
+  }
+
+  const localPath = path.join(repoRoot, importPath);
+  try {
+    return { contents: readFileSync(localPath, "utf8") };
+  } catch (error) {
+    return { error: `Unable to resolve ${importPath}: ${error.message}` };
+  }
+}
+
+function sliceSource(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+  assert.notEqual(start, -1, `Missing source marker: ${startMarker}`);
+  assert.notEqual(end, -1, `Missing source marker: ${endMarker}`);
+  assert.ok(start < end, `${startMarker} must appear before ${endMarker}`);
+  return source.slice(start, end);
+}
+
+function assertBefore(source, beforeMarker, afterMarker) {
+  const before = source.indexOf(beforeMarker);
+  const after = source.indexOf(afterMarker);
+  assert.notEqual(before, -1, `Missing source marker: ${beforeMarker}`);
+  assert.notEqual(after, -1, `Missing source marker: ${afterMarker}`);
+  assert.ok(before < after, `${beforeMarker} must appear before ${afterMarker}`);
+}
+
+function compileContracts() {
+  const vaultSource = readFileSync(path.join(solidityRoot, "contracts", "StakingVault.sol"), "utf8");
+  const input = {
+    language: "Solidity",
+    sources: {
+      "solidity/contracts/StakingVault.sol": {
+        content: vaultSource,
+      },
+      "test/StakingHarness.sol": {
+        content: testContractsSource,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: resolveImport }));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  assert.match(vaultSource, /import\s+"@openzeppelin\/contracts\/utils\/ReentrancyGuard.sol";/);
+  assert.match(vaultSource, /contract\s+StakingVault\s+is\s+ReentrancyGuard/);
+  assert.match(vaultSource, /function\s+withdraw\(uint256 amount\)\s+external\s+nonReentrant/);
+  assert.match(vaultSource, /function\s+claimRewards\(\)\s+external\s+nonReentrant/);
+
+  const withdrawBody = sliceSource(vaultSource, "function withdraw", "function claimRewards");
+  assertBefore(withdrawBody, "balances[msg.sender] -= amount;", ".call{value: amount}");
+  assertBefore(withdrawBody, "totalStaked -= amount;", ".call{value: amount}");
+
+  const claimRewardsBody = sliceSource(
+    vaultSource,
+    "function claimRewards",
+    "function getStakedBalance",
+  );
+  assertBefore(claimRewardsBody, "rewards[msg.sender] = 0;", ".call{value: reward}");
+
+  return {
+    vault: output.contracts["solidity/contracts/StakingVault.sol"].StakingVault,
+    token: output.contracts["test/StakingHarness.sol"].MockToken,
+    attacker: output.contracts["test/StakingHarness.sol"].ReenteringStaker,
+  };
+}
+
+async function deploy(contract, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    contract.abi,
+    `0x${contract.evm.bytecode.object}`,
+    signer,
+  );
+  const deployment = await factory.deploy(...args);
+  await deployment.waitForDeployment();
+  return deployment;
+}
+
+async function expectRevert(action) {
+  try {
+    await action();
+  } catch (error) {
+    assert.match(String(error.shortMessage ?? error.message), /revert/i);
+    return;
+  }
+  assert.fail("Expected revert");
+}
+
+const contracts = compileContracts();
+const ganacheProvider = ganache.provider({
+  chain: { chainId: 31_337 },
+  logging: { quiet: true },
+  wallet: { deterministic: true },
+});
+const provider = new ethers.BrowserProvider(ganacheProvider);
+const owner = await provider.getSigner(0);
+const user = await provider.getSigner(1);
+const userAddress = await user.getAddress();
+const token = await deploy(contracts.token, owner);
+const vault = await deploy(contracts.vault, owner, [
+  await token.getAddress(),
+  ethers.parseEther("0.01"),
+]);
+const vaultAddress = await vault.getAddress();
+
+await owner.sendTransaction({ to: vaultAddress, value: ethers.parseEther("50") });
+
+await (await token.mint(userAddress, ethers.parseEther("10"))).wait();
+await (await token.connect(user).approve(vaultAddress, ethers.parseEther("10"))).wait();
+await (await vault.connect(user).stake(ethers.parseEther("10"))).wait();
+assert.equal(await vault.getStakedBalance(userAddress), ethers.parseEther("10"));
+
+const normalWithdraw = await (await vault.connect(user).withdraw(ethers.parseEther("2"))).wait();
+assert.equal(await vault.getStakedBalance(userAddress), ethers.parseEther("8"));
+assert.equal(await vault.totalStaked(), ethers.parseEther("8"));
+assert.ok(normalWithdraw.gasUsed < 150_000n);
+
+await ganacheProvider.request({ method: "evm_increaseTime", params: [10] });
+await ganacheProvider.request({ method: "evm_mine", params: [] });
+const rewardBefore = await vault.getPendingRewards(userAddress);
+assert.ok(rewardBefore > 0n);
+const rewardClaim = await (await vault.connect(user).claimRewards()).wait();
+assert.equal(await vault.rewards(userAddress), 0n);
+assert.ok(rewardClaim.gasUsed < 150_000n);
+
+const attacker = await deploy(contracts.attacker, owner, [vaultAddress, await token.getAddress()]);
+const attackerAddress = await attacker.getAddress();
+await (await token.mint(attackerAddress, ethers.parseEther("5"))).wait();
+await (await attacker.stakeAndApprove(ethers.parseEther("5"))).wait();
+
+await expectRevert(async () => {
+  const tx = await attacker.withdrawAttack(ethers.parseEther("5"));
+  await tx.wait();
+});
+assert.equal(await vault.getStakedBalance(attackerAddress), ethers.parseEther("5"));
+assert.equal(await attacker.reentryCount(), 0n);
+
+const withdrawProbe = await deploy(contracts.attacker, owner, [vaultAddress, await token.getAddress()]);
+const withdrawProbeAddress = await withdrawProbe.getAddress();
+await (await token.mint(withdrawProbeAddress, ethers.parseEther("5"))).wait();
+await (await withdrawProbe.stakeAndApprove(ethers.parseEther("5"))).wait();
+await (await withdrawProbe.withdrawProbe(ethers.parseEther("1"))).wait();
+assert.equal(await withdrawProbe.reentryCount(), 1n);
+assert.equal(await withdrawProbe.reentryBlocked(), true);
+assert.equal(await vault.getStakedBalance(withdrawProbeAddress), ethers.parseEther("4"));
+
+await ganacheProvider.request({ method: "evm_increaseTime", params: [10] });
+await ganacheProvider.request({ method: "evm_mine", params: [] });
+await expectRevert(async () => {
+  const tx = await attacker.rewardAttack();
+  await tx.wait();
+});
+assert.ok(await vault.getPendingRewards(attackerAddress) > 0n);
+
+const rewardProbe = await deploy(contracts.attacker, owner, [vaultAddress, await token.getAddress()]);
+const rewardProbeAddress = await rewardProbe.getAddress();
+await (await token.mint(rewardProbeAddress, ethers.parseEther("2"))).wait();
+await (await rewardProbe.stakeAndApprove(ethers.parseEther("2"))).wait();
+await ganacheProvider.request({ method: "evm_increaseTime", params: [10] });
+await ganacheProvider.request({ method: "evm_mine", params: [] });
+await (await rewardProbe.rewardProbe()).wait();
+assert.equal(await rewardProbe.reentryCount(), 1n);
+assert.equal(await rewardProbe.reentryBlocked(), true);
+assert.equal(await vault.rewards(rewardProbeAddress), 0n);
+
+console.log("StakingVault reentrancy tests passed");


### PR DESCRIPTION
/claim #911

## Summary
- Add OpenZeppelin ReentrancyGuard and apply nonReentrant to withdraw and claimRewards.
- Move balance, totalStaked, and reward state updates before ETH callbacks.
- Add a Solidity runtime test harness with a malicious reentering contract, normal stake/withdraw/reward flows, state-order source assertions, and gas sanity checks.

## Verification
- npm install --no-package-lock
- npm test
- git diff --check

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-911-pr-4436-demo.mp4)


