### PR TITLE
OpenAI Codex [ T3 Code ] Add sidebar resize reset

### DIFF
--- a/t3code/apps/web/src/components/.provenance.json
+++ b/t3code/apps/web/src/components/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe non-sensitive summary: autonomous coding agent running in a local checkout, following repository AGENTS.md instructions for t3code; used test-driven development, kept changes scoped to sidebar resize behavior, and did not include hidden system, developer, account, credential, or private session instructions.",
+  "created_at": "2026-05-26T08:55:21Z"
+}

--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, type CSSProperties, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import ThreadSidebar from "./Sidebar";
@@ -9,7 +9,9 @@ import {
 } from "../shortcutModifierState";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
-const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
+const THREAD_SIDEBAR_DEFAULT_WIDTH = 280;
+const THREAD_SIDEBAR_MIN_WIDTH = 200;
+const THREAD_SIDEBAR_MAX_WIDTH = 500;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
@@ -54,12 +56,18 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   }, [navigate]);
 
   return (
-    <SidebarProvider className="h-dvh! min-h-0!" defaultOpen>
+    <SidebarProvider
+      className="h-dvh! min-h-0!"
+      defaultOpen
+      style={{ "--sidebar-width": `${THREAD_SIDEBAR_DEFAULT_WIDTH}px` } as CSSProperties}
+    >
       <Sidebar
         side="left"
         collapsible="offcanvas"
         className="border-r border-border bg-card text-foreground"
         resizable={{
+          defaultWidth: THREAD_SIDEBAR_DEFAULT_WIDTH,
+          maxWidth: THREAD_SIDEBAR_MAX_WIDTH,
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,
           shouldAcceptWidth: ({ nextWidth, wrapper }) =>
             wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,

--- a/t3code/apps/web/src/components/ui/sidebar.browser.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.browser.tsx
@@ -1,0 +1,60 @@
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { Sidebar, SidebarProvider, SidebarRail } from "./sidebar";
+
+const STORAGE_KEY = "t3code:test:sidebar-width";
+
+describe("SidebarRail resizable behavior", () => {
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    document.body.innerHTML = "";
+  });
+
+  it("resets a persisted sidebar width to the configured default on double click", async () => {
+    await page.viewport(1280, 800);
+    localStorage.setItem(STORAGE_KEY, "420");
+    const onResize = vi.fn();
+
+    const screen = await render(
+      <SidebarProvider defaultOpen>
+        <Sidebar
+          collapsible="offcanvas"
+          resizable={{
+            defaultWidth: 280,
+            maxWidth: 500,
+            minWidth: 200,
+            onResize,
+            storageKey: STORAGE_KEY,
+          }}
+        >
+          <div>Navigation</div>
+          <SidebarRail />
+        </Sidebar>
+        <main>Content</main>
+      </SidebarProvider>,
+    );
+
+    try {
+      const wrapper = document.querySelector<HTMLElement>("[data-slot='sidebar-wrapper']");
+      expect(wrapper).not.toBeNull();
+
+      await vi.waitFor(() => {
+        expect(wrapper?.style.getPropertyValue("--sidebar-width")).toBe("420px");
+      });
+
+      const rail = document.querySelector<HTMLButtonElement>("[data-slot='sidebar-rail']");
+      expect(rail).not.toBeNull();
+      rail?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+
+      await vi.waitFor(() => {
+        expect(wrapper?.style.getPropertyValue("--sidebar-width")).toBe("280px");
+        expect(localStorage.getItem(STORAGE_KEY)).toBe("280");
+      });
+      expect(onResize).toHaveBeenLastCalledWith(280);
+    } finally {
+      await screen.unmount();
+    }
+  });
+});

--- a/t3code/apps/web/src/components/ui/sidebar.tsx
+++ b/t3code/apps/web/src/components/ui/sidebar.tsx
@@ -39,6 +39,7 @@ type SidebarContextProps = {
 };
 
 type SidebarResizableOptions = {
+  defaultWidth?: number;
   maxWidth?: number;
   minWidth?: number;
   onResize?: (width: number) => void;
@@ -54,6 +55,7 @@ type SidebarResizableOptions = {
 };
 
 type SidebarResolvedResizableOptions = {
+  defaultWidth: number | null;
   maxWidth: number;
   minWidth: number;
   onResize?: (width: number) => void;
@@ -192,6 +194,7 @@ function Sidebar({
 
     const options = typeof resizable === "boolean" ? {} : resizable;
     return {
+      defaultWidth: options.defaultWidth ?? null,
       maxWidth: options.maxWidth ?? Number.POSITIVE_INFINITY,
       minWidth: options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
       storageKey: options.storageKey ?? null,
@@ -338,6 +341,7 @@ function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptio
 function SidebarRail({
   className,
   onClick,
+  onDoubleClick,
   onPointerCancel,
   onPointerDown,
   onPointerMove,
@@ -365,7 +369,11 @@ function SidebarRail({
   const resolvedResizable = sidebarInstance?.resizable ?? null;
   const canResize = resolvedResizable !== null && open;
   const railLabel = canResize ? "Resize Sidebar" : "Toggle Sidebar";
-  const railTitle = canResize ? "Drag to resize sidebar" : "Toggle Sidebar";
+  const railTitle = canResize
+    ? resolvedResizable.defaultWidth !== null
+      ? "Drag to resize sidebar. Double-click to reset."
+      : "Drag to resize sidebar"
+    : "Toggle Sidebar";
 
   const stopResize = React.useCallback(
     (pointerId: number) => {
@@ -543,6 +551,47 @@ function SidebarRail({
     [onClick, open, resolvedResizable, toggleSidebar],
   );
 
+  const handleDoubleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onDoubleClick?.(event);
+      if (event.defaultPrevented) return;
+      if (!resolvedResizable || !open || resolvedResizable.defaultWidth === null) return;
+
+      const wrapper = event.currentTarget.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
+      const sidebarRoot = event.currentTarget.closest<HTMLElement>("[data-slot='sidebar']");
+      const sidebarContainer = sidebarRoot?.querySelector<HTMLElement>(
+        "[data-slot='sidebar-container']",
+      );
+      if (!wrapper || !sidebarRoot || !sidebarContainer) {
+        return;
+      }
+
+      const currentWidth = sidebarContainer.getBoundingClientRect().width;
+      const nextWidth = clampSidebarWidth(resolvedResizable.defaultWidth, resolvedResizable);
+      const accepted =
+        resolvedResizable.shouldAcceptWidth?.({
+          currentWidth,
+          nextWidth,
+          rail: event.currentTarget,
+          side: sidebarInstance?.side ?? "left",
+          sidebarRoot,
+          wrapper,
+        }) ?? true;
+      if (!accepted) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
+      if (resolvedResizable.storageKey && typeof window !== "undefined") {
+        setLocalStorageItem(resolvedResizable.storageKey, nextWidth, Schema.Finite);
+      }
+      resolvedResizable.onResize?.(nextWidth);
+    },
+    [onDoubleClick, open, resolvedResizable, sidebarInstance?.side],
+  );
+
   React.useEffect(() => {
     if (!resolvedResizable?.storageKey || typeof window === "undefined") return;
     const rail = railRef.current;
@@ -587,6 +636,7 @@ function SidebarRail({
       data-sidebar="rail"
       data-slot="sidebar-rail"
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onPointerCancel={handlePointerCancel}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}


### PR DESCRIPTION
/claim #840

## Summary
- Adds an optional `defaultWidth` for resizable sidebars and resets to it on double-clicking the resize rail.
- Configures the main chat thread sidebar to use the requested 280px default with 200px/500px bounds.
- Adds focused browser coverage for restoring a persisted width and double-click resetting it back to default.
- Includes a safe non-sensitive provenance file without private system/developer/runtime instructions.

## Verification
- `mise exec -- bun fmt`
- `bash -lc 'cd apps/web && mise exec -- bun run test:browser -- src/components/ui/sidebar.browser.tsx'`
- `bash -lc 'cd apps/web && mise exec -- bun run test -- src/components/ui/sidebar.test.tsx'`
- `mise exec -- bun lint` (0 errors, existing repo warnings only)
- `mise exec -- bun typecheck`
- `mise exec -- bun run test --filter=@t3tools/web`
- `mise exec -- bun run build --filter=@t3tools/web`
- `git diff --check`

