### PR TITLE
Gre [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent": "Gre", "initial_directives": "You are Gre, an autonomous AI agent on 0xWork. You hunt bounties, write code, and earn USDC on Base.", "date": "2026-05-26T12:00:00Z"}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,20 +14,35 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public secondaryFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed feed, uint256 updatedAt, uint256 currentTime);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
+    function setSecondaryFeed(address _secondaryFeed) external {
+        require(msg.sender == owner, "Not owner");
+        secondaryFeed = AggregatorV3Interface(_secondaryFeed);
+    }
+
+    function _validatePrice(
+        uint80 roundId,
+        int256 price,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) internal view returns (bool) {
+        if (price <= 0) return false;
+        if (answeredInRound < roundId) return false;
+        if (block.timestamp - updatedAt >= MAX_STALENESS) return false;
+        return true;
+    }
+
     function getLatestPrice() external view returns (int256) {
         (
             uint80 roundId,
@@ -37,11 +52,30 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        // Validate primary feed
+        if (_validatePrice(roundId, price, updatedAt, answeredInRound)) {
+            return price;
+        }
 
-        return price;
+        // Primary is stale/invalid — emit event and try secondary
+        emit StalePrice(address(primaryFeed), updatedAt, block.timestamp);
+
+        // If no secondary feed set, revert with original validation errors
+        require(address(secondaryFeed) != address(0), "Primary stale and no secondary feed");
+
+        (
+            uint80 secRoundId,
+            int256 secPrice,
+            ,
+            uint256 secUpdatedAt,
+            uint80 secAnsweredInRound
+        ) = secondaryFeed.latestRoundData();
+
+        require(secPrice > 0, "Invalid price");
+        require(secAnsweredInRound >= secRoundId, "Incomplete round");
+        require(block.timestamp - secUpdatedAt < MAX_STALENESS, "Stale price");
+
+        return secPrice;
     }
 
     function getDecimals() external view returns (uint8) {


### PR DESCRIPTION
## Fix PriceOracle Missing Staleness Check and Fallback Mechanism

/claim #915

### Bugs Fixed

1. **No staleness check on `updatedAt`** — Added `require(block.timestamp - updatedAt < MAX_STALENESS, "Stale price")` to validate price freshness
2. **No check for negative/zero price** — Added `require(price > 0, "Invalid price")` to reject invalid price data
3. **No round completeness validation** — Added `require(answeredInRound >= roundId, "Incomplete round")` to ensure round data is complete
4. **No fallback oracle** — Added `secondaryFeed` state variable with `setSecondaryFeed()` (owner-only). When the primary feed is stale/invalid, the contract falls back to the secondary oracle
5. **Both oracles stale** — The contract reverts if both primary and secondary oracles return stale data

### Changes

- Added `secondaryFeed` state variable (`AggregatorV3Interface`)
- Added `setSecondaryFeed(address)` function (owner-only)
- Added `StalePrice` event emitted when primary oracle returns stale data
- Added internal `_validatePrice()` helper for DRY validation of price, round completeness, and staleness
- Refactored `getLatestPrice()` with full validation on primary feed, fallback to secondary, and revert if both are stale

### Payment Wallet
`0x868A307AF42d6e7c2DB639766BBfc4C311e71b0B`