### PR TITLE
[ H4ck3r-netizen ] [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OWL Alpha Agent",
+  "initial_directives": "[OWL session - autonomous bounty hunter monitoring cron job - fixing PriceOracle staleness check, fallback oracle, round completeness validation, and negative price rejection]",
+  "date": "2026-05-26T05:00:00Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,34 +14,60 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed oracle, uint256 lastUpdateTimestamp);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
     function getLatestPrice() external view returns (int256) {
-        (
+        // Try primary feed first
+        try primaryFeed.latestRoundData() returns (
             uint80 roundId,
             int256 price,
-            ,
+            uint256 startedAt,
             uint256 updatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) {
+            // Validate round completeness
+            if (answeredInRound < roundId) revert("Incomplete round");
+            // Validate price is positive
+            if (price <= 0) revert("Invalid price");
+            // Check staleness
+            if (block.timestamp - updatedAt < MAX_STALENESS) {
+                return price;
+            }
+        } catch {
+            // Primary feed failed entirely
+        }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        // Primary feed is stale or failed — try fallback
+        try fallbackFeed.latestRoundData() returns (
+            uint80 fallbackRoundId,
+            int256 fallbackPrice,
+            uint256 fallbackStartedAt,
+            uint256 fallbackUpdatedAt,
+            uint80 fallbackAnsweredInRound
+        ) {
+            if (fallbackAnsweredInRound < fallbackRoundId) revert("Fallback: Incomplete round");
+            if (fallbackPrice <= 0) revert("Fallback: Invalid price");
+            if (block.timestamp - fallbackUpdatedAt < MAX_STALENESS) {
+                emit StalePrice(address(primaryFeed), block.timestamp);
+                return fallbackPrice;
+            }
+        } catch {
+            // Fallback also failed
+        }
 
-        return price;
+        // Both oracles are stale or failed
+        revert("Both oracles stale");
     }
 
     function getDecimals() external view returns (uint8) {
@@ -51,5 +77,10 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
     }
 }

--- a/solidity/test/PriceOracle.t.sol
+++ b/solidity/test/PriceOracle.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/PriceOracle.sol";
+
+contract MockAggregatorV3 {
+    uint80 public roundId;
+    int256 public answer;
+    uint256 public startedAt;
+    uint256 public updatedAt;
+    uint80 public answeredInRound;
+    uint8 public _decimals = 8;
+
+    function latestRoundData() external view returns (
+        uint80, int256, uint256, uint256, uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function setValues(uint80 _roundId, int256 _answer, uint256 _updatedAt, uint80 _answeredInRound) external {
+        roundId = _roundId;
+        answer = _answer;
+        updatedAt = _updatedAt;
+        answeredInRound = _answeredInRound;
+    }
+}
+
+contract PriceOracleTest is Test {
+    PriceOracle oracle;
+    MockAggregatorV3 primaryFeed;
+    MockAggregatorV3 fallbackFeed;
+
+    function setUp() public {
+        primaryFeed = new MockAggregatorV3();
+        fallbackFeed = new MockAggregatorV3();
+        oracle = new PriceOracle(address(primaryFeed), address(fallbackFeed));
+    }
+
+    function test_ValidPrice() public {
+        primaryFeed.setValues(100, 50000 * 10**8, block.timestamp, 100);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 50000 * 10**8);
+    }
+
+    function test_StalePriceTriggersFallback() public {
+        // Primary feed is stale (updated 2 hours ago)
+        primaryFeed.setValues(100, 50000 * 10**8, block.timestamp - 7200, 100);
+        // Fallback is fresh
+        fallbackFeed.setValues(200, 51000 * 10**8, block.timestamp, 200);
+
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 51000 * 10**8, "Should return fallback price");
+    }
+
+    function test_NegativePriceReverts() public {
+        primaryFeed.setValues(100, -1, block.timestamp, 100);
+        fallbackFeed.setValues(200, -1, block.timestamp, 200);
+
+        try oracle.getLatestPrice() {
+            revert("Should have reverted");
+        } catch (bytes memory reason) {
+            assertTrue(true);
+        }
+    }
+
+    function test_ZeroPriceReverts() public {
+        primaryFeed.setValues(100, 0, block.timestamp, 100);
+        fallbackFeed.setValues(200, 0, block.timestamp, 200);
+
+        try oracle.getLatestPrice() {
+            revert("Should have reverted");
+        } catch (bytes memory reason) {
+            assertTrue(true);
+        }
+    }
+
+    function test_IncompleteRoundReverts() public {
+        // answeredInRound < roundId means incomplete
+        primaryFeed.setValues(100, 50000 * 10**8, block.timestamp, 99);
+        fallbackFeed.setValues(200, 51000 * 10**8, block.timestamp, 199);
+
+        try oracle.getLatestPrice() {
+            revert("Should have reverted");
+        } catch (bytes memory reason) {
+            assertTrue(true);
+        }
+    }
+
+    function test_BothOraclesStaleReverts() public {
+        primaryFeed.setValues(100, 50000 * 10**8, block.timestamp - 7200, 100);
+        fallbackFeed.setValues(200, 51000 * 10**8, block.timestamp - 7200, 200);
+
+        try oracle.getLatestPrice() {
+            revert("Should have reverted");
+        } catch (bytes memory reason) {
+            assertTrue(true);
+        }
+    }
+
+    function test_SetMaxStaleness() public {
+        oracle.setMaxStaleness(7200);
+        // Now a 2-hour-old price should be accepted from primary
+        primaryFeed.setValues(100, 50000 * 10**8, block.timestamp - 7200, 100);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 50000 * 10**8);
+    }
+
+    function test_GetDecimals() public {
+        uint8 d = oracle.getDecimals();
+        assertEq(d, 8);
+    }
+
+    function test_SetFallbackFeed() public {
+        MockAggregatorV3 newFallback = new MockAggregatorV3();
+        newFallback.setValues(300, 52000 * 10**8, block.timestamp, 300);
+        oracle.setFallbackFeed(address(newFallback));
+
+        // Primary stale, new fallback should work
+        primaryFeed.setValues(100, 50000 * 10**8, block.timestamp - 7200, 100);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 52000 * 10**8);
+    }
+}


### PR DESCRIPTION
Fixes #915

## Summary
Fixes PriceOracle missing staleness check, negative/zero price validation, round completeness check, and adds fallback oracle support.

### Changes
- Added staleness check: prices older than MAX_STALENESS (3600s) trigger fallback oracle
- Reject zero or negative prices with clear error messages
- Validate round completeness (answeredInRound >= roundId)
- Added fallback oracle that is queried when primary returns stale data
- StalePrice event emitted when falling back to secondary oracle
- If both oracles return stale data, the function reverts
- MAX_STALENESS is configurable by contract owner via setMaxStaleness()
- setFallbackFeed() allows updating the fallback oracle address

### Files
- solidity/contracts/PriceOracle.sol
- solidity/test/PriceOracle.t.sol
- solidity/contracts/.generation_meta.json