### PR TITLE
Harden PriceOracle feed validation

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,88 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event FallbackFeedUpdated(address indexed oldFeed, address indexed newFeed);
+    event MaxStalenessUpdated(uint256 oldMaxStaleness, uint256 newMaxStaleness);
 
     constructor(address _primaryFeed) {
+        require(_primaryFeed != address(0), "Primary feed required");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
     function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        (bool primaryValid, int256 primaryPrice,) = _validatedPrice(primaryFeed);
+        if (primaryValid) {
+            return primaryPrice;
+        }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        if (address(fallbackFeed) != address(0)) {
+            (bool fallbackValid, int256 fallbackPrice,) = _validatedPrice(fallbackFeed);
+            if (fallbackValid) {
+                return fallbackPrice;
+            }
+        }
 
-        return price;
+        revert("No valid oracle price");
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        require(_fallbackFeed != address(primaryFeed), "Fallback must differ");
+
+        address oldFeed = address(fallbackFeed);
+        if (_fallbackFeed == address(0)) {
+            fallbackFeed = AggregatorV3Interface(address(0));
+            emit FallbackFeedUpdated(oldFeed, address(0));
+            return;
+        }
+
+        AggregatorV3Interface candidate = AggregatorV3Interface(_fallbackFeed);
+        require(candidate.decimals() == primaryFeed.decimals(), "Decimals mismatch");
+        fallbackFeed = candidate;
+        emit FallbackFeedUpdated(oldFeed, _fallbackFeed);
+    }
+
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
+        require(_maxStaleness > 0, "Invalid staleness");
+        uint256 oldMaxStaleness = MAX_STALENESS;
         MAX_STALENESS = _maxStaleness;
+        emit MaxStalenessUpdated(oldMaxStaleness, _maxStaleness);
+    }
+
+    function _validatedPrice(
+        AggregatorV3Interface feed
+    ) internal view returns (bool, int256, uint256) {
+        try feed.latestRoundData() returns (
+            uint80 roundId,
+            int256 price,
+            uint256,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) {
+            if (
+                roundId == 0 ||
+                price <= 0 ||
+                updatedAt == 0 ||
+                updatedAt > block.timestamp ||
+                answeredInRound < roundId ||
+                block.timestamp - updatedAt > MAX_STALENESS
+            ) {
+                return (false, 0, updatedAt);
+            }
+            return (true, price, updatedAt);
+        } catch {
+            return (false, 0, 0);
+        }
     }
 }


### PR DESCRIPTION
/claim #915

## Summary
- Validates Chainlink rounds before returning prices: nonzero round, positive answer, nonzero timestamp, no future timestamp, complete answered round, and max staleness.
- Adds an owner-configured fallback feed that is used only when the primary feed is invalid or stale.
- Requires fallback decimals to match the primary feed so callers do not receive prices in a different unit.

## Tests
- Docker solc compile of `solidity/contracts/PriceOracle.sol` produced ABI/bin successfully.
- `git diff --check`

## Security
- Blocks stale, incomplete, zero, negative, and future-dated oracle responses instead of returning unsafe prices.
- Fallback is opt-in, owner-controlled, and decimals-checked to avoid silent price-scale mismatches.
- If neither feed is valid, the oracle reverts with `No valid oracle price` rather than returning a bad value.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: metadata edited to request the repository single-issue check on the current PR head.