### PR TITLE
Add FastAPI test client auth and websocket helpers

### DIFF
--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,47 @@
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 from starlette.testclient import TestClient as TestClient  # noqa
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> FastAPITestClient:
+        self.headers["Authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(self, username: str, password: str) -> FastAPITestClient:
+        credentials = f"{username}:{password}".encode()
+        token = base64.b64encode(credentials).decode("ascii")
+        self.headers["Authorization"] = f"Basic {token}"
+        return self
+
+    def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        subprotocols: Sequence[str] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        ws_headers = dict(self.headers)
+        if headers:
+            ws_headers.update(headers)
+        return self.websocket_connect(
+            url,
+            subprotocols=subprotocols,
+            headers=ws_headers,
+            **kwargs,
+        )
+
+    def assert_status(
+        self, method: str, url: str, status_code: int, **kwargs: Any
+    ) -> Any:
+        response = self.request(method, url, **kwargs)
+        assert response.status_code == status_code, (
+            f"Expected {status_code} for {method.upper()} {url}, "
+            f"got {response.status_code}: {response.text}"
+        )
+        return response

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,105 @@
+import base64
+
+from fastapi import FastAPI, Header, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+from starlette.testclient import TestClient as StarletteTestClient
+
+
+def test_testclient_keeps_starlette_alias() -> None:
+    assert TestClient is StarletteTestClient
+
+
+def test_authenticate_sets_bearer_header_for_later_requests() -> None:
+    app = FastAPI()
+
+    @app.get("/headers")
+    def get_headers(
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, str | None]:
+        return {"authorization": authorization}
+
+    client = FastAPITestClient(app)
+    client.authenticate("secret-token")
+
+    response = client.get("/headers")
+
+    assert response.json() == {"authorization": "Bearer secret-token"}
+
+
+def test_authenticate_basic_sets_encoded_basic_header() -> None:
+    app = FastAPI()
+
+    @app.get("/headers")
+    def get_headers(
+        authorization: str | None = Header(default=None),
+    ) -> dict[str, str | None]:
+        return {"authorization": authorization}
+
+    client = FastAPITestClient(app)
+    client.authenticate_basic("alice", "s3cret")
+
+    encoded = base64.b64encode(b"alice:s3cret").decode("ascii")
+    response = client.get("/headers")
+
+    assert response.json() == {"authorization": f"Basic {encoded}"}
+
+
+def test_ws_connect_merges_auth_and_custom_headers_with_subprotocols() -> None:
+    app = FastAPI()
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(websocket: WebSocket) -> None:
+        await websocket.accept(subprotocol="chat")
+        await websocket.send_json(
+            {
+                "authorization": websocket.headers.get("authorization"),
+                "trace": websocket.headers.get("x-trace-id"),
+                "subprotocol": websocket.scope.get("subprotocols"),
+            }
+        )
+        await websocket.close()
+
+    client = FastAPITestClient(app)
+    client.authenticate("ws-token")
+
+    with client.ws_connect(
+        "/ws",
+        headers={"X-Trace-ID": "abc-123"},
+        subprotocols=["chat"],
+    ) as websocket:
+        assert websocket.receive_json() == {
+            "authorization": "Bearer ws-token",
+            "trace": "abc-123",
+            "subprotocol": ["chat"],
+        }
+
+
+def test_assert_status_returns_response_when_expected_status_matches() -> None:
+    app = FastAPI()
+
+    @app.post("/items", status_code=201)
+    def create_item() -> dict[str, bool]:
+        return {"ok": True}
+
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("POST", "/items", 201)
+
+    assert response.json() == {"ok": True}
+
+
+def test_assert_status_raises_when_status_does_not_match() -> None:
+    app = FastAPI()
+
+    @app.get("/items")
+    def list_items() -> dict[str, bool]:
+        return {"ok": True}
+
+    client = FastAPITestClient(app)
+
+    try:
+        client.assert_status("GET", "/items", 201)
+    except AssertionError as exc:
+        assert "Expected 201 for GET /items, got 200" in str(exc)
+    else:
+        raise AssertionError("assert_status should raise when the status differs")


### PR DESCRIPTION
/claim #804

## Summary
- Added `FastAPITestClient` as an opt-in subclass while keeping the existing `TestClient` Starlette re-export unchanged.
- Added bearer and basic auth helpers that persist default `Authorization` headers on the client instance.
- Added `ws_connect()` for WebSocket tests with inherited auth headers, custom headers, and subprotocols.
- Added `assert_status()` to make a request and assert the expected status in one call.

## Tests
- `.\.venv\Scripts\python.exe -m pytest tests/test_fastapi_testclient.py -q`
- `.\.venv\Scripts\python.exe -m ruff check fastapi/testclient.py tests/test_fastapi_testclient.py`
- `.\.venv\Scripts\python.exe -m ruff format --check fastapi/testclient.py tests/test_fastapi_testclient.py`
- `git diff --check`

## Security
- Auth helpers only set headers on the local test client instance; they do not log, persist, or expose token/password values.
- Existing `TestClient` behavior is preserved for compatibility; users must opt into the new helper class.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: metadata edited to request the repository single-issue check on the current PR head.