### PR TITLE
Add ChatView timeline keyboard accessibility

### DIFF
--- a/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -5,6 +5,7 @@ import {
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  resolveTimelineKeyboardNavigationIndex,
 } from "./MessagesTimeline.logic";
 
 describe("computeMessageDurationStart", () => {
@@ -201,6 +202,76 @@ describe("resolveAssistantMessageCopyState", () => {
       text: "Interim thought",
       visible: false,
     });
+  });
+});
+
+describe("resolveTimelineKeyboardNavigationIndex", () => {
+  it("moves through timeline rows with arrow keys", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 4,
+        currentIndex: 1,
+        key: "ArrowDown",
+      }),
+    ).toBe(2);
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 4,
+        currentIndex: 1,
+        key: "ArrowUp",
+      }),
+    ).toBe(0);
+  });
+
+  it("clamps navigation at timeline boundaries", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 3,
+        currentIndex: 0,
+        key: "ArrowUp",
+      }),
+    ).toBe(0);
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 3,
+        currentIndex: 2,
+        key: "ArrowDown",
+      }),
+    ).toBe(2);
+  });
+
+  it("supports Home and End shortcuts", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 5,
+        currentIndex: 2,
+        key: "Home",
+      }),
+    ).toBe(0);
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 5,
+        currentIndex: 2,
+        key: "End",
+      }),
+    ).toBe(4);
+  });
+
+  it("ignores unsupported keys or invalid indexes", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 3,
+        currentIndex: 1,
+        key: "Enter",
+      }),
+    ).toBeNull();
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        rowCount: 3,
+        currentIndex: -1,
+        key: "ArrowDown",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -84,6 +84,29 @@ export function resolveAssistantMessageCopyState({
   };
 }
 
+export function resolveTimelineKeyboardNavigationIndex(input: {
+  rowCount: number;
+  currentIndex: number;
+  key: string;
+}): number | null {
+  if (input.rowCount <= 0 || input.currentIndex < 0 || input.currentIndex >= input.rowCount) {
+    return null;
+  }
+
+  switch (input.key) {
+    case "ArrowDown":
+      return Math.min(input.rowCount - 1, input.currentIndex + 1);
+    case "ArrowUp":
+      return Math.max(0, input.currentIndex - 1);
+    case "Home":
+      return 0;
+    case "End":
+      return input.rowCount - 1;
+    default:
+      return null;
+  }
+}
+
 function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<TimelineEntry>) {
   const lastAssistantMessageIdByResponseKey = new Map<string, string>();
   let nullTurnResponseIndex = 0;

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
@@ -45,6 +46,7 @@ import {
   MAX_VISIBLE_WORK_LOG_ENTRIES,
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
+  resolveTimelineKeyboardNavigationIndex,
   resolveAssistantMessageCopyState,
   type StableMessagesTimelineRowsState,
   type MessagesTimelineRow,
@@ -98,6 +100,7 @@ const TimelineRowActivityCtx = createContext<TimelineRowActivityState>(null!);
 const TIMELINE_LIST_HEADER = <div className="h-3 sm:h-4" />;
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const TIMELINE_KEYBOARD_ROW_SELECTOR = '[data-timeline-keyboard-row="true"]';
 
 // ---------------------------------------------------------------------------
 // Props (public API)
@@ -278,6 +281,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           maintainVisibleContentPosition
           onScroll={handleScroll}
           className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions text"
+          aria-label="Conversation messages"
+          aria-busy={isWorking}
+          data-timeline-keyboard-root="true"
           ListHeaderComponent={TIMELINE_LIST_HEADER}
           ListFooterComponent={TIMELINE_LIST_FOOTER}
         />
@@ -310,6 +319,11 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
       data-message-role={row.kind === "message" ? row.message.role : undefined}
+      data-timeline-keyboard-row="true"
+      tabIndex={0}
+      role="article"
+      aria-label={buildTimelineRowAriaLabel(row)}
+      onKeyDown={handleTimelineRowKeyDown}
     >
       {row.kind === "work" ? <WorkGroupSection groupedEntries={row.groupedEntries} /> : null}
       {row.kind === "message" && row.message.role === "user" ? <UserTimelineRow row={row} /> : null}
@@ -321,6 +335,41 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
     </div>
   );
 });
+
+function buildTimelineRowAriaLabel(row: TimelineRow): string {
+  if (row.kind === "message") {
+    return `${row.message.role} message`;
+  }
+  if (row.kind === "work") {
+    return "work log group";
+  }
+  if (row.kind === "proposed-plan") {
+    return "proposed plan";
+  }
+  return "assistant working";
+}
+
+function handleTimelineRowKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+  const root = event.currentTarget.closest('[data-timeline-keyboard-root="true"]');
+  if (!root) {
+    return;
+  }
+
+  const rows = Array.from(root.querySelectorAll<HTMLElement>(TIMELINE_KEYBOARD_ROW_SELECTOR));
+  const currentIndex = rows.indexOf(event.currentTarget);
+  const nextIndex = resolveTimelineKeyboardNavigationIndex({
+    rowCount: rows.length,
+    currentIndex,
+    key: event.key,
+  });
+
+  if (nextIndex === null) {
+    return;
+  }
+
+  event.preventDefault();
+  rows[nextIndex]?.focus();
+}
 
 function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);


### PR DESCRIPTION
/claim #852

## Summary
- Exposed the ChatView message timeline as a polite live region for assistive tech.
- Made timeline rows keyboard-focusable with ArrowUp, ArrowDown, Home, and End navigation.
- Added row labels and isolated the keyboard navigation decision into tested logic.

## Approach
The UI layer only wires ARIA/focus behavior; the navigation boundary rules live in `MessagesTimeline.logic.ts` so the change stays easy to review and maintain.

## Security
This is a UI-only accessibility change. It does not alter auth, API calls, message persistence, or any user-controlled HTML rendering path.

## Verification
- `bun run --cwd t3code/apps/web test src/components/chat/MessagesTimeline.logic.test.ts` (23 tests passed)
- `bun run --cwd t3code/apps/web typecheck`
- `bun run fmt:check apps/web/src/components/chat/MessagesTimeline.tsx apps/web/src/components/chat/MessagesTimeline.logic.ts apps/web/src/components/chat/MessagesTimeline.logic.test.ts`
- `git diff --check`

Prepared with AI assistance and manually reviewed before submission.