### PR TITLE
[Codex for charlie12520] [ Crypto ] Fix TokenVesting overflow and revoke accounting

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/solidity/contracts/.audit.json
+++ b/solidity/contracts/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Private platform instructions, hidden prompts, credentials, and non-public runtime context are intentionally not disclosed. Public task context: implement issue #917 by fixing TokenVesting overflow-safe vesting math, remainder precision, and revoke accounting.",
+  "completed_at": "2026-05-26T21:32:00-04:00"
+}

--- a/solidity/contracts/.audit.json
+++ b/solidity/contracts/.audit.json
@@ -1,5 +1,5 @@
 {
-  "contributor": "OpenAI Codex",
+  "contributor": "Codex for charlie12520",
   "environment_config": "Private platform instructions, hidden prompts, credentials, and non-public runtime context are intentionally not disclosed. Public task context: implement issue #917 by fixing TokenVesting overflow-safe vesting math, remainder precision, and revoke accounting.",
   "completed_at": "2026-05-26T21:32:00-04:00"
 }

--- a/solidity/contracts/TokenVesting.sol
+++ b/solidity/contracts/TokenVesting.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract TokenVesting {
     IERC20 public token;
@@ -26,6 +27,10 @@ contract TokenVesting {
         uint256 _cliffDuration,
         uint256 _vestingDuration
     ) {
+        require(_token != address(0), "Invalid token");
+        require(_beneficiary != address(0), "Invalid beneficiary");
+        require(_vestingDuration > 0, "Invalid duration");
+
         token = IERC20(_token);
         beneficiary = _beneficiary;
         owner = msg.sender;
@@ -35,44 +40,53 @@ contract TokenVesting {
         duration = _vestingDuration;
     }
 
-    // BUG: Overflow risk for large allocations — totalAllocation * elapsed can exceed uint256
     function vestedAmount() public view returns (uint256) {
         if (block.timestamp < cliff) return 0;
         if (block.timestamp >= start + duration) return totalAllocation;
 
         uint256 elapsed = block.timestamp - start;
-        // This multiplication can overflow for large totalAllocation values
-        return totalAllocation * elapsed / duration;
+        uint256 wholeTokenRate = totalAllocation / duration;
+        uint256 remainder = totalAllocation % duration;
+
+        return wholeTokenRate * elapsed + Math.mulDiv(remainder, elapsed, duration);
     }
 
     function claimable() public view returns (uint256) {
+        if (revoked) return 0;
         return vestedAmount() - claimed;
     }
 
     function claim() external {
         require(msg.sender == beneficiary, "Not beneficiary");
+        require(!revoked, "Vesting revoked");
+
         uint256 amount = claimable();
         require(amount > 0, "Nothing to claim");
+
         claimed += amount;
-        token.transfer(beneficiary, amount);
+        require(token.transfer(beneficiary, amount), "Transfer failed");
+
         emit TokensClaimed(beneficiary, amount);
     }
 
-    // BUG: Incorrect unvested calculation during cliff period
     function revoke() external {
         require(msg.sender == owner, "Not owner");
         require(!revoked, "Already revoked");
         revoked = true;
 
         uint256 vested = vestedAmount();
-        // BUG: Should be totalAllocation - claimed, not totalAllocation - vested
-        // during cliff, vested is 0 but user may have claimed nothing
-        uint256 unvested = totalAllocation - vested;
+        uint256 claimableVested = vested > claimed ? vested - claimed : 0;
+        uint256 unvested = totalAllocation - claimed - claimableVested;
 
-        if (vested > claimed) {
-            token.transfer(beneficiary, vested - claimed);
+        if (claimableVested > 0) {
+            claimed += claimableVested;
+            require(token.transfer(beneficiary, claimableVested), "Transfer failed");
         }
-        token.transfer(owner, unvested);
+
+        if (unvested > 0) {
+            require(token.transfer(owner, unvested), "Transfer failed");
+        }
+
         emit VestingRevoked(beneficiary, unvested);
     }
 }

--- a/solidity/contracts/TokenVesting.sol
+++ b/solidity/contracts/TokenVesting.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract TokenVesting {
+    using SafeERC20 for IERC20;
+
     IERC20 public token;
     address public beneficiary;
     address public owner;
@@ -30,6 +33,8 @@ contract TokenVesting {
         require(_token != address(0), "Invalid token");
         require(_beneficiary != address(0), "Invalid beneficiary");
         require(_vestingDuration > 0, "Invalid duration");
+        require(_cliffDuration <= _vestingDuration, "Invalid cliff");
+        require(_start <= type(uint256).max - _vestingDuration, "Invalid schedule");
 
         token = IERC20(_token);
         beneficiary = _beneficiary;
@@ -64,7 +69,7 @@ contract TokenVesting {
         require(amount > 0, "Nothing to claim");
 
         claimed += amount;
-        require(token.transfer(beneficiary, amount), "Transfer failed");
+        token.safeTransfer(beneficiary, amount);
 
         emit TokensClaimed(beneficiary, amount);
     }
@@ -80,11 +85,11 @@ contract TokenVesting {
 
         if (claimableVested > 0) {
             claimed += claimableVested;
-            require(token.transfer(beneficiary, claimableVested), "Transfer failed");
+            token.safeTransfer(beneficiary, claimableVested);
         }
 
         if (unvested > 0) {
-            require(token.transfer(owner, unvested), "Transfer failed");
+            token.safeTransfer(owner, unvested);
         }
 
         emit VestingRevoked(beneficiary, unvested);

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/tokenVesting.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.15.0",
+    "ganache": "^7.9.2",
+    "solc": "^0.8.20"
+  }
+}

--- a/solidity/test/tokenVesting.test.mjs
+++ b/solidity/test/tokenVesting.test.mjs
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+
+const mockTokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory n, string memory s, uint256 supply) {
+        name = n;
+        symbol = s;
+        totalSupply = supply;
+        balanceOf[msg.sender] = supply;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}`;
+
+function resolveImport(importPath) {
+  if (importPath.startsWith("@openzeppelin/")) {
+    const resolved = require.resolve(importPath, { paths: [solidityRoot] });
+    return { contents: readFileSync(resolved, "utf8") };
+  }
+  return { error: `Unable to resolve ${importPath}` };
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "contracts/TokenVesting.sol": {
+        content: readFileSync(path.join(solidityRoot, "contracts", "TokenVesting.sol"), "utf8"),
+      },
+      "test/MockERC20.sol": { content: mockTokenSource },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: resolveImport }));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  return {
+    vesting: output.contracts["contracts/TokenVesting.sol"].TokenVesting,
+    token: output.contracts["test/MockERC20.sol"].MockERC20,
+  };
+}
+
+function artifact(contract) {
+  return {
+    abi: contract.abi,
+    bytecode: `0x${contract.evm.bytecode.object}`,
+  };
+}
+
+async function deploy(contract, signer, args = []) {
+  const { abi, bytecode } = artifact(contract);
+  const factory = new ethers.ContractFactory(abi, bytecode, signer);
+  const deployed = await factory.deploy(...args);
+  await deployed.waitForDeployment();
+  return deployed;
+}
+
+function expectedVested(totalAllocation, elapsed, duration) {
+  const wholeTokenRate = totalAllocation / duration;
+  const remainder = totalAllocation % duration;
+  return wholeTokenRate * elapsed + remainder * elapsed / duration;
+}
+
+async function setTimestamp(provider, timestamp) {
+  const latest = await provider.request({ method: "eth_getBlockByNumber", params: ["latest", false] });
+  const delta = Number(timestamp - BigInt(latest.timestamp));
+  if (delta > 0) {
+    await provider.request({ method: "evm_increaseTime", params: [delta] });
+  }
+  await provider.request({ method: "evm_mine", params: [] });
+}
+
+const contracts = compileContracts();
+const ganacheProvider = ganache.provider({
+  chain: { chainId: 31_337 },
+  logging: { quiet: true },
+  wallet: { deterministic: true },
+});
+const provider = new ethers.BrowserProvider(ganacheProvider);
+const owner = await provider.getSigner(0);
+const beneficiary = await provider.getSigner(1);
+const beneficiaryAddress = await beneficiary.getAddress();
+const ownerAddress = await owner.getAddress();
+
+const token = await deploy(contracts.token, owner, [
+  "Vesting Token",
+  "VEST",
+  ethers.parseEther("1000000000000"),
+]);
+const tokenAddress = await token.getAddress();
+const baseTime = BigInt((await provider.getBlock("latest")).timestamp + 1000);
+const longDuration = 126_144_000n;
+const postLongBaseTime = baseTime + longDuration / 2n + 10_000n;
+
+async function deployVesting(totalAllocation, start, cliffDuration, duration, fund = true) {
+  const vesting = await deploy(contracts.vesting, owner, [
+    tokenAddress,
+    beneficiaryAddress,
+    totalAllocation,
+    start,
+    cliffDuration,
+    duration,
+  ]);
+
+  if (fund) {
+    await (await token.transfer(await vesting.getAddress(), totalAllocation)).wait();
+  }
+
+  return vesting;
+}
+
+{
+  const hugeAllocation = ethers.parseEther("1000000000");
+  const duration = longDuration;
+  const elapsed = duration / 2n;
+  const vesting = await deployVesting(hugeAllocation, baseTime, 0n, duration, false);
+  await setTimestamp(ganacheProvider, baseTime + elapsed);
+  assert.equal(await vesting.vestedAmount(), expectedVested(hugeAllocation, elapsed, duration));
+}
+
+{
+  const duration = 1000n;
+  const elapsed = 500n;
+  const hugeAllocation = ethers.MaxUint256 - 1000n;
+  const vesting = await deployVesting(hugeAllocation, postLongBaseTime, 0n, duration, false);
+  await setTimestamp(ganacheProvider, postLongBaseTime + elapsed);
+  assert.equal(await vesting.vestedAmount(), expectedVested(hugeAllocation, elapsed, duration));
+}
+
+{
+  const total = ethers.parseEther("1000");
+  const vesting = await deployVesting(total, postLongBaseTime + 20_000n, 500n, 2000n);
+  await setTimestamp(ganacheProvider, postLongBaseTime + 20_100n);
+
+  const ownerBefore = await token.balanceOf(ownerAddress);
+  const beneficiaryBefore = await token.balanceOf(beneficiaryAddress);
+  await (await vesting.revoke()).wait();
+
+  assert.equal(await token.balanceOf(beneficiaryAddress), beneficiaryBefore);
+  assert.equal(await token.balanceOf(ownerAddress), ownerBefore + total);
+  assert.equal(await token.balanceOf(await vesting.getAddress()), 0n);
+}
+
+{
+  const total = 1000n;
+  const start = postLongBaseTime + 30_000n;
+  const vesting = await deployVesting(total, start, 0n, 10n);
+  await setTimestamp(ganacheProvider, start + 4n);
+  await (await vesting.connect(beneficiary).claim()).wait();
+  assert.equal(await token.balanceOf(beneficiaryAddress), 400n);
+
+  await setTimestamp(ganacheProvider, start + 6n);
+  const ownerBefore = await token.balanceOf(ownerAddress);
+  await (await vesting.revoke()).wait();
+
+  assert.equal(await token.balanceOf(beneficiaryAddress), 600n);
+  assert.equal(await token.balanceOf(ownerAddress), ownerBefore + 400n);
+  assert.equal(await token.balanceOf(await vesting.getAddress()), 0n);
+}
+
+{
+  const total = 1000n;
+  const start = postLongBaseTime + 40_000n;
+  const duration = 6n;
+  const vesting = await deployVesting(total, start, 0n, duration);
+  await setTimestamp(ganacheProvider, start + 5n);
+  assert.equal(await vesting.vestedAmount(), 833n);
+
+  await setTimestamp(ganacheProvider, start + duration);
+  assert.equal(await vesting.vestedAmount(), total);
+  await (await vesting.connect(beneficiary).claim()).wait();
+  assert.equal(await token.balanceOf(await vesting.getAddress()), 0n);
+}
+
+console.log("TokenVesting overflow, revoke, completion, and remainder tests passed");

--- a/solidity/test/tokenVesting.test.mjs
+++ b/solidity/test/tokenVesting.test.mjs
@@ -162,6 +162,16 @@ async function deployVesting(totalAllocation, start, cliffDuration, duration, fu
 }
 
 {
+  await assert.rejects(async () => {
+    await deployVesting(100n, baseTime, 101n, 100n, false);
+  });
+
+  await assert.rejects(async () => {
+    await deployVesting(100n, ethers.MaxUint256, 0n, 1n, false);
+  });
+}
+
+{
   const hugeAllocation = ethers.parseEther("1000000000");
   const duration = longDuration;
   const elapsed = duration / 2n;


### PR DESCRIPTION
/claim #917

## Summary
- Fix TokenVesting's overflow-prone vesting calculation by avoiding `totalAllocation * elapsed` and preserving remainder precision.
- Harden constructor and claim paths with zero-address/duration validation, revoked-vesting checks, and transfer return validation.
- Fix revoke accounting so already-claimed, newly-vested, and unvested amounts are handled without double-counting.
- Add a focused Solidity/Ganache regression test covering large allocations, near-uint256 allocations, cliff revocation, partial claims before revoke, and final completion.

## Validation
- `cd solidity; npm test`
- Result: pass. Ganache printed its Windows uWS native-binary fallback warning, then the test suite completed successfully.

## Agent Metadata
- Contributor: OpenAI Codex
- Private platform instructions, hidden prompts, credentials, and non-public runtime context are intentionally not disclosed.
