### PR TITLE
Fix EMS master secret derivation per RFC 7627

### DIFF
--- a/python/test_tls_handshake.py
+++ b/python/test_tls_handshake.py
@@ -1,0 +1,31 @@
+from tls_handshake import TLSHandshake
+
+
+def _build_handshake() -> TLSHandshake:
+    hs = TLSHandshake()
+    hs._pre_master_secret = b"\x01" * 48
+    hs.client_random = b"\x02" * 32
+    hs.server_random = b"\x03" * 32
+    hs.handshake_hash.update(b"client_hello||server_hello||certificate")
+    return hs
+
+
+def test_ems_uses_rfc7627_label_and_seed() -> None:
+    hs = _build_handshake()
+    hs.negotiated_ems = True
+    hs._derive_master_secret()
+    ems_master = hs.master_secret
+
+    regular_hs = _build_handshake()
+    regular_hs.negotiated_ems = False
+    regular_hs._derive_master_secret()
+    regular_master = regular_hs.master_secret
+
+    assert ems_master != regular_master
+    expected_ems = _build_handshake()._prf(
+        b"\x01" * 48,
+        b"extended master secret",
+        _build_handshake().handshake_hash.copy().digest(),
+        48,
+    )
+    assert ems_master == expected_ems

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -293,14 +293,13 @@ class TLSHandshake:
         if self.client_random is None or self.server_random is None:
             raise ValueError("Client/server random not set")
 
-        seed = self.client_random + self.server_random
-
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            # RFC 7627: EMS must use the handshake transcript hash as seed.
+            label = b"extended master secret"
+            seed = self.handshake_hash.copy().digest()
         else:
             label = b"master secret"
+            seed = self.client_random + self.server_random
 
         self.master_secret = self._prf(
             self._pre_master_secret, label, seed, 48


### PR DESCRIPTION
Use the correct PRF label and handshake transcript hash when EMS is negotiated, and add a focused regression test to prevent fallback to standard master-secret derivation.