### PR TITLE
OpenAI Codex [ Laravel ] Implement file upload system with checksum dedup and thumbnails

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Private runtime instructions were not disclosed. Implementation followed the public GitHub issue requirements and Laravel/PHP documentation.",
+  "date": "2026-05-27T00:00:00-04:00"
+}

--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File as StoredFile;
+use App\Services\ThumbnailGenerator;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class FileController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(
+            StoredFile::query()->latest()->paginate(20)
+        );
+    }
+
+    public function upload(Request $request, ThumbnailGenerator $thumbnails): JsonResponse
+    {
+        $validated = $request->validate([
+            'file' => ['required', 'file', 'max:10240'],
+        ]);
+
+        $upload = $validated['file'];
+        $contents = $upload->get();
+        $checksum = hash('sha256', $contents);
+
+        if (StoredFile::query()->where('checksum_sha256', $checksum)->exists()) {
+            return response()->json([
+                'message' => 'A file with this checksum already exists.',
+                'checksum_sha256' => $checksum,
+            ], 409);
+        }
+
+        $datePath = now()->format('Y/m/d');
+        $extension = $upload->guessExtension() ?: $upload->getClientOriginalExtension() ?: 'bin';
+        $storedPath = "uploads/{$datePath}/{$checksum}.{$extension}";
+        $mimeType = $upload->getMimeType() ?: 'application/octet-stream';
+        $thumbnailPath = null;
+
+        Storage::disk('uploads')->put($storedPath, $contents);
+
+        if (Str::startsWith($mimeType, 'image/')) {
+            $thumbnailPath = $thumbnails->generate(
+                $contents,
+                "thumbnails/{$datePath}/{$checksum}.png"
+            );
+        }
+
+        $file = StoredFile::query()->create([
+            'original_name' => $upload->getClientOriginalName(),
+            'stored_path' => $storedPath,
+            'mime_type' => $mimeType,
+            'size_bytes' => $upload->getSize(),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => $request->user()?->id,
+            'thumbnail_path' => $thumbnailPath,
+        ]);
+
+        return response()->json([
+            'data' => $file,
+        ], 201);
+    }
+
+    public function download(StoredFile $file): StreamedResponse
+    {
+        abort_unless(Storage::disk('uploads')->exists($file->stored_path), 404);
+
+        return Storage::disk('uploads')->download(
+            $file->stored_path,
+            $file->original_name,
+            ['Content-Type' => $file->mime_type]
+        );
+    }
+
+    public function destroy(StoredFile $file): JsonResponse
+    {
+        Storage::disk('uploads')->delete($file->stored_path);
+
+        if ($file->thumbnail_path !== null) {
+            Storage::disk('uploads')->delete($file->thumbnail_path);
+        }
+
+        $file->delete();
+
+        return response()->json(status: 204);
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'original_name',
+    'stored_path',
+    'mime_type',
+    'size_bytes',
+    'checksum_sha256',
+    'uploaded_by',
+    'thumbnail_path',
+])]
+class File extends Model
+{
+    use HasFactory;
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by');
+    }
+
+    public function hasThumbnail(): bool
+    {
+        return $this->thumbnail_path !== null;
+    }
+}

--- a/laravel/app/Services/ThumbnailGenerator.php
+++ b/laravel/app/Services/ThumbnailGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Storage;
+
+class ThumbnailGenerator
+{
+    public function generate(string $contents, string $path): ?string
+    {
+        $source = @imagecreatefromstring($contents);
+
+        if ($source === false) {
+            return null;
+        }
+
+        $thumbnail = imagecreatetruecolor(200, 200);
+        imagealphablending($thumbnail, false);
+        imagesavealpha($thumbnail, true);
+
+        $transparent = imagecolorallocatealpha($thumbnail, 0, 0, 0, 127);
+        imagefilledrectangle($thumbnail, 0, 0, 200, 200, $transparent);
+
+        imagecopyresampled(
+            $thumbnail,
+            $source,
+            0,
+            0,
+            0,
+            0,
+            200,
+            200,
+            imagesx($source),
+            imagesy($source)
+        );
+
+        ob_start();
+        imagepng($thumbnail);
+        $thumbnailContents = ob_get_clean();
+
+        imagedestroy($source);
+        imagedestroy($thumbnail);
+
+        if ($thumbnailContents === false) {
+            return null;
+        }
+
+        Storage::disk('uploads')->put($path, $thumbnailContents);
+
+        return $path;
+    }
+}

--- a/laravel/config/filesystems.php
+++ b/laravel/config/filesystems.php
@@ -47,6 +47,13 @@ return [
             'report' => false,
         ],
 
+        'uploads' => [
+            'driver' => 'local',
+            'root' => storage_path('app'),
+            'throw' => false,
+            'report' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/laravel/database/migrations/2026_05_27_000100_create_files_table.php
+++ b/laravel/database/migrations/2026_05_27_000100_create_files_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table): void {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path')->unique();
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size_bytes');
+            $table->string('checksum_sha256', 64)->unique();
+            $table->foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+
+            $table->index('mime_type');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,16 @@
 <?php
 
+use App\Http\Controllers\FileController;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::withoutMiddleware([PreventRequestForgery::class])->group(function (): void {
+    Route::get('/files', [FileController::class, 'index'])->name('files.index');
+    Route::post('/files/upload', [FileController::class, 'upload'])->name('files.upload');
+    Route::get('/files/{file}/download', [FileController::class, 'download'])->name('files.download');
+    Route::delete('/files/{file}', [FileController::class, 'destroy'])->name('files.destroy');
 });

--- a/laravel/tests/Feature/FileControllerTest.php
+++ b/laravel/tests/Feature/FileControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File as StoredFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FileControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_upload_stores_file_and_metadata(): void
+    {
+        Storage::fake('uploads');
+
+        $upload = UploadedFile::fake()->createWithContent('report.txt', 'Quarterly results');
+        $checksum = hash('sha256', 'Quarterly results');
+
+        $this->post('/files/upload', ['file' => $upload])
+            ->assertCreated()
+            ->assertJsonPath('data.original_name', 'report.txt')
+            ->assertJsonPath('data.checksum_sha256', $checksum);
+
+        $file = StoredFile::query()->firstOrFail();
+
+        Storage::disk('uploads')->assertExists($file->stored_path);
+        $this->assertSame('report.txt', $file->original_name);
+        $this->assertSame($checksum, $file->checksum_sha256);
+        $this->assertNull($file->thumbnail_path);
+    }
+
+    public function test_duplicate_checksum_is_rejected(): void
+    {
+        Storage::fake('uploads');
+
+        $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('first.txt', 'same bytes'),
+        ])->assertCreated();
+
+        $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('second.txt', 'same bytes'),
+        ])
+            ->assertConflict()
+            ->assertJsonPath('checksum_sha256', hash('sha256', 'same bytes'));
+
+        $this->assertSame(1, StoredFile::query()->count());
+    }
+
+    public function test_image_upload_generates_200_by_200_thumbnail(): void
+    {
+        Storage::fake('uploads');
+
+        $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->image('photo.jpg', 400, 300),
+        ])->assertCreated();
+
+        $file = StoredFile::query()->firstOrFail();
+
+        $this->assertNotNull($file->thumbnail_path);
+        Storage::disk('uploads')->assertExists($file->thumbnail_path);
+
+        $size = getimagesizefromstring(Storage::disk('uploads')->get($file->thumbnail_path));
+
+        $this->assertSame(200, $size[0]);
+        $this->assertSame(200, $size[1]);
+    }
+
+    public function test_download_streams_file_with_original_name_and_content_type(): void
+    {
+        Storage::fake('uploads');
+
+        $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('manual.txt', 'download me'),
+        ])->assertCreated();
+
+        $file = StoredFile::query()->firstOrFail();
+
+        $this->get("/files/{$file->id}/download")
+            ->assertOk()
+            ->assertHeaderContains('Content-Type', $file->mime_type)
+            ->assertDownload('manual.txt');
+    }
+
+    public function test_delete_removes_file_thumbnail_and_database_record(): void
+    {
+        Storage::fake('uploads');
+
+        $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->image('photo.png', 300, 300),
+        ])->assertCreated();
+
+        $file = StoredFile::query()->firstOrFail();
+
+        $this->delete("/files/{$file->id}")
+            ->assertNoContent();
+
+        Storage::disk('uploads')->assertMissing($file->stored_path);
+        Storage::disk('uploads')->assertMissing($file->thumbnail_path);
+        $this->assertDatabaseMissing('files', ['id' => $file->id]);
+    }
+
+    public function test_list_endpoint_paginates_20_files_per_page(): void
+    {
+        Storage::fake('uploads');
+
+        for ($index = 1; $index <= 21; $index++) {
+            StoredFile::query()->create([
+                'original_name' => "file-{$index}.txt",
+                'stored_path' => "uploads/file-{$index}.txt",
+                'mime_type' => 'text/plain',
+                'size_bytes' => 12,
+                'checksum_sha256' => hash('sha256', "file-{$index}"),
+                'thumbnail_path' => null,
+            ]);
+        }
+
+        $this->get('/files')
+            ->assertOk()
+            ->assertJsonPath('per_page', 20)
+            ->assertJsonCount(20, 'data');
+    }
+}

--- a/laravel/tests/Unit/ThumbnailGeneratorTest.php
+++ b/laravel/tests/Unit/ThumbnailGeneratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ThumbnailGenerator;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ThumbnailGeneratorTest extends TestCase
+{
+    public function test_invalid_image_contents_return_null(): void
+    {
+        Storage::fake('uploads');
+
+        $this->assertNull(
+            (new ThumbnailGenerator)->generate('not an image', 'thumbnails/bad.png')
+        );
+
+        Storage::disk('uploads')->assertMissing('thumbnails/bad.png');
+    }
+
+    public function test_valid_image_contents_are_resampled_to_square_png(): void
+    {
+        Storage::fake('uploads');
+
+        $contents = UploadedFile::fake()->image('wide.jpg', 400, 200)->get();
+
+        $path = (new ThumbnailGenerator)->generate($contents, 'thumbnails/wide.png');
+
+        $this->assertSame('thumbnails/wide.png', $path);
+        Storage::disk('uploads')->assertExists($path);
+
+        $size = getimagesizefromstring(Storage::disk('uploads')->get($path));
+
+        $this->assertSame(200, $size[0]);
+        $this->assertSame(200, $size[1]);
+    }
+}


### PR DESCRIPTION
/claim #790

## Summary
- Add File model, migration, and upload storage disk rooted at `storage/app`
- Add `/files` list, `/files/upload`, `/files/{file}/download`, and `DELETE /files/{file}` routes
- Store uploads under dated `uploads/YYYY/MM/DD` paths and persist original name, path, MIME type, size, checksum, uploader, and thumbnail path
- Reject duplicate SHA-256 checksums with `409 Conflict`
- Generate 200x200 PNG thumbnails for image uploads using GD
- Stream downloads with the original filename and stored MIME type
- Delete stored file, thumbnail, and database record
- Add feature/unit tests for upload metadata, duplicate rejection, thumbnail generation, downloads, deletion, and pagination

## Validation
- Exa-checked current Laravel 13 docs for `Storage::fake`, `UploadedFile::fake`, `Storage::download`, request validation, pagination, route middleware exclusion, and route listing
- Exa-checked PHP GD docs for `imagecreatefromstring` and `imagecopyresampled`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test tests/Feature/FileControllerTest.php tests/Unit/ThumbnailGeneratorTest.php` -> 8 passed, 36 assertions
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test` -> 10 passed, 38 assertions
- `./vendor/bin/pint --test` -> passed
- `find app routes database tests -name '*.php' -print0 | xargs -0 -n1 php -l` -> no syntax errors\n- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan route:list --path=files` -> shows all four requested routes\n- `git diff --check` -> clean before commit\n\n## Scope note\nThe issue intro mentions virus scanning, but the implementation bullets and acceptance criteria do not define a scanner requirement. I checked current Laravel/ClamAV options with Exa; real virus scanning requires ClamAV or a package/runtime dependency, so this PR implements the explicit accepted criteria instead of adding a fake scanner.\n\n## Safety note\nThe requested generation metadata file is included with safe, non-sensitive public context only. I did not disclose private system, developer, runtime, or user instructions.\n