### PR TITLE
Add Laravel API token authentication

### DIFF
--- a/laravel/app/Http/Controllers/Api/AuthController.php
+++ b/laravel/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ApiToken;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:8'],
+        ]);
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
+        ]);
+
+        return response()->json($this->tokenResponse($user), 201);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::query()->where('email', strtolower($validated['email']))->first();
+
+        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => ['The provided credentials are incorrect.'],
+            ]);
+        }
+
+        return response()->json($this->tokenResponse($user));
+    }
+
+    public function me(Request $request): JsonResponse
+    {
+        return response()->json([
+            'user' => $request->user(),
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $token = $request->attributes->get('api_token');
+
+        if ($token instanceof ApiToken) {
+            $token->delete();
+        }
+
+        return response()->json([
+            'message' => 'Logged out.',
+        ]);
+    }
+
+    /**
+     * @return array{token: string, token_type: string, expires_at: string, user: User}
+     */
+    private function tokenResponse(User $user): array
+    {
+        $plainToken = Str::random(80);
+        $expiresAt = now()->addDays(30);
+
+        $user->apiTokens()->create([
+            'name' => 'api',
+            'token' => hash('sha256', $plainToken),
+            'expires_at' => $expiresAt,
+        ]);
+
+        return [
+            'token' => $plainToken,
+            'token_type' => 'Bearer',
+            'expires_at' => $expiresAt->toISOString(),
+            'user' => $user,
+        ];
+    }
+}

--- a/laravel/app/Http/Middleware/AuthenticateApiToken.php
+++ b/laravel/app/Http/Middleware/AuthenticateApiToken.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ApiToken;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateApiToken
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $plainToken = $request->bearerToken();
+
+        if (! $plainToken) {
+            abort(401, 'Unauthenticated.');
+        }
+
+        $token = ApiToken::query()
+            ->where('token', hash('sha256', $plainToken))
+            ->where(function ($query): void {
+                $query
+                    ->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', now());
+            })
+            ->first();
+
+        if (! $token) {
+            abort(401, 'Unauthenticated.');
+        }
+
+        $token->forceFill(['last_used_at' => now()])->save();
+        $request->setUserResolver(fn () => $token->user);
+        $request->attributes->set('api_token', $token);
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/ApiToken.php
+++ b/laravel/app/Models/ApiToken.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['user_id', 'name', 'token', 'last_used_at', 'expires_at'])]
+#[Hidden(['token'])]
+class ApiToken extends Model
+{
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'last_used_at' => 'datetime',
+            'expires_at' => 'datetime',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,6 +7,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -16,6 +17,14 @@ class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    /**
+     * @return HasMany<ApiToken, $this>
+     */
+    public function apiTokens(): HasMany
+    {
+        return $this->hasMany(ApiToken::class);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AuthenticateApiToken;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -7,11 +8,14 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'api.token' => AuthenticateApiToken::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/database/migrations/2026_05_26_000000_create_api_tokens_table.php
+++ b/laravel/database/migrations/2026_05_26_000000_create_api_tokens_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name')->default('api');
+            $table->string('token', 64)->unique();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_tokens');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Http\Controllers\Api\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware('api.token')->group(function (): void {
+    Route::get('/user', [AuthController::class, 'me']);
+    Route::post('/logout', [AuthController::class, 'logout']);
+});

--- a/laravel/tests/Feature/ApiAuthTest.php
+++ b/laravel/tests/Feature/ApiAuthTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ApiToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ApiAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_register_and_receive_bearer_token(): void
+    {
+        $response = $this->postJson('/api/register', [
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password' => 'correct-horse-battery',
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('token_type', 'Bearer')
+            ->assertJsonPath('user.email', 'ada@example.com')
+            ->assertJsonStructure(['token', 'expires_at']);
+
+        $token = $response->json('token');
+
+        $this->assertDatabaseHas('users', ['email' => 'ada@example.com']);
+        $this->assertDatabaseMissing('api_tokens', ['token' => $token]);
+        $this->assertDatabaseHas('api_tokens', ['token' => hash('sha256', $token)]);
+    }
+
+    public function test_user_can_login_and_access_current_user(): void
+    {
+        User::factory()->create([
+            'email' => 'grace@example.com',
+            'password' => Hash::make('secure-password'),
+        ]);
+
+        $login = $this->postJson('/api/login', [
+            'email' => 'grace@example.com',
+            'password' => 'secure-password',
+        ]);
+
+        $login->assertOk()->assertJsonPath('token_type', 'Bearer');
+
+        $this
+            ->withToken($login->json('token'))
+            ->getJson('/api/user')
+            ->assertOk()
+            ->assertJsonPath('user.email', 'grace@example.com');
+    }
+
+    public function test_invalid_login_does_not_issue_token(): void
+    {
+        User::factory()->create([
+            'email' => 'alan@example.com',
+            'password' => Hash::make('right-password'),
+        ]);
+
+        $this
+            ->postJson('/api/login', [
+                'email' => 'alan@example.com',
+                'password' => 'wrong-password',
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('email');
+
+        $this->assertDatabaseCount('api_tokens', 0);
+    }
+
+    public function test_logout_revokes_current_token(): void
+    {
+        $user = User::factory()->create();
+        $plainToken = 'plain-test-token';
+        ApiToken::create([
+            'user_id' => $user->id,
+            'name' => 'api',
+            'token' => hash('sha256', $plainToken),
+            'expires_at' => now()->addDay(),
+        ]);
+
+        $this
+            ->withToken($plainToken)
+            ->postJson('/api/logout')
+            ->assertOk()
+            ->assertJsonPath('message', 'Logged out.');
+
+        $this->assertDatabaseCount('api_tokens', 0);
+
+        $this
+            ->withToken($plainToken)
+            ->getJson('/api/user')
+            ->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
/claim #752

## Summary
- Adds Laravel JSON API auth endpoints for registration, login, current user, and logout under `routes/api.php`.
- Adds a self-contained bearer-token model, migration, and middleware instead of pulling in a new package.
- Stores only SHA-256 token hashes, returns the plaintext token once, updates `last_used_at`, and revokes the current token on logout.

## Tests
- `docker run --rm -v ${PWD}\laravel:/app -w /app composer:2 bash -lc 'set -e; cp -n .env.example .env; php artisan key:generate --force >/dev/null; php artisan test'` -> 6 passed
- `docker run --rm -v ${PWD}\laravel:/app -w /app composer:2 bash -lc 'set -e; ./vendor/bin/pint --test app/Http/Controllers/Api/AuthController.php app/Http/Middleware/AuthenticateApiToken.php app/Models/ApiToken.php app/Models/User.php bootstrap/app.php routes/api.php tests/Feature/ApiAuthTest.php database/migrations/2026_05_26_000000_create_api_tokens_table.php'`
- `docker run --rm -v ${PWD}\laravel:/app -w /app composer:2 bash -lc 'set -e; for f in app/Http/Controllers/Api/AuthController.php app/Http/Middleware/AuthenticateApiToken.php app/Models/ApiToken.php app/Models/User.php bootstrap/app.php routes/api.php tests/Feature/ApiAuthTest.php database/migrations/2026_05_26_000000_create_api_tokens_table.php; do php -l $f >/dev/null; done; echo php-lint-ok'`
- `git diff --cached --check`

## Security
- Bearer tokens are generated with high entropy and are never stored in plaintext.
- Expired or revoked tokens return 401, and logout deletes only the presented token.
- API auth is isolated from session cookies, which keeps browser session state from authenticating JSON API calls by accident.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: branch was refreshed after an earlier workflow setup failure; implementation code is unchanged.