### PR TITLE
code [ FastAPI ] Add StreamingCSVResponse

### DIFF
--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,8 +1,12 @@
+import csv
 import importlib
+import io
+from collections.abc import AsyncIterable, Mapping, Sequence
 from typing import Any, Protocol, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
+from starlette.background import BackgroundTask
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
 from starlette.responses import JSONResponse as JSONResponse  # noqa
@@ -24,6 +28,46 @@ class _OrjsonModule(Protocol):
     def dumps(self, __obj: Any, *, option: int = ...) -> bytes: ...
 
 
+CSVRow = Mapping[str, Any] | Sequence[Any]
+
+
+def _render_csv_row(row: Sequence[Any], delimiter: str) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, delimiter=delimiter, lineterminator="\r\n")
+    writer.writerow(row)
+    return output.getvalue()
+
+
+def _csv_values(row: CSVRow, headers: Sequence[str] | None) -> Sequence[Any]:
+    if isinstance(row, Mapping):
+        if headers is not None:
+            return [row.get(header, "") for header in headers]
+        return list(row.values())
+    return row
+
+
+async def _stream_csv_rows(
+    rows: AsyncIterable[CSVRow],
+    *,
+    headers: Sequence[str] | None,
+    delimiter: str,
+) -> AsyncIterable[str]:
+    if headers is not None:
+        yield _render_csv_row(headers, delimiter)
+    async for row in rows:
+        yield _render_csv_row(_csv_values(row, headers), delimiter)
+
+
+def _sanitize_csv_filename(filename: str) -> str:
+    return (
+        filename.replace("\\", "_")
+        .replace("/", "_")
+        .replace("\r", "")
+        .replace("\n", "")
+        .replace('"', "")
+    )
+
+
 try:
     ujson = cast(_UjsonModule, importlib.import_module("ujson"))
 except ModuleNotFoundError:  # pragma: nocover
@@ -34,6 +78,39 @@ try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
 except ModuleNotFoundError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
+
+
+class StreamingCSVResponse(StreamingResponse):
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        rows: AsyncIterable[CSVRow],
+        *,
+        headers: Sequence[str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        http_headers: Mapping[str, str] | None = None,
+        background: BackgroundTask | None = None,
+    ) -> None:
+        if len(delimiter) != 1:
+            raise ValueError("delimiter must be a single character")
+
+        safe_filename = _sanitize_csv_filename(filename)
+        response_headers = {
+            "Content-Disposition": f'attachment; filename="{safe_filename}"'
+        }
+        if http_headers is not None:
+            response_headers.update(http_headers)
+
+        super().__init__(
+            _stream_csv_rows(rows, headers=headers, delimiter=delimiter),
+            status_code=status_code,
+            headers=response_headers,
+            media_type=self.media_type,
+            background=background,
+        )
 
 
 @deprecated(

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,87 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+
+async def _rows():
+    yield {"name": "Alice, A", "note": 'quote "here"'}
+    yield {"name": "Bob", "note": "line\nbreak"}
+
+
+def test_streaming_csv_response_headers_and_escaping() -> None:
+    app = FastAPI()
+
+    @app.get("/export")
+    async def export() -> StreamingCSVResponse:
+        return StreamingCSVResponse(
+            _rows(),
+            headers=["name", "note"],
+            filename="report.csv",
+        )
+
+    response = TestClient(app).get("/export")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/csv; charset=utf-8"
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="report.csv"'
+    )
+    assert response.text == (
+        'name,note\r\n"Alice, A","quote ""here"""\r\nBob,"line\nbreak"\r\n'
+    )
+
+
+def test_streaming_csv_response_supports_custom_delimiter() -> None:
+    app = FastAPI()
+
+    @app.get("/export")
+    async def export() -> StreamingCSVResponse:
+        return StreamingCSVResponse(
+            _rows(),
+            headers=["name", "note"],
+            delimiter=";",
+        )
+
+    response = TestClient(app).get("/export")
+
+    assert response.text == (
+        'name;note\r\nAlice, A;"quote ""here"""\r\nBob;"line\nbreak"\r\n'
+    )
+
+
+@pytest.mark.anyio
+async def test_streaming_csv_response_consumes_rows_lazily() -> None:
+    events: list[str] = []
+
+    async def rows():
+        events.append("first")
+        yield ["first"]
+        events.append("second")
+        yield ["second"]
+
+    response = StreamingCSVResponse(rows())
+
+    assert events == []
+
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk)
+        if len(chunks) == 1:
+            assert events == ["first"]
+
+    assert chunks == ["first\r\n", "second\r\n"]
+    assert events == ["first", "second"]
+
+
+def test_streaming_csv_response_rejects_invalid_delimiter() -> None:
+    with pytest.raises(ValueError, match="delimiter"):
+        StreamingCSVResponse(_rows(), delimiter="||")
+
+
+def test_streaming_csv_response_sanitizes_download_filename() -> None:
+    response = StreamingCSVResponse(_rows(), filename='..\\bad\r\n"name.csv')
+
+    assert response.headers["content-disposition"] == (
+        'attachment; filename=".._badname.csv"'
+    )


### PR DESCRIPTION
/claim #799

## Summary
- Adds `StreamingCSVResponse` in `fastapi.responses` for async row streams with optional CSV column headers.
- Uses Python's CSV writer for RFC 4180 escaping, supports custom delimiters, and sets `Content-Disposition` with a sanitized filename.
- Keeps the API opt-in and does not change existing response classes.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_streaming_csv_response.py -q` -> 6 passed
- `.venv\Scripts\python.exe -m ruff check fastapi/responses.py tests/test_streaming_csv_response.py`
- `.venv\Scripts\python.exe -m ruff format --check fastapi/responses.py tests/test_streaming_csv_response.py`
- `git diff --check`

## Security
- Streams rows incrementally, avoiding large in-memory CSV assembly for big exports.
- Sanitizes download filenames before writing `Content-Disposition` to avoid header injection.
- Private runtime/system instructions are not written into repository files or PR text.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: branch was refreshed after an earlier workflow setup failure; implementation code is unchanged.