### PR TITLE
[ Hermes Agent ] [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,10 @@
+{
+  "agent": "Hermes Agent",
+  "bounty": "#797 FastAPI request ID middleware",
+  "changes": [
+    "fastapi/fastapi/middleware/request_id.py - New middleware that adds X-Request-ID header to responses",
+    "fastapi/fastapi/middleware/__init__.py - Added RequestIDMiddleware export",
+    "fastapi/tests/test_request_id.py - Tests for request ID middleware"
+  ],
+  "testing": "python3 -m pytest fastapi/tests/test_request_id.py -x -v"
+}

--- a/fastapi/fastapi/middleware/__init__.py
+++ b/fastapi/fastapi/middleware/__init__.py
@@ -1,1 +1,3 @@
 from starlette.middleware import Middleware as Middleware
+
+from .request_id import RequestIDMiddleware as RequestIDMiddleware

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,37 @@
+from uuid import uuid4
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class RequestIDMiddleware:
+    """Middleware that adds an X-Request-ID header to responses.
+
+    If the client sends an X-Request-ID header, it will be preserved.
+    Otherwise, a new UUID will be generated.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = None
+        for header_name, header_value in scope.get("headers", []):
+            if header_name == b"x-request-id":
+                request_id = header_value.decode()
+                break
+
+        if request_id is None:
+            request_id = str(uuid4())
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers.append("X-Request-ID", request_id)
+            await send(message)
+
+        await self.app(scope, receive, send_with_request_id)

--- a/fastapi/tests/test_request_id.py
+++ b/fastapi/tests/test_request_id.py
@@ -1,0 +1,73 @@
+from uuid import UUID
+
+from fastapi import FastAPI
+from fastapi.middleware import RequestIDMiddleware
+from fastapi.testclient import TestClient
+
+
+def test_request_id_middleware_adds_header():
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def root():
+        return {"message": "Hello World"}
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "X-Request-ID" in response.headers
+    # Verify it's a valid UUID
+    request_id = response.headers["X-Request-ID"]
+    UUID(request_id)  # Will raise if invalid
+
+
+def test_request_id_middleware_preserves_client_header():
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def root():
+        return {"message": "Hello World"}
+
+    client = TestClient(app)
+    response = client.get("/", headers={"X-Request-ID": "my-custom-id"})
+
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"] == "my-custom-id"
+
+
+def test_request_id_middleware_generates_uuid():
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def root():
+        return {"message": "Hello World"}
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    request_id = response.headers["X-Request-ID"]
+    # Verify it's a UUID v4
+    uuid_obj = UUID(request_id)
+    assert uuid_obj.version == 4
+
+
+def test_request_id_middleware_unique_per_request():
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/")
+    def root():
+        return {"message": "Hello World"}
+
+    client = TestClient(app)
+    response1 = client.get("/")
+    response2 = client.get("/")
+
+    id1 = response1.headers["X-Request-ID"]
+    id2 = response2.headers["X-Request-ID"]
+    assert id1 != id2


### PR DESCRIPTION
## Summary

Adds a `RequestIDMiddleware` that adds an `X-Request-ID` header to every response.

- If the client sends an `X-Request-ID` header, it is preserved.
- Otherwise, a new UUID v4 is generated.
- Exported from `fastapi.middleware`.
- Includes tests.

Closes #797