### PR TITLE
Harden flash loan fees, caps, and repayment accounting

### DIFF
--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -2,64 +2,114 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 interface IFlashLoanReceiver {
     function onFlashLoan(address token, uint256 amount, uint256 fee, bytes calldata data) external;
 }
 
 contract FlashLoan {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant BPS_DENOMINATOR = 10000;
+    uint256 public constant MAX_LOAN_BPS = 5000;
+
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
+    uint256 public poolBalance;
     address public owner;
     bool public paused;
+    bool private loanInProgress;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event PoolDeposit(address indexed depositor, uint256 amount);
+    event PauseUpdated(bool paused);
+    event FeesWithdrawn(address indexed owner, uint256 amount);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier noActiveLoan() {
+        require(!loanInProgress, "Loan in progress");
+        loanInProgress = true;
+        _;
+        loanInProgress = false;
+    }
 
     constructor(address _loanToken, uint256 _feeBPS) {
+        require(_loanToken != address(0), "Invalid token");
+        require(_feeBPS <= BPS_DENOMINATOR, "Invalid fee");
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
-    function flashLoan(uint256 amount, bytes calldata data) external {
+    function flashLoan(uint256 amount, bytes calldata data) external noActiveLoan {
         require(!paused, "Paused");
         require(amount > 0, "Amount must be > 0");
+        require(amount <= maxLoanAmount(), "Amount exceeds max loan");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        uint256 fee = calculateFee(amount);
+        poolBalance -= amount;
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
-
-        loanToken.transfer(msg.sender, amount);
+        loanToken.safeTransfer(msg.sender, amount);
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        loanToken.safeTransferFrom(msg.sender, address(this), amount + fee);
 
         totalFees += fee;
+        poolBalance += amount + fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(amount > 0, "Amount must be > 0");
+        loanToken.safeTransferFrom(msg.sender, address(this), amount);
+        poolBalance += amount;
+        emit PoolDeposit(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
+        require(fees > 0, "No fees");
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        poolBalance -= fees;
+        loanToken.safeTransfer(owner, fees);
+        emit FeesWithdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit PauseUpdated(true);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit PauseUpdated(false);
+    }
+
+    function calculateFee(uint256 amount) public view returns (uint256) {
+        if (amount == 0) {
+            return 0;
+        }
+
+        uint256 fee = amount * feeBPS / BPS_DENOMINATOR;
+        if (amount * feeBPS % BPS_DENOMINATOR != 0) {
+            fee += 1;
+        }
+
+        return fee == 0 ? 1 : fee;
+    }
+
+    function maxLoanAmount() public view returns (uint256) {
+        return poolBalance * MAX_LOAN_BPS / BPS_DENOMINATOR;
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolBalance;
     }
 }


### PR DESCRIPTION
﻿/claim #919

## Summary
- Added a minimum 1-unit fee for every nonzero flash loan, with ceiling rounding for proportional fees.
- Limited loans to 50% of internally tracked pool liquidity.
- Replaced `balanceOf` repayment validation with explicit `safeTransferFrom(amount + fee)` repayment after the callback.
- Tracks pool liquidity internally, subtracting the active loan during callback execution and adding principal + fee after repayment.
- Added owner-only pause/unpause controls and fee withdrawal events.
- Added a simple active-loan guard so borrowers cannot re-enter `flashLoan()` during callback execution to bypass the cap.

## Tests
- `docker run --rm -v "${PWD}\\solidity\\contracts:/contracts:ro" node:22 bash -lc "set -e; mkdir -p /tmp/build /tmp/out; cd /tmp/build; npm init -y >/dev/null; npm install --silent solc @openzeppelin/contracts; npx solcjs --bin --abi /contracts/FlashLoan.sol --base-path / --include-path node_modules -o /tmp/out; test -s /tmp/out/contracts_FlashLoan_sol_FlashLoan.bin; ls /tmp/out/contracts_FlashLoan_sol_FlashLoan.*"`
- `git diff --check`

## Security
- Repayment no longer trusts callback-time `balanceOf` changes; the borrower must explicitly return principal plus fee.
- Internal accounting and active-loan guard prevent nested callback loans from bypassing the 50% cap.
- Owner pause is limited by `onlyOwner`; no public pause toggle is exposed.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: metadata edited to request the repository single-issue check on the current PR head.
