### PR TITLE
Hermes [ Crypto ] Fix StakingVault: CEI pattern, nonReentrant guard

### DIFF
--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -12,6 +12,15 @@ contract StakingVault {
     mapping(address => uint256) public rewards;
     mapping(address => uint256) public lastStakeTime;
 
+    // FIX: Reentrancy guard
+    uint256 private _locked = 1;
+    modifier nonReentrant() {
+        require(_locked == 1, "Reentrancy");
+        _locked = 2;
+        _;
+        _locked = 1;
+    }
+
     event Staked(address indexed user, uint256 amount);
     event Withdrawn(address indexed user, uint256 amount);
     event RewardClaimed(address indexed user, uint256 amount);
@@ -21,7 +30,7 @@ contract StakingVault {
         rewardRate = _rewardRate;
     }
 
-    function stake(uint256 amount) external {
+    function stake(uint256 amount) external nonReentrant {
         require(amount > 0, "Cannot stake 0");
         stakingToken.transferFrom(msg.sender, address(this), amount);
         _updateReward(msg.sender);
@@ -39,31 +48,33 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    // FIX: State updates BEFORE external call (CEI pattern) + nonReentrant
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        // FIX: State update before external call (Checks-Effects-Interactions)
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    // FIX: State update before external call + nonReentrant
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // FIX: Zero out rewards BEFORE transfer (CEI pattern)
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
Fixes #911

### Security Vulnerabilities Fixed
1. **Reentrancy in withdraw()**: Moved state updates (`balances`, `totalStaked`) BEFORE external call — follows Checks-Effects-Interactions pattern
2. **Reentrancy in claimRewards()**: Zero out `rewards[msg.sender]` BEFORE transfer — prevents double-claim
3. **Global Reentrancy Guard**: Added `nonReentrant` modifier with `_locked` flag

### Acceptance Criteria Met
- [x] CEI pattern in withdraw()
- [x] CEI pattern in claimRewards()
- [x] nonReentrant modifier on all state-changing functions
- [x] `_contributor.json` added

/bounty
