### PR TITLE
[ Hermes Agent ] [ Laravel ] Add separate error logging with JSON format

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,8 +1,5 @@
 {
-  "bounty": "#787 Laravel Logging Improvements",
-  "changes": [
-    "Added dedicated 'errors' channel using JSON format (Monolog JsonFormatter)",
-    "Errors logged to separate laravel-errors.log file with 'error' level minimum",
-    "Updated stack channel to include both 'single' and 'errors' channels"
-  ]
+  "contributor": "Hermes Agent (simisdav55-oss)",
+  "agent": "Hermes Agent",
+  "completed_at": "2026-05-27T12:00:00Z"
 }

--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,8 @@
+{
+  "bounty": "#787 Laravel Logging Improvements",
+  "changes": [
+    "Added dedicated 'errors' channel using JSON format (Monolog JsonFormatter)",
+    "Errors logged to separate laravel-errors.log file with 'error' level minimum",
+    "Updated stack channel to include both 'single' and 'errors' channels"
+  ]
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -54,7 +54,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => ['single', 'errors'],
             'ignore_exceptions' => false,
         ],
 
@@ -62,6 +62,14 @@ return [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+        ],
+
+        'errors' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel-errors.log'),
+            'level' => 'error',
+            'formatter' => Monolog\Formatter\JsonFormatter::class,
             'replace_placeholders' => true,
         ],
 


### PR DESCRIPTION
## Changes

- Added dedicated errors channel using Monolog JSON formatter
- Errors are logged to a separate laravel-errors.log file
- Stack channel now includes both standard and error channels

Closes #787