### PR TITLE
code [ Laravel ] Add database health check

### DIFF
--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    public function database(): JsonResponse
+    {
+        $connectionName = DB::getDefaultConnection();
+        $driver = Config::get("database.connections.{$connectionName}.driver");
+        $startedAt = hrtime(true);
+        $lastError = null;
+
+        for ($attempt = 1; $attempt <= 3; $attempt++) {
+            try {
+                DB::connection($connectionName)->getPdo();
+
+                return response()->json([
+                    'status' => 'ok',
+                    'driver' => $driver,
+                    'latency_ms' => $this->elapsedMilliseconds($startedAt),
+                    'connection_name' => $connectionName,
+                ]);
+            } catch (Throwable $exception) {
+                $lastError = $exception;
+
+                if ($attempt < 3) {
+                    usleep(500_000);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'error',
+            'driver' => $driver,
+            'latency_ms' => $this->elapsedMilliseconds($startedAt),
+            'connection_name' => $connectionName,
+            'error' => $lastError?->getMessage(),
+        ], 503);
+    }
+
+    private function elapsedMilliseconds(int $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000, 2);
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);

--- a/laravel/tests/Feature/DatabaseHealthTest.php
+++ b/laravel/tests/Feature/DatabaseHealthTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use RuntimeException;
+use stdClass;
+use Tests\TestCase;
+
+class DatabaseHealthTest extends TestCase
+{
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        $response = $this->getJson('/health/database');
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('driver', 'sqlite')
+            ->assertJsonPath('connection_name', 'sqlite')
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+            ]);
+
+        $this->assertIsNumeric($response->json('latency_ms'));
+    }
+
+    public function test_database_health_endpoint_retries_before_success(): void
+    {
+        $connection = Mockery::mock();
+        $connection->shouldReceive('getPdo')->once()->andReturn(new stdClass);
+
+        DB::shouldReceive('getDefaultConnection')->once()->andReturn('sqlite');
+        DB::shouldReceive('connection')->once()->with('sqlite')->andThrow(
+            new RuntimeException('temporary failure')
+        );
+        DB::shouldReceive('connection')->once()->with('sqlite')->andThrow(
+            new RuntimeException('temporary failure')
+        );
+        DB::shouldReceive('connection')->once()->with('sqlite')->andReturn($connection);
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('driver', 'sqlite')
+            ->assertJsonPath('connection_name', 'sqlite');
+    }
+
+    public function test_database_health_endpoint_returns_503_after_retries_fail(): void
+    {
+        DB::shouldReceive('getDefaultConnection')->once()->andReturn('sqlite');
+        DB::shouldReceive('connection')->times(3)->with('sqlite')->andThrow(
+            new RuntimeException('database unavailable')
+        );
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertStatus(503)
+            ->assertJsonPath('status', 'error')
+            ->assertJsonPath('driver', 'sqlite')
+            ->assertJsonPath('connection_name', 'sqlite')
+            ->assertJsonPath('error', 'database unavailable');
+    }
+}


### PR DESCRIPTION
/claim #785

## Summary
- Adds `HealthController::database` and `GET /health/database` for active Laravel DB connection checks.
- Reports `status`, `driver`, `latency_ms`, and `connection_name` on success.
- Retries the connection check up to 3 times with 500ms delay before returning JSON 503 with the final error.

## Tests
- `docker run --rm -v ${PWD}:/app -w /app composer:2 php artisan test tests/Feature/DatabaseHealthTest.php` -> 3 passed / 25 assertions
- `docker run --rm -v ${PWD}:/app -w /app composer:2 vendor/bin/pint --test app/Http/Controllers/HealthController.php routes/web.php tests/Feature/DatabaseHealthTest.php`
- `docker run --rm -v ${PWD}:/app -w /app composer:2 php -l app/Http/Controllers/HealthController.php`
- `docker run --rm -v ${PWD}:/app -w /app composer:2 php -l tests/Feature/DatabaseHealthTest.php`
- `git diff --check`

## Security
- Health output is limited to connection metadata and the final connection error; no credentials are exposed.
- The endpoint uses the configured default connection and does not mutate database state.
- Private runtime/system instructions are not written into repository files or PR text.

Prepared with AI assistance and manually reviewed before submission.