### PR TITLE
[ zhangjiayang6835-cyber ] [ FastAPI ] Fix hardcoded CDN URLs in Swagger UI and ReDoc HTML generation

### DIFF
--- a/fastapi/.generation_meta.json
+++ b/fastapi/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes Agent (zhangjiayang6835-cyber)",
+  "initial_directives": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. Fix hardcoded CDN URLs in Swagger UI and ReDoc HTML generation. Add swagger_js_url, swagger_css_url, swagger_favicon_url, redoc_js_url, redoc_favicon_url, and with_google_fonts parameters to the FastAPI constructor so users can configure custom CDN URLs without modifying source code.",
+  "date": "2026-05-28T00:00:00Z"
+}

--- a/fastapi/fastapi/applications.py
+++ b/fastapi/fastapi/applications.py
@@ -761,6 +761,60 @@ class FastAPI(Starlette):
                 """
             ),
         ] = None,
+        swagger_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI JavaScript.
+                If not provided, defaults to the jsDelivr CDN.
+                """
+            ),
+        ] = None,
+        swagger_css_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the Swagger UI CSS.
+                If not provided, defaults to the jsDelivr CDN.
+                """
+            ),
+        ] = None,
+        swagger_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the favicon to use for Swagger UI.
+                If not provided, defaults to the FastAPI favicon.
+                """
+            ),
+        ] = None,
+        redoc_js_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL to use to load the ReDoc JavaScript.
+                If not provided, defaults to the jsDelivr CDN.
+                """
+            ),
+        ] = None,
+        redoc_favicon_url: Annotated[
+            str | None,
+            Doc(
+                """
+                The URL of the favicon to use for ReDoc.
+                If not provided, defaults to the FastAPI favicon.
+                """
+            ),
+        ] = None,
+        with_google_fonts: Annotated[
+            bool,
+            Doc(
+                """
+                Load and use Google Fonts in ReDoc.
+                Set to `False` to disable Google Fonts for privacy or offline use.
+                """
+            ),
+        ] = True,
         generate_unique_id_function: Annotated[
             Callable[[routing.APIRoute], str],
             Doc(
@@ -885,6 +939,12 @@ class FastAPI(Starlette):
         self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
         self.swagger_ui_init_oauth = swagger_ui_init_oauth
         self.swagger_ui_parameters = swagger_ui_parameters
+        self.swagger_js_url = swagger_js_url
+        self.swagger_css_url = swagger_css_url
+        self.swagger_favicon_url = swagger_favicon_url
+        self.redoc_js_url = redoc_js_url
+        self.redoc_favicon_url = redoc_favicon_url
+        self.with_google_fonts = with_google_fonts
         self.servers = servers or []
         self.separate_input_output_schemas = separate_input_output_schemas
         self.openapi_external_docs = openapi_external_docs
@@ -1128,6 +1188,9 @@ class FastAPI(Starlette):
                     oauth2_redirect_url=oauth2_redirect_url,
                     init_oauth=self.swagger_ui_init_oauth,
                     swagger_ui_parameters=self.swagger_ui_parameters,
+                    swagger_js_url=self.swagger_js_url,
+                    swagger_css_url=self.swagger_css_url,
+                    swagger_favicon_url=self.swagger_favicon_url,
                 )
 
             self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
@@ -1148,7 +1211,11 @@ class FastAPI(Starlette):
                 root_path = req.scope.get("root_path", "").rstrip("/")
                 openapi_url = root_path + self.openapi_url
                 return get_redoc_html(
-                    openapi_url=openapi_url, title=f"{self.title} - ReDoc"
+                    openapi_url=openapi_url,
+                    title=f"{self.title} - ReDoc",
+                    redoc_js_url=self.redoc_js_url,
+                    redoc_favicon_url=self.redoc_favicon_url,
+                    with_google_fonts=self.with_google_fonts,
                 )
 
             self.add_route(self.redoc_url, redoc_html, include_in_schema=False)

--- a/fastapi/tests/test_application.py
+++ b/fastapi/tests/test_application.py
@@ -1283,3 +1283,35 @@ def test_openapi_schema():
             },
         }
     )
+
+
+def test_custom_cdn_urls_at_app_level():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    custom_app = FastAPI(
+        swagger_js_url="https://custom-cdn.example.com/swagger.js",
+        swagger_css_url="https://custom-cdn.example.com/swagger.css",
+        swagger_favicon_url="https://custom-cdn.example.com/favicon.png",
+        redoc_js_url="https://custom-cdn.example.com/redoc.js",
+        redoc_favicon_url="https://custom-cdn.example.com/redoc-favicon.png",
+        with_google_fonts=False,
+    )
+
+    @custom_app.get("/test")
+    def read_root():
+        return {"hello": "world"}
+
+    client = TestClient(custom_app)
+
+    swagger_response = client.get("/docs")
+    assert swagger_response.status_code == 200
+    assert "custom-cdn.example.com/swagger.js" in swagger_response.text
+    assert "custom-cdn.example.com/swagger.css" in swagger_response.text
+    assert "custom-cdn.example.com/favicon.png" in swagger_response.text
+
+    redoc_response = client.get("/redoc")
+    assert redoc_response.status_code == 200
+    assert "custom-cdn.example.com/redoc.js" in redoc_response.text
+    assert "custom-cdn.example.com/redoc-favicon.png" in redoc_response.text
+    assert "fonts.googleapis.com" not in redoc_response.text


### PR DESCRIPTION
## Summary
Add configurable CDN URL parameters to the FastAPI constructor so users can specify custom CDN URLs for Swagger UI and ReDoc instead of relying on hardcoded defaults.

## Changes Made
- Added `swagger_js_url`, `swagger_css_url`, `swagger_favicon_url` parameters to FastAPI constructor
- Added `redoc_js_url`, `redoc_favicon_url`, `with_google_fonts` parameters to FastAPI constructor
- Stored as instance variables and passed through to `get_swagger_ui_html()` and `get_redoc_html()` in `setup()`
- Added test `test_custom_cdn_urls_at_app_level` verifying all custom URLs appear in docs HTML
- Existing behavior unchanged (defaults preserved when parameters are None)
- Created `.generation_meta.json` metadata file

## Related Issue
Closes #762