### PR TITLE
code [ T3 Code ] Add environment detection info

### DIFF
--- a/t3code/packages/client-runtime/src/knownEnvironment.test.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.test.ts
@@ -1,7 +1,11 @@
 import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { createKnownEnvironment, getKnownEnvironmentHttpBaseUrl } from "./knownEnvironment.ts";
+import {
+  createKnownEnvironment,
+  detectEnvironmentInfo,
+  getKnownEnvironmentHttpBaseUrl,
+} from "./knownEnvironment.ts";
 import {
   parseScopedProjectKey,
   parseScopedThreadKey,
@@ -57,6 +61,92 @@ describe("known environment bootstrap helpers", () => {
         }),
       ),
     ).toBe("https://remote.example.com/api");
+  });
+});
+
+describe("environment info detection", () => {
+  it("detects Docker from dockerenv", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        arch: "x64",
+        fileExists: (path) => path === "/.dockerenv",
+      }),
+    ).toMatchObject({
+      runtime: "node",
+      platform: "linux",
+      arch: "x64",
+      isContainer: true,
+      isCI: false,
+      ciProvider: null,
+      isWSL: false,
+    });
+  });
+
+  it("detects containers from cgroup entries", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        platform: "linux",
+        readFile: (path) =>
+          path === "/proc/self/cgroup" ? "0::/system.slice/docker/test.scope" : null,
+      }).isContainer,
+    ).toBe(true);
+  });
+
+  it.each([
+    ["GITHUB_ACTIONS", "github-actions"],
+    ["GITLAB_CI", "gitlab"],
+    ["JENKINS_URL", "jenkins"],
+    ["CIRCLECI", "circleci"],
+    ["TRAVIS", "travis"],
+  ] as const)("detects %s as %s", (variableName, provider) => {
+    expect(
+      detectEnvironmentInfo({
+        env: { [variableName]: "true" },
+      }),
+    ).toMatchObject({
+      isCI: true,
+      ciProvider: provider,
+    });
+  });
+
+  it("detects generic CI without a provider name", () => {
+    expect(detectEnvironmentInfo({ env: { CI: "true" } })).toMatchObject({
+      isCI: true,
+      ciProvider: null,
+    });
+  });
+
+  it("detects WSL from proc version", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        platform: "linux",
+        readFile: (path) => (path === "/proc/version" ? "Linux version Microsoft WSL2" : null),
+      }).isWSL,
+    ).toBe(true);
+  });
+
+  it("returns false flags when no container or CI signals exist", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        runtime: "browser",
+        platform: "win32",
+        arch: "x64",
+      }),
+    ).toMatchObject({
+      runtime: "browser",
+      platform: "win32",
+      arch: "x64",
+      isContainer: false,
+      isCI: false,
+      ciProvider: null,
+      isWSL: false,
+    });
   });
 });
 

--- a/t3code/packages/client-runtime/src/knownEnvironment.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.ts
@@ -7,12 +7,118 @@ export interface KnownEnvironmentConnectionTarget {
 
 export type KnownEnvironmentSource = "configured" | "desktop-managed" | "manual" | "window-origin";
 
+export type CiProvider = "circleci" | "github-actions" | "gitlab" | "jenkins" | "travis";
+
+export interface EnvironmentInfo {
+  readonly runtime: string;
+  readonly platform: string;
+  readonly arch: string;
+  readonly isContainer: boolean;
+  readonly isCI: boolean;
+  readonly ciProvider: CiProvider | null;
+  readonly isWSL: boolean;
+}
+
+export interface EnvironmentInfoDetectionInput {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly runtime?: string;
+  readonly platform?: string;
+  readonly arch?: string;
+  readonly fileExists?: (path: string) => boolean;
+  readonly readFile?: (path: string) => string | null | undefined;
+}
+
 export interface KnownEnvironment {
   readonly id: string;
   readonly label: string;
   readonly source: KnownEnvironmentSource;
   readonly environmentId?: EnvironmentId;
   readonly target: KnownEnvironmentConnectionTarget;
+}
+
+const CI_PROVIDER_ENV: ReadonlyArray<readonly [CiProvider, string]> = [
+  ["github-actions", "GITHUB_ACTIONS"],
+  ["gitlab", "GITLAB_CI"],
+  ["jenkins", "JENKINS_URL"],
+  ["circleci", "CIRCLECI"],
+  ["travis", "TRAVIS"],
+];
+
+const getProcess = () =>
+  typeof process === "undefined"
+    ? null
+    : (process as {
+        readonly env?: Record<string, string | undefined>;
+        readonly platform?: string;
+        readonly arch?: string;
+        readonly versions?: { readonly bun?: string; readonly node?: string };
+      });
+
+const getNavigatorPlatform = () => (typeof navigator === "undefined" ? null : navigator.platform);
+
+const defaultRuntime = (): string => {
+  const currentProcess = getProcess();
+
+  if (currentProcess?.versions?.bun !== undefined) {
+    return "bun";
+  }
+
+  if (currentProcess?.versions?.node !== undefined) {
+    return "node";
+  }
+
+  if (typeof window !== "undefined") {
+    return "browser";
+  }
+
+  return "unknown";
+};
+
+const detectCiProvider = (env: Readonly<Record<string, string | undefined>>): CiProvider | null => {
+  for (const [provider, variableName] of CI_PROVIDER_ENV) {
+    if (env[variableName] !== undefined && env[variableName] !== "") {
+      return provider;
+    }
+  }
+
+  return null;
+};
+
+const detectContainer = (
+  fileExists: (path: string) => boolean,
+  readFile: (path: string) => string | null | undefined,
+) => {
+  if (fileExists("/.dockerenv")) {
+    return true;
+  }
+
+  const cgroup = readFile("/proc/self/cgroup")?.toLowerCase() ?? "";
+  return cgroup.includes("docker") || cgroup.includes("containerd") || cgroup.includes("kubepods");
+};
+
+const detectWsl = (platform: string, readFile: (path: string) => string | null | undefined) =>
+  platform === "linux" && /microsoft|wsl/i.test(readFile("/proc/version") ?? "");
+
+export function detectEnvironmentInfo(input: EnvironmentInfoDetectionInput = {}): EnvironmentInfo {
+  const currentProcess = getProcess();
+  const env = input.env ?? currentProcess?.env ?? {};
+  const platform =
+    input.platform ?? currentProcess?.platform ?? getNavigatorPlatform() ?? "unknown";
+  const arch = input.arch ?? currentProcess?.arch ?? "unknown";
+  const fileExists = input.fileExists ?? (() => false);
+  const readFile = input.readFile ?? (() => null);
+  const ciProvider = detectCiProvider(env);
+  const isCI = ciProvider !== null || env["CI"] !== undefined;
+
+  return {
+    runtime: input.runtime ?? defaultRuntime(),
+    platform,
+    arch,
+    isContainer: detectContainer(fileExists, readFile),
+    isCI,
+    ciProvider,
+    isWSL: detectWsl(platform, readFile),
+  };
 }
 
 export function createKnownEnvironment(input: {


### PR DESCRIPTION
/claim #836

## Summary
- Adds `detectEnvironmentInfo()` with runtime, platform, arch, container, CI provider, and WSL flags.
- Detects Docker via `/.dockerenv` or cgroup contents, maps common CI provider variables, and detects WSL from `/proc/version`.
- Uses injectable file/env readers so client-runtime stays browser-safe and tests can mock missing files/env vars cleanly.
- Keeps existing known-environment helpers unchanged.

## Tests
- `bun run --cwd packages/client-runtime test src/knownEnvironment.test.ts` -> 15 passed
- `bun run --cwd packages/client-runtime typecheck`
- `bun run fmt:check packages/client-runtime/src/knownEnvironment.ts packages/client-runtime/src/knownEnvironment.test.ts`
- `git diff --check`

## Security
- Detection is read-only and tolerant of missing files/env vars.
- CI/container signals are returned as structured booleans/provider names without exposing environment variable values.
- I did not add a contributor metadata file that copies private runtime/system instructions into the repository.

Prepared with AI assistance and manually reviewed before submission.