### PR TITLE
OpenAI Codex [ Laravel ] Add scheduled log cleanup command

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Task #753 requested a Laravel logs:clear closure command in laravel/routes/console.php with a default 7-day retention window, an optional --days override, human-readable output for deleted files and freed space, and a scheduled daily midnight cleanup. Private system, developer, account, credential, runtime, and hidden policy instructions are intentionally not included.",
+  "timestamp": "2026-05-26T14:26:42Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,70 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
+use Symfony\Component\Console\Command\Command;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days of log files to keep}', function () {
+    $days = (int) $this->option('days');
+
+    if ($days < 0) {
+        $this->error('The --days option must be zero or greater.');
+
+        return Command::FAILURE;
+    }
+
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deletedFiles = 0;
+    $freedBytes = 0;
+
+    foreach (File::glob(storage_path('logs/*.log')) ?: [] as $path) {
+        if (filemtime($path) >= $cutoff) {
+            continue;
+        }
+
+        $fileSize = (int) filesize($path);
+
+        if (File::delete($path)) {
+            $deletedFiles++;
+            $freedBytes += $fileSize;
+        }
+    }
+
+    $this->info(sprintf(
+        'Deleted %d log %s, freed %s.',
+        $deletedFiles,
+        $deletedFiles === 1 ? 'file' : 'files',
+        formatLogCleanupBytes($freedBytes),
+    ));
+
+    return Command::SUCCESS;
+})->purpose('Delete old log files from storage/logs');
+
+Schedule::command('logs:clear')->dailyAt('00:00');
+
+if (! function_exists('formatLogCleanupBytes')) {
+    function formatLogCleanupBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return "{$bytes} B";
+        }
+
+        $units = ['KB', 'MB', 'GB', 'TB'];
+        $size = $bytes / 1024;
+
+        foreach ($units as $unit) {
+            if ($size < 1024) {
+                return rtrim(rtrim(number_format($size, 2), '0'), '.') . " {$unit}";
+            }
+
+            $size /= 1024;
+        }
+
+        return rtrim(rtrim(number_format($size, 2), '0'), '.') . ' PB';
+    }
+}

--- a/laravel/tests/Feature/LogCleanupCommandTest.php
+++ b/laravel/tests/Feature/LogCleanupCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class LogCleanupCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->deleteTestLogs();
+
+        parent::tearDown();
+    }
+
+    public function test_logs_clear_deletes_logs_older_than_seven_days_by_default(): void
+    {
+        $oldLog = $this->writeLog('old-default.log', 2048, '-8 days');
+        $recentLog = $this->writeLog('recent-default.log', 1024, '-6 days');
+
+        $this->artisan('logs:clear')
+            ->expectsOutput('Deleted 1 log file, freed 2 KB.')
+            ->assertSuccessful();
+
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($recentLog);
+    }
+
+    public function test_logs_clear_days_option_overrides_retention_window(): void
+    {
+        $oldLog = $this->writeLog('old-thirty-day.log', 1024, '-31 days');
+        $keptLog = $this->writeLog('kept-thirty-day.log', 1024, '-29 days');
+
+        $this->artisan('logs:clear', ['--days' => 30])
+            ->expectsOutput('Deleted 1 log file, freed 1 KB.')
+            ->assertSuccessful();
+
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($keptLog);
+    }
+
+    public function test_logs_clear_is_scheduled_daily_at_midnight(): void
+    {
+        $events = app(Schedule::class)->events();
+
+        $event = collect($events)->first(
+            fn ($event) => str_contains($event->command ?? '', 'logs:clear')
+        );
+
+        $this->assertNotNull($event);
+        $this->assertSame('0 0 * * *', $event->expression);
+    }
+
+    private function writeLog(string $name, int $bytes, string $modifiedAt): string
+    {
+        $path = storage_path("logs/test-{$name}");
+
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, str_repeat('x', $bytes));
+        touch($path, strtotime($modifiedAt));
+
+        return $path;
+    }
+
+    private function deleteTestLogs(): void
+    {
+        foreach (File::glob(storage_path('logs/test-*.log')) ?: [] as $path) {
+            File::delete($path);
+        }
+    }
+}


### PR DESCRIPTION
/claim #753

## Summary
- Add a `logs:clear` closure Artisan command in `laravel/routes/console.php`.
- Keep log files from the last 7 days by default, with a `--days` override for custom retention.
- Delete only `.log` files under `storage/logs`, report deleted file count and human-readable freed space, and reject negative retention values.
- Schedule the cleanup command to run daily at `00:00`.
- Add focused feature tests for default cleanup, `--days=30`, and the midnight schedule registration.
- Include safe non-sensitive `_generation.json` metadata.

## Validation
- `git diff --check`
- `python3 -m json.tool laravel/_generation.json >/dev/null`

## Not run
- Laravel/PHP tests and `php -l`: local `php`/`composer` are not installed, and `mise x php@8.3 -- php -v` failed while downloading PHP source from GitHub with `curl: (35) LibreSSL SSL_connect: SSL_ERROR_SYSCALL`.
