### PR TITLE
Hermes [ Crypto ] Fix GovernanceToken: replace all tx.origin with msg.sender

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,30 +28,30 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // FIX: Replaced tx.origin with msg.sender to prevent phishing attacks
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    // FIX: Replaced tx.origin with msg.sender
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
+    // FIX: Replaced tx.origin with msg.sender
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        require(msg.sender == admin, "Not admin");
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
Fixes #912

### Security Vulnerabilities Fixed
1. **Phishing via tx.origin**: Replaced ALL `tx.origin` references with `msg.sender` in:
   - `delegateVote()` — delegation now uses actual caller
   - `revokeDelegate()` — revocation uses actual caller
   - `snapshot()` — admin check uses actual caller
2. **Self-Delegation Check**: Changed to `require(msg.sender != to)` for correct semantics

### Attack Vector
- Malicious contract could call `delegateVote(attacker)` on a user who interacts with it
- `tx.origin` would resolve to the user, delegating their voting power to attacker
- Fix: `msg.sender` ensures only the direct caller can delegate their own tokens

### Acceptance Criteria Met
- [x] All `tx.origin` replaced with `msg.sender`
- [x] `_contributor.json` added

/bounty $700
