### PR TITLE
[OpenAI Codex] [ T3 Code ] Add ARIA attributes and keyboard navigation to ChatView

### DIFF
--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -56,6 +56,8 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen>
       <Sidebar
+        id="chat-sidebar"
+        tabIndex={-1}
         side="left"
         collapsible="offcanvas"
         className="border-r border-border bg-card text-foreground"

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3550,6 +3550,20 @@ export default function ChatView(props: ChatViewProps) {
       <div className="flex min-h-0 min-w-0 flex-1">
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <nav
+            aria-label="Chat skip links"
+            className="sr-only focus-within:not-sr-only focus-within:absolute focus-within:z-50 focus-within:flex focus-within:gap-2 focus-within:rounded-md focus-within:border focus-within:border-border focus-within:bg-background focus-within:p-2"
+          >
+            <a href="#chat-sidebar" className="underline">
+              Skip to sidebar
+            </a>
+            <a href="#chat-messages" className="underline">
+              Skip to chat messages
+            </a>
+            <a href="#chat-composer" className="underline">
+              Skip to composer
+            </a>
+          </nav>
           {/* Messages Wrapper */}
           <div className="relative flex min-h-0 flex-1 flex-col">
             {/* Messages — LegendList handles virtualization and scrolling internally */}
@@ -3577,6 +3591,7 @@ export default function ChatView(props: ChatViewProps) {
               workspaceRoot={activeWorkspaceRoot}
               skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
               onIsAtEndChange={onIsAtEndChange}
+              onReturnFocusToComposer={focusComposer}
             />
 
             {/* scroll to bottom pill — shown when user has scrolled away from the bottom */}
@@ -3586,6 +3601,7 @@ export default function ChatView(props: ChatViewProps) {
                   type="button"
                   onClick={() => scrollToEnd(true)}
                   className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
+                  aria-label="Scroll to latest message"
                 >
                   <ChevronDownIcon className="size-3.5" />
                   Scroll to bottom
@@ -3605,7 +3621,7 @@ export default function ChatView(props: ChatViewProps) {
           >
             <div className="relative isolate">
               <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
-              <div className="relative z-10">
+              <div id="chat-composer" className="relative z-10" tabIndex={-1}>
                 <ChatComposer
                   composerRef={composerRef}
                   composerDraftTarget={composerDraftTarget}

--- a/t3code/apps/web/src/components/chat/.provenance.json
+++ b/t3code/apps/web/src/components/chat/.provenance.json
@@ -1,6 +1,7 @@
 {
   "agent_name": "OpenAI Codex",
+  "config_snapshot": "[REDACTED: private system, developer, and user instructions are not disclosed in public pull requests.]",
+  "created": "2026-05-28T06:55:00+08:00",
   "issue": 852,
-  "contribution": "Added live-region semantics, keyboard navigation, skip links, and ARIA labels for the chat flow.",
-  "timestamp": "2026-05-28T06:55:00+08:00"
+  "contribution": "Added live-region semantics, keyboard navigation, skip links, and ARIA labels for the chat flow."
 }

--- a/t3code/apps/web/src/components/chat/.provenance.json
+++ b/t3code/apps/web/src/components/chat/.provenance.json
@@ -1,0 +1,6 @@
+{
+  "agent_name": "OpenAI Codex",
+  "issue": 852,
+  "contribution": "Added live-region semantics, keyboard navigation, skip links, and ARIA labels for the chat flow.",
+  "timestamp": "2026-05-28T06:55:00+08:00"
+}

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -133,6 +133,24 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('data-user-message-footer="true"');
   });
 
+  it("marks the message timeline as a live keyboard-navigable log", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[buildUserTimelineEntry("Keyboard reachable message.")]}
+      />,
+    );
+
+    expect(markup).toContain('id="chat-messages"');
+    expect(markup).toContain('role="log"');
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).toContain('aria-relevant="additions text"');
+    expect(markup).toContain('role="listitem"');
+    expect(markup).toContain('tabindex="0"');
+    expect(markup).toContain('aria-label="User message"');
+  });
+
   it("does not render collapse controls for short user messages", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
@@ -126,6 +127,7 @@ interface MessagesTimelineProps {
   workspaceRoot: string | undefined;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   onIsAtEndChange: (isAtEnd: boolean) => void;
+  onReturnFocusToComposer?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +157,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   workspaceRoot,
   skills = EMPTY_TIMELINE_SKILLS,
   onIsAtEndChange,
+  onReturnFocusToComposer,
 }: MessagesTimelineProps) {
   const rawRows = useMemo(
     () =>
@@ -253,6 +256,48 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [],
   );
 
+  const handleTimelineKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const activeRow = target?.closest<HTMLElement>("[data-timeline-row-id]");
+
+      if (event.key === "Escape") {
+        onReturnFocusToComposer?.();
+        return;
+      }
+
+      if (!activeRow) {
+        return;
+      }
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const rows = Array.from(
+          event.currentTarget.querySelectorAll<HTMLElement>("[data-timeline-row-id]"),
+        );
+        const currentIndex = rows.indexOf(activeRow);
+        if (currentIndex === -1) {
+          return;
+        }
+        const offset = event.key === "ArrowDown" ? 1 : -1;
+        const nextRow = rows[Math.min(rows.length - 1, Math.max(0, currentIndex + offset))];
+        nextRow?.focus();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const expandableControl = activeRow.querySelector<HTMLButtonElement>(
+          "button[aria-expanded]",
+        );
+        if (expandableControl) {
+          event.preventDefault();
+          expandableControl.click();
+        }
+      }
+    },
+    [onReturnFocusToComposer],
+  );
+
   if (rows.length === 0 && !isWorking) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -266,21 +311,31 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   return (
     <TimelineRowCtx value={sharedState}>
       <TimelineRowActivityCtx value={activityState}>
-        <LegendList<MessagesTimelineRow>
-          ref={listRef}
-          data={rows}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          estimatedItemSize={90}
-          initialScrollAtEnd
-          maintainScrollAtEnd
-          maintainScrollAtEndThreshold={0.1}
-          maintainVisibleContentPosition
-          onScroll={handleScroll}
-          className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
-          ListHeaderComponent={TIMELINE_LIST_HEADER}
-          ListFooterComponent={TIMELINE_LIST_FOOTER}
-        />
+        <div
+          id="chat-messages"
+          role="log"
+          aria-label="Chat messages"
+          aria-live="polite"
+          aria-relevant="additions text"
+          className="h-full"
+          onKeyDown={handleTimelineKeyDown}
+        >
+          <LegendList<MessagesTimelineRow>
+            ref={listRef}
+            data={rows}
+            keyExtractor={keyExtractor}
+            renderItem={renderItem}
+            estimatedItemSize={90}
+            initialScrollAtEnd
+            maintainScrollAtEnd
+            maintainScrollAtEndThreshold={0.1}
+            maintainVisibleContentPosition
+            onScroll={handleScroll}
+            className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
+            ListHeaderComponent={TIMELINE_LIST_HEADER}
+            ListFooterComponent={TIMELINE_LIST_FOOTER}
+          />
+        </div>
       </TimelineRowActivityCtx>
     </TimelineRowCtx>
   );
@@ -310,6 +365,9 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
       data-message-role={row.kind === "message" ? row.message.role : undefined}
+      role="listitem"
+      tabIndex={0}
+      aria-label={timelineRowAriaLabel(row)}
     >
       {row.kind === "work" ? <WorkGroupSection groupedEntries={row.groupedEntries} /> : null}
       {row.kind === "message" && row.message.role === "user" ? <UserTimelineRow row={row} /> : null}
@@ -388,6 +446,19 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   );
 }
 
+function timelineRowAriaLabel(row: TimelineRow): string {
+  if (row.kind === "message") {
+    return `${row.message.role === "user" ? "User" : "Assistant"} message`;
+  }
+  if (row.kind === "work") {
+    return `Work log with ${row.groupedEntries.length} entries`;
+  }
+  if (row.kind === "proposed-plan") {
+    return "Proposed plan";
+  }
+  return "Assistant working";
+}
+
 function RevertUserMessageButton({ messageId }: { messageId: MessageId }) {
   const ctx = use(TimelineRowCtx);
   const activity = use(TimelineRowActivityCtx);
@@ -400,6 +471,7 @@ function RevertUserMessageButton({ messageId }: { messageId: MessageId }) {
       disabled={activity.isRevertingCheckpoint || activity.isWorking}
       onClick={() => ctx.onRevertUserMessage(messageId)}
       title="Revert to this message"
+      aria-label="Revert to this message"
     >
       <Undo2Icon className="size-3" />
     </Button>
@@ -621,6 +693,10 @@ const WorkGroupSection = memo(function WorkGroupSection({
             <button
               type="button"
               className="text-[9px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-foreground/75"
+              aria-expanded={isExpanded}
+              aria-label={
+                isExpanded ? "Collapse work log" : `Show ${hiddenCount} more work log entries`
+              }
               onClick={() => setIsExpanded((v) => !v)}
             >
               {isExpanded ? "Show less" : `Show ${hiddenCount} more`}


### PR DESCRIPTION
/claim #852

## Summary
- Added skip links for sidebar, messages, and composer focus targets.
- Marked the chat timeline as a polite live log and made timeline rows keyboard focusable.
- Added ArrowUp/ArrowDown row navigation, Enter expansion for expandable rows, and Escape return-to-composer behavior.
- Added missing ARIA labels for timeline controls and included the required provenance file.

## Privacy note
The requested config_snapshot field is present but redacted because private system, developer, and user instructions must not be published in a public pull request.

## Verification
- git diff --check
- python -m json.tool t3code/apps/web/src/components/chat/.provenance.json

Not run: project test suite, because this environment does not have Bun installed and the checkout has no installed node_modules.

Closes #852