### PR TITLE
code [ T3 Code ] Add terminal copy/paste keybindings

### DIFF
--- a/t3code/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/t3code/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -19,6 +19,7 @@ import {
   useState,
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
+import { toastManager } from "~/components/ui/toast";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
 import { openInPreferredEditor } from "../editorPreferences";
 import {
@@ -33,7 +34,9 @@ import {
   isDiffToggleShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
+  isTerminalCopyShortcut,
   isTerminalNewShortcut,
+  isTerminalPasteShortcut,
   isTerminalSplitShortcut,
   isTerminalToggleShortcut,
   terminalDeleteShortcutData,
@@ -415,6 +418,57 @@ export function TerminalViewport({
       }
     };
 
+    const copyTerminalSelection = async () => {
+      const activeTerminal = terminalRef.current;
+      if (!activeTerminal?.hasSelection()) return;
+      const selectedText = activeTerminal.getSelection();
+      if (selectedText.length === 0) return;
+
+      if (!navigator.clipboard?.writeText) {
+        toastManager.add({
+          type: "error",
+          title: "Terminal clipboard unavailable",
+        });
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(selectedText);
+        toastManager.add({
+          type: "success",
+          title: "Terminal selection copied",
+        });
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Failed to copy terminal selection",
+          description: error instanceof Error ? error.message : "Clipboard write failed.",
+        });
+      }
+    };
+
+    const pasteClipboardText = async () => {
+      if (!navigator.clipboard?.readText) {
+        toastManager.add({
+          type: "error",
+          title: "Terminal clipboard unavailable",
+        });
+        return;
+      }
+
+      try {
+        const clipboardText = await navigator.clipboard.readText();
+        if (clipboardText.length === 0) return;
+        await sendTerminalInput(clipboardText, "Failed to paste terminal input");
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Failed to paste terminal input",
+          description: error instanceof Error ? error.message : "Clipboard read failed.",
+        });
+      }
+    };
+
     terminal.attachCustomKeyEventHandler((event) => {
       const currentKeybindings = keybindingsRef.current;
       const options = { context: { terminalFocus: true, terminalOpen: true } };
@@ -425,6 +479,23 @@ export function TerminalViewport({
         isTerminalCloseShortcut(event, currentKeybindings, options) ||
         isDiffToggleShortcut(event, currentKeybindings, options)
       ) {
+        return false;
+      }
+
+      if (isTerminalCopyShortcut(event)) {
+        if (!terminal.hasSelection()) {
+          return true;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        void copyTerminalSelection();
+        return false;
+      }
+
+      if (isTerminalPasteShortcut(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void pasteClipboardText();
         return false;
       }
 

--- a/t3code/apps/web/src/keybindings.test.ts
+++ b/t3code/apps/web/src/keybindings.test.ts
@@ -16,7 +16,9 @@ import {
   isOpenFavoriteEditorShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
+  isTerminalCopyShortcut,
   isTerminalNewShortcut,
+  isTerminalPasteShortcut,
   isTerminalSplitShortcut,
   isTerminalToggleShortcut,
   resolveShortcutCommand,
@@ -627,6 +629,47 @@ describe("isTerminalClearShortcut", () => {
     assert.isFalse(
       isTerminalClearShortcut(event({ type: "keyup", key: "l", ctrlKey: true }), "Linux"),
     );
+  });
+});
+
+describe("isTerminalCopyShortcut", () => {
+  it("matches Ctrl+Shift+C on non-macOS platforms", () => {
+    assert.isTrue(
+      isTerminalCopyShortcut(event({ key: "c", ctrlKey: true, shiftKey: true }), "Linux"),
+    );
+  });
+
+  it("matches Cmd+C on macOS", () => {
+    assert.isTrue(isTerminalCopyShortcut(event({ key: "c", metaKey: true }), "MacIntel"));
+  });
+
+  it("does not treat Ctrl+C as terminal copy on non-macOS platforms", () => {
+    assert.isFalse(isTerminalCopyShortcut(event({ key: "c", ctrlKey: true }), "Linux"));
+  });
+
+  it("ignores non-keydown events", () => {
+    assert.isFalse(
+      isTerminalCopyShortcut(
+        event({ type: "keyup", key: "c", ctrlKey: true, shiftKey: true }),
+        "Linux",
+      ),
+    );
+  });
+});
+
+describe("isTerminalPasteShortcut", () => {
+  it("matches Ctrl+Shift+V on non-macOS platforms", () => {
+    assert.isTrue(
+      isTerminalPasteShortcut(event({ key: "v", ctrlKey: true, shiftKey: true }), "Win32"),
+    );
+  });
+
+  it("matches Cmd+V on macOS", () => {
+    assert.isTrue(isTerminalPasteShortcut(event({ key: "v", metaKey: true }), "MacIntel"));
+  });
+
+  it("ignores Ctrl+V on non-macOS platforms", () => {
+    assert.isFalse(isTerminalPasteShortcut(event({ key: "v", ctrlKey: true }), "Linux"));
   });
 });
 

--- a/t3code/apps/web/src/keybindings.ts
+++ b/t3code/apps/web/src/keybindings.ts
@@ -427,6 +427,42 @@ export function isTerminalClearShortcut(
   );
 }
 
+export function isTerminalCopyShortcut(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): boolean {
+  if (event.type !== undefined && event.type !== "keydown") {
+    return false;
+  }
+
+  const key = event.key.toLowerCase();
+  if (key !== "c") {
+    return false;
+  }
+
+  return isMacPlatform(platform)
+    ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+    : event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+}
+
+export function isTerminalPasteShortcut(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): boolean {
+  if (event.type !== undefined && event.type !== "keydown") {
+    return false;
+  }
+
+  const key = event.key.toLowerCase();
+  if (key !== "v") {
+    return false;
+  }
+
+  return isMacPlatform(platform)
+    ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+    : event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
+}
+
 export function terminalDeleteShortcutData(
   event: ShortcutEventLike,
   platform = navigator.platform,


### PR DESCRIPTION
﻿/claim #824

Summary
- Added platform-aware terminal clipboard helpers for Ctrl+Shift+C/V on Windows/Linux and Cmd+C/V on macOS.
- Wired xterm's custom key handler so copy only intercepts when terminal text is selected; otherwise Ctrl+C continues through to the terminal process.
- Paste reads from the Clipboard API and sends text through the existing terminal write RPC.
- Added success/error toast feedback for terminal copy/paste clipboard actions.

Tests
- `bun run --cwd apps/web test src/keybindings.test.ts`
- `bun run --cwd apps/web typecheck`
- `bun run fmt:check apps/web/src/keybindings.ts apps/web/src/keybindings.test.ts apps/web/src/components/ThreadTerminalDrawer.tsx`
- `git diff --check`

Security
- Copy only reads xterm's selected text and paste uses the existing terminal write path; no new persistence or network surface is added.
- Ctrl+C behavior is preserved when no selection exists, so terminal SIGINT is not intercepted accidentally.
- I omitted `_generation.json` because it requests private session/runtime instructions.

Prepared with AI assistance and manually reviewed before submission.
