### PR TITLE
code [ FastAPI ] Fix duplicate operation IDs

### DIFF
--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -242,7 +242,8 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
+    base_operation_id = route.operation_id or route.unique_id
+    operation_id = base_operation_id
     if operation_id in operation_ids:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
@@ -250,6 +251,12 @@ def get_openapi_operation_metadata(
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        if route.operation_id is None:
+            suffix = 2
+            operation_id = f"{base_operation_id}_{suffix}"
+            while operation_id in operation_ids:
+                suffix += 1
+                operation_id = f"{base_operation_id}_{suffix}"
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -92,12 +92,16 @@ def generate_operation_id_for_path(
     return operation_id
 
 
+def _sanitize_operation_id(value: str) -> str:
+    return re.sub(r"_+", "_", re.sub(r"\W", "_", value)).strip("_").lower()
+
+
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0].lower()
+    path = _sanitize_operation_id(route.path_format)
+    name = _sanitize_operation_id(route.name)
+    return "_".join(part for part in (method, path, name) if part)
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_operation_id_generation.py
+++ b/fastapi/tests/test_operation_id_generation.py
@@ -1,0 +1,61 @@
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_default_operation_ids_include_method_path_and_function_name() -> None:
+    app = FastAPI()
+    v1 = APIRouter()
+    v2 = APIRouter()
+
+    def list_users() -> dict[str, bool]:
+        return {"ok": True}
+
+    v1.add_api_route("/users", list_users, methods=["GET"])
+    v2.add_api_route("/users", list_users, methods=["GET"])
+    app.include_router(v1, prefix="/api/v1")
+    app.include_router(v2, prefix="/api/v2")
+
+    openapi = TestClient(app).get("/openapi.json").json()
+
+    assert openapi["paths"]["/api/v1/users"]["get"]["operationId"] == (
+        "get_api_v1_users_list_users"
+    )
+    assert openapi["paths"]["/api/v2/users"]["get"]["operationId"] == (
+        "get_api_v2_users_list_users"
+    )
+
+
+def test_generated_operation_ids_are_lowercase_alphanumeric_underscore() -> None:
+    app = FastAPI()
+
+    def Read_Items() -> dict[str, bool]:  # noqa: N802
+        return {"ok": True}
+
+    app.add_api_route("/API/{item-id}", Read_Items, methods=["POST"])
+
+    openapi = TestClient(app).get("/openapi.json").json()
+
+    assert openapi["paths"]["/API/{item-id}"]["post"]["operationId"] == (
+        "post_api_item_id_read_items"
+    )
+
+
+def test_generated_operation_id_collisions_get_numeric_suffix() -> None:
+    app = FastAPI()
+
+    def read_item() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.add_api_route("/items/a-b", read_item, methods=["GET"])
+    app.add_api_route("/items/a_b", read_item, methods=["GET"])
+
+    with pytest.warns(UserWarning, match="Duplicate Operation ID"):
+        openapi = TestClient(app).get("/openapi.json").json()
+
+    assert openapi["paths"]["/items/a-b"]["get"]["operationId"] == (
+        "get_items_a_b_read_item"
+    )
+    assert openapi["paths"]["/items/a_b"]["get"]["operationId"] == (
+        "get_items_a_b_read_item_2"
+    )


### PR DESCRIPTION
/claim #764

## Summary
- Updates default FastAPI operation IDs to use `method_path_function`, with lowercase alphanumeric/underscore sanitization.
- Keeps router prefixes in the generated ID via `route.path_format`, preventing duplicate endpoint names across routers from colliding.
- Adds numeric suffixing for generated OpenAPI operationId collisions while preserving duplicate warnings for compatibility.

## Tests
- `.venv\Scripts\python.exe -m pytest tests/test_operation_id_generation.py tests/test_generate_unique_id_function.py -q` -> 11 passed
- `.venv\Scripts\python.exe -m ruff check fastapi/utils.py fastapi/openapi/utils.py tests/test_operation_id_generation.py`
- `.venv\Scripts\python.exe -m ruff format --check fastapi/utils.py fastapi/openapi/utils.py tests/test_operation_id_generation.py`
- `git diff --check`

## Security
- No request handling, auth, or runtime execution path is changed.
- Stable unique operation IDs reduce generated-client ambiguity across routers.
- Collision suffixing avoids silently emitting duplicate OpenAPI operation IDs.
- Private runtime/system instructions are not written into repository files or PR text.

Prepared with AI assistance and manually reviewed before submission.