### PR TITLE
fix: define T3 Code turbo build graph

### DIFF
--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,32 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/web#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/client-runtime#build"],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build",
+        "@t3tools/tailscale#build",
+        "@t3tools/web#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/desktop#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "@t3tools/ssh#build",
+        "@t3tools/tailscale#build",
+        "@t3tools/web#build",
+        "t3#build"
+      ],
+      "outputs": ["dist-electron/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
## Summary
- Add package-specific Turbo build graph entries for the T3 Code web, server, and desktop apps.
- Make app builds wait on their required workspace package builds instead of relying only on the generic `^build` relationship.
- Keep outputs scoped to generated `dist/**` / `dist-electron/**` artifacts.

/claim #828

## Test Plan
- `bun run fmt:check -- turbo.json`
- `bun x turbo run build --dry=json`
- `bun run typecheck`
- `bun run lint` (passes with existing warnings only)
- `bun run build`
