### PR TITLE
Hermes [ Crypto ] Fix LiquidityPool: MINIMUM_LIQUIDITY lock, reserves-based calculation

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,7 +11,6 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
@@ -27,8 +26,10 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
             lpTokens = sqrt(amountA * amountB);
+            // FIX: Lock MINIMUM_LIQUIDITY to address(0) to prevent first-depositor manipulation
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,17 +45,14 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
+    // FIX: Use internal reserves instead of balanceOf for manipulation-proof calculations
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // FIX: Use reserveA/reserveB instead of balanceOf (prevents direct-transfer manipulation)
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 


### PR DESCRIPTION
Fixes #918

### Security Vulnerabilities Fixed
1. **First-Depositor Manipulation**: Lock `MINIMUM_LIQUIDITY` tokens to `address(0)` on first deposit — prevents price manipulation
2. **Direct Transfer Attack**: `removeLiquidity()` now uses `reserveA/reserveB` instead of `balanceOf` — prevents manipulation via direct token transfers

### Acceptance Criteria Met
- [x] MINIMUM_LIQUIDITY locked to address(0)
- [x] removeLiquidity uses internal reserves
- [x] `_contributor.json` added

/bounty
