### PR TITLE
[ OpenAI Codex for maiarowsky ] [ Laravel ] Fix User model password cast rounds

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,24 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value === null || password_get_info($value)['algoName'] !== 'unknown') {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value, [
+            'rounds' => self::configuredBcryptRounds(),
+        ]);
+    }
+
+    public static function configuredBcryptRounds(): int
+    {
+        return (int) config('hashing.bcrypt.rounds', 12);
     }
 }

--- a/laravel/app/Models/_meta.json
+++ b/laravel/app/Models/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex for maiarowsky",
+  "generation_context": "Public-safe provenance: OpenAI Codex working for GitHub user maiarowsky under private system and developer instructions. Those private instructions cannot be reproduced in a public repository. For this task, Codex inspected issue #745, added a configured bcrypt rounds test, replaced the generic password cast with a mutator, updated the factory, added hashing configuration, and preserved JSON/PHP scope without leaking hidden runtime instructions.",
+  "completed_at": "2026-05-27T19:06:20Z"
+}

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+
+    'argon' => [
+        'memory' => env('ARGON_MEMORY', 65536),
+        'threads' => env('ARGON_THREADS', 1),
+        'time' => env('ARGON_TIME', 4),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+
+    'rehash_on_login' => true,
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,9 +13,11 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
+     * Password hashes cached by configured bcrypt cost.
+     *
+     * @var array<int, string>
      */
-    protected static ?string $password;
+    protected static array $passwords = [];
 
     /**
      * Define the model's default state.
@@ -24,11 +26,15 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $rounds = User::configuredBcryptRounds();
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$passwords[$rounds] ??= Hash::make('password', [
+                'rounds' => $rounds,
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Database\Factories\UserFactory;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_model_hashes_password_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 5]);
+
+        $user = new User;
+        $user->password = 'secret-password';
+
+        $this->assertSame(5, password_get_info($user->password)['options']['cost']);
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+    }
+
+    public function test_user_factory_rehashes_when_configured_bcrypt_rounds_change(): void
+    {
+        config(['hashing.bcrypt.rounds' => 5]);
+        $firstPassword = UserFactory::new()->definition()['password'];
+
+        config(['hashing.bcrypt.rounds' => 6]);
+        $secondPassword = UserFactory::new()->definition()['password'];
+
+        $this->assertSame(5, password_get_info($firstPassword)['options']['cost']);
+        $this->assertSame(6, password_get_info($secondPassword)['options']['cost']);
+    }
+
+    public function test_legacy_bcrypt_passwords_still_verify(): void
+    {
+        $legacyHash = Hash::make('legacy-password', ['rounds' => 4]);
+
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $this->assertTrue(Hash::check('legacy-password', $legacyHash));
+    }
+}


### PR DESCRIPTION
/claim #745

## Summary
- Added `config/hashing.php` so `hashing.bcrypt.rounds` resolves from `BCRYPT_ROUNDS`.
- Replaced the generic `hashed` cast with a `setPasswordAttribute` mutator that uses the configured bcrypt rounds and preserves already-hashed values.
- Updated `UserFactory` to hash generated passwords with the configured rounds, with cache entries keyed by cost.
- Added unit coverage for configured rounds, factory cache behavior, and legacy bcrypt verification.

## Validation
```text
python3 -m json.tool laravel/app/Models/_meta.json
git diff --check
```

I could not run PHPUnit in this local environment because `php` and `composer` are not installed and the Docker daemon is not running. The targeted test added is `laravel/tests/Unit/UserPasswordHashingTest.php`.

## Provenance
I intentionally used public-safe metadata in `_meta.json` and did not paste hidden runtime/system/developer instructions into public files or PR text.