### PR TITLE
OpenAI Codex [ Crypto ] Harden FlashLoan repayment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/solidity/contracts/.contributor.json
+++ b/solidity/contracts/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Public task context for UnsafeLabs/Bounty-Hunters issue #919: harden FlashLoan with a one-unit minimum fee, 50% max-loan cap from internal pool accounting, explicit transferFrom repayment after callback, owner pause/unpause controls, checked transfers, and Ganache/Solc tests for fee floor, cap, balance manipulation, fee accounting, and pause/unpause. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "timestamp": "2026-05-28T18:35:00-05:00"
+}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -11,55 +11,96 @@ contract FlashLoan {
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
+    uint256 private poolBalance;
     address public owner;
     bool public paused;
+    bool private activeLoan;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event PoolDeposit(address indexed depositor, uint256 amount);
+    event FeesWithdrawn(address indexed owner, uint256 amount);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
     constructor(address _loanToken, uint256 _feeBPS) {
+        require(_loanToken != address(0), "Invalid token");
+        require(_feeBPS <= 10000, "Invalid fee");
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
     function flashLoan(uint256 amount, bytes calldata data) external {
         require(!paused, "Paused");
+        require(!activeLoan, "Loan active");
         require(amount > 0, "Amount must be > 0");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        uint256 availablePool = poolBalance;
+        require(amount <= availablePool, "Insufficient pool balance");
+        require(amount <= availablePool / 2, "Amount exceeds max loan");
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
         uint256 fee = amount * feeBPS / 10000;
+        if (fee == 0) {
+            fee = 1;
+        }
 
-        loanToken.transfer(msg.sender, amount);
+        poolBalance = availablePool - amount;
+        activeLoan = true;
+
+        require(loanToken.transfer(msg.sender, amount), "Loan transfer failed");
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(
+            loanToken.transferFrom(msg.sender, address(this), amount + fee),
+            "Loan repayment failed"
+        );
 
+        activeLoan = false;
+        poolBalance = availablePool;
         totalFees += fee;
+        require(
+            loanToken.balanceOf(address(this)) >= poolBalance + totalFees,
+            "Pool accounting mismatch"
+        );
+
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(amount > 0, "Amount must be > 0");
+        require(
+            loanToken.transferFrom(msg.sender, address(this), amount),
+            "Deposit transfer failed"
+        );
+        poolBalance += amount;
+        emit PoolDeposit(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
+        require(fees > 0, "No fees");
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        require(loanToken.transfer(owner, fees), "Fee transfer failed");
+        emit FeesWithdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolBalance;
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "mocha \"test/*.test.mjs\""
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.3.0",
+    "ethers": "^6.14.4",
+    "ganache": "^7.9.2",
+    "mocha": "^11.7.0",
+    "solc": "^0.8.30"
+  }
+}

--- a/solidity/test/flashLoan.test.mjs
+++ b/solidity/test/flashLoan.test.mjs
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(solidityRoot, "..");
+
+const mockTokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock Token", "MOCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract BalanceOverrideToken is MockToken {
+    mapping(address => uint256) public forcedBalances;
+
+    function forceBalance(address account, uint256 amount) external {
+        forcedBalances[account] = amount;
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        uint256 forced = forcedBalances[account];
+        if (forced != 0) {
+            return forced;
+        }
+        return super.balanceOf(account);
+    }
+}
+`;
+
+const borrowerSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20Like {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+interface IFlashLoanLike {
+    function flashLoan(uint256 amount, bytes calldata data) external;
+}
+
+contract FlashBorrower {
+    address public immutable lender;
+    address public immutable token;
+
+    constructor(address lender_, address token_) {
+        lender = lender_;
+        token = token_;
+    }
+
+    function execute(uint256 amount) external {
+        IFlashLoanLike(lender).flashLoan(amount, "");
+    }
+
+    function onFlashLoan(address loanToken, uint256 amount, uint256 fee, bytes calldata) external {
+        require(msg.sender == lender, "unexpected lender");
+        require(loanToken == token, "unexpected token");
+        IERC20Like(token).approve(lender, amount + fee);
+    }
+}
+
+interface IBalanceOverrideToken is IERC20Like {
+    function forceBalance(address account, uint256 amount) external;
+}
+
+contract ManipulativeBorrower {
+    address public immutable lender;
+    address public immutable token;
+
+    constructor(address lender_, address token_) {
+        lender = lender_;
+        token = token_;
+    }
+
+    function execute(uint256 amount) external {
+        IFlashLoanLike(lender).flashLoan(amount, "");
+    }
+
+    function onFlashLoan(address loanToken, uint256, uint256, bytes calldata) external {
+        require(msg.sender == lender, "unexpected lender");
+        require(loanToken == token, "unexpected token");
+        IBalanceOverrideToken(token).forceBalance(lender, type(uint256).max);
+    }
+}
+`;
+
+function resolveImport(importPath) {
+  if (importPath.startsWith("@openzeppelin/")) {
+    const resolved = require.resolve(importPath, { paths: [solidityRoot] });
+    return { contents: readFileSync(resolved, "utf8") };
+  }
+
+  const localPath = path.join(repoRoot, importPath);
+  try {
+    return { contents: readFileSync(localPath, "utf8") };
+  } catch (error) {
+    return { error: `Unable to resolve ${importPath}: ${error.message}` };
+  }
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "solidity/contracts/FlashLoan.sol": {
+        content: readFileSync(path.join(solidityRoot, "contracts", "FlashLoan.sol"), "utf8"),
+      },
+      "test/MockToken.sol": {
+        content: mockTokenSource,
+      },
+      "test/FlashBorrower.sol": {
+        content: borrowerSource,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: resolveImport }));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  return {
+    lender: output.contracts["solidity/contracts/FlashLoan.sol"].FlashLoan,
+    token: output.contracts["test/MockToken.sol"].MockToken,
+    balanceOverrideToken: output.contracts["test/MockToken.sol"].BalanceOverrideToken,
+    borrower: output.contracts["test/FlashBorrower.sol"].FlashBorrower,
+    manipulativeBorrower: output.contracts["test/FlashBorrower.sol"].ManipulativeBorrower,
+  };
+}
+
+async function deploy(contract, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    contract.abi,
+    `0x${contract.evm.bytecode.object}`,
+    signer,
+  );
+  const deployment = await factory.deploy(...args);
+  await deployment.waitForDeployment();
+  return deployment;
+}
+
+async function expectRevert(action, messagePattern = /revert/i) {
+  try {
+    await action();
+  } catch (error) {
+    assert.match(String(error.shortMessage ?? error.message), messagePattern);
+    return;
+  }
+  assert.fail("Expected revert");
+}
+
+describe("FlashLoan", function () {
+  let contracts;
+  let provider;
+  let owner;
+  let other;
+
+  before(function () {
+    contracts = compileContracts();
+  });
+
+  beforeEach(async function () {
+    const ganacheProvider = ganache.provider({
+      chain: { chainId: 31_337 },
+      logging: { quiet: true },
+      wallet: { deterministic: true, totalAccounts: 4 },
+    });
+    provider = new ethers.BrowserProvider(ganacheProvider);
+    owner = await provider.getSigner(0);
+    other = await provider.getSigner(1);
+  });
+
+  async function deployFundedLender({ tokenContract = contracts.token, feeBps = 30n } = {}) {
+    const token = await deploy(tokenContract, owner);
+    const lender = await deploy(contracts.lender, owner, [await token.getAddress(), feeBps]);
+    const poolAmount = 1_000_000n;
+    await (await token.mint(await owner.getAddress(), poolAmount)).wait();
+    await (await token.approve(await lender.getAddress(), poolAmount)).wait();
+    await (await lender.depositToPool(poolAmount)).wait();
+    return { token, lender, poolAmount };
+  }
+
+  it("charges at least one token unit on small flash loans", async function () {
+    const { token, lender, poolAmount } = await deployFundedLender();
+    const borrower = await deploy(contracts.borrower, owner, [
+      await lender.getAddress(),
+      await token.getAddress(),
+    ]);
+    await (await token.mint(await borrower.getAddress(), 1n)).wait();
+
+    await (await borrower.execute(1n)).wait();
+
+    assert.equal(await lender.totalFees(), 1n);
+    assert.equal(await lender.getPoolBalance(), poolAmount);
+    assert.equal(await token.balanceOf(await lender.getAddress()), poolAmount + 1n);
+  });
+
+  it("rejects loans larger than half of the tracked pool balance", async function () {
+    const { lender, poolAmount } = await deployFundedLender();
+
+    await expectRevert(
+      async () => lender.flashLoan(poolAmount / 2n + 1n, "0x"),
+      /Amount exceeds max loan|revert/i,
+    );
+  });
+
+  it("keeps fees separate from principal accounting", async function () {
+    const { token, lender, poolAmount } = await deployFundedLender({ feeBps: 100n });
+    const borrower = await deploy(contracts.borrower, owner, [
+      await lender.getAddress(),
+      await token.getAddress(),
+    ]);
+    const amount = 10_000n;
+    const fee = 100n;
+    await (await token.mint(await borrower.getAddress(), fee)).wait();
+
+    await (await borrower.execute(amount)).wait();
+
+    assert.equal(await lender.getPoolBalance(), poolAmount);
+    assert.equal(await lender.totalFees(), fee);
+
+    const ownerBefore = await token.balanceOf(await owner.getAddress());
+    await (await lender.withdrawFees()).wait();
+    assert.equal(await lender.totalFees(), 0n);
+    assert.equal(await lender.getPoolBalance(), poolAmount);
+    assert.equal(await token.balanceOf(await owner.getAddress()), ownerBefore + fee);
+    assert.equal(await token.balanceOf(await lender.getAddress()), poolAmount);
+  });
+
+  it("does not accept manipulated balanceOf values as repayment", async function () {
+    const { token, lender } = await deployFundedLender({
+      tokenContract: contracts.balanceOverrideToken,
+    });
+    const borrower = await deploy(contracts.manipulativeBorrower, owner, [
+      await lender.getAddress(),
+      await token.getAddress(),
+    ]);
+
+    await expectRevert(async () => {
+      const tx = await borrower.execute(100n);
+      await tx.wait();
+    }, /revert/i);
+
+    assert.equal(await lender.totalFees(), 0n);
+  });
+
+  it("lets only the owner pause and unpause flash loans", async function () {
+    const { token, lender } = await deployFundedLender();
+    const borrower = await deploy(contracts.borrower, owner, [
+      await lender.getAddress(),
+      await token.getAddress(),
+    ]);
+    await (await token.mint(await borrower.getAddress(), 1n)).wait();
+
+    await expectRevert(async () => {
+      const tx = await lender.connect(other).pause();
+      await tx.wait();
+    }, /Not owner|revert/i);
+
+    await (await lender.pause()).wait();
+    await expectRevert(async () => {
+      const tx = await borrower.execute(1n);
+      await tx.wait();
+    }, /Paused|revert/i);
+
+    await (await lender.unpause()).wait();
+    const activeBorrower = await deploy(contracts.borrower, owner, [
+      await lender.getAddress(),
+      await token.getAddress(),
+    ]);
+    await (await token.mint(await activeBorrower.getAddress(), 1n)).wait();
+    await (await activeBorrower.execute(1n)).wait();
+    assert.equal(await lender.totalFees(), 1n);
+  });
+});


### PR DESCRIPTION
/claim #919

Summary:
- Add internal pool principal accounting, keeping accrued fees separate from pool balance.
- Enforce a one-unit minimum flash-loan fee and a 50% max-loan cap from tracked pool liquidity.
- Replace passive post-callback `balanceOf` repayment validation with explicit borrower `transferFrom(amount + fee)` repayment.
- Add owner-only pause/unpause controls, checked ERC20 transfers, and public contributor metadata.

Demo:
- https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-919-flashloan-demo.mp4

Validation:
- `npm install --no-package-lock`
- `npm test` (5 passing)
- `git diff --check`
- `.contributor.json` parsed with `python3 -m json.tool`
- ASCII scan for committed files

Note:
- Ganache printed its known µWS native-binary fallback warning on this Node build, then ran the tests successfully using the NodeJS fallback.