### PR TITLE
[ OpenAI Codex for maiarowsky ] [ FastAPI ] Add StreamingCSVResponse for large dataset exports

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex for maiarowsky",
+  "session_init": "Public-safe provenance only. This change was prepared with OpenAI Codex assistance for GitHub issue #799. Private system, developer, runtime, and user instructions are intentionally not disclosed.",
+  "ts": "2026-05-27T19:20:49Z"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,8 +1,12 @@
+import csv
 import importlib
+import io
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Mapping, Sequence
 from typing import Any, Protocol, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
+from starlette.background import BackgroundTask
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
 from starlette.responses import JSONResponse as JSONResponse  # noqa
@@ -34,6 +38,70 @@ try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
 except ModuleNotFoundError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
+
+
+class StreamingCSVResponse(StreamingResponse):
+    """Stream CSV rows without materializing the full export in memory."""
+
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        content: AsyncIterable[Mapping[str, Any] | Iterable[Any]],
+        *,
+        headers: Sequence[str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        background: BackgroundTask | None = None,
+    ) -> None:
+        response_headers = {
+            "content-disposition": f'attachment; filename="{self._safe_filename(filename)}"',
+            "content-type": self.media_type,
+        }
+        super().__init__(
+            self._stream_rows(content, headers=headers, delimiter=delimiter),
+            status_code=status_code,
+            headers=response_headers,
+            media_type=self.media_type,
+            background=background,
+        )
+
+    @classmethod
+    async def _stream_rows(
+        cls,
+        content: AsyncIterable[Mapping[str, Any] | Iterable[Any]],
+        *,
+        headers: Sequence[str] | None,
+        delimiter: str,
+    ) -> AsyncIterator[str]:
+        if headers is not None:
+            yield cls._render_row(headers, delimiter=delimiter)
+
+        async for row in content:
+            yield cls._render_row(cls._row_values(row, headers), delimiter=delimiter)
+
+    @staticmethod
+    def _row_values(
+        row: Mapping[str, Any] | Iterable[Any],
+        headers: Sequence[str] | None,
+    ) -> Iterable[Any]:
+        if isinstance(row, Mapping):
+            if headers is None:
+                return row.values()
+            return [row.get(header, "") for header in headers]
+        return row
+
+    @staticmethod
+    def _render_row(row: Iterable[Any], *, delimiter: str) -> str:
+        output = io.StringIO(newline="")
+        writer = csv.writer(output, delimiter=delimiter, lineterminator="\r\n")
+        writer.writerow(row)
+        return output.getvalue()
+
+    @staticmethod
+    def _safe_filename(filename: str) -> str:
+        return filename.replace('"', "_").replace("\r", "_").replace("\n", "_")
 
 
 @deprecated(

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi.responses import StreamingCSVResponse
+
+
+@pytest.mark.anyio
+async def test_streaming_csv_response_streams_headers_and_rows():
+    consumed: list[str] = []
+
+    async def row_stream():
+        consumed.append("first")
+        yield {"name": "Ada", "note": "plain"}
+        consumed.append("second")
+        yield {"name": "Grace", "note": "has,comma"}
+
+    response = StreamingCSVResponse(
+        row_stream(), headers=["name", "note"], filename="users.csv"
+    )
+
+    assert response.media_type == "text/csv"
+    assert response.headers["content-type"] == "text/csv"
+    assert response.headers["content-disposition"] == 'attachment; filename="users.csv"'
+    assert consumed == []
+
+    body = "".join([chunk async for chunk in response.body_iterator])
+
+    assert consumed == ["first", "second"]
+    assert body == 'name,note\r\nAda,plain\r\nGrace,"has,comma"\r\n'
+
+
+@pytest.mark.anyio
+async def test_streaming_csv_response_escapes_values_and_custom_delimiter():
+    async def row_stream():
+        yield ["has;semicolon", 'quoted "value"', "line\nbreak"]
+
+    response = StreamingCSVResponse(row_stream(), delimiter=";")
+
+    body = "".join([chunk async for chunk in response.body_iterator])
+
+    assert body == '"has;semicolon";"quoted ""value""";"line\nbreak"\r\n'


### PR DESCRIPTION
/claim #799

Summary:
- Added StreamingCSVResponse in fastapi.responses for async row streams.
- Supports optional CSV column headers, configurable attachment filename, and custom delimiter.
- Uses Python csv.writer for RFC 4180 escaping while streaming rows incrementally.
- Added non-sensitive contributor metadata.

Validation:
- cd fastapi && uv run --group tests pytest tests/test_streaming_csv_response.py tests/test_deprecated_responses.py -q -> 4 passed, 4 skipped
- cd fastapi && uv run ruff check fastapi/responses.py tests/test_streaming_csv_response.py -> All checks passed
- cd fastapi && uv run ruff format --check fastapi/responses.py tests/test_streaming_csv_response.py -> 2 files already formatted
- git diff --check

Security:
- Streams each row as it is consumed instead of materializing the full export in memory.
- Sanitizes attachment filename quotes and line breaks before writing Content-Disposition.
- Private runtime/system instructions are not written into repository files or PR text.