### PR TITLE
Respect configured bcrypt rounds for user passwords

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -6,9 +6,11 @@ namespace App\Models;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +28,28 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    protected function password(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value): ?string => $this->hashPassword($value),
+        );
+    }
+
+    private function hashPassword(?string $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        if (password_get_info($value)['algoName'] !== 'unknown') {
+            return $value;
+        }
+
+        return Hash::make($value, [
+            'rounds' => config('hashing.bcrypt.rounds'),
+        ]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Hash Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default hash driver used to hash passwords for
+    | your application. Bcrypt is a sensible default for password storage.
+    |
+    */
+
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bcrypt Options
+    |--------------------------------------------------------------------------
+    |
+    | These options control the bcrypt work factor. Higher rounds increase the
+    | computational cost of generating each password hash.
+    |
+    */
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -15,7 +15,7 @@ class UserFactory extends Factory
     /**
      * The current password being used by the factory.
      */
-    protected static ?string $password;
+    protected static array $passwords = [];
 
     /**
      * Define the model's default state.
@@ -28,7 +28,9 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$passwords[config('hashing.bcrypt.rounds')] ??= Hash::make('password', [
+                'rounds' => config('hashing.bcrypt.rounds'),
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_password_hashes_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 12]);
+
+        $user = new User;
+        $user->password = 'secret-password';
+
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+        $this->assertSame(12, password_get_info($user->password)['options']['cost']);
+    }
+
+    public function test_user_password_preserves_existing_hashes(): void
+    {
+        config(['hashing.bcrypt.rounds' => 12]);
+        $legacyHash = password_hash('secret-password', PASSWORD_BCRYPT, ['cost' => 10]);
+
+        $user = new User;
+        $user->password = $legacyHash;
+
+        $this->assertSame($legacyHash, $user->password);
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+        $this->assertSame(10, password_get_info($user->password)['options']['cost']);
+    }
+
+    public function test_user_factory_hashes_password_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 13]);
+
+        $user = User::factory()->make();
+
+        $this->assertTrue(Hash::check('password', $user->password));
+        $this->assertSame(13, password_get_info($user->password)['options']['cost']);
+    }
+}


### PR DESCRIPTION
﻿/claim #745

## Summary
- Added Laravel hashing config with configurable bcrypt rounds.
- Replaced the generic `hashed` cast with an explicit password mutator that hashes raw passwords using `config('hashing.bcrypt.rounds')`.
- Preserved already-hashed password values so existing bcrypt hashes are not rehashed on assignment.
- Updated `UserFactory` to cache generated passwords per configured round value.
- Added focused regression tests for configured rounds, legacy hash preservation, and factory hashes.

## Tests
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 bash -lc "cp -n .env.example .env && php artisan key:generate --force >/dev/null && php artisan test tests/Unit/UserPasswordHashingTest.php"`
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 bash -lc './vendor/bin/pint --test app/Models/User.php database/factories/UserFactory.php config/hashing.php tests/Unit/UserPasswordHashingTest.php'`
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 bash -lc 'for f in app/Models/User.php database/factories/UserFactory.php config/hashing.php tests/Unit/UserPasswordHashingTest.php; do php -l "$f" || exit 1; done'`
- `git diff --check`

## Security
- Raw passwords are hashed immediately on assignment and are never logged or stored outside the model attribute.
- Existing bcrypt hashes remain valid and are not rehashed accidentally, preserving backward compatibility.
- Factory cache is keyed by bcrypt rounds so tests using different costs do not reuse stale hashes.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: metadata edited to request the repository single-issue check on the current PR head.
