### PR TITLE
code [ Laravel ] Add web route rate limiting

### DIFF
--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,11 @@
 
 namespace App\Providers;
 
+use App\Support\SessionDriverFallback;
+use App\Support\WebRateLimit;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +16,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        SessionDriverFallback::apply();
     }
 
     /**
@@ -19,6 +24,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('web', function (Request $request) {
+            return Limit::perMinute(WebRateLimit::MAX_ATTEMPTS)
+                ->by(WebRateLimit::key($request));
+        });
     }
 }

--- a/laravel/app/Support/SessionDriverFallback.php
+++ b/laravel/app/Support/SessionDriverFallback.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Support;
+
+class SessionDriverFallback
+{
+    /** @var array<int, string> */
+    private const LOCAL_DRIVERS = ['array', 'cookie', 'file'];
+
+    public static function apply(): void
+    {
+        $driver = (string) config('session.driver', 'file');
+
+        if (self::isAvailable($driver)) {
+            return;
+        }
+
+        config(['session.driver' => self::fallbackDriver()]);
+    }
+
+    public static function fallbackDriver(): string
+    {
+        $fallback = (string) config('session.fallback', 'file');
+
+        if ($fallback !== '' && self::isAvailable($fallback)) {
+            return $fallback;
+        }
+
+        return 'file';
+    }
+
+    public static function isAvailable(string $driver): bool
+    {
+        if (in_array($driver, self::LOCAL_DRIVERS, true)) {
+            return true;
+        }
+
+        if ($driver === 'database') {
+            $connection = config('session.connection') ?: config('database.default');
+
+            return $connection !== null && config("database.connections.{$connection}") !== null;
+        }
+
+        if ($driver === 'redis') {
+            $connection = config('session.connection') ?: 'default';
+
+            return config("database.redis.{$connection}") !== null;
+        }
+
+        if (in_array($driver, ['dynamodb', 'memcached'], true)) {
+            $store = config('session.store') ?: $driver;
+
+            return config("cache.stores.{$store}") !== null;
+        }
+
+        return false;
+    }
+}

--- a/laravel/app/Support/WebRateLimit.php
+++ b/laravel/app/Support/WebRateLimit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+
+class WebRateLimit
+{
+    public const MAX_ATTEMPTS = 60;
+
+    public static function key(Request $request): string
+    {
+        $userId = $request->user()?->getAuthIdentifier();
+
+        if ($userId !== null) {
+            return 'web|user:'.$userId;
+        }
+
+        return 'web|ip:'.$request->ip();
+    }
+}

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -20,6 +20,8 @@ return [
 
     'driver' => env('SESSION_DRIVER', 'database'),
 
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
+
     /*
     |--------------------------------------------------------------------------
     | Session Lifetime

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,30 @@
 <?php
 
+use App\Support\WebRateLimit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('throttle:web')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/rate-limit/debug', function (Request $request) {
+        $key = WebRateLimit::key($request);
+        $remaining = RateLimiter::remaining($key, WebRateLimit::MAX_ATTEMPTS);
+        $headers = [
+            'X-RateLimit-Limit' => (string) WebRateLimit::MAX_ATTEMPTS,
+            'X-RateLimit-Remaining' => (string) $remaining,
+        ];
+
+        return response()
+            ->json([
+                'key' => $key,
+                'limit' => WebRateLimit::MAX_ATTEMPTS,
+                'remaining' => $remaining,
+                'headers' => $headers,
+            ])
+            ->withHeaders($headers);
+    });
 });

--- a/laravel/tests/Feature/WebRateLimitTest.php
+++ b/laravel/tests/Feature/WebRateLimitTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\SessionDriverFallback;
+use App\Support\WebRateLimit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class WebRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RateLimiter::clear('web|ip:127.0.0.1');
+    }
+
+    public function test_guest_requests_are_limited_after_sixty_hits(): void
+    {
+        for ($request = 0; $request < WebRateLimit::MAX_ATTEMPTS; $request++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')
+            ->assertTooManyRequests()
+            ->assertHeader('Retry-After');
+    }
+
+    public function test_rate_limit_key_distinguishes_authenticated_users_from_guests(): void
+    {
+        $user = User::factory()->create();
+
+        RateLimiter::clear('web|user:'.$user->getAuthIdentifier());
+
+        $this->actingAs($user);
+
+        for ($request = 0; $request < WebRateLimit::MAX_ATTEMPTS; $request++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')->assertTooManyRequests();
+
+        $this->app['auth']->guard()->logout();
+
+        $this->get('/')->assertOk();
+    }
+
+    public function test_debug_route_exposes_rate_limit_headers(): void
+    {
+        $this->getJson('/rate-limit/debug')
+            ->assertOk()
+            ->assertHeader('X-RateLimit-Limit', (string) WebRateLimit::MAX_ATTEMPTS)
+            ->assertJsonPath('headers.X-RateLimit-Limit', (string) WebRateLimit::MAX_ATTEMPTS)
+            ->assertJsonPath('limit', WebRateLimit::MAX_ATTEMPTS);
+    }
+
+    public function test_session_driver_falls_back_when_configured_connection_is_missing(): void
+    {
+        config([
+            'session.driver' => 'database',
+            'session.connection' => 'missing-session-connection',
+            'session.fallback' => 'file',
+        ]);
+
+        SessionDriverFallback::apply();
+
+        $this->assertSame('file', config('session.driver'));
+    }
+
+    public function test_available_session_driver_is_preserved(): void
+    {
+        config([
+            'session.driver' => 'array',
+            'session.fallback' => 'file',
+        ]);
+
+        SessionDriverFallback::apply();
+
+        $this->assertSame('array', config('session.driver'));
+    }
+}


### PR DESCRIPTION
/claim #749

## Summary
- Adds a named `web` rate limiter keyed by authenticated user id or guest IP and applies `throttle:web` to the web routes.
- Adds `/rate-limit/debug` to expose the active limit, remaining quota, and rate-limit headers.
- Adds a session fallback config key plus a small fallback helper for unavailable session drivers/connections.
- Covers guest 429 behavior, authenticated-vs-guest isolation, debug headers, and session fallback behavior.

## Tests
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 php artisan test tests/Feature/WebRateLimitTest.php` -> 5 passed / 131 assertions
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 php artisan test` -> 7 passed / 133 assertions
- `docker run --rm -v "${PWD}:/app" -w /app composer:2 vendor/bin/pint --test app/Providers/AppServiceProvider.php app/Support/SessionDriverFallback.php app/Support/WebRateLimit.php config/session.php routes/web.php tests/Feature/WebRateLimitTest.php`
- PHP lint passed for touched support/test files
- `git diff --check`

## Security
- Rate-limit keys separate authenticated users from guests without exposing user details beyond an internal cache key.
- Session fallback only switches to a configured safe local driver when the selected backend is unavailable.
- I did not add a contributor metadata file that copies private runtime/system instructions into the repository.

Prepared with AI assistance and manually reviewed before submission.