### PR TITLE
fix CLIENT_HELLO transition bypass in TLS state machine

### DIFF
--- a/python/test_tls_state_transitions.py
+++ b/python/test_tls_state_transitions.py
@@ -1,0 +1,37 @@
+from tls_handshake import (
+    HandshakeMessage,
+    HandshakeState,
+    HandshakeType,
+    TLSHandshake,
+    VALID_TRANSITIONS,
+)
+
+
+def test_client_hello_allows_only_server_hello() -> None:
+    assert VALID_TRANSITIONS[HandshakeState.CLIENT_HELLO] == [
+        HandshakeState.SERVER_HELLO
+    ]
+
+
+def test_client_hello_to_finished_is_rejected_and_sets_error() -> None:
+    hs = TLSHandshake()
+    hs.state = HandshakeState.CLIENT_HELLO
+
+    transitioned = hs.transition_to(HandshakeState.FINISHED)
+
+    assert transitioned is False
+    assert hs.state is HandshakeState.ERROR
+
+
+def test_process_message_finished_after_client_hello_cannot_bypass() -> None:
+    hs = TLSHandshake()
+    hs.state = HandshakeState.CLIENT_HELLO
+    hs.parse_record = lambda _: HandshakeMessage(HandshakeType.FINISHED, b"")
+
+    ok, message = hs.process_message(b"ignored")
+
+    assert ok is False
+    assert message == "Invalid state for Finished"
+    assert hs.state is HandshakeState.ERROR
+    assert hs.state is not HandshakeState.ESTABLISHED
+    assert hs.master_secret is None

--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -78,10 +78,7 @@ EXT_KEY_SHARE = 0x0033
 
 VALID_TRANSITIONS: Dict[HandshakeState, List[HandshakeState]] = {
     HandshakeState.IDLE: [HandshakeState.CLIENT_HELLO],
-    HandshakeState.CLIENT_HELLO: [
-        HandshakeState.SERVER_HELLO,
-        HandshakeState.FINISHED,       # BUG 1: allows skipping key exchange
-    ],
+    HandshakeState.CLIENT_HELLO: [HandshakeState.SERVER_HELLO],
     HandshakeState.SERVER_HELLO: [HandshakeState.CERTIFICATE],
     HandshakeState.CERTIFICATE: [HandshakeState.KEY_EXCHANGE],
     HandshakeState.KEY_EXCHANGE: [HandshakeState.CHANGE_CIPHER_SPEC],


### PR DESCRIPTION
Remove direct CLIENT_HELLO to FINISHED transition so Finished cannot skip required handshake phases, and add regression tests for transition validation and process_message rejection.