### PR TITLE
OpenAI Codex [ Crypto ] Fix YieldVault phantom rewards

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/solidity/contracts/YieldVault.sol
+++ b/solidity/contracts/YieldVault.sol
@@ -4,9 +4,12 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract YieldVault {
+    uint256 private constant PRECISION = 1e18;
+
     IERC20 public rewardToken;
     IERC20 public stakingToken;
 
+    // Scaled by PRECISION to preserve fractional reward units over long periods.
     uint256 public rewardRate;
     uint256 public periodFinish;
     uint256 public lastUpdateTime;
@@ -29,26 +32,33 @@ contract YieldVault {
         rewardDistributor = msg.sender;
     }
 
-    // BUG: Does not cap at periodFinish — accrues phantom rewards after period ends
+    function lastTimeRewardApplicable() public view returns (uint256) {
+        return block.timestamp < periodFinish ? block.timestamp : periodFinish;
+    }
+
     function rewardPerToken() public view returns (uint256) {
         if (totalSupply == 0) return rewardPerTokenStored;
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / totalSupply
+            (lastTimeRewardApplicable() - lastUpdateTime) * rewardRate / totalSupply
         );
     }
 
-    // BUG: Uses uncapped rewardPerToken
     function earned(address account) public view returns (uint256) {
-        return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / 1e18 + rewards[account];
+        return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / PRECISION + rewards[account];
     }
 
     modifier updateReward(address account) {
         rewardPerTokenStored = rewardPerToken();
-        lastUpdateTime = block.timestamp;
+        lastUpdateTime = lastTimeRewardApplicable();
         if (account != address(0)) {
             rewards[account] = earned(account);
             userRewardPerTokenPaid[account] = rewardPerTokenStored;
         }
+        _;
+    }
+
+    modifier onlyRewardDistributor() {
+        require(msg.sender == rewardDistributor, "Not reward distributor");
         _;
     }
 
@@ -77,10 +87,10 @@ contract YieldVault {
         }
     }
 
-    // BUG: No access control — anyone can call
-    // BUG: Precision loss in rewardRate calculation
-    function notifyRewardAmount(uint256 reward, uint256 duration) external updateReward(address(0)) {
-        rewardRate = reward / duration;
+    function notifyRewardAmount(uint256 reward, uint256 duration) external onlyRewardDistributor updateReward(address(0)) {
+        require(reward > 0, "Reward must be greater than 0");
+        require(duration > 0, "Duration must be greater than 0");
+        rewardRate = reward * PRECISION / duration;
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + duration;
     }

--- a/solidity/contracts/_contributor.json
+++ b/solidity/contracts/_contributor.json
@@ -1,0 +1,6 @@
+{
+  "identity": "OpenAI Codex",
+  "bounty": "914",
+  "runtime_instructions": "Public task context for UnsafeLabs/Bounty-Hunters issue #914: cap YieldVault reward accrual at periodFinish, use capped earned calculations, restrict reward notifications to the distributor, preserve reward-rate precision with fixed-point scaling, and verify active accrual, expiry freeze, access control, precision, and claim/withdraw flows. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "timestamp": "2026-05-28T22:48:00Z"
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "mocha \"test/**/*.test.mjs\""
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.0.2",
+    "ethers": "^6.13.5",
+    "ganache": "^7.9.2",
+    "mocha": "^10.8.2",
+    "solc": "^0.8.26"
+  }
+}

--- a/solidity/test/yieldVault.test.mjs
+++ b/solidity/test/yieldVault.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+
+const mockErc20Source = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}`;
+
+function findImport(importPath) {
+  try {
+    const resolved = require.resolve(importPath, { paths: [rootDir] });
+    return { contents: readFileSync(resolved, "utf8") };
+  } catch (error) {
+    return { error: `File not found: ${importPath}` };
+  }
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "YieldVault.sol": {
+        content: readFileSync(path.join(rootDir, "contracts", "YieldVault.sol"), "utf8"),
+      },
+      "MockERC20.sol": {
+        content: mockErc20Source,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: findImport }));
+  const errors = output.errors?.filter((entry) => entry.severity === "error") ?? [];
+  assert.equal(errors.length, 0, errors.map((entry) => entry.formattedMessage).join("\n"));
+
+  return {
+    YieldVault: output.contracts["YieldVault.sol"].YieldVault,
+    MockERC20: output.contracts["MockERC20.sol"].MockERC20,
+  };
+}
+
+async function increaseTime(provider, seconds) {
+  await provider.send("evm_increaseTime", [seconds]);
+  await provider.send("evm_mine", []);
+}
+
+async function deployFixture() {
+  const contracts = compileContracts();
+  const ganacheProvider = ganache.provider({
+    logging: { quiet: true },
+    wallet: { totalAccounts: 4 },
+    chain: { time: new Date("2026-01-01T00:00:00Z") },
+  });
+  const provider = new ethers.BrowserProvider(ganacheProvider);
+  const [distributor, alice, bob, attacker] = await provider.listAccounts();
+
+  const tokenFactory = new ethers.ContractFactory(
+    contracts.MockERC20.abi,
+    contracts.MockERC20.evm.bytecode.object,
+    distributor,
+  );
+  const stakingToken = await tokenFactory.deploy("Stake Token", "STK");
+  await stakingToken.waitForDeployment();
+  const rewardToken = await tokenFactory.deploy("Reward Token", "RWD");
+  await rewardToken.waitForDeployment();
+
+  const vaultFactory = new ethers.ContractFactory(
+    contracts.YieldVault.abi,
+    contracts.YieldVault.evm.bytecode.object,
+    distributor,
+  );
+  const vault = await vaultFactory.deploy(stakingToken.target, rewardToken.target);
+  await vault.waitForDeployment();
+
+  await stakingToken.mint(alice.address, ethers.parseEther("1000"));
+  await stakingToken.mint(bob.address, ethers.parseEther("1000"));
+  await rewardToken.mint(vault.target, ethers.parseEther("10000"));
+
+  await stakingToken.connect(alice).approve(vault.target, ethers.MaxUint256);
+  await stakingToken.connect(bob).approve(vault.target, ethers.MaxUint256);
+
+  return {
+    provider,
+    distributor,
+    alice,
+    bob,
+    attacker,
+    stakingToken,
+    rewardToken,
+    vault,
+  };
+}
+
+describe("YieldVault", function () {
+  this.timeout(20_000);
+
+  it("accrues rewards during the active reward period", async () => {
+    const { provider, distributor, alice, vault } = await deployFixture();
+
+    await vault.connect(alice).deposit(ethers.parseEther("100"));
+    await vault.connect(distributor).notifyRewardAmount(ethers.parseEther("100"), 100n);
+    await increaseTime(provider, 25);
+
+    const earned = await vault.earned(alice.address);
+
+    assert.ok(earned >= ethers.parseEther("24.999"));
+    assert.ok(earned <= ethers.parseEther("25.001"));
+  });
+
+  it("freezes reward accrual after the reward period finishes", async () => {
+    const { provider, distributor, alice, vault } = await deployFixture();
+
+    await vault.connect(alice).deposit(ethers.parseEther("100"));
+    await vault.connect(distributor).notifyRewardAmount(ethers.parseEther("100"), 100n);
+    await increaseTime(provider, 110);
+    const earnedAtFinish = await vault.earned(alice.address);
+    await increaseTime(provider, 1000);
+    const earnedLater = await vault.earned(alice.address);
+
+    assert.equal(earnedLater, earnedAtFinish);
+    assert.ok(earnedLater <= ethers.parseEther("100.000000000000000001"));
+  });
+
+  it("rejects reward notifications from non-distributors", async () => {
+    const { attacker, vault } = await deployFixture();
+
+    await assert.rejects(
+      vault.connect(attacker).notifyRewardAmount(ethers.parseEther("100"), 100n),
+      (error) => error.code === "CALL_EXCEPTION",
+    );
+  });
+
+  it("keeps reward-rate precision error under 0.01 percent", async () => {
+    const { provider, distributor, alice, vault } = await deployFixture();
+    const reward = 100000n;
+    const duration = 365n * 24n * 60n * 60n + 17n;
+
+    await vault.connect(alice).deposit(1n);
+    await vault.connect(distributor).notifyRewardAmount(reward, duration);
+    await increaseTime(provider, Number(duration) + 100);
+
+    const earned = await vault.earned(alice.address);
+    const error = reward > earned ? reward - earned : earned - reward;
+
+    assert.ok(error * 10000n < reward, `precision error too large: ${error}`);
+  });
+
+  it("supports deposit, withdrawal, and reward claim flows", async () => {
+    const { provider, distributor, alice, bob, stakingToken, rewardToken, vault } =
+      await deployFixture();
+
+    await vault.connect(alice).deposit(ethers.parseEther("100"));
+    await vault.connect(bob).deposit(ethers.parseEther("300"));
+    await vault.connect(distributor).notifyRewardAmount(ethers.parseEther("80"), 80n);
+    await increaseTime(provider, 40);
+
+    await vault.connect(alice).withdraw(ethers.parseEther("40"));
+    assert.equal(await vault.balanceOf(alice.address), ethers.parseEther("60"));
+    assert.equal(await stakingToken.balanceOf(alice.address), ethers.parseEther("940"));
+
+    await increaseTime(provider, 50);
+    await vault.connect(alice).claimReward();
+    await vault.connect(bob).claimReward();
+
+    assert.ok((await rewardToken.balanceOf(alice.address)) > 0n);
+    assert.ok((await rewardToken.balanceOf(bob.address)) > 0n);
+    assert.equal(await vault.rewards(alice.address), 0n);
+    assert.equal(await vault.rewards(bob.address), 0n);
+  });
+});


### PR DESCRIPTION
/claim #914

## Summary
- Cap reward accrual at `periodFinish` with `lastTimeRewardApplicable()` and make `earned()` use the capped reward-per-token value.
- Update `lastUpdateTime` with the capped timestamp so no phantom rewards accrue after expiry.
- Restrict `notifyRewardAmount()` to the configured reward distributor.
- Preserve reward-rate precision with fixed-point scaling and divide at accounting time.
- Add Solidity/Ganache tests for active accrual, reward freeze after expiry, unauthorized notify, precision error under 0.01%, and deposit/withdraw/claim flows.
- Include safe public `_contributor.json` metadata without publishing hidden runtime/system/developer/session instructions.

## Demo Video
- https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-914-yieldvault-demo.mp4

## Validation
- `npm install --no-package-lock`
- `npm test` - 5 passing
- `git diff --check`
- JSON parse check for `solidity/package.json` and `solidity/contracts/_contributor.json`
- ASCII scan over touched files

## Notes
- Ganache prints a local µWS native-binary fallback warning on this machine; the suite still passes using the JS fallback.
