### PR TITLE
OpenAI Codex [ Crypto ] Harden PriceOracle fallback validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Public task context for UnsafeLabs/Bounty-Hunters issue #915: harden PriceOracle with Chainlink round completeness, positive price, timestamp/staleness validation, stale-primary fallback, StalePrice event emission, owner-configurable max staleness, and Ganache/Solc tests for valid, stale fallback, invalid price, incomplete round, both-stale, and owner controls. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "date": "2026-05-28T18:50:00-05:00"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,86 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed feed, uint256 updatedAt);
+    event FallbackOracleUpdated(address indexed previousFeed, address indexed newFeed);
+    event MaxStalenessUpdated(uint256 previousMaxStaleness, uint256 newMaxStaleness);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
     constructor(address _primaryFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+    function getLatestPrice() external returns (int256) {
+        (int256 price, uint256 updatedAt, bool isStale) = _readValidatedPrice(primaryFeed);
+        if (!isStale) {
+            emit PriceQueried(price, updatedAt);
+            return price;
+        }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        emit StalePrice(address(primaryFeed), updatedAt);
+        require(address(fallbackFeed) != address(0), "Stale price");
 
-        return price;
+        (int256 fallbackPrice, uint256 fallbackUpdatedAt, bool fallbackIsStale) =
+            _readValidatedPrice(fallbackFeed);
+        require(!fallbackIsStale, "Stale price");
+
+        emit PriceQueried(fallbackPrice, fallbackUpdatedAt);
+        return fallbackPrice;
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        require(_fallbackFeed != address(primaryFeed), "Invalid fallback feed");
+
+        address previousFeed = address(fallbackFeed);
+        if (_fallbackFeed == address(0)) {
+            fallbackFeed = AggregatorV3Interface(address(0));
+            emit FallbackOracleUpdated(previousFeed, address(0));
+            return;
+        }
+
+        AggregatorV3Interface newFallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        require(newFallbackFeed.decimals() == primaryFeed.decimals(), "Decimals mismatch");
+        fallbackFeed = newFallbackFeed;
+        emit FallbackOracleUpdated(previousFeed, _fallbackFeed);
+    }
+
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        require(_maxStaleness > 0, "Invalid staleness");
+        uint256 previousMaxStaleness = MAX_STALENESS;
         MAX_STALENESS = _maxStaleness;
+        emit MaxStalenessUpdated(previousMaxStaleness, _maxStaleness);
+    }
+
+    function _readValidatedPrice(
+        AggregatorV3Interface feed
+    ) internal view returns (int256, uint256, bool) {
+        (
+            uint80 roundId,
+            int256 price,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(price > 0, "Invalid price");
+        require(updatedAt > 0 && updatedAt <= block.timestamp, "Invalid timestamp");
+
+        return (price, updatedAt, block.timestamp - updatedAt > MAX_STALENESS);
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "mocha \"test/*.test.mjs\""
+  },
+  "devDependencies": {
+    "ethers": "^6.14.4",
+    "ganache": "^7.9.2",
+    "mocha": "^11.7.0",
+    "solc": "^0.8.30"
+  }
+}

--- a/solidity/test/priceOracle.test.mjs
+++ b/solidity/test/priceOracle.test.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ethers } from "ethers";
+import ganache from "ganache";
+import solc from "solc";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+
+const mockFeedSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockFeed {
+    uint8 public decimals;
+    uint80 public roundId = 1;
+    int256 public answer = 1;
+    uint256 public startedAt = 1;
+    uint256 public updatedAt = 1;
+    uint80 public answeredInRound = 1;
+
+    constructor(uint8 decimals_) {
+        decimals = decimals_;
+    }
+
+    function setRoundData(
+        uint80 roundId_,
+        int256 answer_,
+        uint256 startedAt_,
+        uint256 updatedAt_,
+        uint80 answeredInRound_
+    ) external {
+        roundId = roundId_;
+        answer = answer_;
+        startedAt = startedAt_;
+        updatedAt = updatedAt_;
+        answeredInRound = answeredInRound_;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+}
+`;
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "solidity/contracts/PriceOracle.sol": {
+        content: readFileSync(path.join(solidityRoot, "contracts", "PriceOracle.sol"), "utf8"),
+      },
+      "test/MockFeed.sol": {
+        content: mockFeedSource,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  return {
+    oracle: output.contracts["solidity/contracts/PriceOracle.sol"].PriceOracle,
+    feed: output.contracts["test/MockFeed.sol"].MockFeed,
+  };
+}
+
+async function deploy(contract, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    contract.abi,
+    `0x${contract.evm.bytecode.object}`,
+    signer,
+  );
+  const deployment = await factory.deploy(...args);
+  await deployment.waitForDeployment();
+  return deployment;
+}
+
+async function expectRevert(action, messagePattern = /revert/i) {
+  try {
+    await action();
+  } catch (error) {
+    assert.match(String(error.shortMessage ?? error.message), messagePattern);
+    return;
+  }
+  assert.fail("Expected revert");
+}
+
+async function setFeed(feed, { roundId = 1n, answer = 2_000_00000000n, updatedAt, answeredInRound }) {
+  const tx = await feed.setRoundData(
+    roundId,
+    answer,
+    updatedAt,
+    updatedAt,
+    answeredInRound ?? roundId,
+  );
+  await tx.wait();
+}
+
+describe("PriceOracle", function () {
+  let contracts;
+  let provider;
+  let owner;
+  let other;
+  let now;
+
+  before(function () {
+    contracts = compileContracts();
+  });
+
+  beforeEach(async function () {
+    const ganacheProvider = ganache.provider({
+      chain: { chainId: 31_337 },
+      logging: { quiet: true },
+      wallet: { deterministic: true, totalAccounts: 4 },
+    });
+    provider = new ethers.BrowserProvider(ganacheProvider);
+    owner = await provider.getSigner(0);
+    other = await provider.getSigner(1);
+    now = BigInt((await provider.getBlock("latest")).timestamp);
+  });
+
+  async function deployOracle() {
+    const primary = await deploy(contracts.feed, owner, [8]);
+    const fallback = await deploy(contracts.feed, owner, [8]);
+    const oracle = await deploy(contracts.oracle, owner, [await primary.getAddress()]);
+    await (await oracle.setFallbackFeed(await fallback.getAddress())).wait();
+    return { primary, fallback, oracle };
+  }
+
+  it("returns a valid fresh primary price", async function () {
+    const { primary, oracle } = await deployOracle();
+    await setFeed(primary, { answer: 2_500_00000000n, updatedAt: now - 60n });
+
+    assert.equal(await oracle.getLatestPrice.staticCall(), 2_500_00000000n);
+  });
+
+  it("falls back and emits StalePrice when the primary price is stale", async function () {
+    const { primary, fallback, oracle } = await deployOracle();
+    await setFeed(primary, { answer: 1_000_00000000n, updatedAt: now - 7200n });
+    await setFeed(fallback, { answer: 2_000_00000000n, updatedAt: now - 60n });
+
+    assert.equal(await oracle.getLatestPrice.staticCall(), 2_000_00000000n);
+    const receipt = await (await oracle.getLatestPrice()).wait();
+    const staleEvents = receipt.logs
+      .map((log) => {
+        try {
+          return oracle.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .filter((event) => event?.name === "StalePrice");
+
+    assert.equal(staleEvents.length, 1);
+    assert.equal(staleEvents[0].args.feed, await primary.getAddress());
+    assert.equal(staleEvents[0].args.updatedAt, now - 7200n);
+  });
+
+  it("rejects zero or negative prices", async function () {
+    const { primary, oracle } = await deployOracle();
+    await setFeed(primary, { answer: 0n, updatedAt: now - 60n });
+
+    await expectRevert(
+      () => oracle.getLatestPrice.staticCall(),
+      /Invalid price|revert/i,
+    );
+
+    await setFeed(primary, { answer: -1n, updatedAt: now - 60n });
+    await expectRevert(
+      () => oracle.getLatestPrice.staticCall(),
+      /Invalid price|revert/i,
+    );
+  });
+
+  it("rejects incomplete rounds", async function () {
+    const { primary, oracle } = await deployOracle();
+    await setFeed(primary, {
+      roundId: 10n,
+      answer: 2_000_00000000n,
+      updatedAt: now - 60n,
+      answeredInRound: 9n,
+    });
+
+    await expectRevert(
+      () => oracle.getLatestPrice.staticCall(),
+      /Incomplete round|revert/i,
+    );
+  });
+
+  it("reverts when both primary and fallback prices are stale", async function () {
+    const { primary, fallback, oracle } = await deployOracle();
+    await setFeed(primary, { answer: 2_000_00000000n, updatedAt: now - 7200n });
+    await setFeed(fallback, { answer: 2_100_00000000n, updatedAt: now - 7200n });
+
+    await expectRevert(
+      () => oracle.getLatestPrice.staticCall(),
+      /Stale price|revert/i,
+    );
+  });
+
+  it("lets only the owner configure max staleness and fallback feed", async function () {
+    const { primary, fallback, oracle } = await deployOracle();
+    const wrongDecimalsFeed = await deploy(contracts.feed, owner, [18]);
+
+    await expectRevert(
+      async () => {
+        const tx = await oracle.connect(other).setMaxStaleness(7200);
+        await tx.wait();
+      },
+      /Not owner|revert/i,
+    );
+    await expectRevert(
+      async () => {
+        const tx = await oracle.setFallbackFeed(await primary.getAddress());
+        await tx.wait();
+      },
+      /Invalid fallback feed|revert/i,
+    );
+    await expectRevert(
+      async () => {
+        const tx = await oracle.setFallbackFeed(await wrongDecimalsFeed.getAddress());
+        await tx.wait();
+      },
+      /Decimals mismatch|revert/i,
+    );
+
+    await (await oracle.setMaxStaleness(7200)).wait();
+    assert.equal(await oracle.MAX_STALENESS(), 7200n);
+
+    await setFeed(primary, { answer: 2_000_00000000n, updatedAt: now - 5400n });
+    assert.equal(await oracle.getLatestPrice.staticCall(), 2_000_00000000n);
+
+    await (await oracle.setFallbackFeed(await fallback.getAddress())).wait();
+    assert.equal(await oracle.fallbackFeed(), await fallback.getAddress());
+  });
+});


### PR DESCRIPTION
/claim #915

Summary:
- Validate Chainlink round completeness, positive prices, and sane timestamps before returning prices.
- Treat stale primary data as the fallback trigger, emit `StalePrice`, and reject stale fallback data instead of returning unsafe prices.
- Add owner-only fallback feed configuration with decimal matching and owner-configurable `MAX_STALENESS`.
- Add public generation metadata and focused Ganache/Solc tests for the required oracle cases.

Demo:
- https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-915-priceoracle-demo.mp4

Validation:
- `npm install --no-package-lock`
- `npm test` (6 passing)
- `git diff --check`
- `.generation_meta.json` parsed with `python3 -m json.tool`
- ASCII scan for committed files

Note:
- `getLatestPrice` is non-view so it can emit the required `StalePrice` event when falling back.
- Ganache printed its known µWS native-binary fallback warning on this Node build, then ran the tests successfully using the NodeJS fallback.