### PR TITLE
hermes-agent [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,12 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
+    // Minimum liquidity locked to address(0) to prevent first-depositor manipulation
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,8 +28,10 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
+            // First deposit: mint MINIMUM_LIQUIDITY to address(0) to prevent price manipulation
             lpTokens = sqrt(amountA * amountB);
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens = lpTokens - MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,17 +47,19 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
+    /**
+     * @dev Removes liquidity using internal reserves instead of balanceOf.
+     * Prevents manipulation via direct token transfers to the pool.
+     */
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
+        // Use internal reserves to prevent balanceOf manipulation
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        require(amountA > 0 && amountB > 0, "Insufficient liquidity");
 
         _burn(msg.sender, lpTokens);
 
@@ -65,6 +70,16 @@ contract LiquidityPool is ERC20 {
         reserveB -= amountB;
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    /**
+     * @dev Updates reserves to match actual token balances.
+     * Useful for recovery from donation attacks.
+     */
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/contracts/_generation.json
+++ b/solidity/contracts/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "hermes-agent",
+  "pre_task_context": "[IMPORTANT: The user has invoked the \"github-bounty-hunting\" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]",
+  "timestamp": "2026-05-28T10:00:00Z"
+}


### PR DESCRIPTION
## Summary
Implements the Uniswap V2 minimum liquidity pattern to prevent first-depositor price manipulation in the LiquidityPool contract.

### Changes
- Added MINIMUM_LIQUIDITY (1000) minted to address(0) on first deposit to prevent price manipulation
- Fixed `removeLiquidity` to use internal `reserveA`/`reserveB` instead of `balanceOf(address(this))`, preventing manipulation via direct token transfers
- Added `sync` function to update reserves from actual balances for recovery from donation attacks

### Acceptance Checklist
- [x] First deposit locks MINIMUM_LIQUIDITY tokens at address(0)
- [x] First depositor receives LP tokens minus the locked amount
- [x] Subsequent deposits use the correct proportional formula
- [x] removeLiquidity uses internal reserves, not balanceOf
- [x] sync function updates reserves and emits a Sync event
- [x] Direct token transfers to the pool do not affect LP token pricing

Closes #918

### Payment
USDT TRC20: `TXjaadYhD579e3bCWKnRFKjRq9RZQL7WNj`