### PR TITLE
code [ T3 Code ] Add provider config validation

### DIFF
--- a/t3code/packages/contracts/src/index.ts
+++ b/t3code/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@ export * from "./ipc.ts";
 export * from "./terminal.ts";
 export * from "./provider.ts";
 export * from "./providerInstance.ts";
+export * from "./providerConfigValidation.ts";
 export * from "./providerRuntime.ts";
 export * from "./model.ts";
 export * from "./keybindings.ts";

--- a/t3code/packages/contracts/src/providerConfigValidation.test.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import * as Result from "effect/Result";
+
+import type { ProviderInstanceConfig } from "./providerInstance.ts";
+import { validateProviderConfig } from "./providerConfigValidation.ts";
+
+const baseConfig = {
+  driver: "codex",
+} as ProviderInstanceConfig;
+
+const expectFailures = (config: ProviderInstanceConfig) => {
+  const result = validateProviderConfig(config);
+  expect(Result.isFailure(result)).toBe(true);
+
+  if (Result.isFailure(result)) {
+    return result.failure;
+  }
+
+  return [];
+};
+
+describe("validateProviderConfig", () => {
+  it("accepts valid provider config values", () => {
+    const result = validateProviderConfig({
+      ...baseConfig,
+      environment: [
+        { name: "OPENROUTER_API_KEY", value: "sk-valid-key-123", sensitive: true },
+        { name: "ANTHROPIC_BASE_URL", value: "https://api.anthropic.com", sensitive: false },
+      ],
+      config: {
+        endpoint: "https://api.example.com/v1",
+        nested: { apiKey: "provider-key-12345" },
+      },
+    });
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  it("rejects empty and short API keys", () => {
+    const errors = expectFailures({
+      ...baseConfig,
+      environment: [{ name: "OPENROUTER_API_KEY", value: "", sensitive: true }],
+      config: { apiKey: "short" },
+    });
+
+    expect(errors).toHaveLength(2);
+    expect(errors.map((error) => error.field)).toEqual([
+      "environment.OPENROUTER_API_KEY",
+      "config.apiKey",
+    ]);
+  });
+
+  it("rejects HTTP URLs with a clear HTTPS expectation", () => {
+    const errors = expectFailures({
+      ...baseConfig,
+      config: { endpoint: "http://api.example.com/v1" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.field).toBe("config.endpoint");
+    expect(errors[0]?.expected).toContain("https://");
+  });
+
+  it("rejects malformed endpoint URLs", () => {
+    const errors = expectFailures({
+      ...baseConfig,
+      environment: [{ name: "ANTHROPIC_BASE_URL", value: "not a url", sensitive: false }],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.invalidValue).toBe("not a url");
+  });
+
+  it("returns all validation errors at once", () => {
+    const errors = expectFailures({
+      ...baseConfig,
+      environment: [
+        { name: "OPENROUTER_API_KEY", value: "tiny", sensitive: true },
+        { name: "ANTHROPIC_BASE_URL", value: "http://localhost:3000", sensitive: false },
+      ],
+      config: {
+        nested: {
+          apiKey: "bad",
+          endpointUrl: "ftp://api.example.com",
+        },
+      },
+    });
+
+    expect(errors.map((error) => error.field)).toEqual([
+      "environment.OPENROUTER_API_KEY",
+      "environment.ANTHROPIC_BASE_URL",
+      "config.nested.apiKey",
+      "config.nested.endpointUrl",
+    ]);
+  });
+});

--- a/t3code/packages/contracts/src/providerConfigValidation.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.ts
@@ -1,0 +1,140 @@
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+
+import { TrimmedNonEmptyString } from "./baseSchemas.ts";
+import type { ProviderInstanceConfig } from "./providerInstance.ts";
+
+const API_KEY_PATTERN = /^\S{10,}$/;
+const API_KEY_FIELD_PATTERN = /(?:api[_-]?key|apikey|_key$)/i;
+const ENDPOINT_FIELD_PATTERN = /(?:endpoint|url|baseUrl|base_url)$/i;
+
+export const ProviderApiKeyValue = TrimmedNonEmptyString.check(
+  Schema.isMinLength(10),
+  Schema.isPattern(API_KEY_PATTERN),
+);
+export type ProviderApiKeyValue = typeof ProviderApiKeyValue.Type;
+
+export const ProviderHttpsEndpointUrl = TrimmedNonEmptyString.check(
+  Schema.isPattern(/^https:\/\/[^\s/$.?#].[^\s]*$/i),
+);
+export type ProviderHttpsEndpointUrl = typeof ProviderHttpsEndpointUrl.Type;
+
+export class ProviderConfigError extends Schema.TaggedErrorClass<ProviderConfigError>()(
+  "ProviderConfigError",
+  {
+    field: TrimmedNonEmptyString,
+    invalidValue: Schema.String,
+    expected: TrimmedNonEmptyString,
+  },
+) {}
+
+type CandidateField = {
+  readonly field: string;
+  readonly value: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const addError = (
+  errors: Array<ProviderConfigError>,
+  field: string,
+  invalidValue: string,
+  expected: string,
+) => {
+  errors.push(new ProviderConfigError({ field, invalidValue, expected }));
+};
+
+const collectConfigFields = (value: unknown, prefix: string, candidates: Array<CandidateField>) => {
+  if (typeof value === "string") {
+    candidates.push({ field: prefix, value });
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectConfigFields(item, `${prefix}[${index}]`, candidates));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    collectConfigFields(nestedValue, `${prefix}.${key}`, candidates);
+  }
+};
+
+const collectProviderFields = (config: ProviderInstanceConfig): Array<CandidateField> => {
+  const candidates: Array<CandidateField> = [];
+
+  for (const variable of config.environment ?? []) {
+    if (variable.valueRedacted === true) {
+      continue;
+    }
+
+    candidates.push({
+      field: `environment.${variable.name}`,
+      value: variable.value,
+    });
+  }
+
+  if (config.config !== undefined) {
+    collectConfigFields(config.config, "config", candidates);
+  }
+
+  return candidates;
+};
+
+const validateApiKey = (field: CandidateField, errors: Array<ProviderConfigError>) => {
+  if (!API_KEY_FIELD_PATTERN.test(field.field)) {
+    return;
+  }
+
+  const result = Schema.decodeUnknownResult(ProviderApiKeyValue)(field.value);
+  if (Result.isFailure(result)) {
+    addError(
+      errors,
+      field.field,
+      field.value,
+      "non-empty API key with at least 10 non-whitespace characters",
+    );
+  }
+};
+
+const validateEndpoint = (field: CandidateField, errors: Array<ProviderConfigError>) => {
+  if (!ENDPOINT_FIELD_PATTERN.test(field.field)) {
+    return;
+  }
+
+  const result = Schema.decodeUnknownResult(ProviderHttpsEndpointUrl)(field.value);
+  if (Result.isFailure(result)) {
+    const expected = field.value.trim().toLowerCase().startsWith("http://")
+      ? "HTTPS URL; replace http:// with https://"
+      : "valid HTTPS URL with a hostname";
+    addError(errors, field.field, field.value, expected);
+    return;
+  }
+
+  try {
+    const url = new URL(field.value);
+    if (url.protocol !== "https:" || url.hostname.trim() === "") {
+      addError(errors, field.field, field.value, "valid HTTPS URL with a hostname");
+    }
+  } catch {
+    addError(errors, field.field, field.value, "valid HTTPS URL with a hostname");
+  }
+};
+
+export const validateProviderConfig = (
+  config: ProviderInstanceConfig,
+): Result.Result<ProviderInstanceConfig, ReadonlyArray<ProviderConfigError>> => {
+  const errors: Array<ProviderConfigError> = [];
+
+  for (const field of collectProviderFields(config)) {
+    validateApiKey(field, errors);
+    validateEndpoint(field, errors);
+  }
+
+  return errors.length === 0 ? Result.succeed(config) : Result.fail(errors);
+};


### PR DESCRIPTION
/claim #825

## Summary
- Adds `ProviderConfigError` plus `validateProviderConfig()` in the contracts package.
- Validates API-key-like fields from provider environment/config payloads for non-empty, non-whitespace values of at least 10 characters.
- Validates endpoint/url-like fields as HTTPS URLs with hostnames and returns all validation errors together as Effect v4 `Result` failures.
- Exports the validator from the contracts package and covers valid, API key, HTTP URL, malformed URL, and multi-error cases.

## Tests
- `bun run --cwd packages/contracts test src/providerConfigValidation.test.ts` -> 5 passed
- `bun run --cwd packages/contracts typecheck`
- `bun run fmt:check packages/contracts/src/providerConfigValidation.ts packages/contracts/src/providerConfigValidation.test.ts packages/contracts/src/index.ts`
- `git diff --check`

## Security
- API key validation avoids accepting empty/too-short secrets and endpoint validation rejects HTTP endpoints with an HTTPS-specific message.
- The validator does not change the existing opaque provider config envelope, preserving forward compatibility.
- I did not add an attribution/provenance file that copies private runtime/system instructions into the repository.

Prepared with AI assistance and manually reviewed before submission.