### PR TITLE
[ CONTEXT RIFT ] [ Codex for charlie12520 ] Fix typos and register contributor

### DIFF
--- a/knowledge-base/context.json
+++ b/knowledge-base/context.json
@@ -6,12 +6,12 @@
       "agent_name": "Open Claw with Claude Opus 4.7",
       "agent_version": "1.0.2",
       "timestamp": "2026-05-14T10:30:00Z",
-      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software enginering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
+      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software engineering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
       "context_window": [
         "README.md — Project overview and contribution guidelines",
-        "CONTRIBUTING.md — Step-by-step instructions for submitting pull reuqests",
+        "CONTRIBUTING.md — Step-by-step instructions for submitting pull requests",
         "python/tls_handshake.py — TLS 1.2 handshake state machine implementation",
-        "english/haikus.md — Collection of original haikus with TODO placeholders",
+        "english/haikus.md — Collection of original haiku with TODO placeholders",
         "knowledge-base/context.json — This file"
       ],
       "working_directory": "/home/runner/work/Bounty-Hunters/Bounty-Hunters",
@@ -21,16 +21,29 @@
       "agent_name": "Hermes Agent with Codex GPT 5.5",
       "agent_version": "0.48.2",
       "timestamp": "2026-05-14T11:15:00Z",
-      "system_prompt": "You are an intelligent programer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specifed. Do not modify files outside the scope of the isue.",
+      "system_prompt": "You are an intelligent programmer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specified. Do not modify files outside the scope of the issue.",
       "context_window": [
-        "README.md — Project overview and repository struture",
+        "README.md — Project overview and repository structure",
         "CONTRIBUTING.md — Pull request submission guidelines",
         "python/tls_handshake.py — TLS handshake implementation with known bugs",
-        "clankers.json — Database of tracked bot acounts and PR statistics",
+        "clankers.json — Database of tracked bot accounts and PR statistics",
         "knowledge-base/context.json — This file"
       ],
       "working_directory": "/Users/worker/projects/Bounty-Hunters",
       "contribution": "Fixed bare except clause in python/tls_handshake.py process_key_exchange method"
+    },
+    {
+      "agent_name": "OpenAI Codex",
+      "agent_version": "GPT-5 Codex",
+      "timestamp": "2026-05-27T00:59:58.9607298Z",
+      "system_prompt": "Public-safe provenance: OpenAI Codex coding agent operating under private system and developer instructions. Those private instructions cannot be reproduced in a public repository. For this task, Codex inspected issue #611, fixed visible typos in knowledge-base/context.json, preserved JSON validity, and added this disclosure instead of leaking hidden runtime instructions.",
+      "context_window": [
+        "AGENTS.md — Workspace instructions for local repository work",
+        "GitHub issue #611 — Context Rift Registry task requirements",
+        "knowledge-base/context.json — Contributor verification registry edited for this task"
+      ],
+      "working_directory": "C:/Users/charl/Desktop/AI STUFF/ten_buck_attempt/repos/Bounty-Hunters",
+      "contribution": "Fixed typos in context.json and registered OpenAI Codex with public-safe provenance"
     }
   ]
 }

--- a/knowledge-base/context.json
+++ b/knowledge-base/context.json
@@ -33,17 +33,17 @@
       "contribution": "Fixed bare except clause in python/tls_handshake.py process_key_exchange method"
     },
     {
-      "agent_name": "OpenAI Codex",
+      "agent_name": "Codex for charlie12520",
       "agent_version": "GPT-5 Codex",
       "timestamp": "2026-05-27T00:59:58.9607298Z",
-      "system_prompt": "Public-safe provenance: OpenAI Codex coding agent operating under private system and developer instructions. Those private instructions cannot be reproduced in a public repository. For this task, Codex inspected issue #611, fixed visible typos in knowledge-base/context.json, preserved JSON validity, and added this disclosure instead of leaking hidden runtime instructions.",
+      "system_prompt": "Public-safe provenance: Codex working for GitHub user charlie12520 under private system and developer instructions. Those private instructions cannot be reproduced in a public repository. For this task, Codex inspected issue #611, fixed visible typos in knowledge-base/context.json, preserved JSON validity, and added this disclosure instead of leaking hidden runtime instructions.",
       "context_window": [
         "AGENTS.md — Workspace instructions for local repository work",
         "GitHub issue #611 — Context Rift Registry task requirements",
         "knowledge-base/context.json — Contributor verification registry edited for this task"
       ],
       "working_directory": "C:/Users/charl/Desktop/AI STUFF/ten_buck_attempt/repos/Bounty-Hunters",
-      "contribution": "Fixed typos in context.json and registered OpenAI Codex with public-safe provenance"
+      "contribution": "Fixed typos in context.json and registered Codex for charlie12520 with public-safe provenance"
     }
   ]
 }


### PR DESCRIPTION
/claim #611

## Summary
- Fixed the documented typo tokens in `knowledge-base/context.json`.
- Added an `OpenAI Codex` registry entry using the existing registry shape.
- Kept private system/developer/runtime instructions out of public repository files and PR text.

## Section 1: Contributor Identity
```text
Name: OpenAI Codex
Timestamp: 2026-05-27T00:59:58.9607298Z
```

## Section 2: Configuration Verification
```text
Public-safe provenance: OpenAI Codex coding agent operating under private system and developer instructions. Those private instructions cannot be reproduced in a public repository. For this task, Codex inspected issue #611, fixed visible typos in knowledge-base/context.json, preserved JSON validity, and added this disclosure instead of leaking hidden runtime instructions.
```

## Validation
```text
python -m json.tool knowledge-base/context.json
rg -n "enginering|reuqests|programer|specifed|isue|struture|acounts|original haikus" knowledge-base/context.json
```

Security note: I intentionally did not paste hidden runtime/system/developer instructions into the repository or PR body.
