### PR TITLE
Fix TokenVesting overflow-safe vesting calculation

### DIFF
--- a/solidity/contracts/TokenVesting.sol
+++ b/solidity/contracts/TokenVesting.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract TokenVesting {
     IERC20 public token;
@@ -35,14 +36,12 @@ contract TokenVesting {
         duration = _vestingDuration;
     }
 
-    // BUG: Overflow risk for large allocations — totalAllocation * elapsed can exceed uint256
-    function vestedAmount() public view returns (uint256) {
+        function vestedAmount() public view returns (uint256) {
         if (block.timestamp < cliff) return 0;
         if (block.timestamp >= start + duration) return totalAllocation;
 
         uint256 elapsed = block.timestamp - start;
-        // This multiplication can overflow for large totalAllocation values
-        return totalAllocation * elapsed / duration;
+        return Math.mulDiv(totalAllocation, elapsed, duration);
     }
 
     function claimable() public view returns (uint256) {
@@ -58,21 +57,21 @@ contract TokenVesting {
         emit TokensClaimed(beneficiary, amount);
     }
 
-    // BUG: Incorrect unvested calculation during cliff period
     function revoke() external {
         require(msg.sender == owner, "Not owner");
         require(!revoked, "Already revoked");
         revoked = true;
 
         uint256 vested = vestedAmount();
-        // BUG: Should be totalAllocation - claimed, not totalAllocation - vested
-        // during cliff, vested is 0 but user may have claimed nothing
-        uint256 unvested = totalAllocation - vested;
+        uint256 claimableVested = vested > claimed ? vested - claimed : 0;
+        uint256 unvested = totalAllocation - claimed - claimableVested;
 
-        if (vested > claimed) {
-            token.transfer(beneficiary, vested - claimed);
+        if (claimableVested > 0) {
+            token.transfer(beneficiary, claimableVested);
         }
-        token.transfer(owner, unvested);
+        if (unvested > 0) {
+            token.transfer(owner, unvested);
+        }
         emit VestingRevoked(beneficiary, unvested);
     }
 }


### PR DESCRIPTION
Fixes #917.\n\nChanges:\n- Uses OpenZeppelin Math.mulDiv for overflow-safe vesting calculation.\n- Preserves cliff/full-duration behavior.\n- Also corrects revoke accounting so already-claimed tokens are not included in owner refund and remaining vested tokens are paid safely.\n\nEvidence:\n- Diff attached in artifact.\n- Local command attempted: npm test -- --runInBand (see artifact test.log).