### PR TITLE
[8wan] [ FastAPI ] Fix encoders.py bytes handling

### DIFF
--- a/fastapi/_provenance.json
+++ b/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "8wan",
+  "boot_context": "Hermes scheduled bounty job; full hidden/system context is not available for verbatim export. Task: fix FastAPI jsonable_encoder bytes and memoryview support for issue #759.",
+  "timestamp": "2026-05-27T00:00:00Z"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -215,6 +216,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding to use for bytes and memoryview values. Supported values are
+            `"base64"` and `"hex"`.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -255,6 +265,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +280,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -278,6 +290,16 @@ def jsonable_encoder(
         return obj
     if isinstance(obj, PydanticUndefinedType):
         return None
+    if isinstance(obj, memoryview):
+        obj = obj.tobytes()
+    if isinstance(obj, bytes):
+        if bytes_encoding == "base64":
+            return base64.b64encode(obj).decode("ascii")
+        if bytes_encoding == "hex":
+            return obj.hex()
+        raise ValueError(
+            'Unsupported bytes_encoding. Expected "base64" or "hex".'
+        )
     if isinstance(obj, dict):
         encoded_dict = {}
         allowed_keys = set(obj.keys())
@@ -302,6 +324,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +333,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +351,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +386,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -72,6 +72,28 @@ class ModelWithDefault(BaseModel):
     bla: str = "bla"
 
 
+
+def test_encode_bytes_default_base64():
+    assert jsonable_encoder(b"hello") == "aGVsbG8="
+    assert jsonable_encoder({"payload": b"hello"}) == {"payload": "aGVsbG8="}
+
+
+def test_encode_memoryview_default_base64():
+    assert jsonable_encoder(memoryview(b"hello")) == "aGVsbG8="
+    assert jsonable_encoder([memoryview(b"hello")]) == ["aGVsbG8="]
+
+
+def test_encode_bytes_hex():
+    assert jsonable_encoder(b"hello", bytes_encoding="hex") == "68656c6c6f"
+    assert jsonable_encoder(
+        {"payload": memoryview(b"hello")}, bytes_encoding="hex"
+    ) == {"payload": "68656c6c6f"}
+
+
+def test_encode_bytes_invalid_encoding():
+    with pytest.raises(ValueError, match="Unsupported bytes_encoding"):
+        jsonable_encoder(b"hello", bytes_encoding="utf-8")
+
 def test_encode_dict():
     pet = {"name": "Firulais", "owner": {"name": "Foo"}}
     assert jsonable_encoder(pet) == {"name": "Firulais", "owner": {"name": "Foo"}}


### PR DESCRIPTION
## Summary
- Add `bytes_encoding` support to FastAPI `jsonable_encoder` for bytes and memoryview values
- Encode bytes as base64 by default and support hex encoding
- Add regression coverage for bytes, memoryview, nested values, and invalid encoding

## Test Plan
- `cd fastapi && python3 -m pytest tests/test_jsonable_encoder.py -q`

/claim #759