### PR TITLE
Codex [ Crypto ] Fix SimpleSwap slippage and deadline checks

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
 
 contract SimpleSwap {
+    uint256 private constant BASIS_POINTS = 10_000;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
     uint256 public reserveA;
@@ -13,39 +18,42 @@ contract SimpleSwap {
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_fee < BASIS_POINTS, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(tokenA.transferFrom(msg.sender, address(this), amountA), "TokenA transfer failed");
+        require(tokenB.transferFrom(msg.sender, address(this), amountB), "TokenB transfer failed");
         reserveA += amountA;
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
+        require(block.timestamp <= deadline, "Transaction expired");
 
         bool isTokenA = tokenIn == address(tokenA);
         (IERC20 inputToken, IERC20 outputToken, uint256 reserveIn, uint256 reserveOut) = isTokenA
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
-        inputToken.transferFrom(msg.sender, address(this), amountIn);
+        require(reserveIn > 0 && reserveOut > 0, "Insufficient liquidity");
 
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
+        amountOut = _amountOut(reserveIn, reserveOut, amountIn);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+        require(amountOut < reserveOut, "Insufficient output reserve");
 
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
-        outputToken.transfer(msg.sender, amountOut);
+        require(inputToken.transferFrom(msg.sender, address(this), amountIn), "Input transfer failed");
+        require(outputToken.transfer(msg.sender, amountOut), "Output transfer failed");
 
         if (isTokenA) {
             reserveA += amountIn;
@@ -59,11 +67,21 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
+        require(amountIn > 0, "Amount must be > 0");
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-        return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+        require(reserveIn > 0 && reserveOut > 0, "Insufficient liquidity");
+        return _amountOut(reserveIn, reserveOut, amountIn);
+    }
+
+    function _amountOut(
+        uint256 reserveIn,
+        uint256 reserveOut,
+        uint256 amountIn
+    ) internal view returns (uint256) {
+        uint256 amountInWithFee = amountIn * (BASIS_POINTS - fee);
+        return (reserveOut * amountInWithFee) / ((reserveIn * BASIS_POINTS) + amountInWithFee);
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "jtc268",
+  "generation_context": "Private system, developer, runtime, account, and security instructions are intentionally not disclosed. Public task context: UnsafeLabs/Bounty-Hunters issue #913 asks for SimpleSwap slippage protection, deadline enforcement, fixed-point basis-point fee math, tests, and safe AI-agent metadata.",
+  "completed_at": "2026-05-27T07:53:00Z"
+}

--- a/solidity/tests/simple-swap-acceptance.test.mjs
+++ b/solidity/tests/simple-swap-acceptance.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const BASIS_POINTS = 10_000n;
+
+function amountOut({ reserveIn, reserveOut, amountIn, feeBps }) {
+  const inputAfterFee = BigInt(amountIn) * (BASIS_POINTS - BigInt(feeBps));
+  return (BigInt(reserveOut) * inputAfterFee) / (BigInt(reserveIn) * BASIS_POINTS + inputAfterFee);
+}
+
+function simulateSwap({ reserveIn, reserveOut, amountIn, feeBps, minAmountOut, now, deadline }) {
+  if (BigInt(now) > BigInt(deadline)) {
+    throw new Error("Transaction expired");
+  }
+  const output = amountOut({ reserveIn, reserveOut, amountIn, feeBps });
+  if (output < BigInt(minAmountOut)) {
+    throw new Error("Slippage exceeded");
+  }
+  return output;
+}
+
+test("swap succeeds when quoted output satisfies minAmountOut before deadline", () => {
+  const quoted = amountOut({
+    reserveIn: 10_000n,
+    reserveOut: 20_000n,
+    amountIn: 1_000n,
+    feeBps: 30n,
+  });
+
+  assert.equal(quoted, 1_813n);
+  assert.equal(
+    simulateSwap({
+      reserveIn: 10_000n,
+      reserveOut: 20_000n,
+      amountIn: 1_000n,
+      feeBps: 30n,
+      minAmountOut: quoted,
+      now: 100n,
+      deadline: 100n,
+    }),
+    quoted,
+  );
+});
+
+test("swap rejects expired deadlines and excessive slippage", () => {
+  assert.throws(
+    () =>
+      simulateSwap({
+        reserveIn: 10_000n,
+        reserveOut: 20_000n,
+        amountIn: 1_000n,
+        feeBps: 30n,
+        minAmountOut: 1n,
+        now: 101n,
+        deadline: 100n,
+      }),
+    /Transaction expired/,
+  );
+
+  assert.throws(
+    () =>
+      simulateSwap({
+        reserveIn: 10_000n,
+        reserveOut: 20_000n,
+        amountIn: 1_000n,
+        feeBps: 30n,
+        minAmountOut: 1_814n,
+        now: 100n,
+        deadline: 100n,
+      }),
+    /Slippage exceeded/,
+  );
+});
+
+test("basis-point fee math keeps the fee inside the constant-product quote", () => {
+  const oldPreTruncatedFee = 333n - (333n * 30n) / BASIS_POINTS;
+  const oldOutput = (10_000n * oldPreTruncatedFee) / (5_000n + oldPreTruncatedFee);
+  const newOutput = amountOut({
+    reserveIn: 5_000n,
+    reserveOut: 10_000n,
+    amountIn: 333n,
+    feeBps: 30n,
+  });
+
+  assert.equal(oldOutput, 624n);
+  assert.equal(newOutput, 622n);
+  assert.ok(oldOutput > newOutput);
+  assert.notEqual(
+    (333n * 30n) / BASIS_POINTS,
+    333n * 30n,
+    "fee calculation should not be represented as a pre-subtracted integer-only fee",
+  );
+});


### PR DESCRIPTION
/claim #913

Summary:
- Adds deadline and minAmountOut checks to SimpleSwap.swap.
- Uses fee-adjusted constant-product math instead of pre-truncated fee subtraction.
- Keeps getAmountOut consistent with swap.
- Adds safe non-sensitive metadata and Node acceptance tests.

Validation:
- node --test solidity/tests/simple-swap-acceptance.test.mjs
- npx -y solc@0.8.30 --bin --abi -o /tmp/bounty-hunters-simple-swap-solc solidity/contracts/SimpleSwap.sol
- git diff --check

Security note:
- Private system/developer/runtime instructions are not disclosed.