### PR TITLE
Add Laravel email verification flow

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,8 +2,9 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Notifications\CustomVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,10 +13,15 @@ use Illuminate\Notifications\Notifiable;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify(new CustomVerifyEmail);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Notifications/CustomVerifyEmail.php
+++ b/laravel/app/Notifications/CustomVerifyEmail.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomVerifyEmail extends VerifyEmail
+{
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Verify your email address')
+            ->greeting('Welcome to '.config('app.name'))
+            ->line('Please verify your email address before using protected account features.')
+            ->action('Verify email address', $this->verificationUrl($notifiable))
+            ->line('If you did not create an account, no further action is required.');
+    }
+}

--- a/laravel/config/mail.php
+++ b/laravel/config/mail.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'default' => env('MAIL_MAILER', 'log'),
+    'default' => env('MAIL_MAILER', 'failover'),
 
     /*
     |--------------------------------------------------------------------------

--- a/laravel/resources/views/auth/verify-email.blade.php
+++ b/laravel/resources/views/auth/verify-email.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Verify email</title>
+    </head>
+    <body>
+        <main>
+            <h1>Verify your email address</h1>
+
+            @if (session('status') === 'verification-link-sent')
+                <p>A new verification link has been sent to your email address.</p>
+            @else
+                <p>Please check your inbox and follow the verification link before continuing.</p>
+            @endif
+
+            <form method="POST" action="{{ route('verification.send') }}">
+                @csrf
+                <button type="submit">Resend verification email</button>
+            </form>
+        </main>
+    </body>
+</html>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,29 @@
 <?php
 
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/email/verify', function () {
+    return view('auth.verify-email');
+})->middleware('auth')->name('verification.notice');
+
+Route::get('/email/verify/{id}/{hash}', function (EmailVerificationRequest $request) {
+    $request->fulfill();
+
+    return redirect('/')->with('verified', true);
+})->middleware(['auth', 'signed'])->name('verification.verify');
+
+Route::post('/email/verification-notification', function (Request $request) {
+    if ($request->user()->hasVerifiedEmail()) {
+        return redirect('/');
+    }
+
+    $request->user()->sendEmailVerificationNotification();
+
+    return back()->with('status', 'verification-link-sent');
+})->middleware(['auth', 'throttle:6,1'])->name('verification.send');

--- a/laravel/tests/Feature/EmailVerificationTest.php
+++ b/laravel/tests/Feature/EmailVerificationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\CustomVerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class EmailVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_verification_notice_renders_for_authenticated_users(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        $this
+            ->actingAs($user)
+            ->get('/email/verify')
+            ->assertOk()
+            ->assertSee('Verify your email address');
+    }
+
+    public function test_user_receives_custom_verification_notification(): void
+    {
+        Notification::fake();
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        $user->sendEmailVerificationNotification();
+
+        Notification::assertSentTo($user, CustomVerifyEmail::class);
+    }
+
+    public function test_signed_verification_link_marks_email_as_verified(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => null]);
+        $url = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->email)]
+        );
+
+        $this
+            ->actingAs($user)
+            ->get($url)
+            ->assertRedirect('/');
+
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_resend_route_sends_verification_notification(): void
+    {
+        Notification::fake();
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        $this
+            ->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertSessionHas('status', 'verification-link-sent');
+
+        Notification::assertSentTo($user, CustomVerifyEmail::class);
+    }
+
+    public function test_failover_mailer_keeps_smtp_with_log_fallback(): void
+    {
+        $this->assertSame('failover', config('mail.mailers.failover.transport'));
+        $this->assertSame(['smtp', 'log'], config('mail.mailers.failover.mailers'));
+    }
+}


### PR DESCRIPTION
/claim #756

## Summary
- Enables Laravel's built-in email verification contract on `User` and sends a custom verification notification.
- Adds verification notice, signed verification, and throttled resend routes plus a small verification view.
- Changes the default mailer fallback to `failover`, using the existing `smtp -> log` failover mailer so SMTP problems do not hard-stop verification emails in local/default config.

## Tests
- `docker run --rm -v ${PWD}\laravel:/app -w /app composer:2 bash -lc 'set -e; cp -n .env.example .env; php artisan key:generate --force >/dev/null; php artisan test'` -> 7 passed
- `docker run --rm -v ${PWD}\laravel:/app -w /app composer:2 bash -lc 'set -e; ./vendor/bin/pint --test app/Models/User.php app/Notifications/CustomVerifyEmail.php config/mail.php routes/web.php resources/views/auth/verify-email.blade.php tests/Feature/EmailVerificationTest.php'`
- `docker run --rm -v ${PWD}\laravel:/app -w /app composer:2 bash -lc 'set -e; for f in app/Models/User.php app/Notifications/CustomVerifyEmail.php config/mail.php routes/web.php tests/Feature/EmailVerificationTest.php; do php -l $f >/dev/null; done; echo php-lint-ok'`
- `git diff --cached --check`

## Security
- Verification uses Laravel signed URLs and the built-in `EmailVerificationRequest` hash/id validation.
- Resend is authenticated and throttled through `throttle:6,1`.
- Mail fallback is explicit through Laravel's failover mailer rather than silently dropping verification delivery when SMTP is unavailable.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: branch was refreshed after an earlier workflow setup failure; implementation code is unchanged.