### PR TITLE
Add FastAPI concurrent task runner

### DIFF
--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,8 +1,9 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import TypeVar, cast
 
+import anyio
 import anyio.to_thread
 from anyio import CapacityLimiter
 from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
@@ -12,6 +13,58 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        errors: Sequence[BaseException],
+        partial_results: Sequence[object | None],
+    ) -> None:
+        super().__init__(f"{len(errors)} concurrent task(s) failed")
+        self.errors = list(errors)
+        self.partial_results = list(partial_results)
+
+
+async def run_concurrently(
+    awaitables: Sequence[Awaitable[_T]],
+    *,
+    max_concurrency: int = 5,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be greater than 0")
+
+    semaphore = anyio.Semaphore(max_concurrency)
+    results: list[_T | None] = [None] * len(awaitables)
+    errors: list[BaseException] = []
+
+    async def run_one(index: int, awaitable: Awaitable[_T]) -> None:
+        async with semaphore:
+            try:
+                results[index] = await awaitable
+            except Exception as exc:
+                errors.append(exc)
+
+    async def run_all() -> None:
+        async with anyio.create_task_group() as task_group:
+            for index, awaitable in enumerate(awaitables):
+                task_group.start_soon(run_one, index, awaitable)
+
+    if timeout is None:
+        await run_all()
+    else:
+        with anyio.move_on_after(timeout) as cancel_scope:
+            await run_all()
+        if cancel_scope.cancel_called:
+            raise ConcurrencyError(
+                [*errors, TimeoutError("concurrent tasks timed out")], results
+            )
+
+    if errors:
+        raise ConcurrencyError(errors, results)
+
+    return cast(list[_T], results)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,79 @@
+import anyio
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_preserves_order_and_limits_active_tasks() -> None:
+    active = 0
+    max_seen = 0
+
+    async def worker(value: int, delay: float) -> int:
+        nonlocal active, max_seen
+        active += 1
+        max_seen = max(max_seen, active)
+        await anyio.sleep(delay)
+        active -= 1
+        return value
+
+    results = await run_concurrently(
+        [
+            worker(1, 0.03),
+            worker(2, 0.01),
+            worker(3, 0.02),
+            worker(4, 0.01),
+        ],
+        max_concurrency=2,
+    )
+
+    assert results == [1, 2, 3, 4]
+    assert max_seen == 2
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_rejects_invalid_max_concurrency() -> None:
+    with pytest.raises(ValueError, match="max_concurrency"):
+        await run_concurrently([], max_concurrency=0)
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_aggregates_task_failures() -> None:
+    async def ok() -> str:
+        return "ok"
+
+    async def fail_with(error: Exception) -> str:
+        raise error
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [
+                ok(),
+                fail_with(ValueError("bad value")),
+                fail_with(RuntimeError("bad runtime")),
+            ],
+            max_concurrency=3,
+        )
+
+    assert exc_info.value.partial_results[0] == "ok"
+    assert {type(error) for error in exc_info.value.errors} == {
+        ValueError,
+        RuntimeError,
+    }
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_cancels_remaining_tasks_on_timeout() -> None:
+    cancelled = anyio.Event()
+
+    async def slow() -> str:
+        try:
+            await anyio.sleep(10)
+        finally:
+            cancelled.set()
+        return "done"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([slow()], max_concurrency=1, timeout=0.01)
+
+    assert any(isinstance(error, TimeoutError) for error in exc_info.value.errors)
+    assert cancelled.is_set()


### PR DESCRIPTION
/claim #803

## Summary
- Adds `run_concurrently()` to `fastapi.concurrency` with anyio-based semaphore limiting, ordered results, aggregate `ConcurrencyError`, and total timeout cancellation.
- Keeps existing threadpool/contextmanager helpers unchanged.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_concurrency.py -q` -> 8 passed
- `.venv\Scripts\python.exe -m ruff check fastapi/concurrency.py tests/test_concurrency.py`
- `.venv\Scripts\python.exe -m ruff format --check fastapi/concurrency.py tests/test_concurrency.py`
- `git diff --check`

## Security
- No auth/network behavior is changed.
- Timeout path cancels unfinished tasks so background awaitables do not keep running after caller gives up.
- Errors are surfaced explicitly via `ConcurrencyError` instead of being silently dropped.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: branch was refreshed after an earlier workflow setup failure; implementation code is unchanged.