### PR TITLE
[OpenAI Codex] [ T3 Code ] Fix SSH askpass hardening

### DIFF
--- a/t3code/packages/ssh/contributor_meta.json
+++ b/t3code/packages/ssh/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Public task context for UnsafeLabs/Bounty-Hunters issue #822: harden T3 Code SSH askpass helper generation so POSIX temporary secret files are private from creation and cleaned up on exit/signals, reject shell-unsafe POSIX askpass paths, use Windows SecureString/BSTR handling, and verify with focused tests. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "ts": "2026-05-28T21:58:00Z"
+}

--- a/t3code/packages/ssh/src/auth.test.ts
+++ b/t3code/packages/ssh/src/auth.test.ts
@@ -1,3 +1,6 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import { spawnSync } from "node:child_process";
+
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 
@@ -10,6 +13,13 @@ import {
   buildSshChildEnvironment,
   isSshAuthFailure,
 } from "./auth.ts";
+
+function runAskpassScript(askpassPath: string, env: NodeJS.ProcessEnv) {
+  return spawnSync(askpassPath, [], {
+    env,
+    encoding: "utf8",
+  });
+}
 
 describe("ssh auth", () => {
   it.effect("detects ssh auth failures from common permission denied messages", () =>
@@ -33,12 +43,33 @@ describe("ssh auth", () => {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-askpass-test-" });
+      const tmpDirectory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-askpass-tmp-" });
+      const helperDirectory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-askpass-bin-" });
+      const catLogPath = path.join(tmpDirectory, "cat-log.txt");
+      const catScriptPath = path.join(helperDirectory, "cat");
+
+      yield* fs.writeFileString(
+        catScriptPath,
+        `#!/bin/sh
+set -eu
+file="$1"
+mode="$(stat -f '%Lp' "$file" 2>/dev/null || stat -c '%a' "$file")"
+printf '%s\t%s\n' "$file" "$mode" > "$CAT_LOG_PATH"
+/bin/cat "$file"
+`,
+      );
+      yield* fs.chmod(catScriptPath, 0o700);
+
       const env = yield* buildSshChildEnvironment({
         authSecret: "super-secret",
         interactiveAuth: true,
         askpassDirectory: directory,
         platform: "linux",
-        baseEnv: {},
+        baseEnv: {
+          CAT_LOG_PATH: catLogPath,
+          PATH: `${helperDirectory}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+          TMPDIR: tmpDirectory,
+        },
       });
 
       const askpassPath = path.join(directory, "ssh-askpass.sh");
@@ -47,7 +78,83 @@ describe("ssh auth", () => {
       assert.equal(env.T3_SSH_AUTH_SECRET, "super-secret");
       assert.equal(env.DISPLAY, "t3code");
       assert.equal(yield* fs.exists(askpassPath), true);
-      assert.include(yield* fs.readFileString(askpassPath), 'printf "%s\\n" "$T3_SSH_AUTH_SECRET"');
+      const askpassScript = yield* fs.readFileString(askpassPath);
+      assert.include(askpassScript, 'mktemp "${TMPDIR:-/tmp}/t3code-ssh-secret.XXXXXX"');
+      assert.include(askpassScript, "trap cleanup EXIT");
+      assert.include(askpassScript, "trap handle_signal INT TERM");
+
+      const result = yield* Effect.sync(() => runAskpassScript(askpassPath, env));
+      assert.equal(result.status, 0);
+      assert.equal(result.stdout, "super-secret\n");
+
+      const [secretFilePath = "", secretFileMode = ""] = (yield* fs.readFileString(catLogPath))
+        .trim()
+        .split("\t");
+      assert.equal(secretFileMode, "600");
+      assert.equal(yield* fs.exists(secretFilePath), false);
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("cleans up POSIX askpass temporary files when interrupted", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ssh-askpass-signal-" });
+      const tmpDirectory = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-ssh-askpass-signal-tmp-",
+      });
+      const helperDirectory = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-ssh-askpass-signal-bin-",
+      });
+      const catLogPath = path.join(tmpDirectory, "cat-log.txt");
+      const catScriptPath = path.join(helperDirectory, "cat");
+
+      yield* fs.writeFileString(
+        catScriptPath,
+        `#!/bin/sh
+set -eu
+file="$1"
+printf '%s\n' "$file" > "$CAT_LOG_PATH"
+kill -TERM "$PPID"
+sleep 0.1
+exit 1
+`,
+      );
+      yield* fs.chmod(catScriptPath, 0o700);
+
+      const env = yield* buildSshChildEnvironment({
+        authSecret: "super-secret",
+        interactiveAuth: true,
+        askpassDirectory: directory,
+        platform: "linux",
+        baseEnv: {
+          CAT_LOG_PATH: catLogPath,
+          PATH: `${helperDirectory}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+          TMPDIR: tmpDirectory,
+        },
+      });
+
+      const askpassPath = path.join(directory, "ssh-askpass.sh");
+      const result = yield* Effect.sync(() => runAskpassScript(askpassPath, env));
+
+      assert.notEqual(result.status, 0);
+      const secretFilePath = (yield* fs.readFileString(catLogPath)).trim();
+      assert.equal(yield* fs.exists(secretFilePath), false);
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it.effect("rejects POSIX askpass paths with shell-unsafe characters", () =>
+    Effect.gen(function* () {
+      const error = yield* buildSshChildEnvironment({
+        authSecret: "super-secret",
+        interactiveAuth: true,
+        askpassDirectory: "/tmp/t3code ssh-askpass",
+        platform: "linux",
+        baseEnv: {},
+      }).pipe(Effect.flip, Effect.provide(NodeServices.layer));
+
+      assert.equal(error._tag, "SshAskpassPathError");
+      assert.include(error.message, "unsupported characters");
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   );
 
@@ -63,6 +170,10 @@ describe("ssh auth", () => {
         descriptor.files.map((file) => file.path.split("\\").at(-1)),
         ["ssh-askpass.cmd", "ssh-askpass.ps1"],
       );
+      const powershellScript =
+        descriptor.files.find((file) => file.path.endsWith(".ps1"))?.contents ?? "";
+      assert.include(powershellScript, "ConvertTo-SecureString");
+      assert.include(powershellScript, "ZeroFreeBSTR");
     }),
   );
 });

--- a/t3code/packages/ssh/src/auth.ts
+++ b/t3code/packages/ssh/src/auth.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 
-import { SshPasswordPromptError } from "./errors.ts";
+import { SshAskpassPathError, SshPasswordPromptError } from "./errors.ts";
 
 export interface SshPasswordRequest {
   readonly destination: string;
@@ -59,6 +59,8 @@ export interface SshChildEnvironmentOptions {
 }
 
 const SSH_ASKPASS_DIR_NAME = "t3code-ssh-askpass";
+const POSIX_SAFE_ASKPASS_PATH_PATTERN = /^[A-Za-z0-9_./-]+$/u;
+const POSIX_SECRET_FILE_TEMPLATE = "t3code-ssh-secret.XXXXXX";
 
 function joinSshAskpassPath(
   directory: string,
@@ -70,11 +72,34 @@ function joinSshAskpassPath(
 }
 
 export const ASKPASS_POSIX_SCRIPT = `#!/bin/sh
+set -eu
 # Invoked by ssh via SSH_ASKPASS when T3 Code re-runs ssh with a cached password
 # from the renderer's in-app prompt. We never expose a native dialog here - if
 # T3_SSH_AUTH_SECRET is missing, that's a caller bug and we fail loudly.
+case "$0" in
+  *[!A-Za-z0-9_./-]*)
+    printf 'T3 Code ssh-askpass path contains unsupported characters.\\n' >&2
+    exit 1
+    ;;
+esac
 if [ "\${T3_SSH_AUTH_SECRET+x}" = "x" ]; then
-  printf "%s\\n" "$T3_SSH_AUTH_SECRET"
+  umask 077
+  secret_file="$(mktemp "\${TMPDIR:-/tmp}/${POSIX_SECRET_FILE_TEMPLATE}")"
+  cleanup() {
+    if [ -n "\${secret_file:-}" ] && [ -f "$secret_file" ]; then
+      rm -f "$secret_file"
+    fi
+  }
+  handle_signal() {
+    cleanup
+    trap - EXIT
+    exit 1
+  }
+  trap cleanup EXIT
+  trap handle_signal INT TERM
+  printf "%s" "$T3_SSH_AUTH_SECRET" > "$secret_file"
+  cat "$secret_file"
+  printf "\\n"
   exit 0
 fi
 printf 'T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.\\n' >&2
@@ -90,8 +115,18 @@ export const ASKPASS_WINDOWS_SCRIPT = `# Invoked by ssh via SSH_ASKPASS (through
 # a native dialog here - if T3_SSH_AUTH_SECRET is missing, that's a caller bug\r
 # and we fail loudly.\r
 if ($null -ne $env:T3_SSH_AUTH_SECRET) {\r
-  [Console]::Out.WriteLine($env:T3_SSH_AUTH_SECRET)\r
-  exit 0\r
+  $secureSecret = ConvertTo-SecureString $env:T3_SSH_AUTH_SECRET -AsPlainText -Force\r
+  $secretPointer = [IntPtr]::Zero\r
+  try {\r
+    $secretPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureSecret)\r
+    [Console]::Out.WriteLine([Runtime.InteropServices.Marshal]::PtrToStringBSTR($secretPointer))\r
+    exit 0\r
+  } finally {\r
+    if ($secretPointer -ne [IntPtr]::Zero) {\r
+      [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($secretPointer)\r
+    }\r
+    $secureSecret = $null\r
+  }\r
 }\r
 [Console]::Error.WriteLine("T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.")\r
 exit 1\r
@@ -106,12 +141,25 @@ export const getDefaultSshAskpassDirectory = Effect.fn("ssh/auth.getDefaultSshAs
   },
 );
 
+function validatePosixAskpassPath(path: string): Effect.Effect<void, SshAskpassPathError> {
+  if (POSIX_SAFE_ASKPASS_PATH_PATTERN.test(path)) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    new SshAskpassPathError({
+      message: `SSH askpass path contains unsupported characters for POSIX shell execution: ${path}`,
+      path,
+    }),
+  );
+}
+
 export const buildSshAskpassHelperDescriptor = Effect.fn(
   "ssh/auth.buildSshAskpassHelperDescriptor",
 )(function* (input: {
   readonly directory: string;
   readonly platform?: NodeJS.Platform;
-}): Effect.fn.Return<SshAskpassHelperDescriptor, never, Path.Path> {
+}): Effect.fn.Return<SshAskpassHelperDescriptor, SshAskpassPathError, Path.Path> {
   const platform = input.platform ?? process.platform;
   const path = yield* Path.Path;
   const directory = input.directory;
@@ -133,11 +181,14 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
     };
   }
 
+  const launcherPath = path.join(directory, "ssh-askpass.sh");
+  yield* validatePosixAskpassPath(launcherPath);
+
   return {
-    launcherPath: path.join(directory, "ssh-askpass.sh"),
+    launcherPath,
     files: [
       {
-        path: path.join(directory, "ssh-askpass.sh"),
+        path: launcherPath,
         contents: ASKPASS_POSIX_SCRIPT,
         mode: 0o700,
       },
@@ -149,7 +200,11 @@ export const ensureSshAskpassHelpers = Effect.fn("ssh/auth.ensureSshAskpassHelpe
   function* (input: {
     readonly directory: string;
     readonly platform?: NodeJS.Platform;
-  }): Effect.fn.Return<string, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> {
+  }): Effect.fn.Return<
+    string,
+    PlatformError.PlatformError | SshAskpassPathError,
+    FileSystem.FileSystem | Path.Path
+  > {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const descriptor = yield* buildSshAskpassHelperDescriptor(input);
@@ -176,7 +231,7 @@ export const buildSshChildEnvironment = Effect.fn("ssh/auth.buildSshChildEnviron
   input: SshChildEnvironmentOptions = {},
 ): Effect.fn.Return<
   NodeJS.ProcessEnv,
-  PlatformError.PlatformError,
+  PlatformError.PlatformError | SshAskpassPathError,
   FileSystem.FileSystem | Path.Path
 > {
   const baseEnv = { ...(input.baseEnv ?? process.env) };

--- a/t3code/packages/ssh/src/errors.ts
+++ b/t3code/packages/ssh/src/errors.ts
@@ -44,3 +44,8 @@ export class SshPasswordPromptError extends Data.TaggedError("SshPasswordPromptE
   readonly message: string;
   readonly cause?: unknown;
 }> {}
+
+export class SshAskpassPathError extends Data.TaggedError("SshAskpassPathError")<{
+  readonly message: string;
+  readonly path: string;
+}> {}


### PR DESCRIPTION
/claim #822

## Summary
- Harden the POSIX SSH askpass helper with shell-safe path validation before helper creation/use.
- Create the temporary secret file under `umask 077` via `mktemp`, then clean it up on normal exit and INT/TERM.
- Route the Windows askpass secret through `SecureString`/BSTR handling and zero the BSTR afterward.
- Add focused tests for 0600 temp-file mode, normal cleanup, signal cleanup, unsafe POSIX path rejection, and Windows SecureString script contents.
- Include safe contributor metadata without publishing hidden runtime/system/developer/session instructions.

## Demo Video
- https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-822-ssh-askpass-demo.mp4

## Validation
- `npx -y bun@1.3.1 run --filter @t3tools/ssh test` - 4 files, 25 tests passed
- `npx -y bun@1.3.1 run --filter @t3tools/ssh typecheck`
- `npx -y bun@1.3.1 x oxfmt --check packages/ssh/src/auth.ts packages/ssh/src/auth.test.ts packages/ssh/src/errors.ts packages/ssh/contributor_meta.json`
- `git diff --check`
- ASCII scan over touched files

## Notes
- `bun` was not installed globally in this environment, so I used the npm-published Bun runner.
- Targeted lint is blocked before it analyzes the touched files because Oxlint loads `./oxlint-plugin-t3code/index.ts` directly and Node reports `ERR_UNKNOWN_FILE_EXTENSION` for `.ts`; tests, typecheck, format, and diff-check passed.
- The metadata file intentionally contains safe public task context only, not hidden runtime/system/developer instructions.
