### PR TITLE
Codex [ Crypto ] Harden FlashLoan repayment

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/solidity/contracts/.contributor.json
+++ b/solidity/contracts/.contributor.json
@@ -1,0 +1,6 @@
+{
+  "audit_contributor": "OpenAI Codex",
+  "audit_context": "redacted: private runtime, system, developer, and secret-bearing instructions are not included",
+  "audit_timestamp": "2026-05-25T11:54:29Z",
+  "issue": 919
+}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -13,53 +13,83 @@ contract FlashLoan {
     uint256 public totalFees;
     address public owner;
     bool public paused;
+    uint256 internal poolBalance;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event PoolDeposit(address indexed depositor, uint256 amount);
+    event FeesWithdrawn(address indexed owner, uint256 amount);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
     constructor(address _loanToken, uint256 _feeBPS) {
+        require(_loanToken != address(0), "Invalid token");
+        require(_feeBPS <= 10000, "Fee too high");
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
     function flashLoan(uint256 amount, bytes calldata data) external {
         require(!paused, "Paused");
         require(amount > 0, "Amount must be > 0");
+        require(amount <= poolBalance / 2, "Loan exceeds 50% of pool");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
-
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
         uint256 fee = amount * feeBPS / 10000;
+        if (fee == 0) {
+            fee = 1;
+        }
 
-        loanToken.transfer(msg.sender, amount);
+        uint256 previousPoolBalance = poolBalance;
+        poolBalance = previousPoolBalance - amount;
+
+        require(loanToken.transfer(msg.sender, amount), "Loan transfer failed");
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(
+            loanToken.transferFrom(msg.sender, address(this), amount + fee),
+            "Loan not repaid"
+        );
 
+        poolBalance = previousPoolBalance;
         totalFees += fee;
+        require(
+            loanToken.balanceOf(address(this)) >= poolBalance + totalFees,
+            "Accounting invariant failed"
+        );
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(amount > 0, "Amount must be > 0");
+        require(loanToken.transferFrom(msg.sender, address(this), amount), "Deposit failed");
+        poolBalance += amount;
+        emit PoolDeposit(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        require(loanToken.transfer(owner, fees), "Fee transfer failed");
+        emit FeesWithdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolBalance;
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "test": "mocha \"test/**/*.test.mjs\""
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.13.4",
+    "ganache": "^7.9.2",
+    "mocha": "^10.7.3",
+    "solc": "^0.8.26"
+  }
+}

--- a/solidity/test/flashLoan.test.mjs
+++ b/solidity/test/flashLoan.test.mjs
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import ganache from "ganache";
+import solc from "solc";
+import { BrowserProvider, ContractFactory, parseUnits } from "ethers";
+
+const root = process.cwd();
+const flashLoanPath = path.join(root, "contracts", "FlashLoan.sol");
+
+const testContractsSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20Like {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+interface IFlashLoanLike {
+    function flashLoan(uint256 amount, bytes calldata data) external;
+}
+
+contract MockERC20 {
+    string public name = "Mock Token";
+    string public symbol = "MOCK";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) internal balances;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balances[to] += amount;
+        totalSupply += amount;
+    }
+
+    function balanceOf(address account) public view virtual returns (uint256) {
+        return balances[account];
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balances[msg.sender] >= amount, "insufficient balance");
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balances[from] >= amount, "insufficient balance");
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "insufficient allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        balances[from] -= amount;
+        balances[to] += amount;
+        return true;
+    }
+}
+
+contract BalanceOverrideToken is MockERC20 {
+    mapping(address => uint256) public balanceOverride;
+
+    function setBalanceOverride(address account, uint256 amount) external {
+        balanceOverride[account] = amount;
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        uint256 overridden = balanceOverride[account];
+        if (overridden != 0) {
+            return overridden;
+        }
+        return super.balanceOf(account);
+    }
+}
+
+contract FlashBorrower {
+    IERC20Like public immutable token;
+    IFlashLoanLike public immutable lender;
+    uint256 public lastFee;
+
+    constructor(address token_, address lender_) {
+        token = IERC20Like(token_);
+        lender = IFlashLoanLike(lender_);
+    }
+
+    function execute(uint256 amount) external {
+        lender.flashLoan(amount, "");
+    }
+
+    function onFlashLoan(address, uint256 amount, uint256 fee, bytes calldata) external {
+        require(msg.sender == address(lender), "not lender");
+        lastFee = fee;
+        require(token.approve(msg.sender, amount + fee), "approve failed");
+    }
+}
+
+contract ManipulativeBorrower {
+    BalanceOverrideToken public immutable token;
+    IFlashLoanLike public immutable lender;
+
+    constructor(address token_, address lender_) {
+        token = BalanceOverrideToken(token_);
+        lender = IFlashLoanLike(lender_);
+    }
+
+    function execute(uint256 amount) external {
+        lender.flashLoan(amount, "");
+    }
+
+    function onFlashLoan(address, uint256, uint256, bytes calldata) external {
+        require(msg.sender == address(lender), "not lender");
+        token.setBalanceOverride(msg.sender, type(uint256).max);
+    }
+}
+`;
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(root, importPath),
+    path.join(root, "node_modules", importPath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+
+  return { error: `File not found: ${importPath}` };
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "contracts/FlashLoan.sol": {
+        content: fs.readFileSync(flashLoanPath, "utf8"),
+      },
+      "test/TestContracts.sol": {
+        content: testContractsSource,
+      },
+    },
+    settings: {
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.equal(errors.length, 0, errors.map((error) => error.formattedMessage).join("\n"));
+  return output.contracts;
+}
+
+const contracts = compileContracts();
+
+function artifact(source, name) {
+  const compiled = contracts[source][name];
+  return {
+    abi: compiled.abi,
+    bytecode: `0x${compiled.evm.bytecode.object}`,
+  };
+}
+
+async function deploy(signer, source, name, args = []) {
+  const { abi, bytecode } = artifact(source, name);
+  const factory = new ContractFactory(abi, bytecode, signer);
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+describe("FlashLoan", function () {
+  let provider;
+  let owner;
+  let user;
+
+  beforeEach(async function () {
+    provider = new BrowserProvider(ganache.provider({ logging: { quiet: true } }));
+    [owner, user] = await Promise.all([provider.getSigner(0), provider.getSigner(1)]);
+  });
+
+  async function deployFundedPool({ feeBPS = 1n, tokenName = "MockERC20" } = {}) {
+    const token = await deploy(owner, "test/TestContracts.sol", tokenName);
+    const flashLoan = await deploy(owner, "contracts/FlashLoan.sol", "FlashLoan", [
+      await token.getAddress(),
+      feeBPS,
+    ]);
+    const ownerAddress = await owner.getAddress();
+    const principal = parseUnits("1000", 18);
+
+    await (await token.mint(ownerAddress, principal)).wait();
+    await (await token.approve(await flashLoan.getAddress(), principal)).wait();
+    await (await flashLoan.depositToPool(principal)).wait();
+
+    return { token, flashLoan, principal };
+  }
+
+  it("charges at least one token unit for a nonzero flash loan", async function () {
+    const { token, flashLoan } = await deployFundedPool({ feeBPS: 1n });
+    const borrower = await deploy(user, "test/TestContracts.sol", "FlashBorrower", [
+      await token.getAddress(),
+      await flashLoan.getAddress(),
+    ]);
+    await (await token.mint(await borrower.getAddress(), 1n)).wait();
+
+    await (await borrower.connect(user).execute(1n)).wait();
+
+    assert.equal(await borrower.lastFee(), 1n);
+    assert.equal(await flashLoan.totalFees(), 1n);
+  });
+
+  it("rejects flash loans above half of internally accounted pool principal", async function () {
+    const { flashLoan, principal } = await deployFundedPool();
+
+    await assert.rejects(
+      flashLoan.flashLoan(principal / 2n + 1n, "0x")
+    );
+  });
+
+  it("keeps fees separate from pool principal in normal flash loan flow", async function () {
+    const { token, flashLoan, principal } = await deployFundedPool({ feeBPS: 100n });
+    const borrower = await deploy(user, "test/TestContracts.sol", "FlashBorrower", [
+      await token.getAddress(),
+      await flashLoan.getAddress(),
+    ]);
+    const amount = parseUnits("100", 18);
+    const expectedFee = parseUnits("1", 18);
+    await (await token.mint(await borrower.getAddress(), expectedFee)).wait();
+
+    await (await borrower.connect(user).execute(amount)).wait();
+
+    assert.equal(await flashLoan.getPoolBalance(), principal);
+    assert.equal(await flashLoan.totalFees(), expectedFee);
+    assert.equal(await token.balanceOf(await flashLoan.getAddress()), principal + expectedFee);
+  });
+
+  it("does not let balance manipulation fake repayment or corrupt accounting", async function () {
+    const { token, flashLoan, principal } = await deployFundedPool({
+      feeBPS: 100n,
+      tokenName: "BalanceOverrideToken",
+    });
+    const manipulator = await deploy(user, "test/TestContracts.sol", "ManipulativeBorrower", [
+      await token.getAddress(),
+      await flashLoan.getAddress(),
+    ]);
+
+    await assert.rejects(
+      manipulator.connect(user).execute(parseUnits("100", 18))
+    );
+    assert.equal(await flashLoan.getPoolBalance(), principal);
+    assert.equal(await flashLoan.totalFees(), 0n);
+  });
+
+  it("lets the owner pause and unpause flash loans", async function () {
+    const { token, flashLoan } = await deployFundedPool();
+    const borrower = await deploy(user, "test/TestContracts.sol", "FlashBorrower", [
+      await token.getAddress(),
+      await flashLoan.getAddress(),
+    ]);
+    const amount = parseUnits("1", 18);
+    const expectedFee = parseUnits("0.0001", 18);
+    await (await token.mint(await borrower.getAddress(), expectedFee)).wait();
+
+    await (await flashLoan.pause()).wait();
+    assert.equal(await flashLoan.paused(), true);
+    await assert.rejects(borrower.connect(user).execute(1n));
+
+    await (await flashLoan.unpause()).wait();
+    assert.equal(await flashLoan.paused(), false);
+    await (await borrower.connect(user).execute(amount)).wait();
+    assert.equal(await flashLoan.totalFees(), expectedFee);
+  });
+});


### PR DESCRIPTION
## Summary
- add internal principal accounting and a 50% max-loan cap based on accounted pool deposits
- enforce a minimum one-unit fee for every nonzero loan
- require explicit borrower repayment via transferFrom after the callback so manipulated balanceOf values cannot fake repayment
- add owner pause/unpause controls, checked token transfers, and safe redacted contributor metadata
- add a Solidity/Ganache test harness covering fee floor, max-loan cap, internal accounting, manipulated balance reporting, and pause/unpause

## Demo / verification
- npm test
- git diff --check

/claim #919

<!-- codex-demo-video -->

## Demo Video
- [Short demo video for this PR](https://github.com/justusaugust/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-25/bounty-919-pr-4443-demo.mp4)


