### PR TITLE
[ zhangjiayang6835-cyber ] [ Crypto ] Fix reentrancy vulnerability in StakingVault withdraw and claimRewards

### DIFF
--- a/solidity/_meta.json
+++ b/solidity/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent (zhangjiayang6835-cyber)",
+  "generation_context": "You are Hermes Agent. Fix reentrancy vulnerability in StakingVault withdraw and claimRewards. Add OpenZeppelin ReentrancyGuard. Apply checks-effects-interactions pattern (state before external call). Create _meta.json.",
+  "completed_at": "2026-05-28T00:00:00Z"
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -39,31 +40,35 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    /// @notice Withdraws staked tokens with reentrancy protection.
+    /// Uses checks-effects-interactions pattern: state before external call.
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        // Checks-effects-interactions: update state before external call
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
+        // External call after state update
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    /// @notice Claims rewards with reentrancy protection.
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // Checks-effects-interactions: set state before external call
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
## Summary\nFix reentrancy vulnerability in StakingVault by adding OpenZeppelin ReentrancyGuard and applying checks-effects-interactions pattern.

## Changes Made\n- Inherited OpenZeppelin ReentrancyGuard\n- Added `nonReentrant` modifier to both `withdraw()` and `claimRewards()`\n- Moved state updates (balances, totalStaked, rewards) before external .call()\n- Created _meta.json metadata\n\n## Related Issue\nCloses #911