### PR TITLE
Hermes Agent [ T3 Code ] Implement resizable sidebar with drag handle (#840)

### DIFF
--- a/t3code/.bounty_meta.json
+++ b/t3code/.bounty_meta.json
@@ -1,0 +1,11 @@
+{
+  "agent": "Hermes Agent",
+  "category": "T3 Code",
+  "issue": "#840",
+  "title": "Implement resizable sidebar with drag handle (#840)",
+  "description": "Added resizable sidebar functionality with drag handle:\n- Added `defaultWidth` option to SidebarResizableOptions type\n- Added double-click on sidebar rail to reset to default width (280px)\n- Set sidebar minWidth to 200px and maxWidth to 500px\n- All changes build on existing resizable infrastructure",
+  "files_changed": [
+    "apps/web/src/components/ui/sidebar.tsx",
+    "apps/web/src/components/AppSidebarLayout.tsx"
+  ]
+}

--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -9,7 +9,9 @@ import {
 } from "../shortcutModifierState";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
-const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
+const THREAD_SIDEBAR_MIN_WIDTH = 200;
+const THREAD_SIDEBAR_MAX_WIDTH = 500;
+const THREAD_SIDEBAR_DEFAULT_WIDTH = 280;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
@@ -61,6 +63,8 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         className="border-r border-border bg-card text-foreground"
         resizable={{
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+          maxWidth: THREAD_SIDEBAR_MAX_WIDTH,
+          defaultWidth: THREAD_SIDEBAR_DEFAULT_WIDTH,
           shouldAcceptWidth: ({ nextWidth, wrapper }) =>
             wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
           storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,

--- a/t3code/apps/web/src/components/ui/sidebar.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.tsx
@@ -41,6 +41,7 @@ type SidebarContextProps = {
 type SidebarResizableOptions = {
   maxWidth?: number;
   minWidth?: number;
+  defaultWidth?: number;
   onResize?: (width: number) => void;
   shouldAcceptWidth?: (context: {
     currentWidth: number;
@@ -56,6 +57,7 @@ type SidebarResizableOptions = {
 type SidebarResolvedResizableOptions = {
   maxWidth: number;
   minWidth: number;
+  defaultWidth: number | null;
   onResize?: (width: number) => void;
   shouldAcceptWidth?: (context: {
     currentWidth: number;
@@ -194,6 +196,7 @@ function Sidebar({
     return {
       maxWidth: options.maxWidth ?? Number.POSITIVE_INFINITY,
       minWidth: options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
+      defaultWidth: options.defaultWidth ?? null,
       storageKey: options.storageKey ?? null,
       ...(options.onResize ? { onResize: options.onResize } : {}),
       ...(options.shouldAcceptWidth ? { shouldAcceptWidth: options.shouldAcceptWidth } : {}),
@@ -543,6 +546,25 @@ function SidebarRail({
     [onClick, open, resolvedResizable, toggleSidebar],
   );
 
+  const handleDoubleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (!resolvedResizable || !open) return;
+      const defaultWidth = resolvedResizable.defaultWidth;
+      if (defaultWidth === null) return;
+
+      const wrapper = event.currentTarget.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
+      if (!wrapper) return;
+
+      wrapper.style.setProperty("--sidebar-width", `${defaultWidth}px`);
+
+      if (resolvedResizable.storageKey && typeof window !== "undefined") {
+        setLocalStorageItem(resolvedResizable.storageKey, defaultWidth, Schema.Finite);
+      }
+      resolvedResizable.onResize?.(defaultWidth);
+    },
+    [open, resolvedResizable],
+  );
+
   React.useEffect(() => {
     if (!resolvedResizable?.storageKey || typeof window === "undefined") return;
     const rail = railRef.current;
@@ -587,6 +609,7 @@ function SidebarRail({
       data-sidebar="rail"
       data-slot="sidebar-rail"
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onPointerCancel={handlePointerCancel}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}


### PR DESCRIPTION
## Issue
Fixes #840

## Summary
Adds resizable sidebar with drag handle and persisted width:

- Drag handle on right edge of sidebar (existing SidebarRail component)
- Drag to resize between 200px and 500px
- Width persisted to localStorage (chat_thread_sidebar_width)
- Double-click on drag handle resets to default width (280px)
- Visual hover indicator on drag handle

## Acceptance Criteria
- [x] Sidebar width is adjustable by dragging the right edge
- [x] Width persists across page reloads
- [x] Double-click resets to default

## Files Modified
- apps/web/src/components/ui/sidebar.tsx — added defaultWidth support
- apps/web/src/components/AppSidebarLayout.tsx — added min/max/default width constraints