### PR TITLE
Codex [ FastAPI ] Add FastAPITestClient helpers

### DIFF
--- a/fastapi/.audit.json
+++ b/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex / I-Fog",
+  "environment_config": "Private system, developer, and session instructions are intentionally not copied into repository files. This contribution was made from the public issue requirements and repository guidance only; no secrets or hidden instructions are included.",
+  "completed_at": "2026-05-26T01:45:43+02:00"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,54 @@
+from __future__ import annotations
+
+from base64 import b64encode
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from httpx import Response
 from starlette.testclient import TestClient as TestClient  # noqa
+from starlette.testclient import WebSocketTestSession
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> "FastAPITestClient":
+        self.headers["authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(
+        self, username: str, password: str
+    ) -> "FastAPITestClient":
+        credentials = f"{username}:{password}".encode("utf-8")
+        encoded_credentials = b64encode(credentials).decode("ascii")
+        self.headers["authorization"] = f"Basic {encoded_credentials}"
+        return self
+
+    def reset_auth(self) -> "FastAPITestClient":
+        if "authorization" in self.headers:
+            del self.headers["authorization"]
+        return self
+
+    def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        subprotocols: Sequence[str] | None = None,
+        **kwargs: Any,
+    ) -> WebSocketTestSession:
+        return self.websocket_connect(
+            url,
+            subprotocols=subprotocols,
+            headers=dict(headers or {}),
+            **kwargs,
+        )
+
+    def assert_status(
+        self, method: str, url: str, expected_status: int, **kwargs: Any
+    ) -> Response:
+        response = self.request(method, url, **kwargs)
+        if response.status_code != expected_status:
+            raise AssertionError(
+                f"Expected {expected_status} for {method.upper()} {url}, "
+                f"got {response.status_code}: {response.text}"
+            )
+        return response

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,104 @@
+from base64 import b64encode
+
+import pytest
+from fastapi import FastAPI, Header, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+from starlette.testclient import TestClient as StarletteTestClient
+
+
+app = FastAPI()
+
+
+@app.get("/auth")
+def read_auth(authorization: str | None = Header(default=None)):
+    return {"authorization": authorization}
+
+
+@app.get("/ok")
+def read_ok():
+    return {"ok": True}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    await websocket.send_json(
+        {
+            "authorization": websocket.headers.get("authorization"),
+            "x-client": websocket.headers.get("x-client"),
+            "subprotocols": websocket.headers.get("sec-websocket-protocol"),
+        }
+    )
+    await websocket.close()
+
+
+def test_existing_testclient_export_is_unchanged():
+    assert TestClient is StarletteTestClient
+
+
+def test_authenticate_sets_bearer_token_for_following_requests():
+    client = FastAPITestClient(app)
+    assert client.authenticate("first-token") is client
+
+    response = client.get("/auth")
+    assert response.json() == {"authorization": "Bearer first-token"}
+
+    second_response = client.get("/auth")
+    assert second_response.json() == {"authorization": "Bearer first-token"}
+
+
+def test_authenticate_replaces_previous_token():
+    client = FastAPITestClient(app)
+    client.authenticate("first-token")
+    client.authenticate("second-token")
+
+    response = client.get("/auth")
+    assert response.json() == {"authorization": "Bearer second-token"}
+
+
+def test_authenticate_basic_sets_encoded_basic_header():
+    client = FastAPITestClient(app)
+    assert client.authenticate_basic("alice", "wonderland") is client
+
+    expected = b64encode(b"alice:wonderland").decode("ascii")
+    response = client.get("/auth")
+    assert response.json() == {"authorization": f"Basic {expected}"}
+
+
+def test_reset_auth_clears_authentication_state():
+    client = FastAPITestClient(app)
+    assert client.authenticate("first-token").reset_auth() is client
+
+    response = client.get("/auth")
+    assert response.json() == {"authorization": None}
+
+
+def test_ws_connect_passes_auth_custom_headers_and_subprotocols():
+    client = FastAPITestClient(app)
+    client.authenticate("socket-token")
+
+    with client.ws_connect(
+        "/ws", headers={"x-client": "mobile"}, subprotocols=["chat", "json"]
+    ) as websocket:
+        assert websocket.receive_json() == {
+            "authorization": "Bearer socket-token",
+            "x-client": "mobile",
+            "subprotocols": "chat, json",
+        }
+
+
+def test_assert_status_returns_response_when_status_matches():
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("GET", "/ok", 200)
+    assert response.json() == {"ok": True}
+
+
+def test_assert_status_raises_helpful_message_when_status_differs():
+    client = FastAPITestClient(app)
+
+    with pytest.raises(AssertionError) as exc_info:
+        client.assert_status("GET", "/ok", 201)
+
+    assert "Expected 201 for GET /ok, got 200" in str(exc_info.value)
+    assert '{"ok":true}' in str(exc_info.value)


### PR DESCRIPTION
/claim #804

## Summary
- Added `FastAPITestClient` while preserving the existing `TestClient` export.
- Added Bearer auth, Basic auth, auth reset, WebSocket convenience, and `assert_status` helpers.
- Added focused tests covering auth persistence, token replacement, Basic encoding, auth reset, WebSocket headers/subprotocols, helper assertions, and unchanged `TestClient` behavior.
- Added `fastapi/.audit.json` for the issue metadata requirement without copying private or hidden instructions.

## Demo
Demo video: [fastapi-testclient-demo.mp4](https://github.com/I-Fog/Bounty-Hunters/releases/download/fastapi-testclient-demo-b208f2e/fastapi-testclient-demo.mp4)

The 24s MP4 shows:
- existing `TestClient` export remains unchanged
- Bearer auth persists and can be replaced
- Basic auth is encoded correctly
- `reset_auth()` clears auth
- `ws_connect()` carries auth, custom headers, and subprotocols
- `assert_status()` returns the response on success and raises a helpful message on mismatch
- `pytest tests/test_fastapi_testclient.py -q` passes

## Validation
- `python -m pytest tests/test_fastapi_testclient.py -q`
- `python -m pytest tests/test_fastapi_testclient.py tests/test_ws_router.py -q`
- `python -m compileall -q fastapi/testclient.py tests/test_fastapi_testclient.py`
- `git diff --check -- fastapi/fastapi/testclient.py fastapi/tests/test_fastapi_testclient.py fastapi/.audit.json`

`python -m ruff check fastapi/testclient.py tests/test_fastapi_testclient.py` could not run because `ruff` is not installed in this environment.