### PR TITLE
fix: add slippage protection, deadline, and minimum fee to SimpleSwap (#913)

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -10,6 +10,11 @@ contract SimpleSwap {
     uint256 public reserveB;
     uint256 public fee; // basis points, e.g. 30 = 0.3%
 
+    error InvalidToken();
+    error ZeroAmount();
+    error SlippageExceeded();
+    error TransactionExpired();
+
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
@@ -25,12 +30,23 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
-        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
-        require(amountIn > 0, "Amount must be > 0");
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        // Validate deadline to prevent stale transaction execution
+        if (block.timestamp > deadline) {
+            revert TransactionExpired();
+        }
+
+        if (tokenIn != address(tokenA) && tokenIn != address(tokenB)) {
+            revert InvalidToken();
+        }
+        if (amountIn == 0) {
+            revert ZeroAmount();
+        }
 
         bool isTokenA = tokenIn == address(tokenA);
         (IERC20 inputToken, IERC20 outputToken, uint256 reserveIn, uint256 reserveOut) = isTokenA
@@ -39,11 +55,20 @@ contract SimpleSwap {
 
         inputToken.transferFrom(msg.sender, address(this), amountIn);
 
-        uint256 feeAmount = amountIn * fee / 10000;
+        // Fix fee calculation: use max to ensure minimum fee of 1 for non-zero amounts
+        uint256 feeAmount = (amountIn * fee + 9999) / 10000; // ceiling division
+        if (feeAmount == 0 && amountIn > 0) {
+            feeAmount = 1; // minimum fee of 1 token unit
+        }
         uint256 amountInAfterFee = amountIn - feeAmount;
 
         // constant product formula: x * y = k
         amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+
+        // Slippage protection: ensure minimum output amount
+        if (amountOut < minAmountOut) {
+            revert SlippageExceeded();
+        }
 
         outputToken.transfer(msg.sender, amountOut);
 
@@ -62,7 +87,10 @@ contract SimpleSwap {
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
+        uint256 feeAmount = (amountIn * fee + 9999) / 10000;
+        if (feeAmount == 0 && amountIn > 0) {
+            feeAmount = 1;
+        }
         uint256 amountInAfterFee = amountIn - feeAmount;
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
     }


### PR DESCRIPTION
## Summary
Fixes #913

### Changes
- Add minAmountOut parameter to swap function for slippage protection
- Add deadline parameter to prevent stale transaction execution
- Fix fee calculation to use ceiling division ensuring minimum fee of 1
- Add custom errors for clearer revert reasons (SlippageExceeded, TransactionExpired)
- Update getAmountOut to use consistent fee calculation

### Security Improvements
The original swap function was vulnerable to sandwich attacks due to missing slippage protection and had no deadline for stale transactions.

Fixes #913