### PR TITLE
[T3 Code] Surface rebase conflict status in git actions

### DIFF
--- a/t3code/apps/server/src/git/GitManager.ts
+++ b/t3code/apps/server/src/git/GitManager.ts
@@ -698,7 +698,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
   const canonicalizeExistingPath = (value: string) =>
     fileSystem.realPath(value).pipe(Effect.catch(() => Effect.succeed(value)));
   const normalizeStatusCacheKey = canonicalizeExistingPath;
-  const nonRepositoryStatusDetails = {
+  const nonRepositoryStatusDetails: GitStatusDetails = {
     isRepo: false,
     hasOriginRemote: false,
     isDefaultBranch: false,
@@ -710,7 +710,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     aheadCount: 0,
     behindCount: 0,
     aheadOfDefaultCount: 0,
-  } satisfies GitStatusDetails;
+  };
   const readLocalStatus = Effect.fn("readLocalStatus")(function* (cwd: string) {
     const details = yield* gitCore
       .statusDetailsLocal(cwd)
@@ -729,6 +729,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
       refName: details.branch,
       hasWorkingTreeChanges: details.hasWorkingTreeChanges,
       workingTree: details.workingTree,
+      ...(details.conflicts ? { conflicts: details.conflicts } : {}),
     } satisfies VcsStatusLocalResult;
   });
   const localStatusResultCache = yield* Cache.makeWith(readLocalStatus, {

--- a/t3code/apps/server/src/vcs/GitVcsDriver.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriver.ts
@@ -60,6 +60,7 @@ export interface GitStatusDetails {
   upstreamRef: string | null;
   hasWorkingTreeChanges: boolean;
   workingTree: VcsStatusResult["workingTree"];
+  conflicts?: VcsStatusResult["conflicts"];
   hasUpstream: boolean;
   aheadCount: number;
   behindCount: number;

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -107,6 +107,43 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("reports unmerged files and the active rebase operation", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        yield* writeTextFile(cwd, "conflict.txt", "base\n");
+        yield* git(cwd, ["add", "conflict.txt"]);
+        yield* git(cwd, ["commit", "-m", "add conflict base"]);
+        yield* git(cwd, ["checkout", "-b", "feature/conflict"]);
+        yield* writeTextFile(cwd, "conflict.txt", "feature\n");
+        yield* git(cwd, ["commit", "-am", "feature edit"]);
+        yield* git(cwd, ["checkout", initialBranch]);
+        yield* writeTextFile(cwd, "conflict.txt", "main\n");
+        yield* git(cwd, ["commit", "-am", "main edit"]);
+        yield* git(cwd, ["checkout", "feature/conflict"]);
+
+        const rebase = yield* driver.execute({
+          operation: "GitVcsDriver.test.rebaseConflict",
+          cwd,
+          args: ["rebase", initialBranch],
+          allowNonZeroExit: true,
+          timeoutMs: 10_000,
+        });
+        assert.notEqual(rebase.exitCode, 0);
+
+        const status = yield* driver.statusDetails(cwd);
+
+        assert.equal(status.hasWorkingTreeChanges, true);
+        assert.deepStrictEqual(status.conflicts, {
+          hasConflicts: true,
+          operation: "rebase",
+          files: [{ path: "conflict.txt", status: "UU" }],
+        });
+      }),
+    );
+
     it.effect("reports default-branch delta separately from upstream delta", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -136,6 +136,20 @@ function parsePorcelainPath(line: string): string | null {
   return filePath.length > 0 ? filePath : null;
 }
 
+function parseConflictPorcelainLine(line: string): { path: string; status: string } | null {
+  if (!line.startsWith("u ")) {
+    return null;
+  }
+
+  const status = line.slice(2).trim().split(/\s+/g)[0] ?? "";
+  const filePath = parsePorcelainPath(line);
+  if (status.length === 0 || !filePath) {
+    return null;
+  }
+
+  return { path: filePath, status };
+}
+
 function parseBranchLine(line: string): { name: string; current: boolean } | null {
   const trimmed = line.trim();
   if (trimmed.length === 0) return null;
@@ -805,6 +819,47 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       ),
     );
 
+  const gitPathExists = (cwd: string, gitPath: string) =>
+    runGitStdout(
+      "GitVcsDriver.conflictStatus.gitPath",
+      cwd,
+      ["rev-parse", "--git-path", gitPath],
+      true,
+    ).pipe(
+      Effect.map((stdout) => stdout.trim()),
+      Effect.flatMap((resolvedPath) => {
+        if (resolvedPath.length === 0) {
+          return Effect.succeed(false);
+        }
+        const absolutePath = path.isAbsolute(resolvedPath)
+          ? resolvedPath
+          : path.resolve(cwd, resolvedPath);
+        return fileSystem.exists(absolutePath).pipe(Effect.orElseSucceed(() => false));
+      }),
+      Effect.catch(() => Effect.succeed(false)),
+    );
+
+  const detectConflictOperation = Effect.fn("GitVcsDriver.detectConflictOperation")(function* (
+    cwd: string,
+  ): Effect.fn.Return<"merge" | "rebase" | "cherry-pick" | "revert" | "unknown", never> {
+    if (
+      (yield* gitPathExists(cwd, "rebase-merge")) ||
+      (yield* gitPathExists(cwd, "rebase-apply"))
+    ) {
+      return "rebase";
+    }
+    if (yield* gitPathExists(cwd, "MERGE_HEAD")) {
+      return "merge";
+    }
+    if (yield* gitPathExists(cwd, "CHERRY_PICK_HEAD")) {
+      return "cherry-pick";
+    }
+    if (yield* gitPathExists(cwd, "REVERT_HEAD")) {
+      return "revert";
+    }
+    return "unknown";
+  });
+
   const branchExists = (cwd: string, refName: string): Effect.Effect<boolean, GitCommandError> =>
     executeGit(
       "GitVcsDriver.branchExists",
@@ -1218,6 +1273,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     let aheadOfDefaultCount = 0;
     let hasWorkingTreeChanges = false;
     const changedFilesWithoutNumstat = new Set<string>();
+    const conflictFiles: Array<{ path: string; status: string }> = [];
 
     for (const line of statusStdout.split(/\r?\n/g)) {
       if (line.startsWith("# branch.head ")) {
@@ -1241,8 +1297,19 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         hasWorkingTreeChanges = true;
         const pathValue = parsePorcelainPath(line);
         if (pathValue) changedFilesWithoutNumstat.add(pathValue);
+        const conflictFile = parseConflictPorcelainLine(line);
+        if (conflictFile) conflictFiles.push(conflictFile);
       }
     }
+
+    const conflicts =
+      conflictFiles.length > 0
+        ? {
+            hasConflicts: true,
+            operation: yield* detectConflictOperation(cwd),
+            files: conflictFiles.toSorted((a, b) => a.path.localeCompare(b.path)),
+          }
+        : undefined;
 
     const fallbackAheadCount =
       !upstreamRef && refName
@@ -1307,6 +1374,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         insertions,
         deletions,
       },
+      ...(conflicts ? { conflicts } : {}),
       hasUpstream: upstreamRef !== null,
       aheadCount,
       behindCount,
@@ -1339,6 +1407,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         refName: details.branch,
         hasWorkingTreeChanges: details.hasWorkingTreeChanges,
         workingTree: details.workingTree,
+        ...(details.conflicts ? { conflicts: details.conflicts } : {}),
         hasUpstream: details.hasUpstream,
         aheadCount: details.aheadCount,
         behindCount: details.behindCount,

--- a/t3code/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/t3code/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -150,6 +150,56 @@ describe("when: git status is unavailable", () => {
   });
 });
 
+describe("when: git has unresolved conflicts", () => {
+  it("resolveQuickAction shows a conflict-resolution hint", () => {
+    const quick = resolveQuickAction(
+      status({
+        hasWorkingTreeChanges: true,
+        conflicts: {
+          hasConflicts: true,
+          operation: "rebase",
+          files: [
+            { path: "src/a.ts", status: "UU" },
+            { path: "src/b.ts", status: "AA" },
+          ],
+        },
+      }),
+      false,
+    );
+
+    assert.deepInclude(quick, {
+      kind: "show_hint",
+      label: "Resolve conflicts",
+      disabled: true,
+      hint: "Resolve 2 rebase conflicted files before running git actions.",
+    });
+  });
+
+  it("buildMenuItems disables commit, push, and PR actions", () => {
+    const items = buildMenuItems(
+      status({
+        hasWorkingTreeChanges: true,
+        aheadCount: 1,
+        conflicts: {
+          hasConflicts: true,
+          operation: "merge",
+          files: [{ path: "src/a.ts", status: "UU" }],
+        },
+      }),
+      false,
+    );
+
+    assert.deepEqual(
+      items.map((item) => ({ id: item.id, disabled: item.disabled })),
+      [
+        { id: "commit", disabled: true },
+        { id: "push", disabled: true },
+        { id: "pr", disabled: true },
+      ],
+    );
+  });
+});
+
 describe("when: ref is clean, ahead, and has an open PR", () => {
   it("resolveQuickAction prefers push", () => {
     const quick = resolveQuickAction(

--- a/t3code/apps/web/src/components/GitActionsControl.logic.ts
+++ b/t3code/apps/web/src/components/GitActionsControl.logic.ts
@@ -43,6 +43,16 @@ export type DefaultBranchConfirmableAction =
   | "commit_push"
   | "commit_push_pr";
 
+function formatConflictHint(gitStatus: VcsStatusResult): string {
+  const conflictCount = gitStatus.conflicts?.files.length ?? 0;
+  const fileLabel = conflictCount === 1 ? "file" : "files";
+  const operation =
+    gitStatus.conflicts?.operation && gitStatus.conflicts.operation !== "unknown"
+      ? `${gitStatus.conflicts.operation} `
+      : "";
+  return `Resolve ${conflictCount} ${operation}conflicted ${fileLabel} before running git actions.`;
+}
+
 function resolveChangeRequestTerminology(
   gitStatus: VcsStatusResult | null,
 ): ChangeRequestTerminology {
@@ -101,20 +111,23 @@ export function buildMenuItems(
 
   const hasBranch = gitStatus.refName !== null;
   const hasChanges = gitStatus.hasWorkingTreeChanges;
+  const hasConflicts = gitStatus.conflicts?.hasConflicts === true;
   const hasOpenPr = gitStatus.pr?.state === "open";
   const isBehind = gitStatus.behindCount > 0;
   const hasDefaultBranchDelta = (gitStatus.aheadOfDefaultCount ?? gitStatus.aheadCount) > 0;
   const canPushWithoutUpstream = hasPrimaryRemote && !gitStatus.hasUpstream;
-  const canCommit = !isBusy && hasChanges;
+  const canCommit = !isBusy && hasChanges && !hasConflicts;
   const canPush =
     !isBusy &&
     hasBranch &&
+    !hasConflicts &&
     !isBehind &&
     gitStatus.aheadCount > 0 &&
     (gitStatus.hasUpstream || canPushWithoutUpstream);
   const canCreatePr =
     !isBusy &&
     hasBranch &&
+    !hasConflicts &&
     !hasChanges &&
     !hasOpenPr &&
     hasDefaultBranchDelta &&
@@ -185,6 +198,7 @@ export function resolveQuickAction(
 
   const hasBranch = gitStatus.refName !== null;
   const hasChanges = gitStatus.hasWorkingTreeChanges;
+  const hasConflicts = gitStatus.conflicts?.hasConflicts === true;
   const hasOpenPr = gitStatus.pr?.state === "open";
   const isAhead = gitStatus.aheadCount > 0;
   const hasDefaultBranchDelta = (gitStatus.aheadOfDefaultCount ?? gitStatus.aheadCount) > 0;
@@ -198,6 +212,15 @@ export function resolveQuickAction(
       disabled: true,
       kind: "show_hint",
       hint: `Create and checkout a ref before pushing or opening a ${terminology.singular}.`,
+    };
+  }
+
+  if (hasConflicts) {
+    return {
+      label: "Resolve conflicts",
+      disabled: true,
+      kind: "show_hint",
+      hint: formatConflictHint(gitStatus),
     };
   }
 

--- a/t3code/apps/web/src/components/GitActionsControl.tsx
+++ b/t3code/apps/web/src/components/GitActionsControl.tsx
@@ -252,6 +252,15 @@ function getMenuActionDisabledReason({
   const isAhead = gitStatus.aheadCount > 0;
   const isBehind = gitStatus.behindCount > 0;
   const terminology = getSourceControlPresentation(gitStatus.sourceControlProvider).terminology;
+  if (gitStatus.conflicts?.hasConflicts) {
+    const conflictCount = gitStatus.conflicts.files.length;
+    const fileLabel = conflictCount === 1 ? "file" : "files";
+    const operation =
+      gitStatus.conflicts.operation && gitStatus.conflicts.operation !== "unknown"
+        ? `${gitStatus.conflicts.operation} `
+        : "";
+    return `Resolve ${conflictCount} ${operation}conflicted ${fileLabel} before running git actions.`;
+  }
 
   if (item.id === "commit") {
     if (!hasChanges) {

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -194,6 +194,23 @@ const VcsStatusChangeRequest = Schema.Struct({
   headRef: TrimmedNonEmptyStringSchema,
   state: VcsStatusChangeRequestState,
 });
+const VcsConflictOperation = Schema.Literals([
+  "merge",
+  "rebase",
+  "cherry-pick",
+  "revert",
+  "unknown",
+]);
+const VcsConflictFile = Schema.Struct({
+  path: TrimmedNonEmptyStringSchema,
+  status: TrimmedNonEmptyStringSchema,
+});
+const VcsConflictStatus = Schema.Struct({
+  hasConflicts: Schema.Boolean,
+  operation: VcsConflictOperation.pipe(Schema.NullOr),
+  files: Schema.Array(VcsConflictFile),
+});
+export type VcsConflictStatus = typeof VcsConflictStatus.Type;
 
 const VcsStatusLocalShape = {
   isRepo: Schema.Boolean,
@@ -213,6 +230,7 @@ const VcsStatusLocalShape = {
     insertions: NonNegativeInt,
     deletions: NonNegativeInt,
   }),
+  conflicts: Schema.optional(VcsConflictStatus),
 };
 
 const VcsStatusRemoteShape = {


### PR DESCRIPTION
## Summary
- add optional conflict metadata to VCS status results for active merge/rebase/cherry-pick/revert states
- detect unmerged files from git porcelain v2 output and expose the active conflict operation through GitManager status
- block commit/push/PR UI actions while conflicts remain and show a conflict-resolution hint

## Testing
- node node_modules/oxfmt/bin/oxfmt --check apps/server/src/git/GitManager.ts apps/server/src/vcs/GitVcsDriverCore.ts apps/server/src/vcs/GitVcsDriverCore.test.ts apps/web/src/components/GitActionsControl.logic.ts apps/web/src/components/GitActionsControl.logic.test.ts apps/web/src/components/GitActionsControl.tsx packages/contracts/src/git.ts
- node node_modules/typescript/bin/tsc -p packages/contracts/tsconfig.json --noEmit
- node node_modules/typescript/bin/tsc -p apps/server/tsconfig.json --noEmit
- node node_modules/typescript/bin/tsc -p apps/web/tsconfig.json --noEmit
- node node_modules/vitest/vitest.mjs run apps/server/src/vcs/GitVcsDriverCore.test.ts --config vitest.config.ts
- node ../../node_modules/vitest/vitest.mjs run src/components/GitActionsControl.logic.test.ts

Refs #823