### PR TITLE
[ Hermes Agent ] [ FastAPI ] Add file size and content type validation to UploadFile

### DIFF
--- a/brainfuck/.audit.json
+++ b/brainfuck/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent (simisdav55-oss)",
+  "agent": "Hermes Agent",
+  "completed_at": "2026-05-27T12:00:00Z"
+}

--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,14 @@
+{
+  "audits": [
+    {
+      "bounty": "#761",
+      "title": "Add file size and content type validation to UploadFile",
+      "branch": "feat-file-validation",
+      "files_changed": [
+        "fastapi/fastapi/datastructures.py",
+        "fastapi/tests/test_datastructures.py"
+      ],
+      "summary": "Added max_size and allowed_content_types parameters to UploadFile class, along with a validate() method that raises HTTPException when constraints are violated. Tests cover size exceedance, size within limits, allowed content types, and disallowed content types."
+    }
+  ]
+}

--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -16,6 +16,8 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+from starlette.exceptions import HTTPException
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_415_UNSUPPORTED_MEDIA_TYPE
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +64,58 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+    max_size: Annotated[
+        int | None,
+        Doc(
+            "The maximum allowed file size in bytes. "
+            "If set, the file will be validated against this limit."
+        ),
+    ] = None
+    allowed_content_types: Annotated[
+        list[str] | None,
+        Doc(
+            "The list of allowed content types for the file. "
+            "If set, the file's content type will be validated against this list."
+        ),
+    ] = None
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: list[str] | None = None,
+    ) -> None:
+        super().__init__(file=file, size=size, filename=filename, headers=headers)
+        self.max_size = max_size
+        self.allowed_content_types = allowed_content_types
+
+    def validate(self) -> "UploadFile":
+        """
+        Validate the file against the configured constraints.
+
+        Raises `HTTPException` if:
+        - The file size exceeds `max_size`.
+        - The content type is not in `allowed_content_types`.
+
+        Returns the current instance for chaining.
+        """
+        if self.max_size is not None and self.size is not None and self.size > self.max_size:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=f"File size exceeds maximum allowed size of {self.max_size} bytes",
+            )
+        if self.allowed_content_types is not None and self.content_type is not None:
+            if self.content_type not in self.allowed_content_types:
+                raise HTTPException(
+                    status_code=HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                    detail=f"Content type '{self.content_type}' is not allowed. "
+                    f"Allowed content types: {self.allowed_content_types}",
+                )
+        return self
 
     async def write(
         self,

--- a/fastapi/tests/test_datastructures.py
+++ b/fastapi/tests/test_datastructures.py
@@ -48,6 +48,57 @@ def test_upload_file_is_closed(tmp_path: Path):
     assert testing_file_store[0].file.closed
 
 
+def test_upload_file_validate_max_size():
+    """Test that validate() rejects files exceeding max_size."""
+    from starlette.exceptions import HTTPException
+
+    stream = io.BytesIO(b"x" * 1000)
+    file = UploadFile(filename="test.txt", file=stream, size=1000, max_size=500)
+    with pytest.raises(HTTPException) as exc_info:
+        file.validate()
+    assert exc_info.value.status_code == 400
+    assert "File size exceeds maximum allowed size" in str(exc_info.value.detail)
+
+
+def test_upload_file_validate_max_size_ok():
+    """Test that validate() passes when size is within limits."""
+    stream = io.BytesIO(b"x" * 100)
+    file = UploadFile(filename="test.txt", file=stream, size=100, max_size=500)
+    result = file.validate()
+    assert result is file  # returns self for chaining
+
+
+def test_upload_file_validate_content_type_allowed():
+    """Test that validate() passes for an allowed content type."""
+    from starlette.datastructures import Headers
+
+    headers = Headers({"content-type": "image/png"})
+    stream = io.BytesIO(b"fake png data")
+    file = UploadFile(
+        filename="img.png", file=stream, size=12, headers=headers,
+        allowed_content_types=["image/png", "image/jpeg"],
+    )
+    result = file.validate()
+    assert result is file
+
+
+def test_upload_file_validate_content_type_blocked():
+    """Test that validate() rejects a disallowed content type."""
+    from starlette.exceptions import HTTPException
+    from starlette.datastructures import Headers
+
+    headers = Headers({"content-type": "text/html"})
+    stream = io.BytesIO(b"<html></html>")
+    file = UploadFile(
+        filename="doc.html", file=stream, size=15, headers=headers,
+        allowed_content_types=["image/png", "application/pdf"],
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        file.validate()
+    assert exc_info.value.status_code == 415
+    assert "Content type" in str(exc_info.value.detail)
+
+
 # For UploadFile coverage, segments copied from Starlette tests
 
 


### PR DESCRIPTION
Adds file size and content type validation to UploadFile.

### Changes
- Added max_size parameter to limit file upload size
- Added allowed_content_types parameter to restrict accepted MIME types
- Added validate() method to UploadFile that raises HTTPException when constraints are violated
- Added comprehensive tests

Closes #761