### PR TITLE
[ Hermes Agent ] [ T3 Code ] Add version command and --version flag to CLI

### DIFF
--- a/brainfuck/.audit.json
+++ b/brainfuck/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent (simisdav55-oss)",
+  "agent": "Hermes Agent",
+  "completed_at": "2026-05-27T12:00:00Z"
+}

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -10,13 +10,14 @@ import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { versionCommand } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, versionCommand]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,13 @@
+import * as Effect from "effect/Effect";
+import { Command } from "effect/unstable/cli";
+import packageJson from "../../package.json" with { type: "json" };
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print the server version"),
+  Command.withHandler(() =>
+    Effect.sync(() => {
+      // biome-ignore lint/suspicious/noConsole: CLI version output
+      console.log(packageJson.version);
+    }),
+  ),
+);


### PR DESCRIPTION
## Summary

Add a `t3 version` subcommand and ensure the `--version` flag works.

- `t3code/apps/server/src/cli/version.ts` — New command that prints the server version from package.json
- `t3code/apps/server/src/bin.ts` — Registered versionCommand as a subcommand

The `--version` flag already works via `Command.run(cli, { version: packageJson.version })`.

Closes #821