### PR TITLE
fix: replace tx.origin with msg.sender to prevent phishing attacks (#912)

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -19,6 +19,10 @@ contract GovernanceToken is ERC20 {
     Proposal[] public proposals;
     address public admin;
 
+    error CannotDelegateToSelf();
+    error NoDelegate();
+    error NotAdmin();
+
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
@@ -28,30 +32,36 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // Fix: Replace tx.origin with msg.sender to prevent phishing attacks
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
-        if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+        if (msg.sender == to) {
+            revert CannotDelegateToSelf();
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        address previousDelegate = delegates[msg.sender];
+        if (previousDelegate != address(0)) {
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
+        }
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    // Fix: Replace tx.origin with msg.sender
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
-        require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        address currentDelegate = delegates[msg.sender];
+        if (currentDelegate == address(0)) {
+            revert NoDelegate();
+        }
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
+    // Fix: Replace tx.origin with msg.sender for admin check
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        if (msg.sender != admin) {
+            revert NotAdmin();
+        }
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Summary
Fixes #912

### Changes
- Replace all tx.origin usage with msg.sender in delegateVote
- Replace tx.origin with msg.sender in revokeDelegate
- Replace tx.origin with msg.sender in snapshot admin check
- Add custom errors for clearer revert reasons (CannotDelegateToSelf, NoDelegate, NotAdmin)

### Security Impact
tx.origin is vulnerable to phishing attacks where a malicious contract tricks the user into calling it, allowing the attacker to impersonate the user in subsequent calls.

Fixes #912