### PR TITLE
code [ T3 Code ] Add request body size limiting

### DIFF
--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import {
+  DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+  FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES,
+  evaluateRequestBodySizeLimit,
+  isLoopbackHostname,
+  parseContentLengthHeader,
+  resolveDevRedirectUrl,
+  resolveRequestBodySizeLimit,
+} from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +31,79 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("http request body size limits", () => {
+  it("parses safe content-length values", () => {
+    expect(parseContentLengthHeader("1048576")).toBe(1_048_576);
+    expect(parseContentLengthHeader(undefined)).toBeNull();
+    expect(parseContentLengthHeader("-1")).toBeNull();
+    expect(parseContentLengthHeader("not-a-number")).toBeNull();
+  });
+
+  it("uses a 10 MB default limit for regular routes", () => {
+    expect(resolveRequestBodySizeLimit({ method: "POST", pathname: "/api/auth/bootstrap" })).toBe(
+      DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+    );
+  });
+
+  it("uses a 50 MB limit for upload-style routes", () => {
+    expect(resolveRequestBodySizeLimit({ method: "POST", pathname: "/api/upload/file" })).toBe(
+      FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES,
+    );
+  });
+
+  it("prefers the most specific per-route override", () => {
+    expect(
+      resolveRequestBodySizeLimit({
+        method: "POST",
+        pathname: "/api/upload/small",
+        overrides: [
+          { pathPrefix: "/api/upload", maxBytes: 10_000 },
+          { pathPrefix: "/api/upload/small", maxBytes: 512 },
+        ],
+      }),
+    ).toBe(512);
+  });
+
+  it("rejects oversized request bodies for body-carrying methods", () => {
+    expect(
+      evaluateRequestBodySizeLimit({
+        method: "POST",
+        pathname: "/api/auth/bootstrap",
+        contentLengthHeader: String(DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES + 1),
+      }),
+    ).toEqual({
+      ok: false,
+      limit: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+      received: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES + 1,
+    });
+  });
+
+  it("allows requests at the configured limit and ignores body limits for GET", () => {
+    expect(
+      evaluateRequestBodySizeLimit({
+        method: "POST",
+        pathname: "/api/auth/bootstrap",
+        contentLengthHeader: String(DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES),
+      }),
+    ).toEqual({
+      ok: true,
+      limit: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+      received: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+    });
+
+    expect(
+      evaluateRequestBodySizeLimit({
+        method: "GET",
+        pathname: "/api/auth/bootstrap",
+        contentLengthHeader: String(DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES + 1),
+      }),
+    ).toEqual({
+      ok: true,
+      limit: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+      received: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES + 1,
+    });
   });
 });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -38,12 +38,140 @@ const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
+export const DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES = 10 * 1024 * 1024;
+export const FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES = 50 * 1024 * 1024;
+export const REQUEST_BODY_SIZE_LIMIT_HEADER = "X-Max-Body-Size";
+
+const REQUEST_METHODS_WITH_BODY = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const FILE_UPLOAD_ROUTE_PREFIXES = [
+  "/api/upload",
+  "/api/uploads",
+  "/api/attachments",
+  "/attachments",
+];
+
+export interface RequestBodySizeLimitOverride {
+  readonly method?: string;
+  readonly pathPrefix: `/${string}`;
+  readonly maxBytes: number;
+}
 
 export const browserApiCorsLayer = HttpRouter.cors({
   allowedMethods: [...browserApiCorsAllowedMethods],
   allowedHeaders: [...browserApiCorsAllowedHeaders],
   maxAge: 600,
 });
+
+export function parseContentLengthHeader(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function resolveRequestBodySizeLimit(input: {
+  readonly method: string;
+  readonly pathname: string;
+  readonly overrides?: ReadonlyArray<RequestBodySizeLimitOverride>;
+}): number {
+  const normalizedMethod = input.method.toUpperCase();
+  const matchingOverride = input.overrides
+    ?.filter(
+      (override) =>
+        input.pathname.startsWith(override.pathPrefix) &&
+        (!override.method || override.method.toUpperCase() === normalizedMethod),
+    )
+    .toSorted((left, right) => right.pathPrefix.length - left.pathPrefix.length)[0];
+
+  if (matchingOverride) {
+    return matchingOverride.maxBytes;
+  }
+
+  if (FILE_UPLOAD_ROUTE_PREFIXES.some((prefix) => input.pathname.startsWith(prefix))) {
+    return FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES;
+  }
+
+  return DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES;
+}
+
+export function evaluateRequestBodySizeLimit(input: {
+  readonly method: string;
+  readonly pathname: string;
+  readonly contentLengthHeader?: string | undefined;
+  readonly overrides?: ReadonlyArray<RequestBodySizeLimitOverride>;
+}):
+  | {
+      readonly ok: true;
+      readonly limit: number;
+      readonly received: number | null;
+    }
+  | {
+      readonly ok: false;
+      readonly limit: number;
+      readonly received: number;
+    } {
+  const limit = resolveRequestBodySizeLimit(input);
+  const received = parseContentLengthHeader(input.contentLengthHeader);
+
+  if (!REQUEST_METHODS_WITH_BODY.has(input.method.toUpperCase())) {
+    return { ok: true, limit, received };
+  }
+
+  if (received !== null && received > limit) {
+    return { ok: false, limit, received };
+  }
+
+  return { ok: true, limit, received };
+}
+
+function payloadTooLargeResponse(input: { readonly limit: number; readonly received: number }) {
+  return HttpServerResponse.jsonUnsafe(
+    {
+      error: "Payload Too Large",
+      limit: input.limit,
+      received: input.received,
+    },
+    {
+      status: 413,
+      headers: {
+        [REQUEST_BODY_SIZE_LIMIT_HEADER]: String(input.limit),
+      },
+    },
+  );
+}
+
+export const makeRequestBodySizeLimitLayer = (
+  overrides: ReadonlyArray<RequestBodySizeLimitOverride> = [],
+) =>
+  HttpRouter.middleware(
+    (next) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const url = HttpServerRequest.toURL(request);
+        const pathname = Option.isSome(url) ? url.value.pathname : request.url;
+        const result = evaluateRequestBodySizeLimit({
+          method: request.method,
+          pathname,
+          contentLengthHeader: request.headers["content-length"],
+          overrides,
+        });
+
+        if (!result.ok) {
+          return payloadTooLargeResponse(result);
+        }
+
+        return yield* next;
+      }),
+    { global: true },
+  );
+
+export const requestBodySizeLimitLayer = makeRequestBodySizeLimitLayer();
 
 export function isLoopbackHostname(hostname: string): boolean {
   const normalizedHostname = hostname

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -55,6 +55,7 @@ const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
 
 import type { ServerConfigShape } from "./config.ts";
 import { deriveServerPaths, ServerConfig } from "./config.ts";
+import { DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES, REQUEST_BODY_SIZE_LIMIT_HEADER } from "./http.ts";
 import { makeRoutesLayer } from "./server.ts";
 import { resolveAttachmentRelativePath } from "./attachmentPaths.ts";
 import {
@@ -1092,6 +1093,40 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         "bearer-session-token",
       ]);
       assert.isTrue(body.auth.sessionCookieName.startsWith("t3_session_"));
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("rejects request bodies larger than the default limit before route parsing", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const url = yield* getHttpServerUrl("/api/auth/bootstrap");
+      const received = DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES + 1;
+      const response = yield* Effect.promise(() =>
+        fetch(url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: "x".repeat(received),
+        }),
+      );
+      const body = (yield* Effect.promise(() => response.json())) as {
+        readonly error: string;
+        readonly limit: number;
+        readonly received: number;
+      };
+
+      assert.equal(response.status, 413);
+      assert.equal(
+        response.headers.get(REQUEST_BODY_SIZE_LIMIT_HEADER),
+        String(DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES),
+      );
+      assert.deepEqual(body, {
+        error: "Payload Too Large",
+        limit: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+        received,
+      });
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -10,6 +10,7 @@ import {
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  requestBodySizeLimitLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -312,7 +313,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
-).pipe(Layer.provide(browserApiCorsLayer));
+).pipe(Layer.provide(Layer.mergeAll(browserApiCorsLayer, requestBodySizeLimitLayer)));
 
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {


### PR DESCRIPTION
﻿/claim #841

Summary
- Added a global request body size limit middleware for routes with request bodies.
- Default limit is 10 MB, upload-style route prefixes use 50 MB, and the middleware can be constructed with per-route path/method overrides.
- Oversized requests return structured `413 Payload Too Large` JSON containing `limit` and `received`, plus the `X-Max-Body-Size` response header.
- Added focused resolver tests and an HTTP integration test proving an oversized request is rejected before the target route parses JSON.

Tests
- `bun run --cwd apps/server test src/http.test.ts`
- `npx -y node@24 <vitest-cli> run apps/server/src/server.test.ts --config apps/server/vitest.config.ts --testNamePattern "rejects request bodies larger than the default limit"`
- `bun run --cwd apps/server typecheck`
- `bun run fmt:check apps/server/src/http.ts apps/server/src/http.test.ts apps/server/src/server.ts apps/server/src/server.test.ts`
- `git diff --check`

Security
- This is input hardening against oversized HTTP request bodies and reduces memory pressure before route body parsing.
- The middleware is deterministic, path/method scoped, and does not add persistence, external network calls, or new privileges.
- I omitted `_provenance.json` because the requested boot context would expose private runtime/session instructions.

Prepared with AI assistance and manually reviewed before submission.
