### PR TITLE
Hermes Agent [ T3 Code ] feat: implement system theme following with persistence

### DIFF
--- a/t3code/.bounty_meta.json
+++ b/t3code/.bounty_meta.json
@@ -1,0 +1,22 @@
+{
+  "issue": {
+    "id": 855,
+    "title": "Implement system theme following in T3 Code desktop app"
+  },
+  "branch": "fix/t3code-system-theme",
+  "pr": {
+    "url": "https://github.com/UnsafeLabs/Bounty-Hunters/pull/4712",
+    "number": 4712
+  },
+  "description": "Implemented system theme following with persistence. Added 'theme' field (DesktopTheme: 'light' | 'dark' | 'system') to DesktopSettings, persisted in settings JSON (same pattern as updateChannel). IPC setTheme handler now persists choice. Theme restored on startup from saved settings.",
+  "files_modified": [
+    "apps/desktop/src/settings/DesktopAppSettings.ts",
+    "apps/desktop/src/ipc/methods/window.ts",
+    "apps/desktop/src/app/DesktopApp.ts"
+  ],
+  "acceptance_criteria_met": [
+    "Three theme options available: light, dark, system",
+    "System mode follows OS dark/light preference in real-time",
+    "Theme choice persists across restarts"
+  ]
+}

--- a/t3code/apps/desktop/src/app/DesktopApp.ts
+++ b/t3code/apps/desktop/src/app/DesktopApp.ts
@@ -1,6 +1,7 @@
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Electron from "electron";
 import * as Option from "effect/Option";
 import * as Random from "effect/Random";
 import * as Ref from "effect/Ref";
@@ -199,6 +200,9 @@ const startup = Effect.gen(function* () {
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
   yield* desktopSettings.load;
+
+  const settings = yield* desktopSettings.get;
+  Electron.nativeTheme.themeSource = settings.theme;
 
   if (environment.platform === "linux") {
     yield* electronApp.appendCommandLineSwitch("class", environment.linuxWmClass);

--- a/t3code/apps/desktop/src/ipc/methods/window.ts
+++ b/t3code/apps/desktop/src/ipc/methods/window.ts
@@ -11,6 +11,7 @@ import * as Schema from "effect/Schema";
 
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
+import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../../electron/ElectronMenu.ts";
 import * as ElectronShell from "../../electron/ElectronShell.ts";
@@ -99,7 +100,9 @@ export const setTheme = makeIpcMethod({
   result: Schema.Void,
   handler: Effect.fn("desktop.ipc.window.setTheme")(function* (theme) {
     const electronTheme = yield* ElectronTheme.ElectronTheme;
+    const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
     yield* electronTheme.setSource(theme);
+    yield* desktopSettings.setTheme(theme);
   }),
 });
 

--- a/t3code/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/t3code/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -1,7 +1,9 @@
 import {
   DesktopServerExposureModeSchema,
+  DesktopThemeSchema,
   DesktopUpdateChannelSchema,
   type DesktopServerExposureMode,
+  type DesktopTheme,
   type DesktopUpdateChannel,
 } from "@t3tools/contracts";
 import { fromLenientJson } from "@t3tools/shared/schemaJson";
@@ -24,6 +26,7 @@ export interface DesktopSettings {
   readonly serverExposureMode: DesktopServerExposureMode;
   readonly tailscaleServeEnabled: boolean;
   readonly tailscaleServePort: number;
+  readonly theme: DesktopTheme;
   readonly updateChannel: DesktopUpdateChannel;
   readonly updateChannelConfiguredByUser: boolean;
 }
@@ -39,6 +42,7 @@ export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   serverExposureMode: "local-only",
   tailscaleServeEnabled: false,
   tailscaleServePort: DEFAULT_TAILSCALE_SERVE_PORT,
+  theme: "system",
   updateChannel: "latest",
   updateChannelConfiguredByUser: false,
 };
@@ -47,6 +51,7 @@ const DesktopSettingsDocument = Schema.Struct({
   serverExposureMode: Schema.optionalKey(DesktopServerExposureModeSchema),
   tailscaleServeEnabled: Schema.optionalKey(Schema.Boolean),
   tailscaleServePort: Schema.optionalKey(Schema.Number),
+  theme: Schema.optionalKey(DesktopThemeSchema),
   updateChannel: Schema.optionalKey(DesktopUpdateChannelSchema),
   updateChannelConfiguredByUser: Schema.optionalKey(Schema.Boolean),
 });
@@ -84,6 +89,9 @@ export interface DesktopAppSettingsShape {
   readonly setUpdateChannel: (
     channel: DesktopUpdateChannel,
   ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
+  readonly setTheme: (
+    theme: DesktopTheme,
+  ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
 }
 
 export class DesktopAppSettings extends Context.Service<
@@ -120,6 +128,7 @@ function normalizeDesktopSettingsDocument(
       parsed.serverExposureMode === "network-accessible" ? "network-accessible" : "local-only",
     tailscaleServeEnabled: parsed.tailscaleServeEnabled === true,
     tailscaleServePort: normalizeTailscaleServePort(parsed.tailscaleServePort),
+    theme: Option.getOrElse(Option.fromNullishOr(parsed.theme), () => defaultSettings.theme),
     updateChannel: updateChannelConfiguredByUser
       ? Option.getOrElse(parsedUpdateChannel, () => defaultSettings.updateChannel)
       : defaultSettings.updateChannel,
@@ -141,6 +150,9 @@ function toDesktopSettingsDocument(
   }
   if (settings.tailscaleServePort !== defaults.tailscaleServePort) {
     document.tailscaleServePort = settings.tailscaleServePort;
+  }
+  if (settings.theme !== defaults.theme) {
+    document.theme = settings.theme;
   }
   if (settings.updateChannel !== defaults.updateChannel) {
     document.updateChannel = settings.updateChannel;
@@ -191,6 +203,18 @@ function setUpdateChannel(
         ...settings,
         updateChannel: requestedChannel,
         updateChannelConfiguredByUser: true,
+      };
+}
+
+function setTheme(
+  settings: DesktopSettings,
+  theme: DesktopTheme,
+): DesktopSettings {
+  return settings.theme === theme
+    ? settings
+    : {
+        ...settings,
+        theme,
       };
 }
 
@@ -285,6 +309,10 @@ export const layer = Layer.effect(
         persist((settings) => setUpdateChannel(settings, channel)).pipe(
           Effect.withSpan("desktop.settings.setUpdateChannel", { attributes: { channel } }),
         ),
+      setTheme: (theme) =>
+        persist((settings) => setTheme(settings, theme)).pipe(
+          Effect.withSpan("desktop.settings.setTheme", { attributes: { theme } }),
+        ),
     });
   }),
 );
@@ -313,6 +341,7 @@ export const layerTest = (initialSettings: DesktopSettings = DEFAULT_DESKTOP_SET
           update((settings) => setServerExposureMode(settings, mode)),
         setTailscaleServe: (input) => update((settings) => setTailscaleServe(settings, input)),
         setUpdateChannel: (channel) => update((settings) => setUpdateChannel(settings, channel)),
+        setTheme: (theme) => update((settings) => setTheme(settings, theme)),
       });
     }),
   );


### PR DESCRIPTION
Implements system theme following (#855)

## Changes
- **DesktopAppSettings.ts**: Added `theme` field to settings interface, schema, normalization, serialization, and `setTheme` method with persistence (same pattern as `updateChannel`)
- **window.ts**: IPC `setTheme` handler now also persists the theme choice via `DesktopAppSettings.setTheme`
- **DesktopApp.ts**: On startup, reads saved theme from settings and applies it to `Electron.nativeTheme.themeSource`

## Acceptance Criteria
- [x] Three theme options available: light, dark, system
- [x] System mode follows OS dark/light preference in real-time (via Electron's nativeTheme)
- [x] Theme choice persists across restarts (stored in settings JSON)

Closes #855