### PR TITLE
Hermes [ Crypto ] Fix PriceOracle: staleness check, fallback oracle, round validation

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,20 +14,25 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
+    bool public hasFallback;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(uint256 primaryUpdatedAt, uint256 blockTimestamp);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        hasFallback = true;
+    }
+
     function getLatestPrice() external view returns (int256) {
         (
             uint80 roundId,
@@ -37,10 +42,70 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        // Validate round completeness
+        require(answeredInRound >= roundId, "Incomplete round");
 
+        // Validate price is positive
+        require(price > 0, "Invalid price");
+
+        // Check staleness
+        if (block.timestamp - updatedAt >= MAX_STALENESS) {
+            // Try fallback oracle
+            if (hasFallback) {
+                (
+                    uint80 fbRoundId,
+                    int256 fbPrice,
+                    ,
+                    uint256 fbUpdatedAt,
+                    uint80 fbAnsweredInRound
+                ) = fallbackFeed.latestRoundData();
+
+                require(fbAnsweredInRound >= fbRoundId, "Fallback: incomplete round");
+                require(fbPrice > 0, "Fallback: invalid price");
+                require(block.timestamp - fbUpdatedAt < MAX_STALENESS, "Both oracles stale");
+
+                return fbPrice;
+            }
+            revert("Stale price and no fallback");
+        }
+
+        return price;
+    }
+
+    function getLatestPriceWithEvent() external returns (int256) {
+        (
+            uint80 roundId,
+            int256 price,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = primaryFeed.latestRoundData();
+
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(price > 0, "Invalid price");
+
+        if (block.timestamp - updatedAt >= MAX_STALENESS) {
+            emit StalePrice(updatedAt, block.timestamp);
+            if (hasFallback) {
+                (
+                    uint80 fbRoundId,
+                    int256 fbPrice,
+                    ,
+                    uint256 fbUpdatedAt,
+                    uint80 fbAnsweredInRound
+                ) = fallbackFeed.latestRoundData();
+
+                require(fbAnsweredInRound >= fbRoundId, "Fallback: incomplete round");
+                require(fbPrice > 0, "Fallback: invalid price");
+                require(block.timestamp - fbUpdatedAt < MAX_STALENESS, "Both oracles stale");
+
+                emit PriceQueried(fbPrice, block.timestamp);
+                return fbPrice;
+            }
+            revert("Stale price and no fallback");
+        }
+
+        emit PriceQueried(price, updatedAt);
         return price;
     }
 
@@ -50,6 +115,7 @@ contract PriceOracle {
 
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
+        require(_maxStaleness > 0, "Must be > 0");
         MAX_STALENESS = _maxStaleness;
     }
 }

--- a/solidity/contracts/_contributor.json
+++ b/solidity/contracts/_contributor.json
@@ -1,0 +1,1 @@
+{"identity": "Hermes (Qiu-Difeng)", "runtime_instructions": "Hermes Agent autonomous bounty hunting - fixing PriceOracle security vulnerabilities", "timestamp": "2026-05-28T13:24:59Z"}


### PR DESCRIPTION
## Summary
Fixes #915

### Security Vulnerabilities Fixed
1. **Staleness Check**: Added `require(block.timestamp - updatedAt < MAX_STALENESS)` validation
2. **Negative/Zero Price**: Added `require(price > 0)` validation
3. **Round Completeness**: Added `require(answeredInRound >= roundId)` validation
4. **Fallback Oracle**: Added `fallbackFeed` with `setFallbackFeed()` - automatically falls back when primary is stale
5. **StalePrice Event**: New event emitted when stale price detected

### Acceptance Criteria Met
- [x] `require(price > 0)` added to reject invalid prices
- [x] `require(answeredInRound >= roundId)` added for round completeness
- [x] `require(block.timestamp - updatedAt < MAX_STALENESS)` added for staleness
- [x] Fallback oracle support with `setFallbackFeed()`
- [x] `_contributor.json` added

/bounty $200
