### PR TITLE
Codex [ T3 Code ] Fix turbo.json missing dependency graph for incremental builds

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "CharlieLZ via Codex",
+  "generation_context": "Task #828 requested updating t3code/turbo.json so the T3 Code monorepo declares explicit Turbo build dependency edges: web depends on contracts and client-runtime; server depends on contracts, shared, effect-acp, and effect-codex-app-server; desktop depends on web and server; package build outputs should be cacheable; existing build commands must keep working. Private system, developer, account, credential, and hidden policy instructions are intentionally not included.",
+  "completed_at": "2026-05-26T08:07:56Z"
+}

--- a/t3code/apps/desktop/turbo.jsonc
+++ b/t3code/apps/desktop/turbo.jsonc
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@t3tools/web#build", "t3#build"],
       "outputs": ["dist-electron/**"],
     },
     "dev": {

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,24 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/web#build": {
+      "dependsOn": ["^build", "@t3tools/contracts#build", "@t3tools/client-runtime#build"],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "^build",
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/desktop#build": {
+      "dependsOn": ["^build", "@t3tools/web#build", "t3#build"],
+      "outputs": ["dist/**", "dist-electron/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
/claim #828

This updates the T3 Code Turbo build graph so the configured app build order matches the issue requirements:

- `@t3tools/web#build` now explicitly waits for contracts and client-runtime build tasks.
- `t3#build` now explicitly waits for contracts, shared, effect-acp, and effect-codex-app-server build tasks while preserving the existing workspace dependency graph.
- `@t3tools/desktop#build` now waits for both `@t3tools/web#build` and `t3#build`.
- `apps/desktop/turbo.jsonc` also needed the same desktop edge because it extends and overrides the root build task.

I intentionally included only non-sensitive generation metadata in `_meta.json`; private system, developer, account, credential, and hidden policy instructions are not included.

Verification:

- `mise exec -- bun fmt`
- `mise exec -- bun lint` (9 existing warnings, 0 errors)
- `mise exec -- bun typecheck`
- `jq empty turbo.json _meta.json`
- `git diff --check`
- `turbo run build --dry=json --filter=@t3tools/desktop` shows `@t3tools/desktop#build` depends on `@t3tools/web#build` and `t3#build`
