### PR TITLE
Add authenticated Prometheus metrics endpoint

### DIFF
--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -3,6 +3,7 @@ import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Metric from "effect/Metric";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import { cast } from "effect/Function";
@@ -24,6 +25,10 @@ import {
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
 import { resolveStaticDir, ServerConfig } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
+import {
+  formatPrometheusMetricSnapshots,
+  PROMETHEUS_METRICS_CONTENT_TYPE,
+} from "./observability/PrometheusMetrics.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
@@ -132,6 +137,19 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
           Effect.succeed(HttpServerResponse.text("Trace export failed.", { status: 502 })),
         ),
       );
+  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+);
+
+export const metricsRouteLayer = HttpRouter.add(
+  "GET",
+  "/metrics",
+  Effect.gen(function* () {
+    yield* requireAuthenticatedRequest;
+    const snapshots = yield* Metric.snapshot;
+    return HttpServerResponse.text(formatPrometheusMetricSnapshots(snapshots), {
+      status: 200,
+      contentType: PROMETHEUS_METRICS_CONTENT_TYPE,
+    });
   }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
 );
 

--- a/t3code/apps/server/src/observability/PrometheusMetrics.test.ts
+++ b/t3code/apps/server/src/observability/PrometheusMetrics.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type * as Metric from "effect/Metric";
+
+import { formatPrometheusMetricSnapshots } from "./PrometheusMetrics.ts";
+
+describe("formatPrometheusMetricSnapshots", () => {
+  it("formats counters and gauges with escaped labels", () => {
+    const text = formatPrometheusMetricSnapshots([
+      {
+        id: "t3_rpc_requests_total",
+        type: "Counter",
+        description: "Total RPC requests\nhandled by the server.",
+        attributes: {
+          method: "server.list",
+          outcome: 'success"quoted',
+        },
+        state: {
+          count: 3,
+          incremental: true,
+        },
+      },
+      {
+        id: "t3_active_sessions",
+        type: "Gauge",
+        description: "Active sessions.",
+        attributes: undefined,
+        state: {
+          value: 2,
+        },
+      },
+    ] satisfies Metric.Metric.Snapshot[]);
+
+    expect(text).toContain(
+      "# HELP t3_rpc_requests_total Total RPC requests handled by the server.",
+    );
+    expect(text).toContain("# TYPE t3_rpc_requests_total counter");
+    expect(text).toContain(
+      't3_rpc_requests_total{method="server.list",outcome="success\\"quoted"} 3',
+    );
+    expect(text).toContain("# TYPE t3_active_sessions gauge");
+    expect(text).toContain("t3_active_sessions 2");
+  });
+
+  it("formats histogram buckets, sum, and count", () => {
+    const text = formatPrometheusMetricSnapshots([
+      {
+        id: "t3_rpc_request_duration_seconds",
+        type: "Histogram",
+        description: "RPC request duration.",
+        attributes: { route: "rpc" },
+        state: {
+          buckets: [
+            [0.1, 1],
+            [0.5, 3],
+          ],
+          count: 3,
+          min: 0.02,
+          max: 0.4,
+          sum: 0.7,
+        },
+      },
+    ] satisfies Metric.Metric.Snapshot[]);
+
+    expect(text).toContain("# TYPE t3_rpc_request_duration_seconds histogram");
+    expect(text).toContain('t3_rpc_request_duration_seconds_bucket{le="0.1",route="rpc"} 1');
+    expect(text).toContain('t3_rpc_request_duration_seconds_bucket{le="+Inf",route="rpc"} 3');
+    expect(text).toContain('t3_rpc_request_duration_seconds_sum{route="rpc"} 0.7');
+    expect(text).toContain('t3_rpc_request_duration_seconds_count{route="rpc"} 3');
+  });
+});

--- a/t3code/apps/server/src/observability/PrometheusMetrics.ts
+++ b/t3code/apps/server/src/observability/PrometheusMetrics.ts
@@ -1,0 +1,133 @@
+import type * as Metric from "effect/Metric";
+
+export const PROMETHEUS_METRICS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+function sanitizeMetricName(name: string): string {
+  const sanitized = name.replace(/[^a-zA-Z0-9_:]/g, "_");
+  return /^[a-zA-Z_:]/.test(sanitized) ? sanitized : `_${sanitized}`;
+}
+
+function escapeHelpText(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+function formatNumber(value: number | bigint | undefined): string {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value !== "number") {
+    return "0";
+  }
+  if (Number.isNaN(value)) {
+    return "NaN";
+  }
+  if (value === Number.POSITIVE_INFINITY) {
+    return "+Inf";
+  }
+  if (value === Number.NEGATIVE_INFINITY) {
+    return "-Inf";
+  }
+  return String(value);
+}
+
+function formatLabels(
+  attributes: Metric.Metric.Snapshot["attributes"],
+  extra?: Readonly<Record<string, string>>,
+): string {
+  const labels = {
+    ...(attributes ?? {}),
+    ...(extra ?? {}),
+  };
+  const entries = Object.entries(labels).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries.map(([key, value]) => `${key}="${escapeLabelValue(String(value))}"`).join(",")}}`;
+}
+
+function appendMetricHeader(
+  lines: string[],
+  metricName: string,
+  type: "counter" | "gauge" | "histogram" | "summary",
+  description: string | undefined,
+) {
+  if (description) {
+    lines.push(`# HELP ${metricName} ${escapeHelpText(description)}`);
+  }
+  lines.push(`# TYPE ${metricName} ${type}`);
+}
+
+export function formatPrometheusMetricSnapshots(
+  snapshots: ReadonlyArray<Metric.Metric.Snapshot>,
+): string {
+  const lines: string[] = [];
+
+  for (const snapshot of [...snapshots].sort((left, right) => left.id.localeCompare(right.id))) {
+    const metricName = sanitizeMetricName(snapshot.id);
+    const labels = formatLabels(snapshot.attributes);
+
+    switch (snapshot.type) {
+      case "Counter": {
+        appendMetricHeader(lines, metricName, "counter", snapshot.description);
+        lines.push(`${metricName}${labels} ${formatNumber(snapshot.state.count)}`);
+        break;
+      }
+      case "Gauge": {
+        appendMetricHeader(lines, metricName, "gauge", snapshot.description);
+        lines.push(`${metricName}${labels} ${formatNumber(snapshot.state.value)}`);
+        break;
+      }
+      case "Frequency": {
+        appendMetricHeader(lines, metricName, "counter", snapshot.description);
+        for (const [value, count] of [...snapshot.state.occurrences.entries()].sort(
+          ([left], [right]) => left.localeCompare(right),
+        )) {
+          lines.push(
+            `${metricName}${formatLabels(snapshot.attributes, { value })} ${formatNumber(count)}`,
+          );
+        }
+        break;
+      }
+      case "Histogram": {
+        appendMetricHeader(lines, metricName, "histogram", snapshot.description);
+        for (const [upperBound, count] of snapshot.state.buckets) {
+          lines.push(
+            `${metricName}_bucket${formatLabels(snapshot.attributes, {
+              le: formatNumber(upperBound),
+            })} ${formatNumber(count)}`,
+          );
+        }
+        lines.push(
+          `${metricName}_bucket${formatLabels(snapshot.attributes, { le: "+Inf" })} ${formatNumber(
+            snapshot.state.count,
+          )}`,
+        );
+        lines.push(`${metricName}_sum${labels} ${formatNumber(snapshot.state.sum)}`);
+        lines.push(`${metricName}_count${labels} ${formatNumber(snapshot.state.count)}`);
+        break;
+      }
+      case "Summary": {
+        appendMetricHeader(lines, metricName, "summary", snapshot.description);
+        for (const [quantile, value] of snapshot.state.quantiles) {
+          if (value === undefined) {
+            continue;
+          }
+          lines.push(
+            `${metricName}${formatLabels(snapshot.attributes, {
+              quantile: formatNumber(quantile),
+            })} ${formatNumber(value)}`,
+          );
+        }
+        lines.push(`${metricName}_sum${labels} ${formatNumber(snapshot.state.sum)}`);
+        lines.push(`${metricName}_count${labels} ${formatNumber(snapshot.state.count)}`);
+        break;
+      }
+    }
+  }
+
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -10,6 +10,7 @@ import {
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  metricsRouteLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -307,6 +308,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   attachmentsRouteLayer,
   orchestrationDispatchRouteLayer,
   orchestrationSnapshotRouteLayer,
+  metricsRouteLayer,
   otlpTracesProxyRouteLayer,
   projectFaviconRouteLayer,
   serverEnvironmentRouteLayer,


### PR DESCRIPTION
/claim #833

## Summary
- Added a Prometheus formatter for Effect metric snapshots.
- Exposed authenticated `GET /metrics` with the Prometheus text content type.
- Covered counters, gauges, labels, and histogram output with focused tests.

## Approach
The formatter is isolated in `observability/PrometheusMetrics.ts`, while `http.ts` only wires the authenticated route and `server.ts` only registers it. This keeps the endpoint small and reviewable.

## Security
Metrics can expose operational behavior, so the route uses the existing HTTP auth guard instead of being public. The change does not touch session auth, tokens, persistence, or provider execution paths.

## Verification
- `bun run --cwd t3code/apps/server test src/observability/PrometheusMetrics.test.ts` (2 tests passed)
- `bun run --cwd t3code/apps/server typecheck`
- `bun run fmt:check apps/server/src/observability/PrometheusMetrics.ts apps/server/src/observability/PrometheusMetrics.test.ts apps/server/src/http.ts apps/server/src/server.ts`
- `git diff --check`

Prepared with AI assistance and manually reviewed before submission.