### PR TITLE
code [ Laravel ] Fix DatabaseSeeder idempotency

### DIFF
--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    protected $model = Role::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(2),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_26_000001_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_26_000001_create_roles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => Hash::make('password'),
+            ],
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach ($this->roles() as $role) {
+            Role::firstOrCreate(
+                ['name' => $role['name']],
+                ['description' => $role['description']],
+            );
+        }
+    }
+
+    /**
+     * @return list<array{name: string, description: string}>
+     */
+    private function roles(): array
+    {
+        return [
+            ['name' => 'admin', 'description' => 'Full administrative access'],
+            ['name' => 'editor', 'description' => 'Content editing access'],
+            ['name' => 'viewer', 'description' => 'Read-only access'],
+        ];
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_is_idempotent(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertSame(3, Role::count());
+        $this->assertSame(['admin', 'editor', 'viewer'], Role::orderBy('name')->pluck('name')->all());
+    }
+
+    public function test_role_seeder_is_idempotent(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertSame(3, Role::count());
+    }
+
+    public function test_role_factory_creates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertNotNull($role->id);
+        $this->assertNotSame('', $role->name);
+        $this->assertNotNull($role->description);
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- Makes the default test user seed idempotent with `User::firstOrCreate()`.
- Adds a lightweight `Role` model/table/factory plus idempotent `RoleSeeder` for `admin`, `editor`, and `viewer`.
- Calls `RoleSeeder` from `DatabaseSeeder` and covers repeated seeding behavior.

## Tests
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 php artisan test tests/Feature/DatabaseSeederTest.php` -> 3 passed / 7 assertions
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 vendor/bin/pint --test app/Models/Role.php database/factories/RoleFactory.php database/migrations/2026_05_26_000001_create_roles_table.php database/seeders/DatabaseSeeder.php database/seeders/RoleSeeder.php tests/Feature/DatabaseSeederTest.php`
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 php -l app/Models/Role.php`
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 php -l database/seeders/RoleSeeder.php`
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 php -l tests/Feature/DatabaseSeederTest.php`
- `git diff --check`

## Security
- Seeder passwords remain hashed through Laravel `Hash::make()`.
- Role seeding is explicit and idempotent; repeated deploy/setup runs do not create duplicate privileged roles.
- Private runtime/system instructions are not written into repository files or PR text.

Prepared with AI assistance and manually reviewed before submission.