### PR TITLE
[ H4ck3r-netizen ] [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,11 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,34 +27,32 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
+            // FIX: Lock MINIMUM_LIQUIDITY to address(0) to prevent first-depositor price manipulation
             lpTokens = sqrt(amountA * amountB);
+            require(lpTokens > MINIMUM_LIQUIDITY, "Initial liquidity too small");
+            _mint(address(0), MINIMUM_LIQUIDITY); // Lock permanently
+            _mint(msg.sender, lpTokens - MINIMUM_LIQUIDITY);
         } else {
-            uint256 lpFromA = amountA * totalSupply() / reserveA;
-            uint256 lpFromB = amountB * totalSupply() / reserveB;
+            uint256 lpFromA = (amountA * totalSupply()) / reserveA;
+            uint256 lpFromB = (amountB * totalSupply()) / reserveB;
             lpTokens = lpFromA < lpFromB ? lpFromA : lpFromB;
         }
 
         require(lpTokens > 0, "Insufficient liquidity");
-        _mint(msg.sender, lpTokens);
 
-        reserveA += amountA;
-        reserveB += amountB;
+        _updateReserves();
 
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
+    // FIX: Use internal reserves instead of balanceOf for withdrawal calculations
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // FIX: Use reserveA/reserveB (internal accounting) instead of balanceOf
+        amountA = (lpTokens * reserveA) / totalSupply();
+        amountB = (lpTokens * reserveB) / totalSupply();
 
         _burn(msg.sender, lpTokens);
 
@@ -65,6 +63,21 @@ contract LiquidityPool is ERC20 {
         reserveB -= amountB;
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    // FIX: sync function to update reserves and emit Sync event
+    function sync() external {
+        uint256 prevReserveA = reserveA;
+        uint256 prevReserveB = reserveB;
+        _updateReserves();
+        if (reserveA != prevReserveA || reserveB != prevReserveB) {
+            emit Sync(reserveA, reserveB);
+        }
+    }
+
+    function _updateReserves() internal {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/contracts/LiquidityPool.sol.meta.json
+++ b/solidity/contracts/LiquidityPool.sol.meta.json
@@ -1,0 +1,1 @@
+{"name": "OWL Alpha Agent", "session_init": "fix-liquidity-pool-manipulation: Fix first-depositor price manipulation in LiquidityPool.sol. Lock MINIMUM_LIQUIDITY, use reserves not balanceOf, add sync function.", "ts": "2026-05-24T04:41:00Z"}

--- a/solidity/test/LiquidityPool.t.sol
+++ b/solidity/test/LiquidityPool.t.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/LiquidityPool.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol"
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+        _mint(msg.sender, 10000000 * 10**18);
+    }
+}
+
+contract LiquidityPoolTest is Test {
+    LiquidityPool pool;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
+    address provider1;
+    address provider2;
+
+    function setUp() public {
+        tokenA = new MockERC20("Token A", "TKA");
+        tokenB = new MockERC20("Token B", "TKB");
+        pool = new LiquidityPool(address(tokenA), address(tokenB));
+
+        provider1 = makeAddr("provider1");
+        provider2 = makeAddr("provider2");
+
+        // Fund providers
+        tokenA.transfer(provider1, 100000 * 10**18);
+        tokenB.transfer(provider1, 100000 * 10**18);
+        tokenA.transfer(provider2, 100000 * 10**18);
+        tokenB.transfer(provider2, 100000 * 10**18);
+
+        // Approve
+        vm.prank(provider1);
+        tokenA.approve(address(pool), type(uint256).max);
+        vm.prank(provider1);
+        tokenB.approve(address(pool), type(uint256).max);
+        vm.prank(provider2);
+        tokenA.approve(address(pool), type(uint256).max);
+        vm.prank(provider2);
+        tokenB.approve(address(pool), type(uint256).max);
+    }
+
+    // Test: First deposit locks MINIMUM_LIQUIDITY to address(0)
+    function test_FirstDepositLocksMinimumLiquidity() public {
+        vm.prank(provider1);
+        uint256 lpTokens = pool.addLiquidity(10000 * 10**18, 10000 * 10**18);
+
+        // MINIMUM_LIQUIDITY (1000) locked to address(0)
+        assertEq(pool.balanceOf(address(0)), 1000);
+        // Provider gets sqrt(10000*10000)*10**18 - 1000
+        uint256 expectedTotal = sqrt(10000 * 10**18 * 10000 * 10**18);
+        assertEq(lpTokens, expectedTotal - 1000);
+    }
+
+    // Test: First deposit must exceed minimum liquidity
+    function test_RevertSmallFirstDeposit() public {
+        vm.prank(provider1);
+        // Tiny amounts would produce lpTokens < MINIMUM_LIQUIDITY
+        vm.expectRevert("Initial liquidity too small");
+        pool.addLiquidity(1, 1);
+    }
+
+    // Test: First depositor price manipulation attempt fails
+    function test_PriceManipulationPrevented() public {
+        // First depositor adds tiny liquidity
+        vm.prank(provider1);
+        uint256 lp1 = pool.addLiquidity(10000 * 10**18, 10000 * 10**18);
+
+        // Try to manipulate: add huge amount of tokenA directly to pool
+        tokenA.transfer(address(pool), 1000000 * 10**18);
+
+        // Second depositor uses proportional formula based on reserves
+        // Reserves are updated correctly via internal accounting, not balanceOf
+        tokenA.transfer(address(pool), 10000 * 10**18 + 1000000 * 10**18); // direct transfer
+
+        // Get current reserves (internal)
+        uint256 resA = pool.reserveA();
+        uint256 resB = pool.reserveB();
+
+        // The reserves should reflect actual amounts from addLiquidity
+        assertEq(resA, 10000 * 10**18);
+        assertEq(resB, 10000 * 10**18);
+    }
+
+    // Test: Subsequent deposits use correct proportional formula
+    function test_SubsequentDepositProportional() public {
+        vm.prank(provider1);
+        pool.addLiquidity(10000 * 10**18, 10000 * 10**18);
+
+        vm.prank(provider2);
+        uint256 lp2 = pool.addLiquidity(5000 * 10**18, 5000 * 10**18);
+
+        // Provider2 should get roughly half of provider1's LP tokens
+        // (minus the minimum liquidity lock)
+        assertTrue(lp2 > 0);
+    }
+
+    // Test: removeLiquidity uses internal reserves, not balanceOf
+    function test_RemoveLiquidityUsesReserves() public {
+        vm.prank(provider1);
+        uint256 lpTokens = pool.addLiquidity(10000 * 10**18, 10000 * 10**18);
+
+        // Direct token transfer to pool (donation attack)
+        tokenA.transfer(address(pool), 5000 * 10**18);
+
+        // Remove liquidity
+        uint256 lpToRedeem = pool.balanceOf(provider1) - 1000; // Keep some
+        vm.prank(provider1);
+        (uint256 amountA, uint256 amountB) = pool.removeLiquidity(lpToRedeem);
+
+        // Amounts should be based on reserves (10000 each), not balanceOf (15000, 10000)
+        uint256 expectedA = (lpToRedeem * 10000 * 10**18) / pool.totalSupply();
+        assertEq(amountA, expectedA);
+    }
+
+    // Test: sync function updates reserves and emits Sync event
+    function test_SyncUpdatesReserves() public {
+        vm.prank(provider1);
+        pool.addLiquidity(10000 * 10**18, 10000 * 10**18);
+
+        // Direct transfer changes balance but not reserves
+        tokenA.transfer(address(pool), 5000 * 10**18);
+
+        // Sync should update reserves
+        uint256 oldReserveA = pool.reserveA();
+        pool.sync();
+        uint256 newReserveA = pool.reserveA();
+
+        assertGt(newReserveA, oldReserveA);
+        assertEq(newReserveA, 15000 * 10**18);
+    }
+
+    // Test: Direct token transfers to pool do not affect LP token pricing
+    function test_DirectTransferDoesNotAffectPricing() public {
+        vm.prank(provider1);
+        uint256 lp1 = pool.addLiquidity(10000 * 10**18, 10000 * 10**18);
+
+        // Direct transfer (donation) to pool
+        tokenA.transfer(address(pool), 99000 * 10**18);
+
+        // Second provider adds liquidity based on reserves (not balanceOf)
+        vm.prank(provider2);
+        uint256 lp2 = pool.addLiquidity(1000 * 10**18, 1000 * 10**18);
+
+        // LP tokens should be proportional to reserves (10000 each originally)
+        // NOT proportional to balanceOf (which would be 109000 for tokenA)
+        assertTrue(lp2 > 0);
+        // The ratio should be approximately correct
+        uint256 ratio = (lp2 * 10000) / lp1;
+        assertApproxEqRel(ratio, 10, 1); // ~10% of lp1
+    }
+
+    // Test: removeLiquidity successfully returns tokens
+    function test_RemoveLiquiditySuccess() public {
+        vm.prank(provider1);
+        uint256 lpTokens = pool.addLiquidity(10000 * 10**18, 10000 * 10**18);
+
+        uint256 balABefore = tokenA.balanceOf(provider1);
+        uint256 balBBefore = tokenB.balanceOf(provider1);
+
+        uint256 lpToRedeem = pool.balanceOf(provider1) - 1000;
+        vm.prank(provider1);
+        pool.removeLiquidity(lpToRedeem);
+
+        assertGt(tokenA.balanceOf(provider1), balABefore);
+        assertGt(tokenB.balanceOf(provider1), balBBefore);
+    }
+
+    function sqrt(uint256 y) internal pure returns (uint256 z) {
+        if (y > 3) {
+            z = y;
+            uint256 x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            }
+        } else if (y != 0) {
+            z = 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #918

This PR addresses the first-depositor price manipulation vulnerability in `LiquidityPool.sol`:

### Changes
- On first deposit, require minimum liquidity of `MINIMUM_LIQUIDITY = 1000` and permanently lock it by sending to `address(0)` (Uniswap V2 pattern)
- First depositor receives LP tokens minus the locked amount
- Fixed `removeLiquidity` to use internal `reserveA/reserveB` accounting instead of `balanceOf(address(this))` which is manipulable via direct token transfers
- Added `sync()` function that updates internal reserves to match actual balances for recovery from donation attacks

### Files Changed
- `solidity/contracts/LiquidityPool.sol` - Core contract fixes
- `solidity/test/LiquidityPool.t.sol` - Comprehensive test suite (184 lines)
- `solidity/contracts/LiquidityPool.sol.meta.json` - Contributor metadata

### Test Coverage
- First deposit locks MINIMUM_LIQUIDITY tokens at address(0)
- Price manipulation attempt prevention
- Donation attack via direct transfer
- Sync recovery
- Proportional LP token minting for subsequent deposits