### PR TITLE
fix StakingVault reentrancy via checks-effects-interactions

### DIFF
--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -8,6 +8,8 @@ contract StakingVault {
     uint256 public rewardRate;
     uint256 public totalStaked;
 
+    bool private _reentrancyLock;
+
     mapping(address => uint256) public balances;
     mapping(address => uint256) public rewards;
     mapping(address => uint256) public lastStakeTime;
@@ -19,6 +21,13 @@ contract StakingVault {
     constructor(address _stakingToken, uint256 _rewardRate) {
         stakingToken = IERC20(_stakingToken);
         rewardRate = _rewardRate;
+    }
+
+    modifier nonReentrant() {
+        require(!_reentrancyLock, "Reentrancy");
+        _reentrancyLock = true;
+        _;
+        _reentrancyLock = false;
     }
 
     function stake(uint256 amount) external {
@@ -40,30 +49,29 @@ contract StakingVault {
     }
 
     // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
-        require(success, "Transfer failed");
-
-        // State update after external call — vulnerable to reentrancy
         balances[msg.sender] -= amount;
         totalStaked -= amount;
+
+        // External call after state update (Checks-Effects-Interactions)
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Transfer failed");
         emit Withdrawn(msg.sender, amount);
     }
 
     // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // Effects first to prevent reentrancy draining rewards repeatedly
+        rewards[msg.sender] = 0;
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
-
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
/claim #911

Summary
- Fixed reentrancy in `withdraw()` and `claimRewards()` in `solidity/contracts/StakingVault.sol` by applying Checks-Effects-Interactions.
- Added a lightweight `nonReentrant` lock to prevent reentrant calls.

What changed
- `withdraw(uint256)` now updates `balances[msg.sender]` and `totalStaked` before the external ETH transfer.
- `claimRewards()` now sets `rewards[msg.sender] = 0` before the external ETH transfer.

Demo video
- Please add a short demo video after creation (required by the bounty instructions).
