### PR TITLE
OpenAI Codex [ Laravel ] Implement webhook system with signature verification and retry queue

### DIFF
--- a/laravel/app/Http/Controllers/.attribution.json
+++ b/laravel/app/Http/Controllers/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Private runtime instructions were not disclosed. Implementation followed the public GitHub issue requirements and Laravel documentation.",
+  "date": "2026-05-27T00:00:00-04:00"
+}

--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebhookController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json([
+            'data' => Webhook::query()->latest()->get(),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $webhook = Webhook::query()->create($this->validated($request));
+
+        return response()->json([
+            'data' => $webhook,
+        ], 201);
+    }
+
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json([
+            'data' => $webhook->load('deliveries'),
+        ]);
+    }
+
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $webhook->update($this->validated($request, partial: true));
+
+        return response()->json([
+            'data' => $webhook->refresh(),
+        ]);
+    }
+
+    public function destroy(Webhook $webhook): JsonResponse
+    {
+        $webhook->delete();
+
+        return response()->json(status: 204);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validated(Request $request, bool $partial = false): array
+    {
+        $required = $partial ? 'sometimes' : 'required';
+
+        return $request->validate([
+            'url' => [$required, 'url', 'max:2048'],
+            'secret' => [$required, 'string', 'min:16', 'max:255'],
+            'events' => [$required, 'array', 'min:1'],
+            'events.*' => ['string', 'max:255', 'distinct'],
+            'active' => ['sometimes', 'boolean'],
+        ]);
+    }
+}

--- a/laravel/app/Jobs/DispatchWebhookJob.php
+++ b/laravel/app/Jobs/DispatchWebhookJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use RuntimeException;
+
+class DispatchWebhookJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 5;
+
+    public function __construct(public int $deliveryId)
+    {
+        $this->onQueue('webhooks');
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [60, 300, 900, 1800];
+    }
+
+    public function handle(WebhookDispatcher $dispatcher): void
+    {
+        $delivery = WebhookDelivery::query()->findOrFail($this->deliveryId);
+
+        if ($delivery->delivered()) {
+            return;
+        }
+
+        if (! $dispatcher->deliver($delivery)) {
+            throw new RuntimeException("Webhook delivery {$delivery->id} failed.");
+        }
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable(['url', 'secret', 'events', 'active'])]
+class Webhook extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'active' => 'boolean',
+            'events' => 'array',
+        ];
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    public function listensFor(string $event): bool
+    {
+        return in_array($event, $this->events ?? [], true);
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['webhook_id', 'event', 'payload', 'response_code', 'attempts', 'next_retry_at', 'delivered_at'])]
+class WebhookDelivery extends Model
+{
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'next_retry_at' => 'datetime',
+            'delivered_at' => 'datetime',
+        ];
+    }
+
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+
+    public function delivered(): bool
+    {
+        return $this->delivered_at !== null;
+    }
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use JsonException;
+
+class WebhookDispatcher
+{
+    /**
+     * @return array<int, WebhookDelivery>
+     */
+    public function dispatch(string $event, array $payload): array
+    {
+        return Webhook::query()
+            ->where('active', true)
+            ->get()
+            ->filter(fn (Webhook $webhook): bool => $webhook->listensFor($event))
+            ->map(function (Webhook $webhook) use ($event, $payload): WebhookDelivery {
+                $delivery = $webhook->deliveries()->create([
+                    'event' => $event,
+                    'payload' => $payload,
+                ]);
+
+                DispatchWebhookJob::dispatch($delivery->id);
+
+                return $delivery;
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @throws ConnectionException
+     * @throws JsonException
+     */
+    public function deliver(WebhookDelivery $delivery): bool
+    {
+        $delivery->loadMissing('webhook');
+
+        $body = $this->jsonBody($delivery->payload);
+        $attempt = $delivery->attempts + 1;
+
+        try {
+            $response = Http::withBody($body, 'application/json')
+                ->withHeaders([
+                    'X-Webhook-Event' => $delivery->event,
+                    'X-Webhook-Delivery' => (string) $delivery->id,
+                    'X-Webhook-Signature' => $this->signature($body, $delivery->webhook->secret),
+                ])
+                ->timeout(10)
+                ->post($delivery->webhook->url);
+        } catch (ConnectionException $exception) {
+            $this->markFailedAttempt($delivery, $attempt);
+
+            throw $exception;
+        }
+
+        if ($response->successful()) {
+            $delivery->forceFill([
+                'attempts' => $attempt,
+                'response_code' => $response->status(),
+                'next_retry_at' => null,
+                'delivered_at' => now(),
+            ])->save();
+
+            return true;
+        }
+
+        $this->markFailedAttempt($delivery, $attempt, $response->status());
+
+        return false;
+    }
+
+    public function signature(string $body, string $secret): string
+    {
+        return 'sha256='.hash_hmac('sha256', $body, $secret);
+    }
+
+    public function signatureIsValid(string $body, string $secret, string $signature): bool
+    {
+        return hash_equals($this->signature($body, $secret), $signature);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function jsonBody(array $payload): string
+    {
+        return json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+
+    public function nextRetryAt(int $attempt): Carbon
+    {
+        return now()->addSeconds($this->retryDelay($attempt));
+    }
+
+    public function retryDelay(int $attempt): int
+    {
+        return match ($attempt) {
+            1 => 60,
+            2 => 300,
+            3 => 900,
+            default => 1800,
+        };
+    }
+
+    private function markFailedAttempt(WebhookDelivery $delivery, int $attempt, ?int $status = null): void
+    {
+        $delivery->forceFill([
+            'attempts' => $attempt,
+            'response_code' => $status,
+            'next_retry_at' => $this->nextRetryAt($attempt),
+            'delivered_at' => null,
+        ])->save();
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2026_05_27_000000_create_webhooks_table.php
+++ b/laravel/database/migrations/2026_05_27_000000_create_webhooks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table): void {
+            $table->id();
+            $table->string('url', 2048);
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/database/migrations/2026_05_27_000001_create_webhook_deliveries_table.php
+++ b/laravel/database/migrations/2026_05_27_000001_create_webhook_deliveries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event');
+            $table->json('payload');
+            $table->unsignedSmallInteger('response_code')->nullable();
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['webhook_id', 'event']);
+            $table->index('next_retry_at');
+            $table->index('delivered_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\WebhookController;
+use Illuminate\Support\Facades\Route;
+
+Route::apiResource('webhooks', WebhookController::class);

--- a/laravel/tests/Feature/WebhookControllerTest.php
+++ b/laravel/tests/Feature/WebhookControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Webhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebhookControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_webhook_can_be_created_and_listed(): void
+    {
+        $payload = [
+            'url' => 'https://example.com/webhooks/orders',
+            'secret' => 'super-secret-signing-key',
+            'events' => ['order.created', 'order.updated'],
+            'active' => true,
+        ];
+
+        $this->postJson('/api/webhooks', $payload)
+            ->assertCreated()
+            ->assertJsonPath('data.url', $payload['url'])
+            ->assertJsonPath('data.events.0', 'order.created');
+
+        $this->getJson('/api/webhooks')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.active', true);
+
+        $this->assertDatabaseHas('webhooks', [
+            'url' => $payload['url'],
+            'active' => true,
+        ]);
+    }
+
+    public function test_webhook_can_be_updated_and_deleted(): void
+    {
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/old',
+            'secret' => 'super-secret-signing-key',
+            'events' => ['order.created'],
+            'active' => true,
+        ]);
+
+        $this->patchJson("/api/webhooks/{$webhook->id}", [
+            'active' => false,
+            'events' => ['order.cancelled'],
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.active', false)
+            ->assertJsonPath('data.events.0', 'order.cancelled');
+
+        $this->deleteJson("/api/webhooks/{$webhook->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('webhooks', [
+            'id' => $webhook->id,
+        ]);
+    }
+
+    public function test_webhook_validation_rejects_bad_input(): void
+    {
+        $this->postJson('/api/webhooks', [
+            'url' => 'not-a-url',
+            'secret' => 'short',
+            'events' => [],
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['url', 'secret', 'events']);
+    }
+}

--- a/laravel/tests/Feature/WebhookDispatcherTest.php
+++ b/laravel/tests/Feature/WebhookDispatcherTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+use Tests\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dispatch_creates_delivery_only_for_matching_active_webhooks(): void
+    {
+        Queue::fake();
+
+        $matching = Webhook::query()->create([
+            'url' => 'https://example.com/matching',
+            'secret' => 'super-secret-signing-key',
+            'events' => ['order.created'],
+            'active' => true,
+        ]);
+
+        Webhook::query()->create([
+            'url' => 'https://example.com/inactive',
+            'secret' => 'super-secret-signing-key',
+            'events' => ['order.created'],
+            'active' => false,
+        ]);
+
+        Webhook::query()->create([
+            'url' => 'https://example.com/other-event',
+            'secret' => 'super-secret-signing-key',
+            'events' => ['order.cancelled'],
+            'active' => true,
+        ]);
+
+        $deliveries = app(WebhookDispatcher::class)->dispatch('order.created', [
+            'order_id' => 123,
+        ]);
+
+        $this->assertCount(1, $deliveries);
+        $this->assertSame($matching->id, $deliveries[0]->webhook_id);
+
+        Queue::assertPushed(DispatchWebhookJob::class, fn (DispatchWebhookJob $job): bool => $job->deliveryId === $deliveries[0]->id);
+    }
+
+    public function test_deliver_sends_signed_json_and_marks_success(): void
+    {
+        Http::fake([
+            'example.com/*' => Http::response(['ok' => true], 202),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhook',
+            'secret' => 'super-secret-signing-key',
+            'events' => ['order.created'],
+            'active' => true,
+        ]);
+
+        $delivery = WebhookDelivery::query()->create([
+            'webhook_id' => $webhook->id,
+            'event' => 'order.created',
+            'payload' => ['order_id' => 123, 'total' => '49.00'],
+        ]);
+
+        $dispatcher = app(WebhookDispatcher::class);
+
+        $this->assertTrue($dispatcher->deliver($delivery));
+
+        Http::assertSent(function ($request) use ($dispatcher, $webhook): bool {
+            $body = $request->body();
+
+            return $request->url() === 'https://example.com/webhook'
+                && $request->method() === 'POST'
+                && $request->header('X-Webhook-Event')[0] === 'order.created'
+                && $request->header('X-Webhook-Signature')[0] === $dispatcher->signature($body, $webhook->secret);
+        });
+
+        $delivery->refresh();
+
+        $this->assertSame(1, $delivery->attempts);
+        $this->assertSame(202, $delivery->response_code);
+        $this->assertNotNull($delivery->delivered_at);
+        $this->assertNull($delivery->next_retry_at);
+    }
+
+    public function test_failed_delivery_records_attempt_and_job_retries(): void
+    {
+        Http::fake([
+            'example.com/*' => Http::response(['error' => true], 500),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhook',
+            'secret' => 'super-secret-signing-key',
+            'events' => ['order.created'],
+            'active' => true,
+        ]);
+
+        $delivery = WebhookDelivery::query()->create([
+            'webhook_id' => $webhook->id,
+            'event' => 'order.created',
+            'payload' => ['order_id' => 123],
+        ]);
+
+        try {
+            (new DispatchWebhookJob($delivery->id))->handle(app(WebhookDispatcher::class));
+            $this->fail('Expected failed webhook delivery to trigger a retry exception.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('failed', $exception->getMessage());
+        }
+
+        $delivery->refresh();
+
+        $this->assertSame(1, $delivery->attempts);
+        $this->assertSame(500, $delivery->response_code);
+        $this->assertNull($delivery->delivered_at);
+        $this->assertNotNull($delivery->next_retry_at);
+    }
+}

--- a/laravel/tests/Unit/WebhookDispatcherTest.php
+++ b/laravel/tests/Unit/WebhookDispatcherTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Services\WebhookDispatcher;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    public function test_signature_uses_hmac_sha256_prefix(): void
+    {
+        $dispatcher = new WebhookDispatcher;
+        $body = '{"order_id":123}';
+        $secret = 'super-secret-signing-key';
+
+        $signature = $dispatcher->signature($body, $secret);
+
+        $this->assertSame('sha256='.hash_hmac('sha256', $body, $secret), $signature);
+        $this->assertTrue($dispatcher->signatureIsValid($body, $secret, $signature));
+        $this->assertFalse($dispatcher->signatureIsValid($body, $secret, 'sha256=bad'));
+    }
+
+    public function test_json_body_preserves_unescaped_slashes(): void
+    {
+        $body = (new WebhookDispatcher)->jsonBody([
+            'url' => 'https://example.com/orders/123',
+        ]);
+
+        $this->assertSame('{"url":"https://example.com/orders/123"}', $body);
+    }
+
+    public function test_retry_delays_match_exponential_backoff_schedule(): void
+    {
+        $dispatcher = new WebhookDispatcher;
+
+        $this->assertSame(60, $dispatcher->retryDelay(1));
+        $this->assertSame(300, $dispatcher->retryDelay(2));
+        $this->assertSame(900, $dispatcher->retryDelay(3));
+        $this->assertSame(1800, $dispatcher->retryDelay(4));
+        $this->assertSame(1800, $dispatcher->retryDelay(5));
+    }
+
+    public function test_next_retry_at_uses_attempt_delay(): void
+    {
+        Carbon::setTestNow('2026-05-27 12:00:00');
+
+        $nextRetryAt = (new WebhookDispatcher)->nextRetryAt(2);
+
+        $this->assertTrue($nextRetryAt->equalTo(Carbon::parse('2026-05-27 12:05:00')));
+
+        Carbon::setTestNow();
+    }
+
+    public function test_job_retry_configuration_is_explicit(): void
+    {
+        $job = new DispatchWebhookJob(123);
+
+        $this->assertSame(5, $job->tries);
+        $this->assertSame([60, 300, 900, 1800], $job->backoff());
+    }
+}


### PR DESCRIPTION
/claim #754

## Summary
- Add Webhook and WebhookDelivery models, migrations, and relationships
- Add API CRUD routes/controllers for webhook registration and management
- Add WebhookDispatcher for exact JSON-body HMAC-SHA256 signing, delivery records, response codes, attempt counts, and retry scheduling
- Add DispatchWebhookJob with explicit five-attempt retry behavior and exponential backoff
- Add focused feature/unit tests for CRUD, matching active events, signed delivery, failure retry state, signature validation, and retry timing

## Validation
- Exa-checked current Laravel 13 docs for API routing, apiResource controllers, request validation, HTTP client raw bodies/fakes/assertions, queue handle dependency injection, tries/backoff, and Eloquent Fillable/casts/relationships
- `php artisan test --filter=Webhook` -> 11 passed, 44 assertions
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test` -> 13 passed, 46 assertions
- `./vendor/bin/pint --test` -> passed
- `find app routes database tests -name '*.php' -print0 | xargs -0 -n1 php -l` -> no syntax errors\n- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan route:list --path=api/webhooks` -> shows index/store/show/update/destroy routes\n- `git diff --cached --check` -> clean before commit\n\n## Safety note\nThe required attribution file is included with safe, non-sensitive public context only. I did not disclose private system, developer, runtime, or user instructions.\n