### PR TITLE
OpenAI Codex [ T3 Code ] Add HTTP gzip and brotli compression

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Public task context for UnsafeLabs/Bounty-Hunters issue #863: add gzip and brotli compression middleware to the T3 server HTTP layer, including response compression, request decompression, environment-configurable compression level, tests, and safe public provenance metadata. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "timestamp": "2026-05-28T23:20:00Z"
+}

--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,5 +1,15 @@
+import * as zlib from "node:zlib";
+
+import * as Effect from "effect/Effect";
 import { describe, expect, it } from "vitest";
 
+import {
+  compressResponse,
+  decompressBytes,
+  isAlreadyCompressedContentType,
+  selectResponseEncoding,
+} from "./httpCompression.ts";
+import { HttpServerResponse } from "effect/unstable/http";
 import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
 
 describe("http dev routing", () => {
@@ -23,5 +33,74 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("http compression helpers", () => {
+  it("prefers brotli over gzip when both are accepted", () => {
+    expect(selectResponseEncoding("gzip, br")).toBe("br");
+    expect(selectResponseEncoding("gzip")).toBe("gzip");
+    expect(selectResponseEncoding("deflate")).toBeUndefined();
+  });
+
+  it("skips already compressed response content types", () => {
+    expect(isAlreadyCompressedContentType("image/png")).toBe(true);
+    expect(isAlreadyCompressedContentType("application/zip")).toBe(true);
+    expect(isAlreadyCompressedContentType("font/woff2")).toBe(true);
+    expect(isAlreadyCompressedContentType("image/svg+xml")).toBe(false);
+    expect(isAlreadyCompressedContentType("application/json; charset=utf-8")).toBe(false);
+  });
+
+  it("compresses large responses with brotli when supported", async () => {
+    const response = HttpServerResponse.text("A".repeat(2000));
+    const compressed = await Effect.runPromise(compressResponse(response, "gzip, br"));
+    const webResponse = HttpServerResponse.toWeb(compressed);
+    const body = new Uint8Array(await webResponse.arrayBuffer());
+
+    expect(compressed.headers["content-encoding"]).toBe("br");
+    expect(zlib.brotliDecompressSync(body).toString()).toBe("A".repeat(2000));
+  });
+
+  it("compresses large responses with gzip when brotli is not accepted", async () => {
+    const response = HttpServerResponse.text("A".repeat(2000));
+    const compressed = await Effect.runPromise(compressResponse(response, "gzip"));
+    const webResponse = HttpServerResponse.toWeb(compressed);
+    const body = new Uint8Array(await webResponse.arrayBuffer());
+
+    expect(compressed.headers["content-encoding"]).toBe("gzip");
+    expect(zlib.gunzipSync(body).toString()).toBe("A".repeat(2000));
+  });
+
+  it("does not compress small or already-compressed responses", async () => {
+    const small = await Effect.runPromise(
+      compressResponse(HttpServerResponse.text("A".repeat(500)), "br, gzip"),
+    );
+    const image = await Effect.runPromise(
+      compressResponse(
+        HttpServerResponse.uint8Array(new Uint8Array(2000), {
+          contentType: "image/png",
+        }),
+        "br, gzip",
+      ),
+    );
+
+    expect(small.headers["content-encoding"]).toBeUndefined();
+    expect(image.headers["content-encoding"]).toBeUndefined();
+  });
+
+  it("decompresses gzip request bodies", async () => {
+    const payload = new TextEncoder().encode(JSON.stringify({ hello: "world" }));
+    const compressed = zlib.gzipSync(payload);
+    const decompressed = await Effect.runPromise(decompressBytes(compressed, "gzip"));
+
+    expect(JSON.parse(new TextDecoder().decode(decompressed))).toEqual({ hello: "world" });
+  });
+
+  it("decompresses brotli request bodies", async () => {
+    const payload = new TextEncoder().encode(JSON.stringify({ hello: "brotli" }));
+    const compressed = zlib.brotliCompressSync(payload);
+    const decompressed = await Effect.runPromise(decompressBytes(compressed, "br"));
+
+    expect(JSON.parse(new TextDecoder().decode(decompressed))).toEqual({ hello: "brotli" });
   });
 });

--- a/t3code/apps/server/src/httpCompression.ts
+++ b/t3code/apps/server/src/httpCompression.ts
@@ -1,0 +1,237 @@
+import * as zlib from "node:zlib";
+
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+export class HttpCompressionError extends Data.TaggedError("HttpCompressionError")<{
+  readonly cause?: unknown;
+  readonly message: string;
+}> {}
+
+const MIN_COMPRESSIBLE_BYTES = 1024;
+
+function compressionLevel() {
+  const configured = Number.parseInt(process.env.T3CODE_COMPRESSION_LEVEL ?? "", 10);
+  return Number.isFinite(configured) ? configured : undefined;
+}
+
+function gzipOptions(): zlib.ZlibOptions {
+  const level = compressionLevel();
+  return {
+    level:
+      level === undefined ? zlib.constants.Z_DEFAULT_COMPRESSION : Math.max(-1, Math.min(9, level)),
+  };
+}
+
+function brotliOptions(): zlib.BrotliOptions {
+  const level = compressionLevel();
+  return {
+    params: {
+      [zlib.constants.BROTLI_PARAM_QUALITY]:
+        level === undefined ? 5 : Math.max(0, Math.min(11, level)),
+    },
+  };
+}
+
+export function selectResponseEncoding(acceptEncoding: string): "br" | "gzip" | undefined {
+  const accepted = acceptEncoding
+    .toLowerCase()
+    .split(",")
+    .map((encoding) => encoding.trim());
+
+  if (accepted.some((encoding) => encoding === "br" || encoding.startsWith("br;"))) {
+    return "br";
+  }
+  if (accepted.some((encoding) => encoding === "gzip" || encoding.startsWith("gzip;"))) {
+    return "gzip";
+  }
+  return undefined;
+}
+
+export function isAlreadyCompressedContentType(contentType: string | undefined): boolean {
+  const mime = (contentType ?? "").toLowerCase().split(";")[0]?.trim() ?? "";
+  if (!mime) {
+    return false;
+  }
+  if (mime.startsWith("image/") && mime !== "image/svg+xml") {
+    return true;
+  }
+  if (mime.startsWith("audio/") || mime.startsWith("video/")) {
+    return true;
+  }
+  return new Set([
+    "application/gzip",
+    "application/octet-stream",
+    "application/pdf",
+    "application/vnd.rar",
+    "application/x-7z-compressed",
+    "application/x-bzip2",
+    "application/x-gzip",
+    "application/x-rar-compressed",
+    "application/x-tar",
+    "application/zip",
+    "font/otf",
+    "font/ttf",
+    "font/woff",
+    "font/woff2",
+  ]).has(mime);
+}
+
+function compressBytes(
+  bytes: Uint8Array,
+  encoding: "br" | "gzip",
+): Effect.Effect<Uint8Array, HttpCompressionError> {
+  return Effect.try({
+    try: () =>
+      encoding === "br"
+        ? zlib.brotliCompressSync(bytes, brotliOptions())
+        : zlib.gzipSync(bytes, gzipOptions()),
+    catch: (cause) =>
+      new HttpCompressionError({
+        cause,
+        message: "Failed to compress HTTP response body",
+      }),
+  });
+}
+
+export function decompressBytes(
+  bytes: Uint8Array,
+  encoding: "br" | "gzip",
+): Effect.Effect<Uint8Array, HttpCompressionError> {
+  return Effect.try({
+    try: () => (encoding === "br" ? zlib.brotliDecompressSync(bytes) : zlib.gunzipSync(bytes)),
+    catch: (cause) =>
+      new HttpCompressionError({
+        cause,
+        message: "Failed to decompress HTTP request body",
+      }),
+  });
+}
+
+export function compressResponse(
+  response: HttpServerResponse.HttpServerResponse,
+  acceptEncoding: string,
+): Effect.Effect<HttpServerResponse.HttpServerResponse> {
+  const encoding = selectResponseEncoding(acceptEncoding);
+  if (!encoding || response.headers["content-encoding"]) {
+    return Effect.succeed(response);
+  }
+  if (isAlreadyCompressedContentType(response.headers["content-type"])) {
+    return Effect.succeed(response);
+  }
+
+  if (response.body._tag === "Uint8Array") {
+    const body = response.body.body;
+    if (body.byteLength <= MIN_COMPRESSIBLE_BYTES) {
+      return Effect.succeed(response);
+    }
+    return compressBytes(body, encoding).pipe(
+      Effect.map((compressed) =>
+        HttpServerResponse.uint8Array(compressed, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: {
+            ...response.headers,
+            "content-encoding": encoding,
+            "content-length": String(compressed.byteLength),
+          },
+        }),
+      ),
+      Effect.catch((cause) =>
+        Effect.logWarning("HTTP response compression failed", { cause }).pipe(Effect.as(response)),
+      ),
+    );
+  }
+
+  return Effect.succeed(response);
+}
+
+function wrapDecompressedRequest(
+  request: HttpServerRequest.HttpServerRequest,
+  encoding: "br" | "gzip",
+): HttpServerRequest.HttpServerRequest {
+  let arrayBufferPromise: Promise<ArrayBuffer> | undefined;
+  const getDecompressedArrayBuffer = () => {
+    arrayBufferPromise ??= Effect.runPromise(request.arrayBuffer)
+      .then((arrayBuffer) =>
+        Effect.runPromise(decompressBytes(new Uint8Array(arrayBuffer), encoding)),
+      )
+      .then((decompressed) => {
+        const copy = new Uint8Array(decompressed.byteLength);
+        copy.set(decompressed);
+        return copy.buffer;
+      });
+    return arrayBufferPromise;
+  };
+
+  const arrayBuffer = Effect.tryPromise({
+    try: () => getDecompressedArrayBuffer(),
+    catch: (cause) =>
+      new HttpCompressionError({
+        cause,
+        message: "Failed to read decompressed HTTP request body",
+      }),
+  });
+  const text = arrayBuffer.pipe(Effect.map((bodyBuffer) => new TextDecoder().decode(bodyBuffer)));
+  const json = text.pipe(
+    Effect.flatMap((bodyText) =>
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      Effect.try({
+        try: () => JSON.parse(bodyText),
+        catch: (cause) =>
+          new HttpCompressionError({
+            cause,
+            message: "Failed to parse decompressed JSON request body",
+          }),
+      }),
+    ),
+  );
+  const stream = Stream.fromEffect(
+    arrayBuffer.pipe(Effect.map((bodyBuffer) => new Uint8Array(bodyBuffer))),
+  );
+  const headers = { ...request.headers };
+  delete headers["content-encoding"];
+  delete headers["content-length"];
+
+  return new Proxy(request, {
+    get(target, property, receiver) {
+      if (property === "headers") {
+        return headers;
+      }
+      if (property === "arrayBuffer") {
+        return arrayBuffer;
+      }
+      if (property === "text") {
+        return text;
+      }
+      if (property === "json") {
+        return json;
+      }
+      if (property === "stream") {
+        return stream;
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+export const httpCompressionLayer = HttpRouter.middleware(
+  (handler) =>
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const contentEncoding = request.headers["content-encoding"]?.toLowerCase();
+      const activeRequest =
+        contentEncoding === "br" || contentEncoding === "gzip"
+          ? wrapDecompressedRequest(request, contentEncoding)
+          : request;
+
+      const response = yield* handler.pipe(
+        Effect.provideService(HttpServerRequest.HttpServerRequest, activeRequest),
+      );
+      return yield* compressResponse(response, request.headers["accept-encoding"] ?? "");
+    }),
+  { global: true },
+);

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -11,6 +11,7 @@ import {
   staticAndDevRouteLayer,
   browserApiCorsLayer,
 } from "./http.ts";
+import { httpCompressionLayer } from "./httpCompression.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
@@ -312,7 +313,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
-).pipe(Layer.provide(browserApiCorsLayer));
+).pipe(Layer.provide(browserApiCorsLayer), Layer.provide(httpCompressionLayer));
 
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {


### PR DESCRIPTION
/claim #863

Summary:
- Add a global server HTTP compression middleware backed by Node `zlib`.
- Prefer brotli over gzip when both encodings are accepted.
- Compress eligible byte-array responses over 1KB and set `Content-Encoding` / `Content-Length`.
- Skip small responses and already-compressed content types such as images, archives, PDFs, octet-streams, and fonts.
- Decompress incoming `gzip` and `br` request bodies before handlers read `arrayBuffer`, `text`, `json`, or `stream`.
- Read compression level from `T3CODE_COMPRESSION_LEVEL` and include safe public provenance metadata.

Demo:
- https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-863-http-compression-demo.mp4

Validation:
- `npx -y bun@1.3.11 run --cwd apps/server test src/http.test.ts` (10 passed)
- `npx -y bun@1.3.11 run --cwd apps/server typecheck`
- `npx -y bun@1.3.11 run fmt:check apps/server/src/httpCompression.ts apps/server/src/http.test.ts apps/server/src/server.ts apps/server/src/_provenance.json`
- `git diff --check`
- `_provenance.json` parsed with `python3 -m json.tool`
- ASCII scan passed for the new/test/provenance files

Note:
- `bun run lint ...` is blocked by the repository oxlint TypeScript plugin loader (`ERR_UNKNOWN_FILE_EXTENSION` for `oxlint-plugin-t3code/index.ts`) before linting these files.
- The provenance metadata intentionally uses public-safe reproducibility context and does not disclose private system/developer/runtime/session instructions.