### PR TITLE
8万 [ Python ] Fix timing-safe comparison in verify_finished

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -258,8 +258,7 @@ class TLSHandshake:
             12,
         )
 
-        # BUG 3: uses == instead of hmac.compare_digest(), enabling timing attacks
-        return computed_verify == received_verify
+        return hmac.compare_digest(computed_verify, received_verify)
 
     def process_key_exchange(self, message: HandshakeMessage) -> bool:
         """Process a ClientKeyExchange or ServerKeyExchange message."""


### PR DESCRIPTION
## Summary
- Replaces the byte-string equality check in `TLSHandshake.verify_finished` with `hmac.compare_digest` so Finished verify_data comparison is timing-safe.

## Test Plan
- `python3 - <<'PY'` focused import/assertion smoke test for matching and mismatching Finished verify_data

/claim #571
