### PR TITLE
code [ T3 Code ] Add fuzzy search to CommandPalette

### DIFF
--- a/t3code/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/t3code/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,6 +4,7 @@ import type { Thread } from "../types";
 import {
   buildThreadActionItems,
   filterCommandPaletteGroups,
+  fuzzyMatchCommandPaletteText,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -162,5 +163,154 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+describe("filterCommandPaletteGroups fuzzy search", () => {
+  it("matches command titles across gaps and exposes title highlight indices", () => {
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [
+        {
+          value: "actions",
+          label: "Actions",
+          items: [
+            {
+              kind: "action",
+              value: "open-file",
+              searchTerms: ["Open File"],
+              title: "Open File",
+              icon: null,
+              run: async () => undefined,
+            },
+          ],
+        },
+      ],
+      query: "ofl",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.items[0]?.value).toBe("open-file");
+    expect(groups[0]?.items[0]?.titleMatchIndices).toEqual([0, 5, 7]);
+  });
+
+  it("ranks consecutive matches ahead of looser word-boundary matches", () => {
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [
+        {
+          value: "actions",
+          label: "Actions",
+          items: [
+            {
+              kind: "action",
+              value: "other-project",
+              searchTerms: ["Other Project"],
+              title: "Other Project",
+              icon: null,
+              run: async () => undefined,
+            },
+            {
+              kind: "action",
+              value: "open-file",
+              searchTerms: ["Open File"],
+              title: "Open File",
+              icon: null,
+              run: async () => undefined,
+            },
+          ],
+        },
+      ],
+      query: "op",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["open-file", "other-project"]);
+  });
+
+  it("keeps empty queries in their original order", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: [
+        {
+          kind: "action",
+          value: "second",
+          searchTerms: ["Second Action"],
+          title: "Second Action",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "first",
+          searchTerms: ["First Action"],
+          title: "First Action",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["second", "first"]);
+  });
+
+  it("filters single-character queries", () => {
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [
+        {
+          value: "actions",
+          label: "Actions",
+          items: [
+            {
+              kind: "action",
+              value: "save",
+              searchTerms: ["Save File"],
+              title: "Save File",
+              icon: null,
+              run: async () => undefined,
+            },
+            {
+              kind: "action",
+              value: "open",
+              searchTerms: ["Open File"],
+              title: "Open File",
+              icon: null,
+              run: async () => undefined,
+            },
+          ],
+        },
+      ],
+      query: "s",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["save"]);
+  });
+});
+
+describe("fuzzyMatchCommandPaletteText", () => {
+  it("returns matched indices for gapped query characters", () => {
+    expect(fuzzyMatchCommandPaletteText("Open File", "ofl")?.indices).toEqual([0, 5, 7]);
+  });
+
+  it("scores compact consecutive matches above wider matches", () => {
+    const consecutive = fuzzyMatchCommandPaletteText("Open File", "op");
+    const loose = fuzzyMatchCommandPaletteText("Other Project", "op");
+
+    expect(consecutive?.score).toBeGreaterThan(loose?.score ?? 0);
   });
 });

--- a/t3code/apps/web/src/components/CommandPalette.logic.ts
+++ b/t3code/apps/web/src/components/CommandPalette.logic.ts
@@ -14,6 +14,7 @@ export interface CommandPaletteItem {
   readonly value: string;
   readonly searchTerms: ReadonlyArray<string>;
   readonly title: ReactNode;
+  readonly titleMatchIndices?: ReadonlyArray<number>;
   readonly description?: string;
   readonly timestamp?: string;
   readonly icon: ReactNode;
@@ -86,6 +87,89 @@ export function filterBrowseEntries(input: {
 
 export function normalizeSearchText(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export interface CommandPaletteFuzzyMatch {
+  readonly score: number;
+  readonly indices: ReadonlyArray<number>;
+}
+
+function isWordBoundary(value: string, index: number): boolean {
+  if (index === 0) {
+    return true;
+  }
+
+  const previous = value[index - 1] ?? "";
+  const current = value[index] ?? "";
+
+  return (
+    /[\s/_\-.:]/.test(previous) ||
+    (previous.toLowerCase() === previous &&
+      previous.toUpperCase() !== previous &&
+      current.toUpperCase() === current &&
+      current.toLowerCase() !== current)
+  );
+}
+
+export function fuzzyMatchCommandPaletteText(
+  field: string,
+  query: string,
+): CommandPaletteFuzzyMatch | null {
+  const normalizedField = normalizeSearchText(field);
+  const normalizedQuery = normalizeSearchText(query);
+  const queryCharacters = normalizedQuery.replace(/\s+/g, "");
+
+  if (queryCharacters.length === 0) {
+    return { score: 0, indices: [] };
+  }
+  if (normalizedField.length === 0) {
+    return null;
+  }
+
+  const indices: number[] = [];
+  let queryIndex = 0;
+  let score = 1_000;
+  let previousMatchIndex = -1;
+
+  for (
+    let fieldIndex = 0;
+    fieldIndex < field.length && queryIndex < queryCharacters.length;
+    fieldIndex += 1
+  ) {
+    if (field[fieldIndex]?.toLowerCase() !== queryCharacters[queryIndex]) {
+      continue;
+    }
+
+    indices.push(fieldIndex);
+    score += 40;
+
+    if (previousMatchIndex === fieldIndex - 1) {
+      score += 30;
+    } else if (isWordBoundary(field, fieldIndex)) {
+      score += 20;
+    }
+
+    previousMatchIndex = fieldIndex;
+    queryIndex += 1;
+  }
+
+  if (queryIndex !== queryCharacters.length) {
+    return null;
+  }
+
+  if (normalizedField === normalizedQuery) {
+    score += 500;
+  } else if (normalizedField.startsWith(normalizedQuery)) {
+    score += 250;
+  } else if (normalizedField.includes(normalizedQuery)) {
+    score += 100;
+  }
+
+  const compactnessGap = indices.at(-1)! - indices[0]! + 1 - indices.length;
+  score -= compactnessGap * 2;
+  score -= field.length * 0.01;
+
+  return { score, indices };
 }
 
 export function buildProjectActionItems(input: {
@@ -175,37 +259,51 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
   });
 }
 
-function rankSearchFieldMatch(field: string, normalizedQuery: string): number {
-  const normalizedField = normalizeSearchText(field);
-  if (normalizedField.length === 0 || !normalizedField.includes(normalizedQuery)) {
-    return Number.NEGATIVE_INFINITY;
-  }
-  if (normalizedField === normalizedQuery) {
-    return 3;
-  }
-  if (normalizedField.startsWith(normalizedQuery)) {
-    return 2;
-  }
-  return 1;
+interface CommandPaletteItemMatch {
+  readonly rank: number;
+  readonly titleMatchIndices?: ReadonlyArray<number>;
 }
 
 function rankCommandPaletteItemMatch(
   item: CommandPaletteActionItem | CommandPaletteSubmenuItem,
   normalizedQuery: string,
-): number {
+): CommandPaletteItemMatch | null {
   const terms = item.searchTerms.filter((term) => term.length > 0);
   if (terms.length === 0) {
-    return 0;
+    return null;
   }
 
+  let bestMatch: CommandPaletteItemMatch | null = null;
+  const titleMatch =
+    typeof item.title === "string"
+      ? fuzzyMatchCommandPaletteText(item.title, normalizedQuery)
+      : null;
+
   for (const [index, field] of terms.entries()) {
-    const fieldRank = rankSearchFieldMatch(field, normalizedQuery);
-    if (fieldRank !== Number.NEGATIVE_INFINITY) {
-      return 1_000 - index * 100 + fieldRank;
+    const fieldMatch = fuzzyMatchCommandPaletteText(field, normalizedQuery);
+    if (!fieldMatch) {
+      continue;
+    }
+
+    const isTitleField =
+      typeof item.title === "string" &&
+      normalizeSearchText(field) === normalizeSearchText(item.title);
+    const rank = 10_000 - index * 500 + fieldMatch.score + (isTitleField ? 250 : 0);
+    const candidate: CommandPaletteItemMatch = {
+      rank,
+      ...(isTitleField
+        ? { titleMatchIndices: fieldMatch.indices }
+        : titleMatch
+          ? { titleMatchIndices: titleMatch.indices }
+          : {}),
+    };
+
+    if (!bestMatch || candidate.rank > bestMatch.rank) {
+      bestMatch = candidate;
     }
   }
 
-  return 0;
+  return bestMatch;
 }
 
 export function filterCommandPaletteGroups(input: {
@@ -254,15 +352,18 @@ export function filterCommandPaletteGroups(input: {
   return searchableGroups.flatMap((group) => {
     const items = group.items
       .map((item, index) => {
-        const haystack = normalizeSearchText(item.searchTerms.join(" "));
-        if (!haystack.includes(normalizedQuery)) {
+        const match = rankCommandPaletteItemMatch(item, normalizedQuery);
+        if (!match) {
           return null;
         }
 
         return {
-          item,
+          item:
+            match.titleMatchIndices && match.titleMatchIndices.length > 0
+              ? { ...item, titleMatchIndices: match.titleMatchIndices }
+              : item,
           index,
-          rank: rankCommandPaletteItemMatch(item, normalizedQuery),
+          rank: match.rank,
         };
       })
       .filter(

--- a/t3code/apps/web/src/components/CommandPaletteResults.tsx
+++ b/t3code/apps/web/src/components/CommandPaletteResults.tsx
@@ -25,6 +25,26 @@ interface CommandPaletteResultsProps {
   onExecuteItem: (item: CommandPaletteActionItem | CommandPaletteSubmenuItem) => void;
 }
 
+function renderCommandPaletteTitle(item: CommandPaletteActionItem | CommandPaletteSubmenuItem) {
+  if (typeof item.title !== "string" || !item.titleMatchIndices?.length) {
+    return item.title;
+  }
+
+  const highlightedIndices = new Set(item.titleMatchIndices);
+
+  return item.title.split("").map((character, index) => (
+    <span
+      className={cn(
+        highlightedIndices.has(index) &&
+          "font-medium text-foreground underline decoration-primary/70 underline-offset-2",
+      )}
+      key={`${character}-${index}`}
+    >
+      {character}
+    </span>
+  ));
+}
+
 export function CommandPaletteResults(props: CommandPaletteResultsProps) {
   if (props.groups.length === 0) {
     return (
@@ -73,7 +93,7 @@ function DisabledCommandPaletteResultRow(props: {
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="flex min-w-0 items-center gap-1.5 text-sm text-foreground">
             {props.item.titleLeadingContent}
-            <span className="truncate">{props.item.title}</span>
+            <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
           </span>
           <span className="truncate text-muted-foreground/70 text-xs">
             {props.item.description}
@@ -82,7 +102,7 @@ function DisabledCommandPaletteResultRow(props: {
       ) : (
         <span className="flex min-w-0 flex-1 items-center gap-1.5 text-sm text-foreground">
           {props.item.titleLeadingContent}
-          <span className="truncate">{props.item.title}</span>
+          <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
         </span>
       )}
       {props.item.titleTrailingContent}
@@ -119,7 +139,7 @@ function CommandPaletteResultRow(props: {
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="flex min-w-0 items-center gap-1.5 text-sm text-foreground">
             {props.item.titleLeadingContent}
-            <span className="truncate">{props.item.title}</span>
+            <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
           </span>
           <span className="truncate text-muted-foreground/70 text-xs">
             {props.item.description}
@@ -128,7 +148,7 @@ function CommandPaletteResultRow(props: {
       ) : (
         <span className="flex min-w-0 flex-1 items-center gap-1.5 text-sm text-foreground">
           {props.item.titleLeadingContent}
-          <span className="truncate">{props.item.title}</span>
+          <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
         </span>
       )}
       {props.item.titleTrailingContent}


### PR DESCRIPTION
﻿/claim #830

Summary
- Added a deterministic fuzzy matcher for CommandPalette search terms, including gap-based matches such as `ofl` -> `Open File`.
- Preserved default ordering for empty queries and kept title matches ranked ahead of contextual/project matches.
- Added title match metadata and rendering spans so matched command-title characters are highlighted without changing CommandItem values or keyboard navigation.

Tests
- `bun run --cwd apps/web test src/components/CommandPalette.logic.test.ts`
- `bun run --cwd apps/web typecheck`
- `bun run fmt:check apps/web/src/components/CommandPalette.logic.ts apps/web/src/components/CommandPalette.logic.test.ts apps/web/src/components/CommandPaletteResults.tsx`
- `git diff --check`

Security
- The fuzzy matcher is local-only string processing; it does not execute user input, change routing, or add persistence/network access.
- I omitted `_provenance.json` because the requested boot context would expose private runtime/session instructions.

Prepared with AI assistance and manually reviewed before submission.
