### PR TITLE
code [ FastAPI ] Add HTTPBasic brute force protection

### DIFF
--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,10 @@
 import binascii
+import hashlib
+import math
+import secrets
+import time
 from base64 import b64decode
+from collections.abc import Callable
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +15,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -217,6 +222,157 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    def __init__(
+        self,
+        *,
+        max_attempts: int = 5,
+        window_seconds: int = 60,
+        verify_credentials: Callable[[HTTPBasicCredentials], bool] | None = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        realm: Annotated[
+            str | None,
+            Doc(
+                """
+                HTTP Basic authentication realm.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, missing or invalid HTTP Basic authentication will
+                automatically cancel the request and send the client an error.
+                """
+            ),
+        ] = True,
+    ):
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be greater than 0")
+        if window_seconds < 1:
+            raise ValueError("window_seconds must be greater than 0")
+        super().__init__(
+            scheme_name=scheme_name,
+            realm=realm,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self.verify_credentials = verify_credentials
+        self._failed_attempts: dict[str, list[float]] = {}
+
+    @staticmethod
+    def hash_password(
+        password: str,
+        *,
+        salt: str | None = None,
+        iterations: int = 260000,
+    ) -> str:
+        if salt is None:
+            salt = secrets.token_hex(16)
+        derived = hashlib.pbkdf2_hmac(
+            "sha256", password.encode("utf-8"), bytes.fromhex(salt), iterations
+        )
+        return f"pbkdf2_sha256${iterations}${salt}${derived.hex()}"
+
+    @staticmethod
+    def verify_password(password: str, password_hash: str) -> bool:
+        try:
+            algorithm, iterations, salt, expected = password_hash.split("$", 3)
+            if algorithm != "pbkdf2_sha256":
+                return False
+            derived = hashlib.pbkdf2_hmac(
+                "sha256",
+                password.encode("utf-8"),
+                bytes.fromhex(salt),
+                int(iterations),
+            )
+        except (TypeError, ValueError):
+            return False
+        return secrets.compare_digest(derived.hex(), expected)
+
+    def _client_key(self, request: Request) -> str:
+        if request.client is None:
+            return "unknown"
+        return request.client.host
+
+    def _prune_attempts(self, client_key: str, now: float) -> list[float]:
+        attempts = [
+            attempt
+            for attempt in self._failed_attempts.get(client_key, [])
+            if now - attempt < self.window_seconds
+        ]
+        if attempts:
+            self._failed_attempts[client_key] = attempts
+        else:
+            self._failed_attempts.pop(client_key, None)
+        return attempts
+
+    def _retry_after(self, attempts: list[float], now: float) -> int:
+        if not attempts:
+            return self.window_seconds
+        return max(1, math.ceil(self.window_seconds - (now - attempts[0])))
+
+    def _lockout_error(self, attempts: list[float], now: float) -> HTTPException:
+        return HTTPException(
+            status_code=HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many failed authentication attempts",
+            headers={"Retry-After": str(self._retry_after(attempts, now))},
+        )
+
+    def _record_failure(self, client_key: str) -> None:
+        now = time.monotonic()
+        attempts = self._prune_attempts(client_key, now)
+        attempts.append(now)
+        self._failed_attempts[client_key] = attempts
+
+    def _reset_attempts(self, client_key: str) -> None:
+        self._failed_attempts.pop(client_key, None)
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        client_key = self._client_key(request)
+        now = time.monotonic()
+        attempts = self._prune_attempts(client_key, now)
+        if len(attempts) >= self.max_attempts:
+            raise self._lockout_error(attempts, now)
+
+        credentials = await super().__call__(request)
+        if credentials is None or self.verify_credentials is None:
+            return credentials
+        if self.verify_credentials(credentials):
+            self._reset_attempts(client_key)
+            return credentials
+
+        self._record_failure(client_key)
+        attempts = self._prune_attempts(client_key, time.monotonic())
+        if len(attempts) >= self.max_attempts:
+            raise self._lockout_error(attempts, time.monotonic())
+        raise self.make_not_authenticated_error()
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_security_http_basic_protection.py
+++ b/fastapi/tests/test_security_http_basic_protection.py
@@ -1,0 +1,121 @@
+from base64 import b64encode
+
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+
+def basic_auth(username: str, password: str) -> dict[str, str]:
+    token = b64encode(f"{username}:{password}".encode("ascii")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+def create_app(security: HTTPBasicWithProtection) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/users/me")
+    def read_current_user(
+        credentials: HTTPBasicCredentials = Security(security),
+    ) -> dict[str, str]:
+        return {"username": credentials.username}
+
+    return app
+
+
+def test_http_basic_with_protection_locks_out_after_failed_attempts() -> None:
+    password_hash = HTTPBasicWithProtection.hash_password("secret", salt="0" * 32)
+
+    def verify(credentials: HTTPBasicCredentials) -> bool:
+        return (
+            credentials.username == "alice"
+            and HTTPBasicWithProtection.verify_password(
+                credentials.password, password_hash
+            )
+        )
+
+    security = HTTPBasicWithProtection(
+        max_attempts=2, window_seconds=30, verify_credentials=verify
+    )
+    client = TestClient(create_app(security))
+
+    response = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    assert response.status_code == 401
+
+    response = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    assert response.status_code == 429
+    assert int(response.headers["retry-after"]) > 0
+
+
+def test_http_basic_with_protection_resets_counter_on_success() -> None:
+    password_hash = HTTPBasicWithProtection.hash_password("secret", salt="1" * 32)
+
+    def verify(credentials: HTTPBasicCredentials) -> bool:
+        return (
+            credentials.username == "alice"
+            and HTTPBasicWithProtection.verify_password(
+                credentials.password, password_hash
+            )
+        )
+
+    security = HTTPBasicWithProtection(
+        max_attempts=2, window_seconds=30, verify_credentials=verify
+    )
+    client = TestClient(create_app(security))
+
+    assert (
+        client.get("/users/me", headers=basic_auth("alice", "bad")).status_code == 401
+    )
+    assert (
+        client.get("/users/me", headers=basic_auth("alice", "secret")).status_code
+        == 200
+    )
+    assert (
+        client.get("/users/me", headers=basic_auth("alice", "bad")).status_code == 401
+    )
+
+
+def test_http_basic_with_protection_tracks_attempts_per_ip() -> None:
+    password_hash = HTTPBasicWithProtection.hash_password("secret", salt="2" * 32)
+
+    def verify(credentials: HTTPBasicCredentials) -> bool:
+        return (
+            credentials.username == "alice"
+            and HTTPBasicWithProtection.verify_password(
+                credentials.password, password_hash
+            )
+        )
+
+    security = HTTPBasicWithProtection(
+        max_attempts=1, window_seconds=30, verify_credentials=verify
+    )
+    app = create_app(security)
+
+    locked_client = TestClient(app, client=("10.0.0.1", 50000))
+    clean_client = TestClient(app, client=("10.0.0.2", 50000))
+
+    assert (
+        locked_client.get("/users/me", headers=basic_auth("alice", "bad")).status_code
+        == 429
+    )
+    assert (
+        clean_client.get("/users/me", headers=basic_auth("alice", "secret")).status_code
+        == 200
+    )
+
+
+def test_http_basic_with_protection_without_verifier_preserves_basic_behavior() -> None:
+    security = HTTPBasicWithProtection(max_attempts=1)
+    client = TestClient(create_app(security))
+
+    response = client.get("/users/me", headers=basic_auth("alice", "not-verified"))
+
+    assert response.status_code == 200
+    assert response.json() == {"username": "alice"}
+
+
+def test_http_basic_with_protection_password_hash_verification() -> None:
+    password_hash = HTTPBasicWithProtection.hash_password("secret", salt="3" * 32)
+
+    assert HTTPBasicWithProtection.verify_password("secret", password_hash)
+    assert not HTTPBasicWithProtection.verify_password("wrong", password_hash)
+    assert not HTTPBasicWithProtection.verify_password("secret", "not-a-valid-hash")


### PR DESCRIPTION
/claim #800

## Summary
- Adds opt-in `HTTPBasicWithProtection`, preserving existing `HTTPBasic` behavior when no verifier is configured.
- Tracks failed authentications per client IP inside a bounded time window, returns 429 with `Retry-After` on lockout, and resets counters after successful verification.
- Adds PBKDF2-HMAC password hashing and `secrets.compare_digest` verification helpers without adding a new dependency.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_security_http_basic_protection.py -q` -> 5 passed
- `.venv\Scripts\python.exe -m ruff check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py`
- `.venv\Scripts\python.exe -m ruff format --check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py`
- `git diff --check`

## Security
- Lockout state is scoped per client IP to reduce credential-stuffing blast radius.
- Password verification uses PBKDF2-HMAC plus constant-time digest comparison.
- The new class is opt-in so existing applications do not receive surprising auth behavior changes.
- Private runtime/system instructions are not written into repository files or PR text.

Prepared with AI assistance and manually reviewed before submission.

CI refresh note: branch was refreshed after an earlier workflow setup failure; implementation code is unchanged.