### PR TITLE
Antigravity [ T3 Code ] Enable SQLite WAL mode and add Effect.Pool connection pooling

### DIFF
--- a/t3code/apps/server/src/persistence/Layers/.attribution.json
+++ b/t3code/apps/server/src/persistence/Layers/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Antigravity",
+  "platform_config": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding. You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.",
+  "date": "2026-05-26T01:26:00Z"
+}

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.test.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.test.ts
@@ -1,14 +1,21 @@
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
-import { SqlitePersistenceMemory } from "./Sqlite.ts";
+import { makeSqlitePersistenceLive, SqlitePersistenceMemory } from "./Sqlite.ts";
 import { vi } from "vitest";
 import { DatabaseSync } from "node:sqlite";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Layer from "effect/Layer";
 
-const layer = it.layer(SqlitePersistenceMemory);
+// Test Suite 1: In-Memory (Bypasses connection pooling)
+const memoryLayer = it.layer(
+  SqlitePersistenceMemory.pipe(Layer.provideMerge(NodeServices.layer))
+);
 
-layer("SqlitePool", (it) => {
-  it.effect("performs queries and supports healthCheck", () =>
+memoryLayer("SqlitePool - InMemory Database Path", (it) => {
+  it.effect("performs queries and supports healthCheck without pooling issues", () =>
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
 
@@ -25,16 +32,39 @@ layer("SqlitePool", (it) => {
       assert.equal(health.details, "ok");
     })
   );
+});
 
-  it.effect("applies PRAGMA reset on connection release", () =>
+// Test Suite 2: File-Based Database (Supports connection pooling & PRAGMA reset)
+const tempDbPath = path.join(__dirname, `test-${Math.random().toString(36).substring(7)}.db`);
+const fileLayer = it.layer(
+  makeSqlitePersistenceLive(tempDbPath).pipe(Layer.provideMerge(NodeServices.layer))
+);
+
+fileLayer("SqlitePool - File-Based Database Path", (it) => {
+  it.effect("applies connection pooling and runs PRAGMA reset on release", () =>
     Effect.gen(function* () {
+      // Setup cleanup finalizer inside the test block
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          if (fs.existsSync(tempDbPath)) {
+            try {
+              fs.unlinkSync(tempDbPath);
+            } catch (e) {
+              // Ignore cleanup issues
+            }
+          }
+        })
+      );
+
       const prepareSpy = vi.spyOn(DatabaseSync.prototype, "prepare");
       const sql = yield* SqlClient.SqlClient;
 
-      // Perform a basic query, which will acquire and release a connection
-      yield* sql`SELECT 1`;
+      // Perform queries to trigger connection checkout and return
+      const rows = yield* sql`SELECT 1 as val`;
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0]?.val, 1);
 
-      // Verify that PRAGMA reset was prepared
+      // Verify PRAGMA reset was prepared and called when the connection checkout scope is closed
       const calls = prepareSpy.mock.calls.map((c) => c[0]);
       assert.deepInclude(calls, "PRAGMA reset;");
 
@@ -42,4 +72,3 @@ layer("SqlitePool", (it) => {
     })
   );
 });
-

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.test.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.test.ts
@@ -1,0 +1,26 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { SqlitePersistenceMemory } from "./Sqlite.ts";
+
+const layer = it.layer(SqlitePersistenceMemory);
+
+layer("SqlitePool", (it) => {
+  it.effect("performs queries and supports healthCheck", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      // Basic query check
+      const rows = yield* sql`SELECT 1 as value`;
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0]?.value, 1);
+
+      // healthCheck check
+      const pooledSql = sql as any;
+      assert.equal(typeof pooledSql.healthCheck, "function");
+      const health = yield* pooledSql.healthCheck();
+      assert.equal(health.status, "pass");
+      assert.equal(health.details, "ok");
+    })
+  );
+});

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.test.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.test.ts
@@ -2,6 +2,8 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
+import { vi } from "vitest";
+import { DatabaseSync } from "node:sqlite";
 
 const layer = it.layer(SqlitePersistenceMemory);
 
@@ -23,4 +25,21 @@ layer("SqlitePool", (it) => {
       assert.equal(health.details, "ok");
     })
   );
+
+  it.effect("applies PRAGMA reset on connection release", () =>
+    Effect.gen(function* () {
+      const prepareSpy = vi.spyOn(DatabaseSync.prototype, "prepare");
+      const sql = yield* SqlClient.SqlClient;
+
+      // Perform a basic query, which will acquire and release a connection
+      yield* sql`SELECT 1`;
+
+      // Verify that PRAGMA reset was prepared
+      const calls = prepareSpy.mock.calls.map((c) => c[0]);
+      assert.deepInclude(calls, "PRAGMA reset;");
+
+      prepareSpy.mockRestore();
+    })
+  );
 });
+

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -3,6 +3,12 @@ import * as Layer from "effect/Layer";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
+import type * as Connection from "effect/unstable/sql/SqlConnection";
+import * as Pool from "effect/Pool";
+import * as Duration from "effect/Duration";
+import * as Scope from "effect/Scope";
+import * as Context from "effect/Context";
+import * as Reactivity from "effect/unstable/reactivity/Reactivity";
 
 import { runMigrations } from "../Migrations.ts";
 import { ServerConfig } from "../../config.ts";
@@ -29,37 +35,90 @@ const makeRuntimeSqliteLayer = Effect.fn("makeRuntimeSqliteLayer")(function* (
   return clientModule.layer(config);
 }, Layer.unwrap);
 
-const setup = Layer.effectDiscard(
+const acquireConnection = (config: RuntimeSqliteLayerConfig) =>
   Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-    yield* sql`PRAGMA journal_mode = WAL;`;
-    yield* sql`PRAGMA foreign_keys = ON;`;
-    yield* runMigrations();
-  }),
-);
+    const context = yield* Layer.build(makeRuntimeSqliteLayer(config));
+    const client = Context.get(context, SqlClient.SqlClient);
+
+    yield* client`PRAGMA journal_mode = WAL;`;
+    yield* client`PRAGMA busy_timeout = 5000;`;
+    yield* client`PRAGMA synchronous = NORMAL;`;
+    yield* client`PRAGMA foreign_keys = ON;`;
+
+    const connection = yield* client.reserve;
+    return connection;
+  });
 
 export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(function* (
   dbPath: string,
 ) {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  yield* fs.makeDirectory(path.dirname(dbPath), { recursive: true });
+  if (dbPath !== ":memory:") {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.makeDirectory(path.dirname(dbPath), { recursive: true });
+  }
 
-  return Layer.provideMerge(
-    setup,
-    makeRuntimeSqliteLayer({
-      filename: dbPath,
-      spanAttributes: {
-        "db.name": path.basename(dbPath),
-        "service.name": "t3-server",
-      },
+  const config: RuntimeSqliteLayerConfig = {
+    filename: dbPath,
+    spanAttributes: {
+      "db.name": dbPath === ":memory:" ? ":memory:" : "t3-server",
+      "service.name": "t3-server",
+    },
+  };
+
+  return Layer.effect(
+    SqlClient.SqlClient,
+    Effect.gen(function* () {
+      const pool = yield* Pool.makeWithTTL({
+        acquire: acquireConnection(config),
+        min: dbPath === ":memory:" ? 1 : 1,
+        max: dbPath === ":memory:" ? 1 : 5,
+        timeToLive: Duration.seconds(10),
+      });
+
+      const baseContext = yield* Layer.build(makeRuntimeSqliteLayer(config));
+      const baseClient = Context.get(baseContext, SqlClient.SqlClient);
+
+      const tempStatement = baseClient`SELECT 1`;
+      const compiler = tempStatement.compiler;
+      const spanAttributes = tempStatement.spanAttributes;
+      const transformRows = tempStatement.transformRows;
+
+      const pooledAcquirer = Pool.get(pool).pipe(
+        Effect.timeoutOrElse({
+          duration: Duration.seconds(10),
+          orElse: () => Effect.fail(new Error("Database connection acquisition timeout (10s)")),
+        }),
+      );
+
+      const client = yield* SqlClient.make({
+        acquirer: pooledAcquirer,
+        compiler,
+        transactionAcquirer: pooledAcquirer,
+        spanAttributes,
+        transformRows,
+      });
+
+      // Run migrations on the pooled client!
+      const context = Context.make(SqlClient.SqlClient, client);
+      yield* runMigrations().pipe(Effect.provide(context));
+
+      const healthCheck = () =>
+        Effect.gen(function* () {
+          const result = yield* client.unsafe("PRAGMA integrity_check;");
+          const firstRow = result[0];
+          const details = firstRow ? (Object.values(firstRow)[0] as string) : "";
+          const status = details === "ok" ? "pass" : "fail";
+          return { status, details };
+        });
+
+      return Object.assign(client, { healthCheck });
     }),
-  );
+  ).pipe(Layer.provide(Reactivity.layer));
 }, Layer.unwrap);
 
-export const SqlitePersistenceMemory = Layer.provideMerge(
-  setup,
-  makeRuntimeSqliteLayer({ filename: ":memory:" }),
+export const SqlitePersistenceMemory = Layer.unwrap(
+  Effect.succeed(makeSqlitePersistenceLive(":memory:")),
 );
 
 export const layerConfig = Layer.unwrap(

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -34,24 +34,30 @@ const makeRuntimeSqliteLayer = Effect.fn("makeRuntimeSqliteLayer")(function* (
   return clientModule.layer(config);
 }, Layer.unwrap);
 
+// Helper to configure connection parameters directly on a reserved connection
+const configureConnection = (connection: any) =>
+  Effect.gen(function* () {
+    yield* connection.executeUnprepared("PRAGMA journal_mode = WAL;", [], undefined);
+    yield* connection.executeUnprepared("PRAGMA busy_timeout = 5000;", [], undefined);
+    yield* connection.executeUnprepared("PRAGMA synchronous = NORMAL;", [], undefined);
+    yield* connection.executeUnprepared("PRAGMA foreign_keys = ON;", [], undefined);
+  });
+
 const acquireConnection = (config: RuntimeSqliteLayerConfig) =>
   Effect.gen(function* () {
     const context = yield* Layer.build(makeRuntimeSqliteLayer(config));
     const client = Context.get(context, SqlClient.SqlClient);
     const connection = yield* client.reserve;
-
-    yield* connection.executeUnprepared("PRAGMA journal_mode = WAL;", [], undefined);
-    yield* connection.executeUnprepared("PRAGMA busy_timeout = 5000;", [], undefined);
-    yield* connection.executeUnprepared("PRAGMA synchronous = NORMAL;", [], undefined);
-    yield* connection.executeUnprepared("PRAGMA foreign_keys = ON;", [], undefined);
-
+    yield* configureConnection(connection);
     return connection;
   });
 
 export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(function* (
   dbPath: string,
 ) {
-  if (dbPath !== ":memory:") {
+  const isMemory = dbPath === ":memory:";
+
+  if (!isMemory) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     yield* fs.makeDirectory(path.dirname(dbPath), { recursive: true });
@@ -60,34 +66,75 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
   const config: RuntimeSqliteLayerConfig = {
     filename: dbPath,
     spanAttributes: {
-      "db.name": dbPath === ":memory:" ? ":memory:" : "t3-server",
+      "db.name": isMemory ? ":memory:" : "t3-server",
       "service.name": "t3-server",
     },
   };
 
+  // 1. Optimized Path for In-Memory Database (Bypasses pooling & avoids deadlocks)
+  if (isMemory) {
+    return Layer.effect(
+      SqlClient.SqlClient,
+      Effect.gen(function* () {
+        const context = yield* Layer.build(makeRuntimeSqliteLayer(config));
+        const client = Context.get(context, SqlClient.SqlClient);
+
+        // Configure database settings directly on the client (avoids deadlock)
+        yield* client.unsafe("PRAGMA journal_mode = WAL;");
+        yield* client.unsafe("PRAGMA busy_timeout = 5000;");
+        yield* client.unsafe("PRAGMA synchronous = NORMAL;");
+        yield* client.unsafe("PRAGMA foreign_keys = ON;");
+
+        // Run migrations directly
+        const migrationsContext = Context.make(SqlClient.SqlClient, client);
+        yield* runMigrations().pipe(Effect.provide(migrationsContext));
+
+        const healthCheck = () =>
+          Effect.gen(function* () {
+            const result = yield* client.unsafe("PRAGMA integrity_check;");
+            const firstRow = result[0];
+            const details = firstRow ? (Object.values(firstRow)[0] as string) : "";
+            const status = details === "ok" ? "pass" : "fail";
+            return { status, details };
+          });
+
+        return Object.assign(client, { healthCheck });
+      }),
+    ).pipe(Layer.provide(Reactivity.layer));
+  }
+
+  // 2. Production Path for File-based Database (Pooling 1-5 connections)
   return Layer.effect(
     SqlClient.SqlClient,
     Effect.gen(function* () {
       const pool = yield* Pool.makeWithTTL({
         acquire: acquireConnection(config),
-        min: dbPath === ":memory:" ? 1 : 1,
-        max: dbPath === ":memory:" ? 1 : 5,
-        timeToLive: Duration.seconds(60),
+        min: 1,
+        max: 5,
+        timeToLive: Duration.seconds(10),
       });
 
-      const baseContext = yield* Layer.build(makeRuntimeSqliteLayer(config));
-      const baseClient = Context.get(baseContext, SqlClient.SqlClient);
-
-      const tempStatement = baseClient`SELECT 1`;
-      const compiler = tempStatement.compiler;
-      const spanAttributes = tempStatement.spanAttributes;
-      const transformRows = tempStatement.transformRows;
+      // Build and extract compiler metadata within a temporary scope to avoid resource leaks
+      const { compiler, spanAttributes, transformRows } = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const baseContext = yield* Layer.build(makeRuntimeSqliteLayer(config));
+          const baseClient = Context.get(baseContext, SqlClient.SqlClient);
+          const tempStatement = baseClient`SELECT 1`;
+          return {
+            compiler: tempStatement.compiler,
+            spanAttributes: tempStatement.spanAttributes,
+            transformRows: tempStatement.transformRows,
+          };
+        }),
+      );
 
       const pooledAcquirer = Pool.get(pool).pipe(
         Effect.tap((connection) =>
           Effect.addFinalizer(() =>
-            connection.executeUnprepared("PRAGMA reset;", [], undefined).pipe(Effect.orDie)
-          )
+            connection
+              .executeUnprepared("PRAGMA reset;", [], undefined)
+              .pipe(Effect.orDie),
+          ),
         ),
         Effect.timeoutOrElse({
           duration: Duration.seconds(10),
@@ -103,6 +150,10 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
         transformRows,
       });
 
+      // Run migrations on the pooled client!
+      const context = Context.make(SqlClient.SqlClient, client);
+      yield* runMigrations().pipe(Effect.provide(context));
+
       const healthCheck = () =>
         Effect.gen(function* () {
           const result = yield* client.unsafe("PRAGMA integrity_check;");
@@ -112,13 +163,7 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
           return { status, details };
         });
 
-      const sqlClient = Object.assign(client, { healthCheck });
-
-      // Run migrations on the pooled client!
-      const context = Context.make(SqlClient.SqlClient, sqlClient);
-      yield* runMigrations().pipe(Effect.provide(context));
-
-      return sqlClient;
+      return Object.assign(client, { healthCheck });
     }),
   ).pipe(Layer.provide(Reactivity.layer));
 }, Layer.unwrap);

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -3,7 +3,6 @@ import * as Layer from "effect/Layer";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
-import type * as Connection from "effect/unstable/sql/SqlConnection";
 import * as Pool from "effect/Pool";
 import * as Duration from "effect/Duration";
 import * as Scope from "effect/Scope";
@@ -39,13 +38,13 @@ const acquireConnection = (config: RuntimeSqliteLayerConfig) =>
   Effect.gen(function* () {
     const context = yield* Layer.build(makeRuntimeSqliteLayer(config));
     const client = Context.get(context, SqlClient.SqlClient);
-
-    yield* client`PRAGMA journal_mode = WAL;`;
-    yield* client`PRAGMA busy_timeout = 5000;`;
-    yield* client`PRAGMA synchronous = NORMAL;`;
-    yield* client`PRAGMA foreign_keys = ON;`;
-
     const connection = yield* client.reserve;
+
+    yield* connection.executeUnprepared("PRAGMA journal_mode = WAL;", [], undefined);
+    yield* connection.executeUnprepared("PRAGMA busy_timeout = 5000;", [], undefined);
+    yield* connection.executeUnprepared("PRAGMA synchronous = NORMAL;", [], undefined);
+    yield* connection.executeUnprepared("PRAGMA foreign_keys = ON;", [], undefined);
+
     return connection;
   });
 
@@ -73,7 +72,7 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
         acquire: acquireConnection(config),
         min: dbPath === ":memory:" ? 1 : 1,
         max: dbPath === ":memory:" ? 1 : 5,
-        timeToLive: Duration.seconds(10),
+        timeToLive: Duration.seconds(60),
       });
 
       const baseContext = yield* Layer.build(makeRuntimeSqliteLayer(config));
@@ -104,10 +103,6 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
         transformRows,
       });
 
-      // Run migrations on the pooled client!
-      const context = Context.make(SqlClient.SqlClient, client);
-      yield* runMigrations().pipe(Effect.provide(context));
-
       const healthCheck = () =>
         Effect.gen(function* () {
           const result = yield* client.unsafe("PRAGMA integrity_check;");
@@ -117,7 +112,13 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
           return { status, details };
         });
 
-      return Object.assign(client, { healthCheck });
+      const sqlClient = Object.assign(client, { healthCheck });
+
+      // Run migrations on the pooled client!
+      const context = Context.make(SqlClient.SqlClient, sqlClient);
+      yield* runMigrations().pipe(Effect.provide(context));
+
+      return sqlClient;
     }),
   ).pipe(Layer.provide(Reactivity.layer));
 }, Layer.unwrap);

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -85,6 +85,11 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
       const transformRows = tempStatement.transformRows;
 
       const pooledAcquirer = Pool.get(pool).pipe(
+        Effect.tap((connection) =>
+          Effect.addFinalizer(() =>
+            connection.executeUnprepared("PRAGMA reset;", [], undefined).pipe(Effect.orDie)
+          )
+        ),
         Effect.timeoutOrElse({
           duration: Duration.seconds(10),
           orElse: () => Effect.fail(new Error("Database connection acquisition timeout (10s)")),


### PR DESCRIPTION
/claim #858

### Solution Implemented
- **SQLite WAL Mode & PRAGMA Settings**: Enabled WAL mode, busy_timeout=5000, and synchronous NORMAL mode configured directly on reserved raw connection.
- **Connection Pooling**: Integrated dynamic connection pool managing 1-5 connections using `Effect.Pool` with a 10s TTL.
- **Health Check Support**: Added an on-demand health check that runs `PRAGMA integrity_check` and returns structured pass/fail.
- **Timeout and Reset Hooks**: Configured a 10-second acquisition timeout, and a `PRAGMA reset;` finalizer when connections are checked back into the pool to ensure clean state.
- **Bypass for Memory Databases**: Prevented memory database splits and deadlocks by executing settings directly on the base client for `:memory:` databases.

### Verification & Automated Test Outputs
All persistence unit tests (16 tests across 12 files) run and pass successfully:
```
Test Files  12 passed (12)
     Tests  16 passed (16)
```