### PR TITLE
OpenAI Codex [ T3 Code ] Add desktop backend health recovery

### DIFF
--- a/t3code/apps/desktop/_provenance.json
+++ b/t3code/apps/desktop/_provenance.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Non-sensitive provenance only. Private system, developer, runtime, and session instructions are intentionally not copied into repository files.",
+  "timestamp": "2026-05-27T20:25:00Z",
+  "scope": "Issue #820 backend health monitoring and automatic recovery"
+}

--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -23,6 +23,7 @@ import * as DesktopBackendManager from "./DesktopBackendManager.ts";
 import * as DesktopBackendConfiguration from "./DesktopBackendConfiguration.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const decodeDesktopBackendBootstrap = Schema.decodeEffect(
@@ -123,6 +124,22 @@ function makeManagerLayer(input: {
         input.desktopState
           ? Layer.succeed(DesktopState.DesktopState, input.desktopState)
           : DesktopState.layer,
+        Layer.succeed(ElectronApp.ElectronApp, {
+          metadata: Effect.die("unexpected metadata read"),
+          name: Effect.succeed("T3 Code"),
+          whenReady: Effect.void,
+          quit: Effect.void,
+          exit: () => Effect.void,
+          relaunch: () => Effect.void,
+          setPath: () => Effect.void,
+          setName: () => Effect.void,
+          setAboutPanelOptions: () => Effect.void,
+          setAppUserModelId: () => Effect.void,
+          setDesktopName: () => Effect.void,
+          setDockIcon: () => Effect.void,
+          appendCommandLineSwitch: () => Effect.void,
+          on: () => Effect.void,
+        } satisfies ElectronApp.ElectronAppShape),
         Layer.succeed(DesktopObservability.DesktopBackendOutputLog, {
           writeSessionBoundary: () => Effect.void,
           writeOutputChunk: () => Effect.void,
@@ -135,6 +152,8 @@ function makeManagerLayer(input: {
           activate: Effect.void,
           createMainIfBackendReady: Effect.void,
           handleBackendReady: Effect.void,
+          notifyBackendRestarting: Effect.void,
+          promptBackendRecoveryFailed: () => Effect.succeed("retry"),
           dispatchMenuAction: () => Effect.void,
           syncAppearance: Effect.void,
           ...input.desktopWindow,
@@ -488,6 +507,123 @@ describe("DesktopBackendManager", () => {
 
         assert.equal(yield* Queue.size(starts), 0);
         assert.equal((yield* manager.snapshot).desiredRunning, false);
+      }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
+    }),
+  );
+
+  it.effect("restarts the active backend after three failed health checks", () =>
+    Effect.gen(function* () {
+      const starts = yield* Queue.unbounded<number>();
+      const closed = yield* Queue.unbounded<number>();
+      const statuses = [200, 500, 500, 500, 200];
+      let startCount = 0;
+      let notificationCount = 0;
+
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.gen(function* () {
+            const scope = yield* Scope.Scope;
+            const exit = yield* Deferred.make<void>();
+            startCount += 1;
+            const currentStart = startCount;
+            yield* Queue.offer(starts, currentStart);
+            const close = Queue.offer(closed, currentStart).pipe(
+              Effect.andThen(Deferred.succeed(exit, void 0)),
+              Effect.asVoid,
+            );
+            yield* Scope.addFinalizer(scope, close);
+
+            return makeProcess({
+              exitCode: Deferred.await(exit).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
+              kill: () => close,
+            });
+          }),
+        ),
+      );
+
+      const managerLayer = makeManagerLayer({
+        spawnerLayer,
+        httpClientLayer: httpClientLayer((request) =>
+          Effect.sync(() => {
+            const status = statuses.shift();
+            assert.isDefined(status);
+            return responseForRequest(request, status);
+          }),
+        ),
+        desktopWindow: {
+          notifyBackendRestarting: Effect.sync(() => {
+            notificationCount += 1;
+          }),
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const manager = yield* DesktopBackendManager.DesktopBackendManager;
+        yield* manager.start;
+        assert.equal(yield* Queue.take(starts), 1);
+
+        yield* TestClock.adjust(Duration.seconds(60));
+        assert.equal(yield* Queue.take(closed), 1);
+        assert.equal(notificationCount, 1);
+        assert.isFalse((yield* manager.snapshot).ready);
+
+        yield* TestClock.adjust(Duration.millis(500));
+        assert.equal(yield* Queue.take(starts), 2);
+      }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
+    }),
+  );
+
+  it.effect("prompts for retry or quit after the automatic restart limit is reached", () =>
+    Effect.gen(function* () {
+      const starts = yield* Queue.unbounded<number>();
+      const prompted = yield* Queue.unbounded<void>();
+      let startCount = 0;
+      const backendReady = yield* Ref.make(false);
+      const quitting = yield* Ref.make(false);
+
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.sync(() => {
+            startCount += 1;
+            return makeProcess({
+              exitCode: Queue.offer(starts, startCount).pipe(
+                Effect.as(ChildProcessSpawner.ExitCode(1)),
+              ),
+            });
+          }),
+        ),
+      );
+
+      const managerLayer = makeManagerLayer({
+        spawnerLayer,
+        httpClientLayer: httpClientLayer(() => Effect.never),
+        desktopState: {
+          backendReady,
+          quitting,
+        },
+        desktopWindow: {
+          promptBackendRecoveryFailed: () =>
+            Queue.offer(prompted, void 0).pipe(Effect.as("quit" as const)),
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const manager = yield* DesktopBackendManager.DesktopBackendManager;
+        yield* manager.start;
+        assert.equal(yield* Queue.take(starts), 1);
+
+        yield* TestClock.adjust(Duration.millis(500));
+        assert.equal(yield* Queue.take(starts), 2);
+        yield* TestClock.adjust(Duration.seconds(1));
+        assert.equal(yield* Queue.take(starts), 3);
+        yield* TestClock.adjust(Duration.seconds(2));
+        assert.equal(yield* Queue.take(starts), 4);
+
+        yield* Queue.take(prompted);
+        assert.isFalse((yield* manager.snapshot).desiredRunning);
+        assert.isTrue(yield* Ref.get(quitting));
       }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
     }),
   );

--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -27,6 +27,7 @@ import {
 import * as DesktopBackendConfiguration from "./DesktopBackendConfiguration.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const INITIAL_RESTART_DELAY = Duration.millis(500);
@@ -35,6 +36,10 @@ const DEFAULT_BACKEND_READINESS_TIMEOUT = Duration.minutes(1);
 const DEFAULT_BACKEND_READINESS_INTERVAL = Duration.millis(100);
 const DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT = Duration.seconds(1);
 const DEFAULT_BACKEND_TERMINATE_GRACE = Duration.seconds(2);
+const DEFAULT_BACKEND_HEALTH_INTERVAL = Duration.seconds(15);
+const DEFAULT_BACKEND_HEALTH_REQUEST_TIMEOUT = Duration.seconds(1);
+const MAX_BACKEND_HEALTH_FAILURES = 3;
+const MAX_BACKEND_AUTOMATIC_RESTARTS = 3;
 const BACKEND_READINESS_PATH = "/.well-known/t3/environment";
 
 type BackendProcessLayerServices = ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient;
@@ -85,6 +90,15 @@ class BackendProcessSpawnError extends Data.TaggedError("BackendProcessSpawnErro
   }
 }
 
+class BackendHealthCheckError extends Data.TaggedError("BackendHealthCheckError")<{
+  readonly url: URL;
+  readonly cause: unknown;
+}> {
+  override get message() {
+    return `Backend health check failed at ${this.url.href}.`;
+  }
+}
+
 type BackendProcessError = BackendProcessBootstrapEncodeError | BackendProcessSpawnError;
 
 interface RunBackendProcessOptions extends DesktopBackendStartConfig {
@@ -125,6 +139,7 @@ interface ActiveBackendRun {
   readonly id: number;
   readonly scope: Scope.Closeable;
   readonly fiber: Option.Option<Fiber.Fiber<void, never>>;
+  readonly healthFiber: Option.Option<Fiber.Fiber<void, never>>;
   readonly pid: Option.Option<number>;
 }
 
@@ -165,16 +180,42 @@ const closeRun = (
   run: ActiveBackendRun,
   options?: { readonly timeout?: Duration.Duration },
 ): Effect.Effect<void> => {
+  const interruptHealth = Option.match(run.healthFiber, {
+    onNone: () => Effect.void,
+    onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
+  });
   const waitForFiber = Option.match(run.fiber, {
     onNone: () => Effect.void,
     onSome: (fiber) => Fiber.await(fiber).pipe(Effect.asVoid),
   });
-  const close = Scope.close(run.scope, Exit.void).pipe(Effect.andThen(waitForFiber));
+  const close = interruptHealth.pipe(
+    Effect.andThen(Scope.close(run.scope, Exit.void)),
+    Effect.andThen(waitForFiber),
+  );
 
   return (
     options?.timeout ? close.pipe(Effect.timeoutOption(options.timeout), Effect.asVoid) : close
   ).pipe(Effect.ignore);
 };
+
+const checkHttpHealth = Effect.fn("desktop.backendManager.checkHttpHealth")(function* (
+  baseUrl: URL,
+): Effect.fn.Return<void, BackendHealthCheckError, HttpClient.HttpClient> {
+  const readinessUrl = new URL(BACKEND_READINESS_PATH, baseUrl);
+  const client = (yield* HttpClient.HttpClient).pipe(
+    HttpClient.filterStatusOk,
+    HttpClient.transformResponse(Effect.timeout(DEFAULT_BACKEND_HEALTH_REQUEST_TIMEOUT)),
+  );
+
+  yield* client.get(readinessUrl).pipe(
+    Effect.asVoid,
+    Effect.mapError((cause) => new BackendHealthCheckError({ url: readinessUrl, cause })),
+  );
+});
+
+const backendHealthSchedule = Schedule.spaced(DEFAULT_BACKEND_HEALTH_INTERVAL).pipe(
+  Schedule.jittered,
+);
 
 const waitForHttpReady = Effect.fn("desktop.backendManager.waitForHttpReady")(function* (
   baseUrl: URL,
@@ -283,6 +324,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
   const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
   const backendOutputLog = yield* DesktopObservability.DesktopBackendOutputLog;
   const desktopState = yield* DesktopState.DesktopState;
+  const electronApp = yield* ElectronApp.ElectronApp;
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
@@ -318,6 +360,132 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
       onNone: () => Effect.void,
       onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
     });
+  });
+
+  const handleRestartLimitReached = Effect.fn("desktop.backendManager.handleRestartLimitReached")(
+    function* (reason: string) {
+      yield* logBackendManagerError("desktop backend automatic restart limit reached", {
+        reason,
+        attempts: MAX_BACKEND_AUTOMATIC_RESTARTS,
+      });
+
+      const decision = yield* desktopWindow.promptBackendRecoveryFailed({
+        attempts: MAX_BACKEND_AUTOMATIC_RESTARTS,
+        reason,
+      });
+
+      yield* Ref.update(state, (latest) => ({
+        ...latest,
+        restartFiber: Option.none(),
+      }));
+
+      if (decision === "retry") {
+        yield* Ref.update(state, (latest) => ({
+          ...latest,
+          desiredRunning: true,
+          restartAttempt: 0,
+        }));
+        yield* start;
+        return;
+      }
+
+      yield* Ref.update(state, (latest) => ({
+        ...latest,
+        desiredRunning: false,
+        ready: false,
+        active: Option.none(),
+        restartAttempt: 0,
+        restartFiber: Option.none(),
+      }));
+      yield* Ref.set(desktopState.backendReady, false);
+      yield* Ref.set(desktopState.quitting, true);
+      yield* electronApp.quit;
+    },
+  );
+
+  const restartActiveRun = Effect.fn("desktop.backendManager.restartActiveRun")(function* (
+    runId: number,
+    reason: string,
+  ) {
+    const run = yield* mutex.withPermits(1)(
+      Ref.modify(state, (latest) => {
+        const currentRun = Option.getOrUndefined(latest.active);
+        if (currentRun?.id !== runId || !latest.desiredRunning) {
+          return [Option.none<ActiveBackendRun>(), latest] as const;
+        }
+
+        return [
+          Option.some(currentRun),
+          {
+            ...latest,
+            active: Option.none<ActiveBackendRun>(),
+            ready: false,
+          },
+        ] as const;
+      }),
+    );
+
+    yield* Option.match(run, {
+      onNone: () => Effect.void,
+      onSome: Effect.fn("desktop.backendManager.restartCurrentRun")(function* (currentRun) {
+        yield* logBackendManagerError("backend health monitor restarting unresponsive backend", {
+          reason,
+        });
+        yield* desktopWindow.notifyBackendRestarting;
+        if (Option.isSome(currentRun.pid)) {
+          yield* backendOutputLog.writeSessionBoundary({
+            phase: "END",
+            details: `pid=${currentRun.pid.value} ${reason}`,
+          });
+        }
+        yield* Ref.set(desktopState.backendReady, false);
+        yield* closeRun(currentRun);
+        yield* scheduleRestart(reason);
+      }),
+    });
+  });
+
+  const monitorBackendHealth = Effect.fn("desktop.backendManager.monitorBackendHealth")(function* (
+    runId: number,
+    config: DesktopBackendStartConfig,
+  ) {
+    const consecutiveFailures = yield* Ref.make(0);
+    yield* Effect.sleep(DEFAULT_BACKEND_HEALTH_INTERVAL);
+
+    const probe = Effect.gen(function* () {
+      const failureCount = yield* checkHttpHealth(config.httpBaseUrl).pipe(
+        Effect.tap(() => Ref.set(consecutiveFailures, 0)),
+        Effect.as(0),
+        Effect.catchCause((cause) =>
+          Ref.updateAndGet(consecutiveFailures, (count) => count + 1).pipe(
+            Effect.tap((count) =>
+              logBackendManagerWarning("backend health check failed", {
+                runId,
+                consecutiveFailures: count,
+                maxFailures: MAX_BACKEND_HEALTH_FAILURES,
+                cause: Cause.pretty(cause),
+              }),
+            ),
+          ),
+        ),
+      );
+
+      if (failureCount >= MAX_BACKEND_HEALTH_FAILURES) {
+        yield* Effect.forkIn(
+          restartActiveRun(runId, `health check failed ${failureCount} consecutive times`).pipe(
+            Effect.catchCause((cause) =>
+              logBackendManagerError("backend health restart failed", {
+                cause: Cause.pretty(cause),
+              }),
+            ),
+          ),
+          parentScope,
+        );
+        return;
+      }
+    });
+
+    yield* probe.pipe(Effect.repeat(backendHealthSchedule), Effect.asVoid);
   });
 
   const start: Effect.Effect<void> = Effect.suspend(() =>
@@ -356,6 +524,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
               id: latest.nextRunId,
               scope: runScope,
               fiber: Option.none(),
+              healthFiber: Option.none(),
               pid: Option.none(),
             } satisfies ActiveBackendRun),
             nextRunId: latest.nextRunId + 1,
@@ -464,6 +633,21 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                 }),
               ),
             );
+            const healthFiber = yield* Effect.forkIn(
+              monitorBackendHealth(runId, config).pipe(
+                Effect.provideService(HttpClient.HttpClient, httpClient),
+                Effect.catchCause((cause) =>
+                  logBackendManagerError("desktop backend health monitor failed", {
+                    cause: Cause.pretty(cause),
+                  }),
+                ),
+              ),
+              parentScope,
+            );
+            yield* updateActiveRun(runId, (run) => ({
+              ...run,
+              healthFiber: Option.some(healthFiber),
+            }));
           }),
           onReadinessFailure: (error) =>
             logBackendManagerWarning("backend readiness check failed during bootstrap", {
@@ -495,12 +679,22 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
   ) {
     const scheduled = yield* Ref.modify(state, (latest) => {
       if (!latest.desiredRunning || Option.isSome(latest.restartFiber)) {
-        return [Option.none<Duration.Duration>(), latest] as const;
+        return [
+          Option.none<
+            | { readonly _tag: "delay"; readonly delay: Duration.Duration }
+            | { readonly _tag: "limit" }
+          >(),
+          latest,
+        ] as const;
+      }
+
+      if (latest.restartAttempt >= MAX_BACKEND_AUTOMATIC_RESTARTS) {
+        return [Option.some({ _tag: "limit" as const }), latest] as const;
       }
 
       const delay = calculateRestartDelay(latest.restartAttempt);
       return [
-        Option.some(delay),
+        Option.some({ _tag: "delay" as const, delay }),
         {
           ...latest,
           restartAttempt: latest.restartAttempt + 1,
@@ -510,7 +704,30 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
 
     yield* Option.match(scheduled, {
       onNone: () => Effect.void,
-      onSome: Effect.fn("desktop.backendManager.scheduleRestartFiber")(function* (delay) {
+      onSome: Effect.fn("desktop.backendManager.scheduleRestartFiber")(function* (restart) {
+        if (restart._tag === "limit") {
+          const recoveryFiber = yield* Effect.forkIn(
+            handleRestartLimitReached(reason).pipe(
+              Effect.catchCause((cause) =>
+                logBackendManagerError("backend recovery dialog fiber failed", {
+                  cause: Cause.pretty(cause),
+                }),
+              ),
+            ),
+            parentScope,
+          );
+          yield* Ref.update(state, (latest) =>
+            Option.isNone(latest.restartFiber)
+              ? {
+                  ...latest,
+                  restartFiber: Option.some(recoveryFiber),
+                }
+              : latest,
+          );
+          return;
+        }
+
+        const { delay } = restart;
         yield* logBackendManagerError("backend exited unexpectedly; restart scheduled", {
           reason,
           delayMs: Duration.toMillis(delay),

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -71,6 +71,8 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     activate: Effect.void,
     createMainIfBackendReady: Effect.void,
     handleBackendReady: Effect.void,
+    notifyBackendRestarting: Effect.void,
+    promptBackendRecoveryFailed: () => Effect.succeed("retry"),
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     syncAppearance: Effect.void,
   } satisfies DesktopWindow.DesktopWindowShape);

--- a/t3code/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopWindow.test.ts
@@ -12,6 +12,7 @@ import * as DesktopAssets from "../app/DesktopAssets.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
@@ -38,6 +39,7 @@ function makeFakeBrowserWindow() {
     on: vi.fn(),
     once: vi.fn(),
     openDevTools: vi.fn(),
+    reload: vi.fn(),
     replaceMisspelling: vi.fn(),
     send: vi.fn(),
     setWindowOpenHandler: vi.fn(),
@@ -63,6 +65,7 @@ function makeFakeBrowserWindow() {
     window: window as unknown as Electron.BrowserWindow,
     loadURL: window.loadURL,
     openDevTools: webContents.openDevTools,
+    reload: webContents.reload,
   };
 }
 
@@ -95,6 +98,13 @@ const electronMenuLayer = Layer.succeed(ElectronMenu.ElectronMenu, {
   popupTemplate: () => Effect.void,
   showContextMenu: () => Effect.succeed(Option.none()),
 } satisfies ElectronMenu.ElectronMenuShape);
+
+const electronDialogLayer = Layer.succeed(ElectronDialog.ElectronDialog, {
+  pickFolder: () => Effect.succeed(Option.none()),
+  confirm: () => Effect.succeed(false),
+  showMessageBox: () => Effect.succeed({ response: 0, checkboxChecked: false }),
+  showErrorBox: () => Effect.void,
+} satisfies ElectronDialog.ElectronDialogShape);
 
 const electronShellLayer = Layer.succeed(ElectronShell.ElectronShell, {
   openExternal: () => Effect.succeed(true),
@@ -144,6 +154,7 @@ function makeTestLayer(input: {
         desktopEnvironmentLayer,
         desktopServerExposureLayer,
         DesktopState.layer,
+        electronDialogLayer,
         electronMenuLayer,
         electronShellLayer,
         electronThemeLayer,
@@ -174,6 +185,29 @@ describe("DesktopWindow", () => {
         assert.equal(yield* Ref.get(createCount), 1);
         assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["http://127.0.0.1:5733/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("reloads an existing main window when the backend becomes ready again", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(
+        Option.some(fakeWindow.window),
+      );
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady;
+
+        assert.equal(yield* Ref.get(createCount), 0);
+        assert.equal(fakeWindow.reload.mock.calls.length, 1);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/t3code/apps/desktop/src/window/DesktopWindow.ts
+++ b/t3code/apps/desktop/src/window/DesktopWindow.ts
@@ -5,13 +5,14 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
-import type * as Electron from "electron";
+import * as Electron from "electron";
 
 import * as DesktopAssets from "../app/DesktopAssets.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopState from "../app/DesktopState.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
@@ -33,10 +34,13 @@ type DesktopWindowRuntimeServices =
   | DesktopAssets.DesktopAssets
   | DesktopServerExposure.DesktopServerExposure
   | DesktopState.DesktopState
+  | ElectronDialog.ElectronDialog
   | ElectronMenu.ElectronMenu
   | ElectronShell.ElectronShell
   | ElectronTheme.ElectronTheme
   | ElectronWindow.ElectronWindow;
+
+export type DesktopBackendRecoveryDecision = "retry" | "quit";
 
 export class DesktopWindowDevServerUrlMissingError extends Data.TaggedError(
   "DesktopWindowDevServerUrlMissingError",
@@ -57,6 +61,11 @@ export interface DesktopWindowShape {
   readonly activate: Effect.Effect<void, DesktopWindowError>;
   readonly createMainIfBackendReady: Effect.Effect<void, DesktopWindowError>;
   readonly handleBackendReady: Effect.Effect<void, DesktopWindowError>;
+  readonly notifyBackendRestarting: Effect.Effect<void>;
+  readonly promptBackendRecoveryFailed: (input: {
+    readonly attempts: number;
+    readonly reason: string;
+  }) => Effect.Effect<DesktopBackendRecoveryDecision>;
   readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
   readonly syncAppearance: Effect.Effect<void>;
 }
@@ -147,6 +156,7 @@ function bindFirstRevealTrigger(
 const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const assets = yield* DesktopAssets.DesktopAssets;
+  const electronDialog = yield* ElectronDialog.ElectronDialog;
   const electronMenu = yield* ElectronMenu.ElectronMenu;
   const electronShell = yield* ElectronShell.ElectronShell;
   const electronTheme = yield* ElectronTheme.ElectronTheme;
@@ -336,8 +346,39 @@ const make = Effect.gen(function* () {
     handleBackendReady: Effect.gen(function* () {
       yield* Ref.set(state.backendReady, true);
       yield* logWindowInfo("backend ready", { source: "http" });
+      const existingWindow = yield* electronWindow.currentMainOrFirst;
+      if (Option.isSome(existingWindow) && !existingWindow.value.isDestroyed()) {
+        existingWindow.value.webContents.reload();
+        yield* electronWindow.reveal(existingWindow.value);
+        return;
+      }
       yield* createMainIfBackendReady;
     }).pipe(Effect.withSpan("desktop.window.handleBackendReady")),
+    notifyBackendRestarting: Effect.sync(() => {
+      if (!Electron.Notification.isSupported()) {
+        return;
+      }
+      new Electron.Notification({
+        title: `${environment.displayName} is reconnecting`,
+        body: "The local backend stopped responding. Restarting it now.",
+        silent: true,
+      }).show();
+    }).pipe(Effect.withSpan("desktop.window.notifyBackendRestarting")),
+    promptBackendRecoveryFailed: Effect.fn("desktop.window.promptBackendRecoveryFailed")(
+      function* (input) {
+        const result = yield* electronDialog.showMessageBox({
+          type: "error",
+          buttons: ["Retry", "Quit"],
+          defaultId: 0,
+          cancelId: 1,
+          noLink: true,
+          title: `${environment.displayName} backend failed`,
+          message: "The local backend could not be restarted.",
+          detail: `Tried ${input.attempts} times.\nLast failure: ${input.reason}`,
+        });
+        return result.response === 0 ? "retry" : "quit";
+      },
+    ),
     dispatchMenuAction: Effect.fn("desktop.window.dispatchMenuAction")(function* (action) {
       yield* Effect.annotateCurrentSpan({ action });
       const existingWindow = yield* electronWindow.focusedMainOrFirst;


### PR DESCRIPTION
Fixes #820.

## Summary
- Add post-readiness backend health monitoring in DesktopBackendManager with a 15 second Effect.Schedule.spaced interval and jitter.
- Restart the active backend after three consecutive failed health probes, notify the user during recovery, and cap automatic restarts with a Retry/Quit dialog after three failed restart attempts.
- Reload the existing main window after backend readiness so the web view reconnects after a successful restart.
- Include apps/desktop/_provenance.json with non-sensitive provenance only; private system/developer/runtime/session instructions are intentionally not copied into repository files.

## Validation
- bun run fmt:check apps/desktop/_provenance.json apps/desktop/src/backend/DesktopBackendManager.ts apps/desktop/src/backend/DesktopBackendManager.test.ts apps/desktop/src/window/DesktopWindow.ts apps/desktop/src/window/DesktopWindow.test.ts apps/desktop/src/window/DesktopApplicationMenu.test.ts
- bun run lint apps/desktop/src/backend/DesktopBackendManager.ts apps/desktop/src/backend/DesktopBackendManager.test.ts apps/desktop/src/window/DesktopWindow.ts apps/desktop/src/window/DesktopWindow.test.ts apps/desktop/src/window/DesktopApplicationMenu.test.ts
- bun run test --filter=@t3tools/desktop -- DesktopBackendManager.test.ts DesktopWindow.test.ts DesktopApplicationMenu.test.ts
- bun run typecheck --filter=@t3tools/desktop
- bun run build --filter=@t3tools/desktop