### PR TITLE
[ Hermes Agent ] [ Laravel ] Implement API authentication controller with token-based login and registration

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,5 +1,5 @@
 {
-  "agent": "Hermes Agent (simisdav55-oss)",
-  "initial_directives": "You are a CLI AI Agent. You have persistent memory across sessions. Save durable facts using the memory tool. Only proceed without loading a skill if genuinely none are relevant to the task. Host: WSL (Windows Subsystem for Linux). User home directory: /home/shenhua. You are running inside WSL. The Windows host filesystem is mounted under /mnt/. Active Hermes profile: default. You have access to a set of tools: terminal, read_file, write_file, patch, search_files, execute_code, browser tools, web_search, delegate_task, etc. You respond in Chinese when the user speaks Chinese. Skills system available for specialized workflows. The user prefers direct action over explanation. No fluff, just results.",
-  "date": "2026-05-27T11:30:00+08:00"
+  "contributor": "Hermes Agent (simisdav55-oss)",
+  "agent": "Hermes Agent",
+  "completed_at": "2026-05-27T12:00:00Z"
 }

--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes Agent (simisdav55-oss)",
+  "initial_directives": "You are a CLI AI Agent. You have persistent memory across sessions. Save durable facts using the memory tool. Only proceed without loading a skill if genuinely none are relevant to the task. Host: WSL (Windows Subsystem for Linux). User home directory: /home/shenhua. You are running inside WSL. The Windows host filesystem is mounted under /mnt/. Active Hermes profile: default. You have access to a set of tools: terminal, read_file, write_file, patch, search_files, execute_code, browser tools, web_search, delegate_task, etc. You respond in Chinese when the user speaks Chinese. Skills system available for specialized workflows. The user prefers direct action over explanation. No fluff, just results.",
+  "date": "2026-05-27T11:30:00+08:00"
+}

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    /**
+     * Register a new user and return an API token.
+     */
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
+        ]);
+
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return response()->json([
+            'message' => 'User registered successfully.',
+            'user' => $user,
+            'token' => $token,
+        ], 201);
+    }
+
+    /**
+     * Log in an existing user and return an API token.
+     */
+    public function login(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email' => 'required|string|email',
+            'password' => 'required|string',
+        ]);
+
+        $user = User::where('email', $validated['email'])->first();
+
+        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+            return response()->json([
+                'message' => 'The provided credentials are incorrect.',
+            ], 401);
+        }
+
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return response()->json([
+            'message' => 'Logged in successfully.',
+            'token' => $token,
+        ], 200);
+    }
+
+    /**
+     * Log out the current user by revoking the current token.
+     */
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json([
+            'message' => 'Logged out successfully.',
+        ], 200);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,13 +9,14 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.3",
         "laravel/framework": "^13.8",
+        "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0"
     },
     "require-dev": {

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| API Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register API routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| is assigned the "api" middleware group.
+|
+*/
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
## Summary

Implemented Laravel API authentication controller with Sanctum token-based auth.

### Changes

- **laravel/app/Http/Controllers/AuthController.php**: Created with `register`, `login`, and `logout` methods
- **laravel/routes/api.php**: API routes for POST /api/register, /api/login, /api/logout
- **laravel/app/Http/Controllers/.generation_meta.json**: Agent metadata

### Features
- Registration validates name, email, password (min 8 chars, confirmed)
- Login returns 401 with message for invalid credentials
- Logout revokes the current access token
- All responses are JSON formatted with proper HTTP status codes
- Uses Laravel Sanctum for token management

Closes #752