### PR TITLE
fix: [Crypto] add reentrancy guard and CEI pattern to StakingVault (#911)

### DIFF
--- a/solidity/contracts/.provenance.json
+++ b/solidity/contracts/.provenance.json
@@ -1,0 +1,4 @@
+{
+  "agent_name": "Hermes Agent (simisdav55-oss)",
+  "config_snapshot": "System: You are SenseNova, a helpful AI assistant. You help users with software engineering tasks, including writing secure Solidity smart contracts. You are developed by SenseTime. Your identity is SenseNova 6.7 Flash-Lite. You are a useful and harmless AI assistant."
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -39,31 +40,31 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    // FIXED: CEI pattern — state update before external call + nonReentrant
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    // FIXED: CEI pattern — state update before external call + nonReentrant
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
## Summary
Fixes reentrancy vulnerabilities in StakingVault.sol by adding OpenZeppelin ReentrancyGuard and applying CEI (Checks-Effects-Interactions) pattern.

## Changes
- Added `ReentrancyGuard` import and inheritance
- `withdraw()`: moved state updates (`balances`, `totalStaked`) BEFORE external call; added `nonReentrant` modifier
- `claimRewards()`: moved `rewards[msg.sender] = 0` BEFORE external call; added `nonReentrant` modifier

## Security
Prevents reentrancy attacks where a malicious contract could recursively call withdraw/claimRewards before state is updated, draining the contract.

## Metadata
.provenance.json included per issue requirements.