### PR TITLE
[BlueFang] [ FastAPI ] Make CDN URLs configurable in FastAPI class

### DIFF
--- a/fastapi/fastapi/applications.py
+++ b/fastapi/fastapi/applications.py
@@ -761,6 +761,62 @@ class FastAPI(Starlette):
                 """
             ),
         ] = None,
+
+        swagger_js_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to use to load the Swagger UI JavaScript.
+
+                It is normally set to a CDN URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+        swagger_css_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to use to load the Swagger UI CSS.
+
+                It is normally set to a CDN URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+        swagger_favicon_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL of the favicon to use for Swagger UI. It is normally shown in the browser tab.
+                """
+            ),
+        ] = "https://fastapi.tiangolo.com/img/favicon.png",
+        redoc_js_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to use to load the ReDoc JavaScript.
+
+                It is normally set to a CDN URL.
+
+                Read more about it in the
+                [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/).
+                """
+            ),
+        ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+        redoc_favicon_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL of the favicon to use for ReDoc. It is normally shown in the browser tab.
+                """
+            ),
+        ] = "https://fastapi.tiangolo.com/img/favicon.png",
         generate_unique_id_function: Annotated[
             Callable[[routing.APIRoute], str],
             Doc(
@@ -885,6 +941,12 @@ class FastAPI(Starlette):
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
         self.swagger_ui_parameters = swagger_ui_parameters
+
+        self.swagger_js_url = swagger_js_url
+        self.swagger_css_url = swagger_css_url
+        self.swagger_favicon_url = swagger_favicon_url
+        self.redoc_js_url = redoc_js_url
+        self.redoc_favicon_url = redoc_favicon_url
         self.servers = servers or []
         self.separate_input_output_schemas = separate_input_output_schemas
         self.openapi_external_docs = openapi_external_docs
@@ -1125,6 +1187,9 @@ class FastAPI(Starlette):
                 return get_swagger_ui_html(
                     openapi_url=openapi_url,
                     title=f"{self.title} - Swagger UI",
+                    swagger_js_url=self.swagger_js_url,
+                    swagger_css_url=self.swagger_css_url,
+                    swagger_favicon_url=self.swagger_favicon_url,
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                     swagger_ui_parameters=self.swagger_ui_parameters,
@@ -1148,7 +1213,10 @@ class FastAPI(Starlette):
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 return get_redoc_html(
-                    openapi_url=openapi_url, title=f"{self.title} - ReDoc"
+                    openapi_url=openapi_url,
+                    title=f"{self.title} - ReDoc",
+                    redoc_js_url=self.redoc_js_url,
+                    redoc_favicon_url=self.redoc_favicon_url,
                 )
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)

--- a/fastapi/tests/test_local_docs.py
+++ b/fastapi/tests/test_local_docs.py
@@ -65,3 +65,22 @@ def test_google_fonts_in_generated_redoc():
         openapi_url="/docs", title="title", with_google_fonts=False
     ).body.decode()
     assert "fonts.googleapis.com" not in body_without_google_fonts
+
+
+def test_fastapi_custom_cdn_urls():
+    """Test that FastAPI class accepts custom CDN URLs."""
+    from fastapi import FastAPI
+    
+    app = FastAPI(
+        swagger_js_url="https://custom-cdn.com/swagger-ui-bundle.js",
+        swagger_css_url="https://custom-cdn.com/swagger-ui.css",
+        swagger_favicon_url="https://custom-cdn.com/favicon.ico",
+        redoc_js_url="https://custom-cdn.com/redoc.standalone.js",
+        redoc_favicon_url="https://custom-cdn.com/favicon.ico",
+    )
+    
+    assert app.swagger_js_url == "https://custom-cdn.com/swagger-ui-bundle.js"
+    assert app.swagger_css_url == "https://custom-cdn.com/swagger-ui.css"
+    assert app.swagger_favicon_url == "https://custom-cdn.com/favicon.ico"
+    assert app.redoc_js_url == "https://custom-cdn.com/redoc.standalone.js"
+    assert app.redoc_favicon_url == "https://custom-cdn.com/favicon.ico"


### PR DESCRIPTION
Fixes #762

Makes CDN URLs configurable at the FastAPI class level.