### PR TITLE
[ Hermes Agent ] [ FastAPI ] Fix hardcoded CDN URLs in Swagger UI and ReDoc

### DIFF
--- a/brainfuck/.audit.json
+++ b/brainfuck/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent (simisdav55-oss)",
+  "agent": "Hermes Agent",
+  "completed_at": "2026-05-27T12:00:00Z"
+}

--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,28 @@
+{
+  "app": "fastapi",
+  "issue": "#762 - Make CDN URLs configurable in FastAPI",
+  "changes": [
+    {
+      "file": "fastapi/applications.py",
+      "description": "Added swagger_js_url, swagger_css_url, swagger_favicon_url, redoc_js_url, redoc_favicon_url, with_google_fonts constructor parameters to FastAPI.__init__ with sensible defaults matching the existing hardcoded CDN URLs"
+    },
+    {
+      "file": "fastapi/applications.py",
+      "description": "Stored new parameters as instance attributes in __init__"
+    },
+    {
+      "file": "fastapi/applications.py",
+      "description": "Passed swagger_js_url, swagger_css_url, swagger_favicon_url to get_swagger_ui_html() in setup()"
+    },
+    {
+      "file": "fastapi/applications.py",
+      "description": "Passed redoc_js_url, redoc_favicon_url, with_google_fonts to get_redoc_html() in setup()"
+    },
+    {
+      "file": "tests/test_custom_cdn_urls.py",
+      "description": "Added test verifying custom CDN URLs are used in Swagger UI and ReDoc"
+    }
+  ],
+  "status": "implemented",
+  "timestamp": "2026-05-27"
+}

--- a/fastapi/fastapi/applications.py
+++ b/fastapi/fastapi/applications.py
@@ -761,6 +761,74 @@ class FastAPI(Starlette):
                 """
             ),
         ] = None,
+        swagger_js_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to load the Swagger UI JavaScript bundle from.
+
+                It is normally set to a CDN URL. You can use this parameter to
+                override it and use a custom or self-hosted URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+        swagger_css_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to load the Swagger UI CSS from.
+
+                It is normally set to a CDN URL. You can use this parameter to
+                override it and use a custom or self-hosted URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+        swagger_favicon_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL of the favicon to use in the Swagger UI docs.
+                It is normally shown in the browser tab.
+                """
+            ),
+        ] = "https://fastapi.tiangolo.com/img/favicon.png",
+        redoc_js_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to load the ReDoc JavaScript bundle from.
+
+                It is normally set to a CDN URL. You can use this parameter to
+                override it and use a custom or self-hosted URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+        redoc_favicon_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL of the favicon to use in the ReDoc docs.
+                It is normally shown in the browser tab.
+                """
+            ),
+        ] = "https://fastapi.tiangolo.com/img/favicon.png",
+        with_google_fonts: Annotated[
+            bool,
+            Doc(
+                """
+                Load and use Google Fonts in ReDoc.
+                """
+            ),
+        ] = True,
         generate_unique_id_function: Annotated[
             Callable[[routing.APIRoute], str],
             Doc(
@@ -885,6 +953,12 @@ class FastAPI(Starlette):
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
         self.swagger_ui_parameters = swagger_ui_parameters
+        self.swagger_js_url = swagger_js_url
+        self.swagger_css_url = swagger_css_url
+        self.swagger_favicon_url = swagger_favicon_url
+        self.redoc_js_url = redoc_js_url
+        self.redoc_favicon_url = redoc_favicon_url
+        self.with_google_fonts = with_google_fonts
         self.servers = servers or []
         self.separate_input_output_schemas = separate_input_output_schemas
         self.openapi_external_docs = openapi_external_docs
@@ -1125,6 +1199,9 @@ class FastAPI(Starlette):
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=f"{self.title} - Swagger UI",
+                    swagger_js_url=self.swagger_js_url,
+                    swagger_css_url=self.swagger_css_url,
+                    swagger_favicon_url=self.swagger_favicon_url,
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                     swagger_ui_parameters=self.swagger_ui_parameters,
@@ -1148,7 +1225,11 @@ class FastAPI(Starlette):
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 return get_redoc_html(
-                    openapi_url=openapi_url, title=f"{self.title} - ReDoc"
+                    openapi_url=openapi_url,
+                    title=f"{self.title} - ReDoc",
+                    redoc_js_url=self.redoc_js_url,
+                    redoc_favicon_url=self.redoc_favicon_url,
+                    with_google_fonts=self.with_google_fonts,
                 )
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)

--- a/fastapi/tests/test_custom_cdn_urls.py
+++ b/fastapi/tests/test_custom_cdn_urls.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app = FastAPI(
+    swagger_js_url="https://example.com/swagger-ui-bundle.js",
+    swagger_css_url="https://example.com/swagger-ui.css",
+    swagger_favicon_url="https://example.com/favicon.png",
+    redoc_js_url="https://example.com/redoc.standalone.js",
+    redoc_favicon_url="https://example.com/favicon.png",
+    with_google_fonts=False,
+)
+
+
+@app.get("/items/")
+async def read_items():
+    return {"id": "foo"}
+
+
+client = TestClient(app)
+
+
+def test_swagger_ui_with_custom_cdn_urls():
+    response = client.get("/docs")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert "https://example.com/swagger-ui-bundle.js" in response.text
+    assert "https://example.com/swagger-ui.css" in response.text
+    assert "https://example.com/favicon.png" in response.text
+    assert "swagger-ui-dist" not in response.text
+
+
+def test_redoc_with_custom_cdn_urls():
+    response = client.get("/redoc")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert "https://example.com/redoc.standalone.js" in response.text
+    assert "https://example.com/favicon.png" in response.text
+    assert "fonts.googleapis.com" not in response.text
+
+
+def test_response():
+    response = client.get("/items/")
+    assert response.json() == {"id": "foo"}


### PR DESCRIPTION
## Summary

Make Swagger UI and ReDoc CDN URLs configurable in the FastAPI() constructor instead of hardcoded. Added 6 new parameters:
- `swagger_js_url`
- `swagger_css_url`
- `swagger_favicon_url`
- `redoc_js_url`
- `redoc_favicon_url`
- `with_google_fonts`

All default to existing CDN values for backward compatibility.

### Changes
- `fastapi/fastapi/applications.py` — Added parameters, store as instance attributes, pass to docs functions
- `fastapi/tests/test_custom_cdn_urls.py` — Tests verifying custom URLs appear in responses

Closes #762