### PR TITLE
[OpenAI Codex] [ T3 Code ] Fix Turbo build dependency graph

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "AI-assisted configuration change. Private platform instructions, hidden prompts, credentials, and non-public runtime context are intentionally not included.",
+  "completed_at": "2026-05-26T08:10:00Z"
+}

--- a/t3code/apps/desktop/turbo.jsonc
+++ b/t3code/apps/desktop/turbo.jsonc
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@t3tools/web#build", "t3#build"],
       "outputs": ["dist-electron/**"],
     },
     "dev": {

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,29 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/web#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/client-runtime#build",
+        "@t3tools/shared#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "@t3tools/tailscale#build",
+        "@t3tools/web#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/desktop#build": {
+      "dependsOn": ["^build", "@t3tools/web#build", "t3#build"],
+      "outputs": ["dist-electron/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
/claim #828

## Summary
- Add package-specific Turbo build task definitions for web and server so their build dependencies and cache outputs are explicit.
- Add the missing desktop build dependencies on the web and server bundles in the desktop package Turbo override.
- Include a non-sensitive `_meta.json` file; private platform instructions and hidden runtime context are intentionally not disclosed.

## Verification
- Red check before the fix: `bunx turbo run build --dry=json --filter=@t3tools/desktop ... | jq ...` returned `false` because `@t3tools/desktop#build` did not depend on `@t3tools/web#build` or `t3#build`.
- `jq . t3code/turbo.json t3code/_meta.json >/dev/null`
- `bunx turbo run build --dry=json >/tmp/t3code-turbo-build-dry.json`
- `jq` assertions confirmed:
  - `@t3tools/desktop#build` depends on `@t3tools/web#build` and `t3#build`, with `dist-electron/**` output.
  - `@t3tools/web#build` depends on `@t3tools/contracts#build` and `@t3tools/client-runtime#build`, with `dist/**` output.
  - `t3#build` depends on `@t3tools/contracts#build`, `@t3tools/shared#build`, `effect-acp#build`, and `effect-codex-app-server#build`, with `dist/**` output.
- `git diff --check`

Demo note: this is a Turbo configuration change, so the dry-run dependency graph output is the review/demo surface.
