### PR TITLE
Fix Laravel public entrypoint performance headers

### DIFF
--- a/laravel/public/.htaccess
+++ b/laravel/public/.htaccess
@@ -3,6 +3,29 @@
         Options -MultiViews -Indexes
     </IfModule>
 
+    <IfModule mod_headers.c>
+        Header always set X-Content-Type-Options "nosniff"
+    </IfModule>
+
+    <IfModule mod_deflate.c>
+        AddOutputFilterByType DEFLATE text/plain text/html text/xml text/css
+        AddOutputFilterByType DEFLATE text/javascript application/javascript application/json
+        AddOutputFilterByType DEFLATE application/xml application/rss+xml image/svg+xml
+    </IfModule>
+
+    <IfModule mod_expires.c>
+        ExpiresActive On
+        ExpiresByType text/css "access plus 1 month"
+        ExpiresByType application/javascript "access plus 1 month"
+        ExpiresByType text/javascript "access plus 1 month"
+        ExpiresByType image/svg+xml "access plus 1 month"
+        ExpiresByType image/png "access plus 1 year"
+        ExpiresByType image/jpeg "access plus 1 year"
+        ExpiresByType image/gif "access plus 1 year"
+        ExpiresByType image/webp "access plus 1 year"
+        ExpiresByType font/woff2 "access plus 1 year"
+    </IfModule>
+
     RewriteEngine On
 
     # Handle Authorization Header

--- a/laravel/public/index.php
+++ b/laravel/public/index.php
@@ -3,6 +3,10 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 
+ini_set('display_errors', '0');
+ini_set('display_startup_errors', '0');
+ini_set('expose_php', '0');
+
 define('LARAVEL_START', microtime(true));
 
 // Determine if the application is in maintenance mode...


### PR DESCRIPTION
/claim #755

## Summary
- Added Apache compression, cache-expiry, and `X-Content-Type-Options: nosniff` rules to `laravel/public/.htaccess`.
- Set production-safe PHP runtime flags in `laravel/public/index.php` before Laravel boots.

## Approach
Kept the change limited to the public entrypoint so the existing Laravel rewrite flow and application logic stay unchanged.

## Security
This reduces MIME-sniffing risk and avoids exposing PHP/runtime errors from the public entrypoint. No secrets, auth behavior, or route logic were changed.

## Verification
- `git diff --check`
- Reviewed the `.htaccess` diff to confirm the original rewrite rules remain intact

Note: `php` is not installed in this local PATH, so PHP syntax linting could not be run here.

Prepared with AI assistance and manually reviewed before submission.