### PR TITLE
[ Hermes Agent ] [ FastAPI ] Add brute force protection to HTTPBasic authentication

### DIFF
--- a/.audit_feat-brute-force.json
+++ b/.audit_feat-brute-force.json
@@ -1,0 +1,8 @@
+{
+  "bounty": "#800 FastAPI brute force protection",
+  "branch": "feat-brute-force",
+  "changes": [
+    "Modified fastapi/fastapi/security/http.py - added brute force tracking (failed attempts per IP, configurable threshold and lockout duration, lockout check with 429 response)",
+    "Added fastapi/tests/test_security_http_basic_brute_force.py - tests for lockout after failures and clearing on success"
+  ]
+}

--- a/brainfuck/.audit.json
+++ b/brainfuck/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent (simisdav55-oss)",
+  "agent": "Hermes Agent",
+  "completed_at": "2026-05-27T12:00:00Z"
+}

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,7 @@
 import binascii
+import time
 from base64 import b64decode
+from collections import defaultdict
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +12,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -188,11 +190,32 @@ class HTTPBasic(HTTPBase):
                 """
             ),
         ] = True,
+        max_failed_attempts: Annotated[
+            int,
+            Doc(
+                """
+                Maximum number of failed authentication attempts before the IP is
+                temporarily locked out. Defaults to 5.
+                """
+            ),
+        ] = 5,
+        lockout_duration_seconds: Annotated[
+            int,
+            Doc(
+                """
+                Duration in seconds for which an IP is locked out after exceeding the
+                maximum failed attempts. Defaults to 300 (5 minutes).
+                """
+            ),
+        ] = 300,
     ):
         self.model = HTTPBaseModel(scheme="basic", description=description)
         self.scheme_name = scheme_name or self.__class__.__name__
         self.realm = realm
         self.auto_error = auto_error
+        self.max_failed_attempts = max_failed_attempts
+        self.lockout_duration = lockout_duration_seconds
+        self._failed_attempts: dict[str, list[float]] = defaultdict(list)
 
     def make_authenticate_headers(self) -> dict[str, str]:
         if self.realm:
@@ -202,20 +225,46 @@ class HTTPBasic(HTTPBase):
     async def __call__(  # type: ignore
         self, request: Request
     ) -> HTTPBasicCredentials | None:
+        # Resolve client IP, falling back to a placeholder
+        client_ip = request.client.host if request.client else "unknown"
+        now = time.time()
+
+        # Prune expired entries for this IP
+        self._failed_attempts[client_ip] = [
+            ts for ts in self._failed_attempts[client_ip]
+            if now - ts < self.lockout_duration
+        ]
+
+        # Check if IP is currently locked out
+        if len(self._failed_attempts[client_ip]) >= self.max_failed_attempts:
+            retry_after = int(self.lockout_duration - (now - self._failed_attempts[client_ip][0]))
+            raise HTTPException(
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many failed authentication attempts. Try again later.",
+                headers={"Retry-After": str(max(retry_after, 1))},
+            )
+
         authorization = request.headers.get("Authorization")
         scheme, param = get_authorization_scheme_param(authorization)
         if not authorization or scheme.lower() != "basic":
             if self.auto_error:
+                self._failed_attempts[client_ip].append(now)
                 raise self.make_not_authenticated_error()
             else:
                 return None
         try:
             data = b64decode(param).decode("ascii")
         except (ValueError, UnicodeDecodeError, binascii.Error) as e:
+            if self.auto_error:
+                self._failed_attempts[client_ip].append(now)
             raise self.make_not_authenticated_error() from e
         username, separator, password = data.partition(":")
         if not separator:
+            if self.auto_error:
+                self._failed_attempts[client_ip].append(now)
             raise self.make_not_authenticated_error()
+        # On success, clear failed attempts for this IP
+        self._failed_attempts.pop(client_ip, None)
         return HTTPBasicCredentials(username=username, password=password)
 
 

--- a/fastapi/tests/test_security_http_basic_brute_force.py
+++ b/fastapi/tests/test_security_http_basic_brute_force.py
@@ -1,0 +1,82 @@
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+# Use a low threshold for testing
+security = HTTPBasic(max_failed_attempts=3, lockout_duration_seconds=60)
+
+
+@app.get("/users/me")
+def read_current_user(credentials: HTTPBasicCredentials = Security(security)):
+    return {"username": credentials.username, "password": credentials.password}
+
+
+client = TestClient(app)
+
+
+def test_brute_force_lockout_after_failures():
+    """Test that after exceeding max_failed_attempts the IP gets locked out."""
+    # Send 3 invalid requests to trigger lockout
+    for i in range(3):
+        response = client.get(
+            "/users/me",
+            headers={"Authorization": "Basic invalidcredential"},
+        )
+        assert response.status_code == 401, f"Expected 401, got {response.status_code}"
+
+    # The 4th request should be blocked with 429
+    response = client.get(
+        "/users/me",
+        headers={"Authorization": "Basic invalidcredential"},
+    )
+    assert response.status_code == 429, f"Expected 429, got {response.status_code}"
+    assert response.json() == {"detail": "Too many failed authentication attempts. Try again later."}
+    assert "Retry-After" in response.headers
+
+
+def test_brute_force_lockout_cleared_on_success():
+    """Test that a successful auth clears the failed attempt counter."""
+    # Reset by creating a fresh instance
+    local_security = HTTPBasic(max_failed_attempts=2, lockout_duration_seconds=60)
+
+    local_app = FastAPI()
+
+    @local_app.get("/users/me")
+    def local_user(credentials: HTTPBasicCredentials = Security(local_security)):
+        return {"username": credentials.username, "password": credentials.password}
+
+    local_client = TestClient(local_app)
+
+    # Send one bad request
+    response = local_client.get(
+        "/users/me",
+        headers={"Authorization": "Basic invalidcredential"},
+    )
+    assert response.status_code == 401
+
+    # Send a valid request
+    response = local_client.get("/users/me", auth=("john", "secret"))
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "john", "password": "secret"}
+
+    # Failed attempts should now be cleared, so another bad request should still
+    # return 401 (not 429) since the counter was reset
+    response = local_client.get(
+        "/users/me",
+        headers={"Authorization": "Basic invalidcredential"},
+    )
+    assert response.status_code == 401, f"Expected 401 after success, got {response.status_code}"
+    # After this bad request, we should have 1 failure, need one more to lockout
+    response = local_client.get(
+        "/users/me",
+        headers={"Authorization": "Basic invalidcredential"},
+    )
+    assert response.status_code == 401
+    # Now the 3rd bad request should lockout
+    response = local_client.get(
+        "/users/me",
+        headers={"Authorization": "Basic invalidcredential"},
+    )
+    assert response.status_code == 429, f"Expected 429 after 2 failures, got {response.status_code}"


### PR DESCRIPTION
Add brute force protection to HTTPBasic authentication.

- Track failed attempts per IP with in-memory store
- Configurable max_failed_attempts and lockout_duration_seconds
- Return 429 Too Many Requests on lockout
- Clear failed attempts on successful authentication