### PR TITLE
Hermes Agent [ T3 Code ] Add toast notification system with history panel

### DIFF
--- a/t3code/.bounty_meta.json
+++ b/t3code/.bounty_meta.json
@@ -1,0 +1,29 @@
+{
+  "issue": 862,
+  "title": "Add toast notification system with history panel",
+  "agent": "Hermes Agent",
+  "project": "T3 Code",
+  "project_path": "t3code",
+  "changes": [
+    {
+      "file": "apps/web/src/stores/notificationStore.ts",
+      "description": "Zustand store for notification history with persistence, supporting add/markRead/clear operations"
+    },
+    {
+      "file": "apps/web/src/components/NotificationToast.tsx",
+      "description": "Notification system wrapper integrating with existing Base UI toast system: notify() helper function, NotificationHistory sheet panel component"
+    },
+    {
+      "file": "apps/web/src/components/Sidebar.tsx",
+      "description": "Added NotificationHistory button to SidebarChromeFooter for accessing notification history panel"
+    }
+  ],
+  "requirements_met": [
+    "Create a notification store using Zustand in apps/web/src/stores/notificationStore.ts",
+    "Create apps/web/src/components/NotificationToast.tsx that renders toast notifications",
+    "Support types: success, error, warning, info with corresponding colors and icons",
+    "Notifications auto-dismiss after 5 seconds by default with configurable duration",
+    "Stack multiple notifications vertically with smooth enter/exit animations",
+    "Add a notification history panel accessible from the sidebar"
+  ]
+}

--- a/t3code/apps/web/src/components/NotificationToast.tsx
+++ b/t3code/apps/web/src/components/NotificationToast.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { BellIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toastManager, type ThreadToastData } from "~/components/ui/toast";
+import {
+  Sheet,
+  SheetHeader,
+  SheetPanel,
+  SheetPopup,
+  SheetTitle,
+  SheetTrigger,
+} from "~/components/ui/sheet";
+import { ScrollArea } from "~/components/ui/scroll-area";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
+import {
+  useNotificationStore,
+  type NotificationType,
+} from "~/stores/notificationStore";
+import { SidebarMenuButton } from "~/components/ui/sidebar";
+
+// ─── Icon mapping ───────────────────────────────────────────────────────────────
+
+const TYPE_ICONS: Record<string, string> = {
+  success: "✓",
+  error: "✕",
+  warning: "⚠",
+  info: "ℹ",
+  loading: "◌",
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  success: "text-success bg-success/10 border-success/20",
+  error: "text-destructive bg-destructive/10 border-destructive/20",
+  warning: "text-warning bg-warning/10 border-warning/20",
+  info: "text-info bg-info/10 border-info/20",
+  loading: "text-muted-foreground bg-muted/30 border-muted/40",
+};
+
+// ─── Notify helper ──────────────────────────────────────────────────────────────
+
+export type NotifyOptions = {
+  type: NotificationType;
+  title: string;
+  description?: string;
+  /** Duration in ms before auto-dismiss (default: 5000). Set to 0 for no auto-dismiss. */
+  duration?: number;
+  actionProps?: React.ComponentPropsWithoutRef<"button">;
+  data?: Omit<ThreadToastData, "actionLayout">;
+};
+
+/**
+ * Show a toast notification AND record it in the notification history.
+ *
+ * Replaces bare `toastManager.add()` / `stackedThreadToast()` calls where
+ * history tracking is desired.
+ */
+export function notify(options: NotifyOptions): string {
+  const {
+    type,
+    title,
+    description,
+    duration = 5000,
+    actionProps,
+    data,
+  } = options;
+
+  const toastData: ThreadToastData = {
+    ...(data ?? {}),
+    actionLayout: "stacked-end",
+    dismissAfterVisibleMs: duration > 0 ? duration : undefined,
+  };
+
+  const toastId = toastManager.add({
+    type,
+    title,
+    description,
+    timeout: duration > 0 ? duration : undefined,
+    actionProps,
+    data: toastData,
+  });
+
+  // Record in history
+  useNotificationStore.getState().addToHistory({
+    type,
+    title,
+    description,
+  });
+
+  return toastId;
+}
+
+/**
+ * Shortcut: show an info toast.
+ */
+export function notifyInfo(title: string, description?: string, duration?: number): string {
+  return notify({ type: "info", title, description, duration });
+}
+
+/**
+ * Shortcut: show a success toast.
+ */
+export function notifySuccess(title: string, description?: string, duration?: number): string {
+  return notify({ type: "success", title, description, duration });
+}
+
+/**
+ * Shortcut: show a warning toast.
+ */
+export function notifyWarning(title: string, description?: string, duration?: number): string {
+  return notify({ type: "warning", title, description, duration });
+}
+
+/**
+ * Shortcut: show an error toast.
+ */
+export function notifyError(title: string, description?: string, duration?: number): string {
+  return notify({ type: "error", title, description, duration });
+}
+
+// ─── History panel ──────────────────────────────────────────────────────────────
+
+/**
+ * Notification history panel, shown in a sheet from the sidebar.
+ */
+export function NotificationHistory() {
+  const [open, setOpen] = useState(false);
+  const history = useNotificationStore((s) => s.history);
+  const unreadCount = useNotificationStore((s) => s.unreadCount);
+  const markAsRead = useNotificationStore((s) => s.markAsRead);
+  const markAllAsRead = useNotificationStore((s) => s.markAllAsRead);
+  const clearHistory = useNotificationStore((s) => s.clearHistory);
+  const removeFromHistory = useNotificationStore((s) => s.removeFromHistory);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (nextOpen) {
+        // Mark all as read when opening
+        markAllAsRead();
+      }
+    },
+    [markAllAsRead],
+  );
+
+  return (
+    <>
+      {/* Sidebar menu button */}
+      <SidebarMenuButton
+        size="sm"
+        className="relative gap-2 px-2 py-1.5 text-muted-foreground/70 hover:bg-accent hover:text-foreground"
+        onClick={() => setOpen(true)}
+      >
+        <BellIcon className="size-3.5" />
+        <span className="text-xs">Notifications</span>
+        {unreadCount > 0 && (
+          <span className="absolute right-1.5 top-1/2 -translate-y-1/2 inline-flex min-w-[18px] items-center justify-center rounded-full bg-primary px-1 py-0.5 text-[10px] font-semibold leading-none text-primary-foreground">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </SidebarMenuButton>
+
+      {/* Sheet panel */}
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetPopup side="right" className="w-96 max-w-[calc(100vw-3rem)]">
+          <SheetHeader>
+            <SheetTitle>Notification History</SheetTitle>
+          </SheetHeader>
+          <SheetPanel>
+            {history.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-12 text-center text-muted-foreground">
+                <BellIcon className="mb-3 size-8 opacity-40" />
+                <p className="text-sm">No notifications yet</p>
+                <p className="mt-1 text-xs text-muted-foreground/60">
+                  Notifications will appear here as they arrive.
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className="mb-3 flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">
+                    {history.length} notification{history.length !== 1 ? "s" : ""}
+                  </span>
+                  <div className="flex gap-1">
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      className="text-xs"
+                      onClick={markAllAsRead}
+                    >
+                      Mark all read
+                    </Button>
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      className="text-xs text-destructive/70 hover:text-destructive"
+                      onClick={clearHistory}
+                    >
+                      Clear all
+                    </Button>
+                  </div>
+                </div>
+                <ScrollArea className="h-[calc(100vh-12rem)]">
+                  <div className="flex flex-col gap-1">
+                    {history.map((entry) => (
+                      <div
+                        key={entry.id}
+                        className={cn(
+                          "group relative flex items-start gap-2.5 rounded-lg border p-3 text-sm transition-colors",
+                          TYPE_COLORS[entry.type] ?? "text-muted-foreground bg-muted/30 border-muted/40",
+                          !entry.read && "ring-1 ring-primary/10",
+                        )}
+                      >
+                        {/* Icon indicator */}
+                        <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center text-xs font-bold">
+                          {TYPE_ICONS[entry.type] ?? "•"}
+                        </span>
+
+                        {/* Content */}
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-start justify-between gap-2">
+                            <span
+                              className={cn(
+                                "text-sm font-medium",
+                                !entry.read && "text-foreground",
+                              )}
+                            >
+                              {String(entry.title)}
+                            </span>
+                            <button
+                              className="mt-0.5 shrink-0 text-muted-foreground/40 opacity-0 transition-opacity hover:text-muted-foreground group-hover:opacity-100"
+                              onClick={() => removeFromHistory(entry.id)}
+                              aria-label="Remove"
+                            >
+                              ✕
+                            </button>
+                          </div>
+                          {entry.description && (
+                            <p className="mt-0.5 text-xs text-muted-foreground/80">
+                              {String(entry.description)}
+                            </p>
+                          )}
+                          <p className="mt-1 text-[10px] text-muted-foreground/40">
+                            {formatTimestamp(entry.timestamp)}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </>
+            )}
+          </SheetPanel>
+        </SheetPopup>
+      </Sheet>
+    </>
+  );
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+function formatTimestamp(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "Just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 604_800_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return new Date(ts).toLocaleDateString();
+}

--- a/t3code/apps/web/src/components/Sidebar.tsx
+++ b/t3code/apps/web/src/components/Sidebar.tsx
@@ -197,6 +197,7 @@ import {
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
 import { SidebarProviderUpdatePill } from "./sidebar/SidebarProviderUpdatePill";
+import { NotificationHistory } from "./NotificationToast";
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
@@ -2501,6 +2502,9 @@ const SidebarChromeFooter = memo(function SidebarChromeFooter() {
       <SidebarProviderUpdatePill />
       <SidebarUpdatePill />
       <SidebarMenu>
+        <SidebarMenuItem>
+          <NotificationHistory />
+        </SidebarMenuItem>
         <SidebarMenuItem>
           <SidebarMenuButton
             size="sm"

--- a/t3code/apps/web/src/stores/notificationStore.ts
+++ b/t3code/apps/web/src/stores/notificationStore.ts
@@ -1,0 +1,127 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { ReactNode } from "react";
+
+export type NotificationType = "success" | "error" | "warning" | "info" | "loading";
+
+export interface NotificationEntry {
+  id: string;
+  type: NotificationType;
+  title: ReactNode;
+  description?: ReactNode;
+  timestamp: number;
+  dismissed: boolean;
+  read: boolean;
+}
+
+interface NotificationState {
+  /** Ordered list of notifications (newest first). */
+  history: NotificationEntry[];
+  /** Maximum number of entries to retain. */
+  maxEntries: number;
+  /** Unread count (derived from history). */
+  unreadCount: number;
+}
+
+interface NotificationActions {
+  /** Add a notification to history. */
+  addToHistory: (
+    entry: Omit<NotificationEntry, "id" | "timestamp" | "dismissed" | "read">,
+  ) => string;
+  /** Mark a notification as read. */
+  markAsRead: (id: string) => void;
+  /** Mark all notifications as read. */
+  markAllAsRead: () => void;
+  /** Remove a single entry from history. */
+  removeFromHistory: (id: string) => void;
+  /** Clear all history. */
+  clearHistory: () => void;
+  /** Recalculate unread count. */
+  recalculateUnreadCount: () => void;
+}
+
+export type NotificationStore = NotificationState & NotificationActions;
+
+let nextId = 1;
+function generateId(): string {
+  return `notification-${Date.now()}-${nextId++}`;
+}
+
+const MAX_ENTRIES = 100;
+
+export const useNotificationStore = create<NotificationStore>()(
+  persist(
+    (set, get) => ({
+      // State
+      history: [],
+      maxEntries: MAX_ENTRIES,
+      unreadCount: 0,
+
+      // Actions
+      addToHistory: (entry) => {
+        const id = generateId();
+        const newEntry: NotificationEntry = {
+          ...entry,
+          id,
+          timestamp: Date.now(),
+          dismissed: false,
+          read: false,
+        };
+        set((state) => {
+          const next = [newEntry, ...state.history].slice(0, state.maxEntries);
+          const unreadCount = next.filter((n) => !n.read).length;
+          return { history: next, unreadCount };
+        });
+        return id;
+      },
+
+      markAsRead: (id) => {
+        set((state) => {
+          const next = state.history.map((n) => (n.id === id ? { ...n, read: true } : n));
+          const unreadCount = next.filter((n) => !n.read).length;
+          return { history: next, unreadCount };
+        });
+      },
+
+      markAllAsRead: () => {
+        set((state) => {
+          const next = state.history.map((n) => ({ ...n, read: true }));
+          return { history: next, unreadCount: 0 };
+        });
+      },
+
+      removeFromHistory: (id) => {
+        set((state) => {
+          const next = state.history.filter((n) => n.id !== id);
+          const unreadCount = next.filter((n) => !n.read).length;
+          return { history: next, unreadCount };
+        });
+      },
+
+      clearHistory: () => {
+        set({ history: [], unreadCount: 0 });
+      },
+
+      recalculateUnreadCount: () => {
+        set((state) => ({
+          unreadCount: state.history.filter((n) => !n.read).length,
+        }));
+      },
+    }),
+    {
+      name: "t3code:notification-history:v1",
+      partialize: (state) => ({
+        history: state.history.map((n) => ({
+          ...n,
+          title: typeof n.title === "string" ? n.title : "[Notification]",
+          description:
+            typeof n.description === "string"
+              ? n.description
+              : n.description !== undefined
+                ? "[Details]"
+                : undefined,
+        })),
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
Implements #862 - Adds a toast notification system with history panel.

## Changes
- **apps/web/src/stores/notificationStore.ts**: New Zustand store with persistence for tracking notification history
- **apps/web/src/components/NotificationToast.tsx**: 
  - `notify()` helper that integrates with existing `@base-ui/react/toast` system and records notifications in history
  - `NotificationHistory` sheet panel component for viewing past notifications
  - Shortcut functions: `notifyInfo()`, `notifySuccess()`, `notifyWarning()`, `notifyError()`
- **apps/web/src/components/Sidebar.tsx**: Added notification bell button with unread count badge in sidebar footer

## Requirements Met
- ✅ Zustand notification store with history tracking and persistence
- ✅ Toast notifications with success/error/warning/info types with colored icons
- ✅ Auto-dismiss after 5 seconds (configurable) via `duration` parameter
- ✅ Stack and animations handled by existing Base UI toast infrastructure
- ✅ Notification history panel accessible from sidebar via sheet popup

Closes #862