### PR TITLE
Add collapsible ChatMarkdown code blocks

### DIFF
--- a/t3code/apps/web/src/components/ChatMarkdown.browser.tsx
+++ b/t3code/apps/web/src/components/ChatMarkdown.browser.tsx
@@ -138,4 +138,27 @@ describe("ChatMarkdown", () => {
       await screen.unmount();
     }
   });
+
+  it("collapses long code blocks and lets users expand them", async () => {
+    const longCode = Array.from({ length: 24 }, (_, index) => `console.log(${index + 1});`).join(
+      "\n",
+    );
+    const screen = await render(
+      <ChatMarkdown text={`\`\`\`ts\n${longCode}\n\`\`\``} cwd="/repo/project" />,
+    );
+
+    try {
+      const expandButton = page.getByRole("button", { name: "Show full code (24 lines)" });
+      await expect.element(expandButton).toBeInTheDocument();
+      await expect.element(expandButton).toHaveAttribute("aria-expanded", "false");
+
+      await expandButton.click();
+
+      const collapseButton = page.getByRole("button", { name: "Collapse code" });
+      await expect.element(collapseButton).toBeInTheDocument();
+      await expect.element(collapseButton).toHaveAttribute("aria-expanded", "true");
+    } finally {
+      await screen.unmount();
+    }
+  });
 });

--- a/t3code/apps/web/src/components/ChatMarkdown.tsx
+++ b/t3code/apps/web/src/components/ChatMarkdown.tsx
@@ -10,6 +10,7 @@ import React, {
   useCallback,
   memo,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -67,6 +68,7 @@ interface ChatMarkdownProps {
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
 
 const CODE_FENCE_LANGUAGE_REGEX = /(?:^|\s)language-([^\s]+)/;
+const COLLAPSIBLE_CODE_BLOCK_LINE_THRESHOLD = 18;
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
 const MAX_HIGHLIGHT_CACHE_MEMORY_BYTES = 50 * 1024 * 1024;
 const highlightedCodeCache = new LRUCache<string>(
@@ -125,6 +127,13 @@ function estimateHighlightedSize(html: string, code: string): number {
   return Math.max(html.length * 2, code.length * 3);
 }
 
+function countCodeLines(code: string): number {
+  if (code.length === 0) {
+    return 0;
+  }
+  return code.replace(/\n$/, "").split("\n").length;
+}
+
 function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
   const cached = highlighterPromiseCache.get(language);
   if (cached) return cached;
@@ -148,6 +157,10 @@ function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
 
 function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNode }) {
   const [copied, setCopied] = useState(false);
+  const lineCount = countCodeLines(code);
+  const isCollapsible = lineCount > COLLAPSIBLE_CODE_BLOCK_LINE_THRESHOLD;
+  const [expanded, setExpanded] = useState(!isCollapsible);
+  const bodyId = useId();
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handleCopy = useCallback(() => {
     if (typeof navigator === "undefined" || navigator.clipboard == null) {
@@ -178,8 +191,16 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNo
     [],
   );
 
+  useEffect(() => {
+    setExpanded(!isCollapsible);
+  }, [code, isCollapsible]);
+
   return (
-    <div className="chat-markdown-codeblock leading-snug">
+    <div
+      className="chat-markdown-codeblock leading-snug"
+      data-collapsible={isCollapsible ? "true" : undefined}
+      data-expanded={expanded ? "true" : "false"}
+    >
       <button
         type="button"
         className="chat-markdown-copy-button"
@@ -189,7 +210,24 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNo
       >
         {copied ? <CheckIcon className="size-3" /> : <CopyIcon className="size-3" />}
       </button>
-      {children}
+      <div
+        id={bodyId}
+        className="chat-markdown-codeblock-body"
+        data-collapsed={isCollapsible && !expanded ? "true" : undefined}
+      >
+        {children}
+      </div>
+      {isCollapsible && (
+        <button
+          type="button"
+          className="chat-markdown-codeblock-toggle"
+          aria-controls={bodyId}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? "Collapse code" : `Show full code (${lineCount} lines)`}
+        </button>
+      )}
     </div>
   );
 }

--- a/t3code/apps/web/src/index.css
+++ b/t3code/apps/web/src/index.css
@@ -435,6 +435,50 @@ label:has(> select#reasoning-effort) select {
   padding-right: calc(0.9rem + var(--chat-markdown-codeblock-copy-button-space));
 }
 
+.chat-markdown .chat-markdown-codeblock-body {
+  position: relative;
+}
+
+.chat-markdown .chat-markdown-codeblock-body[data-collapsed="true"] {
+  max-height: 18rem;
+  overflow: hidden;
+}
+
+.chat-markdown .chat-markdown-codeblock-body[data-collapsed="true"]::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 3rem;
+  content: "";
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in srgb, var(--muted) 78%, var(--background))
+  );
+}
+
+.chat-markdown .chat-markdown-codeblock-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-top: 0;
+  border-radius: 0 0 0.5rem 0.5rem;
+  background: color-mix(in srgb, var(--muted) 72%, var(--background));
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  padding: 0.4rem 0.65rem;
+  cursor: pointer;
+}
+
+.chat-markdown .chat-markdown-codeblock-toggle:hover {
+  color: var(--foreground);
+}
+
 .chat-markdown .chat-markdown-copy-button {
   position: absolute;
   top: 0.5rem;


### PR DESCRIPTION
/claim #837

## Summary
- Added collapse/expand controls for long ChatMarkdown code blocks.
- Preserved the existing Shiki highlighting and copy button behavior.
- Added browser coverage for the collapsed and expanded states.

## Approach
ChatMarkdown already had highlighting and copy support, so this keeps the change local to `MarkdownCodeBlock`: count code lines, collapse only long blocks, and expose the state through accessible buttons plus CSS.

## Security
UI-only change. It does not alter markdown URL sanitization, file-link rewriting, clipboard permissions beyond the existing copy button, or the existing highlighter rendering path.

## Verification
- `bun run --cwd t3code/apps/web typecheck`
- `bun run fmt:check apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.browser.tsx apps/web/src/index.css`
- `bun run --cwd t3code/apps/web test:browser src/components/ChatMarkdown.browser.tsx` (1 file, 6 tests passed)
- `git diff --check`

Prepared with AI assistance and manually reviewed before submission.