### PR TITLE
unsiqasik [ FastAPI ] Add StreamingCSVResponse for large dataset exports

### DIFF
--- a/fastapi/fastapi/contributor_meta.json
+++ b/fastapi/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "unsiqasik",
+  "session_init": "Bounty hunter autonomous loop - searching for GitHub bounties to work on. Found issue #799 on UnsafeLabs/Bounty-Hunters: [FastAPI] Add StreamingCSVResponse for large dataset exports - $65 bounty.",
+  "ts": "2026-05-28T14:30:00Z"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -96,3 +96,88 @@ class ORJSONResponse(JSONResponse):
         return orjson.dumps(
             content, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
         )
+
+
+class StreamingCSVResponse(StreamingResponse):
+    """A streaming CSV response for large dataset exports.
+
+    Accepts an async generator of row data and streams it as a CSV file
+    without loading the entire dataset into memory.
+
+    Implements RFC 4180 escaping: values containing commas, double quotes,
+    or newlines are wrapped in double quotes, with internal double quotes
+    escaped by doubling.
+
+    ## Usage
+
+    ```python
+    from fastapi import FastAPI
+    from fastapi.responses import StreamingCSVResponse
+
+    app = FastAPI()
+
+    async def generate_rows():
+        yield [\"Alice\", 30, \"Engineer\"]
+        yield [\"Bob\", 25, \"Designer\"]
+
+    @app.get(\"/export\")
+    async def export():
+        return StreamingCSVResponse(
+            generate_rows(),
+            headers=[\"Name\", \"Age\", \"Role\"],
+            filename=\"users.csv\",
+        )
+    ```
+    """
+
+    def __init__(
+        self,
+        rows,
+        headers: list[str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        media_type: str = "text/csv",
+        **kwargs,
+    ):
+        self._rows = rows
+        self._headers = headers
+        self._delimiter = delimiter
+
+        content = self._stream()
+        content_headers = {
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        }
+
+        super().__init__(
+            content=content,
+            media_type=media_type,
+            headers=content_headers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _escape_field(value: Any, delimiter: str) -> str:
+        """Escape a CSV field per RFC 4180."""
+        s = str(value)
+        # If the value contains a comma, double quote, newline, or the
+        # delimiter itself, wrap in double quotes and escape internal quotes.
+        needs_escaping = (
+            delimiter in s or '"' in s or "\n" in s or "\r" in s or "," in s
+        )
+        if needs_escaping:
+            return '"' + s.replace('"', '""') + '"'
+        return s
+
+    async def _stream(self):
+        """Async generator that yields CSV content as bytes."""
+        if self._headers:
+            line = self._delimiter.join(
+                self._escape_field(h, self._delimiter) for h in self._headers
+            )
+            yield (line + "\r\n").encode("utf-8")
+
+        async for row in self._rows:
+            line = self._delimiter.join(
+                self._escape_field(cell, self._delimiter) for cell in row
+            )
+            yield (line + "\r\n").encode("utf-8")

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _async_rows(data):
+    """Helper async generator that yields rows."""
+    for row in data:
+        yield row
+
+
+def _make_app(rows, **kwargs):
+    app = FastAPI()
+
+    @app.get("/export")
+    async def export():
+        return StreamingCSVResponse(_async_rows(rows), **kwargs)
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingCSVResponse:
+    def test_basic_rows(self):
+        app = _make_app([["Alice", 30], ["Bob", 25]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "text/csv; charset=utf-8"
+        assert "attachment" in resp.headers.get("content-disposition", "")
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == "Alice,30"
+        assert lines[1] == "Bob,25"
+
+    def test_with_headers(self):
+        app = _make_app(
+            [["Alice", 30], ["Bob", 25]],
+            headers=["Name", "Age"],
+        )
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        assert resp.status_code == 200
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == "Name,Age"
+        assert lines[1] == "Alice,30"
+        assert lines[2] == "Bob,25"
+
+    def test_custom_filename(self):
+        app = _make_app([["a"]], filename="data.csv")
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        assert 'filename="data.csv"' in resp.headers["content-disposition"]
+
+    def test_default_filename(self):
+        app = _make_app([["a"]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        assert 'filename="export.csv"' in resp.headers["content-disposition"]
+
+    def test_escape_comma_in_value(self):
+        app = _make_app([["Smith, John", 30]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == '"Smith, John",30'
+
+    def test_escape_double_quote_in_value(self):
+        app = _make_app([['He said "hello"', 30]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == '"He said ""hello""",30'
+
+    def test_escape_newline_in_value(self):
+        app = _make_app([["Line1\nLine2", 30]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == '"Line1\nLine2",30'
+
+    def test_custom_delimiter(self):
+        app = _make_app(
+            [["Alice", 30], ["Bob", 25]],
+            headers=["Name", "Age"],
+            delimiter=";",
+        )
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == "Name;Age"
+        assert lines[1] == "Alice;30"
+
+    def test_empty_rows(self):
+        app = _make_app([], headers=["A", "B"])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        assert resp.status_code == 200
+        lines = resp.text.strip().split("\r\n")
+        assert lines == ["A,B"]
+
+    def test_no_headers(self):
+        app = _make_app([["x", "y"]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == "x,y"
+        assert len(lines) == 1
+
+    def test_numeric_values(self):
+        app = _make_app([[1, 2.5, True]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        lines = resp.text.strip().split("\r\n")
+        assert lines[0] == "1,2.5,True"
+
+    def test_media_type(self):
+        app = _make_app([["a"]])
+        client = TestClient(app)
+
+        resp = client.get("/export")
+        assert "text/csv" in resp.headers["content-type"]


### PR DESCRIPTION
## Summary

Adds a `StreamingCSVResponse` class for streaming large CSV exports without loading the entire dataset into memory.

### Changes

**`fastapi/fastapi/responses.py`**
- Added `StreamingCSVResponse` class extending `StreamingResponse`
- Accepts an async generator of row data
- RFC 4180 escaping: values with commas, double quotes, or newlines are properly escaped
- Configurable `headers` (column names as first row), `filename`, and `delimiter`
- Sets `Content-Type: text/csv` and `Content-Disposition: attachment`

**`fastapi/tests/test_streaming_csv_response.py`** — 12 tests:
- Basic rows, with headers, custom filename, default filename
- Escape comma, double quote, newline in values
- Custom delimiter, empty rows, no headers, numeric values, media type

**`fastapi/fastapi/contributor_meta.json`** — contributor metadata

### Usage

```python
from fastapi import FastAPI
from fastapi.responses import StreamingCSVResponse

app = FastAPI()

async def generate_rows():
    yield ["Alice", 30, "Engineer"]
    yield ["Bob", 25, "Designer"]

@app.get("/export")
async def export():
    return StreamingCSVResponse(
        generate_rows(),
        headers=["Name", "Age", "Role"],
        filename="users.csv",
    )
```

Fixes #799