### PR TITLE
code [ T3 Code ] Enable SQLite WAL and pooling

### DIFF
--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -33,10 +33,23 @@ const setup = Layer.effectDiscard(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     yield* sql`PRAGMA journal_mode = WAL;`;
+    yield* sql`PRAGMA busy_timeout = 5000;`;
+    yield* sql`PRAGMA synchronous = NORMAL;`;
     yield* sql`PRAGMA foreign_keys = ON;`;
     yield* runMigrations();
   }),
 );
+
+export const checkSqliteHealth = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const rows = yield* sql<{ readonly integrity_check: string }>`PRAGMA integrity_check;`;
+  const details = rows.map((row) => row.integrity_check);
+
+  return {
+    ok: details.length > 0 && details.every((detail) => detail === "ok"),
+    details,
+  };
+});
 
 export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(function* (
   dbPath: string,

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -5,6 +5,16 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqliteClient from "./NodeSqliteClient.ts";
 
 const layer = it.layer(SqliteClient.layerMemory());
+const fileLayer = it.layer(
+  SqliteClient.layer({
+    filename: `${
+      process.env["TEMP"] ?? process.env["TMP"] ?? "."
+    }/t3-sqlite-pool-${globalThis.crypto.randomUUID()}.sqlite`,
+  }),
+);
+
+const firstPragmaValue = (row: Record<string, unknown> | undefined) =>
+  Number(Object.values(row ?? {})[0] ?? 0);
 
 layer("NodeSqliteClient", (it) => {
   it.effect("runs prepared queries and returns positional values", () =>
@@ -25,6 +35,68 @@ layer("NodeSqliteClient", (it) => {
       assert.equal(values.length, 2);
       assert.equal(values[0]?.[1], "alpha");
       assert.equal(values[1]?.[1], "beta");
+    }),
+  );
+});
+
+fileLayer("NodeSqliteClient pooled file database", (it) => {
+  it.effect("initializes WAL, busy timeout, and synchronous pragmas", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      const journalMode = yield* sql<{ readonly journal_mode: string }>`PRAGMA journal_mode;`;
+      const busyTimeout = yield* sql<Record<string, unknown>>`PRAGMA busy_timeout;`;
+      const synchronous = yield* sql<Record<string, unknown>>`PRAGMA synchronous;`;
+
+      assert.equal(journalMode[0]?.journal_mode, "wal");
+      assert.equal(firstPragmaValue(busyTimeout[0]), 5000);
+      assert.equal(firstPragmaValue(synchronous[0]), 1);
+    }),
+  );
+
+  it.effect("exposes pool bounds and integrity health check", () =>
+    Effect.gen(function* () {
+      const client = yield* SqliteClient.SqliteClient;
+
+      assert.equal(client.pool.config.minSize, SqliteClient.SQLITE_POOL_MIN_SIZE);
+      assert.equal(client.pool.config.maxSize, SqliteClient.SQLITE_POOL_MAX_SIZE);
+
+      const health = yield* client.healthCheck;
+      assert.isTrue(health.ok);
+      assert.deepEqual(health.details, ["ok"]);
+    }),
+  );
+
+  it.effect("resets connections before returning them to the pool", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`PRAGMA foreign_keys = OFF;`;
+
+      const foreignKeys = yield* sql<Record<string, unknown>>`PRAGMA foreign_keys;`;
+      assert.equal(firstPragmaValue(foreignKeys[0]), 1);
+    }),
+  );
+
+  it.effect("handles concurrent reads and writes without deadlock", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`CREATE TABLE concurrent_items(id INTEGER PRIMARY KEY, value TEXT NOT NULL)`;
+
+      yield* Effect.all(
+        Array.from(
+          { length: 12 },
+          (_, index) => sql`INSERT INTO concurrent_items(value) VALUES (${`item-${index}`})`,
+        ),
+        { concurrency: SqliteClient.SQLITE_POOL_MAX_SIZE },
+      );
+
+      const rows = yield* sql<{ readonly count: number }>`
+        SELECT COUNT(*) AS count FROM concurrent_items
+      `;
+
+      assert.equal(Number(rows[0]?.count), 12);
     }),
   );
 });

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.ts
@@ -8,22 +8,25 @@ import { DatabaseSync, type StatementSync } from "node:sqlite";
 
 import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
+import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
-import * as Fiber from "effect/Fiber";
 import { identity } from "effect/Function";
 import * as Layer from "effect/Layer";
+import * as Pool from "effect/Pool";
 import * as Scope from "effect/Scope";
-import * as Semaphore from "effect/Semaphore";
-import * as Context from "effect/Context";
 import * as Stream from "effect/Stream";
 import * as Reactivity from "effect/unstable/reactivity/Reactivity";
 import * as Client from "effect/unstable/sql/SqlClient";
 import type { Connection } from "effect/unstable/sql/SqlConnection";
-import { SqlError, classifySqliteError } from "effect/unstable/sql/SqlError";
+import { SqlError, classifySqliteError, isSqlError } from "effect/unstable/sql/SqlError";
 import * as Statement from "effect/unstable/sql/Statement";
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name";
+export const SQLITE_POOL_MIN_SIZE = 1;
+export const SQLITE_POOL_MAX_SIZE = 5;
+export const SQLITE_POOL_ACQUIRE_TIMEOUT = Duration.seconds(10);
+const SQLITE_POOL_TTL = Duration.minutes(5);
 
 export const TypeId: TypeId = "~local/sqlite-node/SqliteClient";
 
@@ -32,7 +35,7 @@ export type TypeId = "~local/sqlite-node/SqliteClient";
 /**
  * SqliteClient - Effect service tag for the sqlite SQL client.
  */
-export const SqliteClient = Context.Service<Client.SqlClient>("t3/persistence/NodeSqliteClient");
+export const SqliteClient = Context.Service<SqliteClient>("t3/persistence/NodeSqliteClient");
 
 export interface SqliteClientConfig {
   readonly filename: string;
@@ -49,6 +52,80 @@ export interface SqliteMemoryClientConfig extends Omit<
   SqliteClientConfig,
   "filename" | "readonly"
 > {}
+
+export interface SqliteHealthCheckResult {
+  readonly ok: boolean;
+  readonly details: ReadonlyArray<string>;
+}
+
+interface PooledConnection extends Connection {
+  readonly reset: Effect.Effect<void, SqlError>;
+  readonly healthCheck: Effect.Effect<SqliteHealthCheckResult, SqlError>;
+}
+
+export interface SqliteClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId;
+  readonly pool: Pool.Pool<PooledConnection, SqlError>;
+  readonly healthCheck: Effect.Effect<SqliteHealthCheckResult, SqlError>;
+}
+
+const makeSqlError = (cause: unknown, message: string, operation: string) =>
+  new SqlError({
+    reason: classifySqliteError(cause, {
+      message,
+      operation,
+    }),
+  });
+
+const executePragma = (db: DatabaseSync, sql: string, operation: string) =>
+  Effect.try({
+    try: () => {
+      db.exec(sql);
+    },
+    catch: (cause) => makeSqlError(cause, `Failed to ${operation}`, operation),
+  });
+
+const initializeConnection = (db: DatabaseSync, filename: string) =>
+  Effect.all(
+    [
+      filename === ":memory:"
+        ? Effect.void
+        : executePragma(db, "PRAGMA journal_mode = WAL;", "enable WAL mode"),
+      executePragma(db, "PRAGMA busy_timeout = 5000;", "set busy timeout"),
+      executePragma(db, "PRAGMA synchronous = NORMAL;", "set synchronous mode"),
+      executePragma(db, "PRAGMA foreign_keys = ON;", "enable foreign keys"),
+    ],
+    { discard: true },
+  );
+
+const resetConnection = (db: DatabaseSync) =>
+  Effect.all(
+    [
+      executePragma(db, "PRAGMA busy_timeout = 5000;", "reset busy timeout"),
+      executePragma(db, "PRAGMA synchronous = NORMAL;", "reset synchronous mode"),
+      executePragma(db, "PRAGMA foreign_keys = ON;", "reset foreign keys"),
+    ],
+    { discard: true },
+  );
+
+const runIntegrityCheck = (db: DatabaseSync) =>
+  Effect.map(
+    Effect.try({
+      try: () =>
+        db
+          .prepare("PRAGMA integrity_check;")
+          .all()
+          .map((row) => {
+            const values = Object.values(row as Record<string, unknown>);
+            return String((row as Record<string, unknown>).integrity_check ?? values[0] ?? "");
+          }),
+      catch: (cause) => makeSqlError(cause, "Failed to run integrity check", "integrity_check"),
+    }),
+    (details): SqliteHealthCheckResult => ({
+      ok: details.length > 0 && details.every((detail) => detail === "ok"),
+      details,
+    }),
+  );
 
 /**
  * Verify that the current Node.js version includes the `node:sqlite` APIs
@@ -75,7 +152,7 @@ const checkNodeSqliteCompat = () => {
 const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
   options: SqliteClientConfig,
   openDatabase: () => DatabaseSync,
-): Effect.fn.Return<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> {
+): Effect.fn.Return<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> {
   yield* checkNodeSqliteCompat();
 
   const compiler = Statement.makeCompilerSqlite(options.transformQueryNames);
@@ -86,6 +163,7 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
   const makeConnection = Effect.gen(function* () {
     const scope = yield* Effect.scope;
     const db = openDatabase();
+    yield* initializeConnection(db, options.filename);
     yield* Scope.addFinalizer(
       scope,
       Effect.sync(() => db.close()),
@@ -174,7 +252,7 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
           }),
       );
 
-    return identity<Connection>({
+    return identity<PooledConnection>({
       execute(sql, params, rowTransform) {
         return rowTransform ? Effect.map(run(sql, params), rowTransform) : run(sql, params);
       },
@@ -191,37 +269,56 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
       executeStream(_sql, _params) {
         return Stream.die("executeStream not implemented");
       },
+      reset: resetConnection(db),
+      healthCheck: runIntegrityCheck(db),
     });
   });
 
-  const semaphore = yield* Semaphore.make(1);
-  const connection = yield* makeConnection;
-
-  const acquirer = semaphore.withPermits(1)(Effect.succeed(connection));
-  const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
-    const fiber = Fiber.getCurrent()!;
-    const scope = Context.getUnsafe(fiber.context, Scope.Scope);
-    return Effect.as(
-      Effect.tap(restore(semaphore.take(1)), () => Scope.addFinalizer(scope, semaphore.release(1))),
-      connection,
-    );
+  const poolBounds =
+    options.filename === ":memory:"
+      ? { min: 1, max: 1 }
+      : { min: SQLITE_POOL_MIN_SIZE, max: SQLITE_POOL_MAX_SIZE };
+  const pool = yield* Pool.makeWithTTL({
+    acquire: makeConnection,
+    min: poolBounds.min,
+    max: poolBounds.max,
+    timeToLive: SQLITE_POOL_TTL,
   });
 
-  return yield* Client.make({
-    acquirer,
-    compiler,
-    transactionAcquirer,
-    spanAttributes: [
-      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [ATTR_DB_SYSTEM_NAME, "sqlite"],
-    ],
-    transformRows,
-  });
+  const acquirer: Effect.Effect<PooledConnection, SqlError, Scope.Scope> = Pool.get(pool).pipe(
+    Effect.timeout(SQLITE_POOL_ACQUIRE_TIMEOUT),
+    Effect.mapError((cause) =>
+      isSqlError(cause)
+        ? cause
+        : makeSqlError(cause, "Timed out acquiring sqlite connection", "acquire"),
+    ),
+    Effect.tap((connection) =>
+      Effect.addFinalizer(() => connection.reset.pipe(Effect.catch(() => Effect.void))),
+    ),
+  );
+
+  return Object.assign(
+    yield* Client.make({
+      acquirer,
+      compiler,
+      transactionAcquirer: acquirer,
+      spanAttributes: [
+        ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+        [ATTR_DB_SYSTEM_NAME, "sqlite"],
+      ],
+      transformRows,
+    }),
+    {
+      [TypeId]: TypeId as TypeId,
+      pool,
+      healthCheck: Effect.scoped(Effect.flatMap(acquirer, (connection) => connection.healthCheck)),
+    },
+  );
 });
 
 const make = (
   options: SqliteClientConfig,
-): Effect.Effect<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
   makeWithDatabase(
     options,
     () =>
@@ -233,7 +330,7 @@ const make = (
 
 const makeMemory = (
   config: SqliteMemoryClientConfig = {},
-): Effect.Effect<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
   makeWithDatabase(
     {
       ...config,
@@ -250,7 +347,7 @@ const makeMemory = (
 
 export const layerConfig = (
   config: Config.Wrap<SqliteClientConfig>,
-): Layer.Layer<Client.SqlClient, Config.ConfigError> =>
+): Layer.Layer<SqliteClient | Client.SqlClient, Config.ConfigError> =>
   Layer.effectContext(
     Config.unwrap(config)
       .asEffect()
@@ -262,14 +359,16 @@ export const layerConfig = (
       ),
   ).pipe(Layer.provide(Reactivity.layer));
 
-export const layer = (config: SqliteClientConfig): Layer.Layer<Client.SqlClient> =>
+export const layer = (config: SqliteClientConfig): Layer.Layer<SqliteClient | Client.SqlClient> =>
   Layer.effectContext(
     Effect.map(make(config), (client) =>
       Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
     ),
   ).pipe(Layer.provide(Reactivity.layer));
 
-export const layerMemory = (config: SqliteMemoryClientConfig = {}): Layer.Layer<Client.SqlClient> =>
+export const layerMemory = (
+  config: SqliteMemoryClientConfig = {},
+): Layer.Layer<SqliteClient | Client.SqlClient> =>
   Layer.effectContext(
     Effect.map(makeMemory(config), (client) =>
       Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),


### PR DESCRIPTION
/claim #858

## Summary
- Initializes file-backed SQLite connections with WAL, `busy_timeout=5000`, `synchronous=NORMAL`, and foreign keys.
- Replaces the singleton Node SQLite connection with an Effect.Pool-backed client: min 1, max 5, scoped 10-second acquisition timeout, and reset-on-release PRAGMAs.
- Adds an integrity-check health method and shared persistence-layer health helper.
- Extends SQLite tests for PRAGMA setup, pool bounds, health check, reset behavior, and concurrent read/write access.

## Tests
- `npx -y node@24 <vitest-cli> run apps/server/src/persistence/NodeSqliteClient.test.ts --config apps/server/vitest.config.ts` -> 5 passed
- `bun run --cwd apps/server typecheck`
- `bun run fmt:check apps/server/src/persistence/NodeSqliteClient.ts apps/server/src/persistence/NodeSqliteClient.test.ts apps/server/src/persistence/Layers/Sqlite.ts`
- `git diff --check`

## Security
- WAL and busy timeout reduce lock-contention failure modes without weakening SQLite integrity settings.
- Pool reset re-applies foreign keys and performance PRAGMAs before a connection is reused.
- I did not add an attribution/provenance file that copies private runtime/system instructions into the repository.

Prepared with AI assistance and manually reviewed before submission.