### PR TITLE
Codex [ T3 Code ] Add version command and --version flag to CLI

### DIFF
--- a/t3code/apps/server/.contributor.json
+++ b/t3code/apps/server/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Private system, developer, and session instructions are intentionally not disclosed. Repository instructions were followed and no secrets, tokens, or hidden runtime context are included.",
+  "timestamp": "2026-05-26T08:51:04Z"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -16,6 +16,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
+import packageJson from "../package.json" with { type: "json" };
 import { cli } from "./bin.ts";
 import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "./config.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
@@ -48,6 +49,14 @@ const captureStdout = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
       "";
     return { result, output };
   }).pipe(Effect.provide(Layer.mergeAll(CliRuntimeLayer, TestConsole.layer)));
+
+const currentRuntimeInfo = () => {
+  const bunRuntime = (globalThis as { readonly Bun?: { readonly version?: string } }).Bun;
+  return {
+    name: bunRuntime ? "bun" : "node",
+    version: bunRuntime?.version ?? process.versions.node,
+  };
+};
 
 const makeCliTestServerConfig = (baseDir: string) =>
   Effect.gen(function* () {
@@ -150,6 +159,18 @@ const withLiveProjectCliServer = <A, E, R>(baseDir: string, run: () => Effect.Ef
   });
 
 it.layer(NodeServices.layer)("bin cli parsing", (it) => {
+  it.effect("prints detailed version information from the version subcommand", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCliWithRuntime(["version"]));
+      const runtime = currentRuntimeInfo();
+
+      assert.equal(
+        output,
+        `t3code v${packageJson.version} (${runtime.name} ${runtime.version}, ${process.platform} ${process.arch})`,
+      );
+    }),
+  );
+
   it.effect("accepts the built-in lowercase log-level flag values", () =>
     runCliWithRuntime(["--log-level", "debug", "--version"]),
   );

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -10,17 +10,24 @@ import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { formatCliVersionValue, versionCommand } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    versionCommand,
+  ]),
 );
 
 if (import.meta.main) {
-  Command.run(cli, { version: packageJson.version }).pipe(
+  Command.run(cli, { version: formatCliVersionValue(packageJson.version) }).pipe(
     Effect.scoped,
     Effect.provide(CliRuntimeLayer),
     NodeRuntime.runMain,

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,36 @@
+import * as Console from "effect/Console";
+import { Command } from "effect/unstable/cli";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+export type CliVersionRuntimeInfo = {
+  readonly name: "bun" | "node";
+  readonly version: string;
+  readonly platform: NodeJS.Platform;
+  readonly arch: NodeJS.Architecture;
+};
+
+export const getCliVersionRuntimeInfo = (): CliVersionRuntimeInfo => {
+  const bunRuntime = (globalThis as { readonly Bun?: { readonly version?: string } }).Bun;
+  return {
+    name: bunRuntime ? "bun" : "node",
+    version: bunRuntime?.version ?? process.versions.node,
+    platform: process.platform,
+    arch: process.arch,
+  };
+};
+
+export const formatCliVersionValue = (
+  version: string = packageJson.version,
+  runtime: CliVersionRuntimeInfo = getCliVersionRuntimeInfo(),
+) => `${version} (${runtime.name} ${runtime.version}, ${runtime.platform} ${runtime.arch})`;
+
+export const formatCliVersionInfo = (
+  version: string = packageJson.version,
+  runtime: CliVersionRuntimeInfo = getCliVersionRuntimeInfo(),
+) => `t3code v${formatCliVersionValue(version, runtime)}`;
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print T3 Code version information."),
+  Command.withHandler(() => Console.log(formatCliVersionInfo())),
+);


### PR DESCRIPTION
/claim #821

## Issue
Addresses #821.

## Summary
Add a dedicated `t3 version` subcommand that reads the server package version and prints detailed runtime, platform, and architecture information. Keep root `--version` on Effect CLI built-in version support, using the same package version with runtime details.

## Acceptance criteria
- [x] `t3 --version` outputs a version string and exits with code 0.
- [x] `t3 version` outputs detailed version info in the requested shape.
- [x] The version comes from `apps/server/package.json`, not a hardcoded literal.
- [x] Existing CLI commands remain registered and covered by the existing CLI tests.
- [x] Added requested non-sensitive `.contributor.json` metadata.

## Validation
- `mise exec -- bun fmt`
- `mise exec -- bun lint` (0 errors; existing warnings only)
- `mise exec -- bun typecheck`
- `mise exec -- bun run test src/bin.test.ts`
- `mise exec -- bun src/bin.ts version`
- `mise exec -- bun src/bin.ts --version`
- `git diff --check`
- `jq . t3code/apps/server/.contributor.json`