### PR TITLE
OpenAI Codex [ FastAPI ] Fix hardcoded CDN URLs in Swagger UI and ReDoc HTML generation

### DIFF
--- a/fastapi/fastapi/applications.py
+++ b/fastapi/fastapi/applications.py
@@ -442,6 +442,55 @@ class FastAPI(Starlette):
                 """
             ),
         ] = "/redoc",
+        swagger_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI JavaScript for the automatic
+                interactive API documentation. If unset, FastAPI uses the default
+                configured in `get_swagger_ui_html()`.
+                """
+            ),
+        ] = None,
+        swagger_css_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI CSS for the automatic
+                interactive API documentation. If unset, FastAPI uses the default
+                configured in `get_swagger_ui_html()`.
+                """
+            ),
+        ] = None,
+        swagger_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the favicon to use for the Swagger UI documentation.
+                If unset, FastAPI uses the default configured in
+                `get_swagger_ui_html()`.
+                """
+            ),
+        ] = None,
+        redoc_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the ReDoc JavaScript for the automatic
+                alternative API documentation. If unset, FastAPI uses the default
+                configured in `get_redoc_html()`.
+                """
+            ),
+        ] = None,
+        redoc_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the favicon to use for the ReDoc documentation. If unset,
+                FastAPI uses the default configured in `get_redoc_html()`.
+                """
+            ),
+        ] = None,
         swagger_ui_oauth2_redirect_url: Annotated[
             str | None,
             Doc(
@@ -882,6 +931,11 @@ class FastAPI(Starlette):
         self.root_path_in_servers = root_path_in_servers
         self.docs_url = docs_url
         self.redoc_url = redoc_url
+        self.swagger_js_url = swagger_js_url
+        self.swagger_css_url = swagger_css_url
+        self.swagger_favicon_url = swagger_favicon_url
+        self.redoc_js_url = redoc_js_url
+        self.redoc_favicon_url = redoc_favicon_url
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
         self.swagger_ui_parameters = swagger_ui_parameters
@@ -1122,13 +1176,22 @@ class FastAPI(Starlette):
                 oauth2_redirect_url = self.swagger_ui_oauth2_redirect_url
                 if oauth2_redirect_url:
                     oauth2_redirect_url = root_path + oauth2_redirect_url
-                return get_swagger_ui_html(
-                    openapi_url=openapi_url,
-                    title=f"{self.title} - Swagger UI",
-                    oauth2_redirect_url=oauth2_redirect_url,
-                    init_oauth=self.swagger_ui_init_oauth,
-                    swagger_ui_parameters=self.swagger_ui_parameters,
-                )
+                swagger_ui_html_kwargs: dict[str, Any] = {
+                    "openapi_url": openapi_url,
+                    "title": f"{self.title} - Swagger UI",
+                    "oauth2_redirect_url": oauth2_redirect_url,
+                    "init_oauth": self.swagger_ui_init_oauth,
+                    "swagger_ui_parameters": self.swagger_ui_parameters,
+                }
+                if self.swagger_js_url is not None:
+                    swagger_ui_html_kwargs["swagger_js_url"] = self.swagger_js_url
+                if self.swagger_css_url is not None:
+                    swagger_ui_html_kwargs["swagger_css_url"] = self.swagger_css_url
+                if self.swagger_favicon_url is not None:
+                    swagger_ui_html_kwargs["swagger_favicon_url"] = (
+                        self.swagger_favicon_url
+                    )
+                return get_swagger_ui_html(**swagger_ui_html_kwargs)
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
 
@@ -1147,9 +1210,15 @@ class FastAPI(Starlette):
             async def redoc_html(req: Request) -> HTMLResponse:
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
-                return get_redoc_html(
-                    openapi_url=openapi_url, title=f"{self.title} - ReDoc"
-                )
+                redoc_html_kwargs = {
+                    "openapi_url": openapi_url,
+                    "title": f"{self.title} - ReDoc",
+                }
+                if self.redoc_js_url is not None:
+                    redoc_html_kwargs["redoc_js_url"] = self.redoc_js_url
+                if self.redoc_favicon_url is not None:
+                    redoc_html_kwargs["redoc_favicon_url"] = self.redoc_favicon_url
+                return get_redoc_html(**redoc_html_kwargs)
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)
 

--- a/fastapi/fastapi/openapi/.generation_meta.json
+++ b/fastapi/fastapi/openapi/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Non-sensitive public provenance only: OpenAI Codex was asked to address UnsafeLabs/Bounty-Hunters issue #762 by adding configurable FastAPI docs asset URLs, preserving backward compatibility, and validating the change with tests. Private system, developer, account, runtime, and credential-bearing instructions are intentionally not disclosed.",
+  "date": "2026-05-26T07:51:45Z"
+}

--- a/fastapi/fastapi/openapi/docs.py
+++ b/fastapi/fastapi/openapi/docs.py
@@ -76,7 +76,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui-bundle.js",
     swagger_css_url: Annotated[
         str,
         Doc(
@@ -89,7 +89,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui.css",
     swagger_favicon_url: Annotated[
         str,
         Doc(
@@ -233,7 +233,7 @@ def get_redoc_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+    ] = "https://cdn.jsdelivr.net/npm/redoc@2.5.2/bundles/redoc.standalone.js",
     redoc_favicon_url: Annotated[
         str,
         Doc(

--- a/fastapi/tests/test_local_docs.py
+++ b/fastapi/tests/test_local_docs.py
@@ -1,6 +1,11 @@
 import inspect
 
+from fastapi import FastAPI
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.testclient import TestClient
+
+SWAGGER_UI_DIST_VERSION = "5.32.6"
+REDOC_VERSION = "2.5.2"
 
 
 def test_strings_in_generated_swagger():
@@ -8,6 +13,8 @@ def test_strings_in_generated_swagger():
     swagger_js_url = sig.parameters.get("swagger_js_url").default  # type: ignore
     swagger_css_url = sig.parameters.get("swagger_css_url").default  # type: ignore
     swagger_favicon_url = sig.parameters.get("swagger_favicon_url").default  # type: ignore
+    assert f"swagger-ui-dist@{SWAGGER_UI_DIST_VERSION}" in swagger_js_url
+    assert f"swagger-ui-dist@{SWAGGER_UI_DIST_VERSION}" in swagger_css_url
     html = get_swagger_ui_html(openapi_url="/docs", title="title")
     body_content = html.body.decode()
     assert swagger_js_url in body_content
@@ -36,6 +43,7 @@ def test_strings_in_generated_redoc():
     sig = inspect.signature(get_redoc_html)
     redoc_js_url = sig.parameters.get("redoc_js_url").default  # type: ignore
     redoc_favicon_url = sig.parameters.get("redoc_favicon_url").default  # type: ignore
+    assert f"redoc@{REDOC_VERSION}" in redoc_js_url
     html = get_redoc_html(openapi_url="/docs", title="title")
     body_content = html.body.decode()
     assert redoc_js_url in body_content
@@ -65,3 +73,31 @@ def test_google_fonts_in_generated_redoc():
         openapi_url="/docs", title="title", with_google_fonts=False
     ).body.decode()
     assert "fonts.googleapis.com" not in body_without_google_fonts
+
+
+def test_fastapi_app_uses_custom_swagger_asset_urls():
+    app = FastAPI(
+        swagger_js_url="/static/swagger-ui-bundle.js",
+        swagger_css_url="/static/swagger-ui.css",
+        swagger_favicon_url="/static/docs.ico",
+    )
+    response = TestClient(app).get("/docs")
+
+    assert response.status_code == 200
+    assert "/static/swagger-ui-bundle.js" in response.text
+    assert "/static/swagger-ui.css" in response.text
+    assert "/static/docs.ico" in response.text
+    assert "cdn.jsdelivr.net/npm/swagger-ui-dist" not in response.text
+
+
+def test_fastapi_app_uses_custom_redoc_asset_urls():
+    app = FastAPI(
+        redoc_js_url="/static/redoc.standalone.js",
+        redoc_favicon_url="/static/redoc.ico",
+    )
+    response = TestClient(app).get("/redoc")
+
+    assert response.status_code == 200
+    assert "/static/redoc.standalone.js" in response.text
+    assert "/static/redoc.ico" in response.text
+    assert "cdn.jsdelivr.net/npm/redoc" not in response.text


### PR DESCRIPTION
/claim #762

## Summary
- Pin the default Swagger UI and ReDoc CDN assets to the current verified stable npm versions: swagger-ui-dist 5.32.6 and redoc 2.5.2.
- Add optional FastAPI app-level docs asset override parameters for Swagger UI JS/CSS/favicon and ReDoc JS/favicon.
- Preserve backward compatibility by using helper defaults whenever app-level overrides are unset.
- Add focused docs HTML tests for default pinned versions and app-level custom URL rendering.

## Generation metadata
Added safe non-sensitive `.generation_meta.json` metadata only. Private platform, system, developer, runtime, and credential-bearing instructions are not disclosed.

## Demo / validation
```
npm view swagger-ui-dist version -> 5.32.6
npm view redoc version -> 2.5.2
uv run python -m pytest tests/test_local_docs.py -q -> 7 passed
uv run ruff check fastapi/openapi/docs.py fastapi/applications.py tests/test_local_docs.py -> All checks passed
uv run ruff format --check fastapi/openapi/docs.py fastapi/applications.py tests/test_local_docs.py -> already formatted
uv run python -m compileall -q fastapi/openapi/docs.py fastapi/applications.py tests/test_local_docs.py
git diff --check
python3 -m json.tool fastapi/fastapi/openapi/.generation_meta.json >/dev/null
```