### PR TITLE
OpenAI Codex [ FastAPI ] Add standardized pagination utility

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Public task context for UnsafeLabs/Bounty-Hunters issue #802: add a FastAPI pagination utility with offset and cursor pagination, a generic PaginatedResponse model, dependency-backed page parameters, edge-case handling, tests, and safe public attribution metadata. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "date": "2026-05-28T23:05:00Z"
+}

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import base64
+import math
+from collections.abc import Callable, Sequence
+from typing import Annotated, Any, Generic, TypeVar
+
+from fastapi import Query
+from pydantic import BaseModel
+
+ItemT = TypeVar("ItemT")
+
+
+class PaginatedResponse(BaseModel, Generic[ItemT]):
+    items: list[ItemT]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+class Paginator:
+    def __init__(self, page: int = 1, page_size: int = 20, max_page_size: int = 100) -> None:
+        self.page = max(1, page)
+        self.page_size = max(1, min(page_size, max_page_size))
+        self.max_page_size = max(1, max_page_size)
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    def apply_offset(self, query: Any) -> Any:
+        return query.offset(self.offset).limit(self.limit)
+
+    def paginate_offset(
+        self,
+        items: Sequence[ItemT],
+        total: int | None = None,
+        *,
+        already_sliced: bool = False,
+    ) -> PaginatedResponse[ItemT]:
+        total_items = len(items) if total is None else max(0, total)
+        total_pages = self._total_pages(total_items)
+        page_items = list(items) if already_sliced else list(items[self.offset : self.offset + self.page_size])
+
+        return PaginatedResponse[ItemT](
+            items=page_items,
+            total=total_items,
+            page=self.page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=self.page < total_pages,
+            has_previous=self.page > 1 and total_items > 0,
+        )
+
+    def paginate_cursor(
+        self,
+        items: Sequence[ItemT],
+        cursor: str | None = None,
+        *,
+        cursor_getter: Callable[[ItemT], str | int] | None = None,
+        total: int | None = None,
+    ) -> PaginatedResponse[ItemT]:
+        all_items = list(items)
+        total_items = len(all_items) if total is None else max(0, total)
+        cursor_getter = cursor_getter or (lambda item: all_items.index(item))
+        start = self._cursor_start(all_items, cursor, cursor_getter)
+        page_items = all_items[start : start + self.page_size]
+        total_pages = self._total_pages(total_items)
+
+        next_cursor = None
+        if page_items and start + self.page_size < len(all_items):
+            next_cursor = self.encode_cursor(cursor_getter(page_items[-1]))
+
+        previous_cursor = None
+        if start > self.page_size:
+            previous_cursor = self.encode_cursor(cursor_getter(all_items[start - self.page_size - 1]))
+
+        return PaginatedResponse[ItemT](
+            items=page_items,
+            total=total_items,
+            page=(start // self.page_size) + 1,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=next_cursor is not None,
+            has_previous=start > 0,
+            next_cursor=next_cursor,
+            previous_cursor=previous_cursor,
+        )
+
+    @staticmethod
+    def encode_cursor(value: str | int) -> str:
+        payload = str(value).encode("utf-8")
+        return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+    @staticmethod
+    def decode_cursor(cursor: str) -> str:
+        padding = "=" * (-len(cursor) % 4)
+        return base64.urlsafe_b64decode(f"{cursor}{padding}".encode("ascii")).decode("utf-8")
+
+    def _total_pages(self, total: int) -> int:
+        if total <= 0:
+            return 0
+        return math.ceil(total / self.page_size)
+
+    def _cursor_start(
+        self,
+        items: Sequence[ItemT],
+        cursor: str | None,
+        cursor_getter: Callable[[ItemT], str | int],
+    ) -> int:
+        if cursor is None:
+            return 0
+
+        decoded_cursor = self.decode_cursor(cursor)
+        for index, item in enumerate(items):
+            if str(cursor_getter(item)) == decoded_cursor:
+                return index + 1
+        raise ValueError("Cursor not found")
+
+
+def paginate(
+    page: Annotated[int, Query(description="One-based page number")] = 1,
+    page_size: Annotated[
+        int,
+        Query(description="Number of items per page"),
+    ] = 20,
+) -> Paginator:
+    return Paginator(page=page, page_size=page_size)

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,125 @@
+from fastapi.pagination import PaginatedResponse, Paginator, paginate
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+def make_items(count: int = 10) -> list[Item]:
+    return [Item(id=index, name=f"item-{index}") for index in range(1, count + 1)]
+
+
+def test_offset_pagination_calculates_boundaries() -> None:
+    paginator = Paginator(page=2, page_size=3)
+    response = paginator.paginate_offset(make_items(8))
+
+    assert paginator.offset == 3
+    assert paginator.limit == 3
+    assert [item.id for item in response.items] == [4, 5, 6]
+    assert response.total == 8
+    assert response.page == 2
+    assert response.page_size == 3
+    assert response.total_pages == 3
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_offset_pagination_handles_empty_and_invalid_inputs() -> None:
+    paginator = Paginator(page=0, page_size=0)
+    response = paginator.paginate_offset([])
+
+    assert paginator.page == 1
+    assert paginator.page_size == 1
+    assert response.items == []
+    assert response.total == 0
+    assert response.total_pages == 0
+    assert response.has_next is False
+    assert response.has_previous is False
+
+    negative = Paginator(page=-10, page_size=-5)
+    assert negative.page == 1
+    assert negative.page_size == 1
+
+
+def test_offset_pagination_supports_presliced_sqlalchemy_results() -> None:
+    paginator = Paginator(page=3, page_size=2)
+    response = paginator.paginate_offset(make_items(2), total=10, already_sliced=True)
+
+    assert [item.id for item in response.items] == [1, 2]
+    assert response.total == 10
+    assert response.total_pages == 5
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_cursor_pagination_uses_encoded_cursor_navigation() -> None:
+    paginator = Paginator(page_size=3)
+    items = make_items(8)
+
+    first_page = paginator.paginate_cursor(items, cursor_getter=lambda item: item.id)
+    assert [item.id for item in first_page.items] == [1, 2, 3]
+    assert first_page.next_cursor == Paginator.encode_cursor(3)
+    assert first_page.previous_cursor is None
+    assert first_page.has_next is True
+    assert first_page.has_previous is False
+
+    second_page = paginator.paginate_cursor(
+        items,
+        first_page.next_cursor,
+        cursor_getter=lambda item: item.id,
+    )
+    assert [item.id for item in second_page.items] == [4, 5, 6]
+    assert second_page.next_cursor == Paginator.encode_cursor(6)
+    assert second_page.previous_cursor is None
+    assert second_page.has_next is True
+    assert second_page.has_previous is True
+
+    third_page = paginator.paginate_cursor(
+        items,
+        second_page.next_cursor,
+        cursor_getter=lambda item: item.id,
+    )
+    assert [item.id for item in third_page.items] == [7, 8]
+    assert third_page.next_cursor is None
+    assert third_page.previous_cursor == Paginator.encode_cursor(3)
+    assert third_page.has_next is False
+    assert third_page.has_previous is True
+
+
+def test_cursor_pagination_rejects_unknown_cursor() -> None:
+    paginator = Paginator(page_size=3)
+    unknown_cursor = Paginator.encode_cursor("missing")
+
+    try:
+        paginator.paginate_cursor(make_items(), unknown_cursor, cursor_getter=lambda item: item.id)
+    except ValueError as error:
+        assert str(error) == "Cursor not found"
+    else:
+        raise AssertionError("Expected unknown cursor to fail")
+
+
+def test_paginated_response_is_generic_over_pydantic_models() -> None:
+    response = PaginatedResponse[Item](
+        items=[{"id": 1, "name": "item-1"}],
+        total=1,
+        page=1,
+        page_size=20,
+        total_pages=1,
+        has_next=False,
+        has_previous=False,
+    )
+
+    assert isinstance(response.items[0], Item)
+    assert response.items[0].name == "item-1"
+
+
+def test_paginate_dependency_returns_paginator_with_defaults_and_query_values() -> None:
+    default_paginator = paginate()
+    custom_paginator = paginate(page=4, page_size=50)
+
+    assert default_paginator.page == 1
+    assert default_paginator.page_size == 20
+    assert custom_paginator.page == 4
+    assert custom_paginator.page_size == 50


### PR DESCRIPTION
/claim #802

Summary:
- Add `fastapi.pagination.Paginator` with normalized page/page_size handling, offset/limit helpers, and SQLAlchemy-style `apply_offset` support.
- Add generic `PaginatedResponse[T]` with standardized metadata fields plus optional cursor fields.
- Support offset pagination for full sequences or pre-sliced result sets with explicit totals.
- Support URL-safe cursor pagination with next/previous cursor navigation and unknown-cursor failure.
- Add safe public attribution metadata and focused tests for the acceptance criteria.

Demo:
- https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-802-fastapi-pagination-demo.mp4

Validation:
- `uv run --group tests pytest tests/test_pagination.py` (7 passed)
- `uv run ruff check fastapi/pagination.py tests/test_pagination.py`
- `git diff --check`
- `.attribution.json` parsed with `python3 -m json.tool`
- ASCII scan for committed files

Note:
- The attribution metadata intentionally uses public-safe reproducibility context and does not disclose private system/developer/runtime/session instructions.