### PR TITLE
OpenAI Codex [ T3 Code ] Add sliding RPC metrics aggregation

### DIFF
--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -23,6 +23,7 @@ import {
 } from "./attachmentPaths.ts";
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
 import { resolveStaticDir, ServerConfig } from "./config.ts";
+import { METRICS_AGGREGATED_PATH, MetricsAggregator } from "./observability/MetricsAggregator.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
@@ -132,6 +133,20 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
           Effect.succeed(HttpServerResponse.text("Trace export failed.", { status: 502 })),
         ),
       );
+  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+);
+
+export const aggregatedMetricsRouteLayer = HttpRouter.add(
+  "GET",
+  METRICS_AGGREGATED_PATH,
+  Effect.gen(function* () {
+    yield* requireAuthenticatedRequest;
+    const metricsAggregator = yield* MetricsAggregator;
+    const windows = yield* metricsAggregator.snapshot;
+    return HttpServerResponse.jsonUnsafe(windows, {
+      status: 200,
+      headers: browserApiCorsHeaders,
+    });
   }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
 );
 

--- a/t3code/apps/server/src/observability/.generation_meta.json
+++ b/t3code/apps/server/src/observability/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Public task context for UnsafeLabs/Bounty-Hunters issue #856: add sliding-window RPC metrics aggregation in the T3 server observability layer with per-method p50/p95/p99 latency, error rate, throughput, bounded 60-window retention, an authenticated /metrics/aggregated JSON endpoint, focused tests, and safe public generation metadata. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "date": "2026-05-28T23:45:00Z"
+}

--- a/t3code/apps/server/src/observability/MetricsAggregator.test.ts
+++ b/t3code/apps/server/src/observability/MetricsAggregator.test.ts
@@ -1,0 +1,110 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as TestClock from "effect/testing/TestClock";
+
+import {
+  aggregateSlidingMetricBuckets,
+  makeMetricsAggregatorTestLayer,
+  MetricsAggregator,
+  percentileFromSorted,
+  type RpcMetricBucket,
+} from "./MetricsAggregator.ts";
+
+const makeBucket = (
+  bucketStartMs: number,
+  latenciesMs: ReadonlyArray<number>,
+  options?: {
+    readonly method?: string;
+    readonly errorCount?: number;
+    readonly bucketSizeMs?: number;
+  },
+): RpcMetricBucket => ({
+  bucketStartMs,
+  bucketEndMs: bucketStartMs + (options?.bucketSizeMs ?? 30_000),
+  methods: [
+    {
+      method: options?.method ?? "server.getConfig",
+      requestCount: latenciesMs.length,
+      errorCount: options?.errorCount ?? 0,
+      latenciesMs,
+    },
+  ],
+});
+
+describe("MetricsAggregator", () => {
+  it("calculates percentiles from a sorted latency array", () => {
+    const sorted = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+    assert.equal(percentileFromSorted(sorted, 50), 50);
+    assert.equal(percentileFromSorted(sorted, 95), 100);
+    assert.equal(percentileFromSorted(sorted, 99), 100);
+  });
+
+  it.effect("aggregates overlapping sliding windows with Effect.Stream.sliding", () =>
+    Effect.gen(function* () {
+      const windows = yield* aggregateSlidingMetricBuckets(
+        [
+          makeBucket(0, [10], { bucketSizeMs: 30_000 }),
+          makeBucket(30_000, [20], { bucketSizeMs: 30_000 }),
+          makeBucket(60_000, [30], { bucketSizeMs: 30_000 }),
+        ],
+        {
+          windowSizeMs: 60_000,
+          bucketSizeMs: 30_000,
+        },
+      );
+
+      assert.equal(windows.length, 2);
+      assert.deepEqual(
+        windows.map((window) => window.windowStartMs),
+        [0, 30_000],
+      );
+      assert.deepEqual(
+        windows.map((window) => window.methods[0]?.requestCount),
+        [2, 2],
+      );
+      assert.deepEqual(
+        windows.map((window) => window.methods[0]?.p50LatencyMs),
+        [10, 20],
+      );
+    }),
+  );
+
+  it.effect("rotates windows and retains exactly the configured circular buffer size", () =>
+    Effect.gen(function* () {
+      const aggregator = yield* MetricsAggregator;
+
+      for (let index = 0; index < 61; index += 1) {
+        yield* aggregator.recordAt({
+          method: "server.getConfig",
+          latencyMs: index,
+          failed: index % 10 === 0,
+          timestampMs: index * 60_000,
+        });
+      }
+
+      yield* TestClock.adjust(Duration.minutes(62));
+      yield* aggregator.rotate;
+
+      const windows = yield* aggregator.snapshot;
+      assert.equal(windows.length, 60);
+      assert.equal(windows[0]?.windowStartMs, 60_000);
+      assert.equal(windows[59]?.windowStartMs, 60 * 60_000);
+      assert.equal(windows[9]?.methods[0]?.errorRate, 100);
+      assert.equal(windows[9]?.methods[0]?.throughput, 1 / 60);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeMetricsAggregatorTestLayer({
+            retainedWindowCount: 60,
+            windowSizeMs: 60_000,
+            bucketSizeMs: 60_000,
+          }),
+          TestClock.layer(),
+        ),
+      ),
+    ),
+  );
+});

--- a/t3code/apps/server/src/observability/MetricsAggregator.ts
+++ b/t3code/apps/server/src/observability/MetricsAggregator.ts
@@ -1,0 +1,420 @@
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+
+export const METRICS_AGGREGATED_PATH = "/metrics/aggregated";
+
+const DEFAULT_WINDOW_SIZE_MS = 60_000;
+const DEFAULT_BUCKET_SIZE_MS = 60_000;
+const DEFAULT_RETAINED_WINDOW_COUNT = 60;
+const DEFAULT_MAX_LATENCY_SAMPLES_PER_METHOD_BUCKET = 20_000;
+
+export interface RpcMetricObservation {
+  readonly method: string;
+  readonly latencyMs: number;
+  readonly failed: boolean;
+}
+
+export interface TimedRpcMetricObservation extends RpcMetricObservation {
+  readonly timestampMs: number;
+}
+
+export interface RpcMetricMethodBucket {
+  readonly method: string;
+  readonly requestCount: number;
+  readonly errorCount: number;
+  readonly latenciesMs: ReadonlyArray<number>;
+}
+
+export interface RpcMetricBucket {
+  readonly bucketStartMs: number;
+  readonly bucketEndMs: number;
+  readonly methods: ReadonlyArray<RpcMetricMethodBucket>;
+}
+
+export interface AggregatedRpcMethodMetrics {
+  readonly method: string;
+  readonly requestCount: number;
+  readonly errorCount: number;
+  readonly errorRate: number;
+  readonly throughput: number;
+  readonly p50LatencyMs: number;
+  readonly p95LatencyMs: number;
+  readonly p99LatencyMs: number;
+}
+
+export interface AggregatedRpcMetricWindow {
+  readonly timestamp: string;
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly windowStartMs: number;
+  readonly windowEndMs: number;
+  readonly methods: ReadonlyArray<AggregatedRpcMethodMetrics>;
+}
+
+interface MetricsAggregatorState {
+  readonly buckets: ReadonlyArray<RpcMetricBucket>;
+  readonly windows: ReadonlyArray<AggregatedRpcMetricWindow>;
+  readonly lastAggregatedWindowStartMs: number | null;
+}
+
+interface MutableMethodBucket {
+  requestCount: number;
+  errorCount: number;
+  latenciesMs: Array<number>;
+}
+
+export interface MetricsAggregatorShape {
+  readonly record: (observation: RpcMetricObservation) => Effect.Effect<void>;
+  readonly recordAt: (observation: TimedRpcMetricObservation) => Effect.Effect<void>;
+  readonly rotate: Effect.Effect<void>;
+  readonly snapshot: Effect.Effect<ReadonlyArray<AggregatedRpcMetricWindow>>;
+}
+
+export class MetricsAggregator extends Context.Service<MetricsAggregator, MetricsAggregatorShape>()(
+  "t3/observability/MetricsAggregator",
+) {}
+
+export interface MetricsAggregatorOptions {
+  readonly windowSizeMs?: number;
+  readonly bucketSizeMs?: number;
+  readonly retainedWindowCount?: number;
+  readonly maxLatencySamplesPerMethodBucket?: number;
+}
+
+interface ResolvedMetricsAggregatorOptions {
+  readonly windowSizeMs: number;
+  readonly bucketSizeMs: number;
+  readonly retainedWindowCount: number;
+  readonly maxLatencySamplesPerMethodBucket: number;
+}
+
+const resolveOptions = (
+  options: MetricsAggregatorOptions = {},
+): ResolvedMetricsAggregatorOptions => {
+  const windowSizeMs = Math.max(1, Math.trunc(options.windowSizeMs ?? DEFAULT_WINDOW_SIZE_MS));
+  const bucketSizeMs = Math.max(1, Math.trunc(options.bucketSizeMs ?? DEFAULT_BUCKET_SIZE_MS));
+  return {
+    windowSizeMs,
+    bucketSizeMs,
+    retainedWindowCount: Math.max(
+      1,
+      Math.trunc(options.retainedWindowCount ?? DEFAULT_RETAINED_WINDOW_COUNT),
+    ),
+    maxLatencySamplesPerMethodBucket: Math.max(
+      1,
+      Math.trunc(
+        options.maxLatencySamplesPerMethodBucket ?? DEFAULT_MAX_LATENCY_SAMPLES_PER_METHOD_BUCKET,
+      ),
+    ),
+  };
+};
+
+const floorToBucketStart = (timestampMs: number, bucketSizeMs: number): number =>
+  Math.floor(timestampMs / bucketSizeMs) * bucketSizeMs;
+
+const toIso = (timestampMs: number): string => DateTime.formatIso(DateTime.makeUnsafe(timestampMs));
+
+export const percentileFromSorted = (
+  sortedValues: ReadonlyArray<number>,
+  percentile: number,
+): number => {
+  if (sortedValues.length === 0) {
+    return 0;
+  }
+
+  const boundedPercentile = Math.min(100, Math.max(0, percentile));
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil((boundedPercentile / 100) * sortedValues.length) - 1),
+  );
+  return sortedValues[index] ?? 0;
+};
+
+const aggregateMethodMetrics = (
+  methods: ReadonlyArray<RpcMetricMethodBucket>,
+  windowSizeMs: number,
+): ReadonlyArray<AggregatedRpcMethodMetrics> => {
+  const byMethod = new Map<string, MutableMethodBucket>();
+
+  for (const methodBucket of methods) {
+    const current =
+      byMethod.get(methodBucket.method) ??
+      ({
+        requestCount: 0,
+        errorCount: 0,
+        latenciesMs: [],
+      } satisfies MutableMethodBucket);
+    current.requestCount += methodBucket.requestCount;
+    current.errorCount += methodBucket.errorCount;
+    current.latenciesMs.push(...methodBucket.latenciesMs);
+    byMethod.set(methodBucket.method, current);
+  }
+
+  return Array.from(byMethod.entries())
+    .map(([method, metrics]) => {
+      const sortedLatenciesMs = metrics.latenciesMs.toSorted((left, right) => left - right);
+      return {
+        method,
+        requestCount: metrics.requestCount,
+        errorCount: metrics.errorCount,
+        errorRate:
+          metrics.requestCount === 0 ? 0 : (metrics.errorCount / metrics.requestCount) * 100,
+        throughput: metrics.requestCount / (windowSizeMs / 1_000),
+        p50LatencyMs: percentileFromSorted(sortedLatenciesMs, 50),
+        p95LatencyMs: percentileFromSorted(sortedLatenciesMs, 95),
+        p99LatencyMs: percentileFromSorted(sortedLatenciesMs, 99),
+      } satisfies AggregatedRpcMethodMetrics;
+    })
+    .toSorted((left, right) => left.method.localeCompare(right.method));
+};
+
+const emptyBucket = (bucketStartMs: number, bucketSizeMs: number): RpcMetricBucket => ({
+  bucketStartMs,
+  bucketEndMs: bucketStartMs + bucketSizeMs,
+  methods: [],
+});
+
+const fillBucketGaps = (
+  buckets: ReadonlyArray<RpcMetricBucket>,
+  bucketSizeMs: number,
+): ReadonlyArray<RpcMetricBucket> => {
+  const sortedBuckets = buckets.toSorted((left, right) => left.bucketStartMs - right.bucketStartMs);
+  const first = sortedBuckets[0];
+  const last = sortedBuckets[sortedBuckets.length - 1];
+  if (!first || !last) {
+    return [];
+  }
+
+  const byStart = new Map(sortedBuckets.map((bucket) => [bucket.bucketStartMs, bucket]));
+  const filled: Array<RpcMetricBucket> = [];
+  for (
+    let bucketStartMs = first.bucketStartMs;
+    bucketStartMs <= last.bucketStartMs;
+    bucketStartMs += bucketSizeMs
+  ) {
+    filled.push(byStart.get(bucketStartMs) ?? emptyBucket(bucketStartMs, bucketSizeMs));
+  }
+  return filled;
+};
+
+const aggregateBucketWindow = (
+  buckets: ReadonlyArray<RpcMetricBucket>,
+  windowSizeMs: number,
+): AggregatedRpcMetricWindow => {
+  const first = buckets[0];
+  if (!first) {
+    throw new Error("Cannot aggregate an empty metrics window.");
+  }
+
+  const windowStartMs = first.bucketStartMs;
+  const windowEndMs = windowStartMs + windowSizeMs;
+  return {
+    timestamp: toIso(windowEndMs),
+    windowStart: toIso(windowStartMs),
+    windowEnd: toIso(windowEndMs),
+    windowStartMs,
+    windowEndMs,
+    methods: aggregateMethodMetrics(
+      buckets.flatMap((bucket) => bucket.methods),
+      windowSizeMs,
+    ),
+  };
+};
+
+export const aggregateSlidingMetricBuckets = (
+  buckets: ReadonlyArray<RpcMetricBucket>,
+  options: {
+    readonly windowSizeMs?: number;
+    readonly bucketSizeMs?: number;
+  } = {},
+): Effect.Effect<ReadonlyArray<AggregatedRpcMetricWindow>> => {
+  const windowSizeMs = Math.max(1, Math.trunc(options.windowSizeMs ?? DEFAULT_WINDOW_SIZE_MS));
+  const bucketSizeMs = Math.max(1, Math.trunc(options.bucketSizeMs ?? DEFAULT_BUCKET_SIZE_MS));
+  const windowBucketCount = Math.max(1, Math.ceil(windowSizeMs / bucketSizeMs));
+  const filledBuckets = fillBucketGaps(buckets, bucketSizeMs);
+
+  return Stream.fromIterable(filledBuckets).pipe(
+    Stream.sliding(windowBucketCount),
+    Stream.filter((chunk) => chunk.length === windowBucketCount),
+    Stream.map((chunk) => aggregateBucketWindow(Array.from(chunk), windowSizeMs)),
+    Stream.runCollect,
+    Effect.map((windows) => Array.from(windows)),
+  );
+};
+
+const appendObservationToBucket = (
+  bucket: RpcMetricBucket,
+  observation: TimedRpcMetricObservation,
+  maxLatencySamplesPerMethodBucket: number,
+): RpcMetricBucket => {
+  const methods = new Map<string, MutableMethodBucket>(
+    bucket.methods.map((method) => [
+      method.method,
+      {
+        requestCount: method.requestCount,
+        errorCount: method.errorCount,
+        latenciesMs: [...method.latenciesMs],
+      },
+    ]),
+  );
+  const methodBucket =
+    methods.get(observation.method) ??
+    ({
+      requestCount: 0,
+      errorCount: 0,
+      latenciesMs: [],
+    } satisfies MutableMethodBucket);
+
+  methodBucket.requestCount += 1;
+  if (observation.failed) {
+    methodBucket.errorCount += 1;
+  }
+  if (methodBucket.latenciesMs.length < maxLatencySamplesPerMethodBucket) {
+    methodBucket.latenciesMs.push(Math.max(0, observation.latencyMs));
+  }
+  methods.set(observation.method, methodBucket);
+
+  return {
+    ...bucket,
+    methods: Array.from(methods.entries())
+      .map(
+        ([method, metrics]): RpcMetricMethodBucket => ({
+          method,
+          requestCount: metrics.requestCount,
+          errorCount: metrics.errorCount,
+          latenciesMs: metrics.latenciesMs,
+        }),
+      )
+      .toSorted((left, right) => left.method.localeCompare(right.method)),
+  };
+};
+
+const appendToCircularBuffer = <A>(
+  existing: ReadonlyArray<A>,
+  additions: ReadonlyArray<A>,
+  retainedCount: number,
+): ReadonlyArray<A> => {
+  const next = [...existing, ...additions];
+  return next.length <= retainedCount ? next : next.slice(next.length - retainedCount);
+};
+
+const makeMetricsAggregator = (options?: MetricsAggregatorOptions) =>
+  Effect.gen(function* () {
+    const resolvedOptions = resolveOptions(options);
+    const stateRef = yield* Ref.make<MetricsAggregatorState>({
+      buckets: [],
+      windows: [],
+      lastAggregatedWindowStartMs: null,
+    });
+
+    const recordAt = (observation: TimedRpcMetricObservation) =>
+      Ref.update(stateRef, (state) => {
+        const bucketStartMs = floorToBucketStart(
+          observation.timestampMs,
+          resolvedOptions.bucketSizeMs,
+        );
+        const bucketEndMs = bucketStartMs + resolvedOptions.bucketSizeMs;
+        const buckets = [...state.buckets];
+        const existingIndex = buckets.findIndex((bucket) => bucket.bucketStartMs === bucketStartMs);
+        const existingBucket =
+          existingIndex >= 0
+            ? buckets[existingIndex]!
+            : ({
+                bucketStartMs,
+                bucketEndMs,
+                methods: [],
+              } satisfies RpcMetricBucket);
+        const nextBucket = appendObservationToBucket(
+          existingBucket,
+          observation,
+          resolvedOptions.maxLatencySamplesPerMethodBucket,
+        );
+
+        if (existingIndex >= 0) {
+          buckets[existingIndex] = nextBucket;
+        } else {
+          buckets.push(nextBucket);
+        }
+
+        return {
+          ...state,
+          buckets: buckets.toSorted((left, right) => left.bucketStartMs - right.bucketStartMs),
+        };
+      });
+
+    const rotate = Effect.gen(function* () {
+      const nowMs = yield* Clock.currentTimeMillis;
+      const activeBucketStartMs = floorToBucketStart(nowMs, resolvedOptions.bucketSizeMs);
+      const windowBucketCount = Math.max(
+        1,
+        Math.ceil(resolvedOptions.windowSizeMs / resolvedOptions.bucketSizeMs),
+      );
+      const state = yield* Ref.get(stateRef);
+      const completedBuckets = state.buckets.filter(
+        (bucket) => bucket.bucketEndMs <= activeBucketStartMs,
+      );
+      const computedWindows = yield* aggregateSlidingMetricBuckets(completedBuckets, {
+        windowSizeMs: resolvedOptions.windowSizeMs,
+        bucketSizeMs: resolvedOptions.bucketSizeMs,
+      });
+      const newWindows = computedWindows.filter(
+        (window) =>
+          state.lastAggregatedWindowStartMs === null ||
+          window.windowStartMs > state.lastAggregatedWindowStartMs,
+      );
+      const lastNewWindow = newWindows[newWindows.length - 1];
+      const retainedBucketStartMs =
+        activeBucketStartMs - Math.max(0, windowBucketCount - 1) * resolvedOptions.bucketSizeMs;
+
+      yield* Ref.update(stateRef, (current) => ({
+        buckets: current.buckets.filter((bucket) => bucket.bucketStartMs >= retainedBucketStartMs),
+        windows: appendToCircularBuffer(
+          current.windows,
+          newWindows,
+          resolvedOptions.retainedWindowCount,
+        ),
+        lastAggregatedWindowStartMs:
+          lastNewWindow?.windowStartMs ?? current.lastAggregatedWindowStartMs,
+      }));
+    });
+
+    return {
+      record: (observation) =>
+        Clock.currentTimeMillis.pipe(
+          Effect.flatMap((timestampMs) => recordAt({ ...observation, timestampMs })),
+        ),
+      recordAt,
+      rotate,
+      snapshot: Ref.get(stateRef).pipe(Effect.map((state) => state.windows)),
+    } satisfies MetricsAggregatorShape;
+  });
+
+const scheduleMetricsRotation = (
+  aggregator: MetricsAggregatorShape,
+  options: ResolvedMetricsAggregatorOptions,
+) =>
+  Effect.sleep(Duration.millis(options.bucketSizeMs)).pipe(
+    Effect.andThen(aggregator.rotate),
+    Effect.repeat(Schedule.spaced(Duration.millis(options.bucketSizeMs))),
+    Effect.forkScoped,
+  );
+
+export const MetricsAggregatorLive = Layer.effect(
+  MetricsAggregator,
+  Effect.gen(function* () {
+    const options = resolveOptions();
+    const aggregator = yield* makeMetricsAggregator(options);
+    yield* scheduleMetricsRotation(aggregator, options);
+    return aggregator;
+  }),
+);
+
+export const makeMetricsAggregatorTestLayer = (options?: MetricsAggregatorOptions) =>
+  Layer.effect(MetricsAggregator, makeMetricsAggregator(options));

--- a/t3code/apps/server/src/observability/RpcInstrumentation.test.ts
+++ b/t3code/apps/server/src/observability/RpcInstrumentation.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest";
+import { assert, it } from "@effect/vitest";
 import { WS_METHODS } from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -14,6 +14,7 @@ import {
   observeRpcStream,
   observeRpcStreamEffect,
 } from "./RpcInstrumentation.ts";
+import { makeMetricsAggregatorTestLayer } from "./MetricsAggregator.ts";
 
 const hasMetricSnapshot = (
   snapshots: ReadonlyArray<Metric.Metric.Snapshot>,
@@ -64,7 +65,7 @@ const collectSpanNames = <A, E, R>(
     return spanNames;
   });
 
-describe("RpcInstrumentation", () => {
+it.layer(makeMetricsAggregatorTestLayer())("RpcInstrumentation", (it) => {
   it.effect("records success metrics for unary RPC handlers", () =>
     Effect.gen(function* () {
       yield* observeRpcEffect("rpc.instrumentation.success", Effect.succeed("ok"), {

--- a/t3code/apps/server/src/observability/RpcInstrumentation.ts
+++ b/t3code/apps/server/src/observability/RpcInstrumentation.ts
@@ -8,7 +8,8 @@ import * as References from "effect/References";
 import * as Stream from "effect/Stream";
 
 import { outcomeFromExit } from "./Attributes.ts";
-import { metricAttributes, rpcRequestDuration, rpcRequestsTotal, withMetrics } from "./Metrics.ts";
+import { metricAttributes, rpcRequestDuration, rpcRequestsTotal } from "./Metrics.ts";
+import { MetricsAggregator } from "./MetricsAggregator.ts";
 
 const RPC_SPAN_PREFIX = "ws.rpc";
 const DEFAULT_RPC_SPAN_ATTRIBUTES = {
@@ -61,14 +62,15 @@ const withRpcStreamTracing = <A, E, R>(
       )
     : stream.pipe(Stream.provideService(References.TracerEnabled, false));
 
-const recordRpcStreamMetrics = <E>(
+const recordRpcCompletedMetrics = <E>(
   method: string,
   startedAt: bigint,
   exit: Exit.Exit<unknown, E>,
-): Effect.Effect<void, never, never> =>
+): Effect.Effect<void, never, MetricsAggregator> =>
   Effect.gen(function* () {
     const endedAt = yield* Clock.currentTimeNanos;
     const elapsedNanos = endedAt > startedAt ? endedAt - startedAt : 0n;
+    const latencyMs = Number(elapsedNanos) / 1_000_000;
 
     yield* Metric.update(
       Metric.withAttributes(rpcRequestDuration, metricAttributes({ method })),
@@ -84,22 +86,30 @@ const recordRpcStreamMetrics = <E>(
       ),
       1,
     );
+
+    const metricsAggregator = yield* MetricsAggregator;
+    yield* metricsAggregator.record({
+      method,
+      latencyMs,
+      failed: Exit.isFailure(exit),
+    });
   });
 
 export const observeRpcEffect = <A, E, R>(
   method: string,
   effect: Effect.Effect<A, E, R>,
   traceAttributes?: Readonly<Record<string, unknown>>,
-): Effect.Effect<A, E, R> => {
-  const instrumented = effect.pipe(
-    withMetrics({
-      counter: rpcRequestsTotal,
-      timer: rpcRequestDuration,
-      attributes: {
-        method,
-      },
-    }),
-  );
+): Effect.Effect<A, E, R | MetricsAggregator> => {
+  const instrumented = Effect.gen(function* () {
+    const startedAt = yield* Clock.currentTimeNanos;
+    const exit = yield* Effect.exit(effect);
+    yield* recordRpcCompletedMetrics(method, startedAt, exit);
+
+    if (Exit.isSuccess(exit)) {
+      return exit.value;
+    }
+    return yield* Effect.failCause(exit.cause);
+  });
 
   return withRpcEffectTracing(method, instrumented, traceAttributes);
 };
@@ -108,11 +118,13 @@ export const observeRpcStream = <A, E, R>(
   method: string,
   stream: Stream.Stream<A, E, R>,
   traceAttributes?: Readonly<Record<string, unknown>>,
-): Stream.Stream<A, E, R> => {
+): Stream.Stream<A, E, R | MetricsAggregator> => {
   const instrumented = Stream.unwrap(
     Effect.gen(function* () {
       const startedAt = yield* Clock.currentTimeNanos;
-      return stream.pipe(Stream.onExit((exit) => recordRpcStreamMetrics(method, startedAt, exit)));
+      return stream.pipe(
+        Stream.onExit((exit) => recordRpcCompletedMetrics(method, startedAt, exit)),
+      );
     }),
   );
 
@@ -123,19 +135,23 @@ export const observeRpcStreamEffect = <A, StreamError, StreamContext, EffectErro
   method: string,
   effect: Effect.Effect<Stream.Stream<A, StreamError, StreamContext>, EffectError, EffectContext>,
   traceAttributes?: Readonly<Record<string, unknown>>,
-): Stream.Stream<A, StreamError | EffectError, StreamContext | EffectContext> => {
+): Stream.Stream<
+  A,
+  StreamError | EffectError,
+  StreamContext | EffectContext | MetricsAggregator
+> => {
   const instrumented = Stream.unwrap(
     Effect.gen(function* () {
       const startedAt = yield* Clock.currentTimeNanos;
       const exit = yield* Effect.exit(effect);
 
       if (Exit.isFailure(exit)) {
-        yield* recordRpcStreamMetrics(method, startedAt, exit);
+        yield* recordRpcCompletedMetrics(method, startedAt, exit);
         return yield* Effect.failCause(exit.cause);
       }
 
       return exit.value.pipe(
-        Stream.onExit((streamExit) => recordRpcStreamMetrics(method, startedAt, streamExit)),
+        Stream.onExit((streamExit) => recordRpcCompletedMetrics(method, startedAt, streamExit)),
       );
     }),
   );

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -88,6 +88,11 @@ import {
   BrowserTraceCollector,
   type BrowserTraceCollectorShape,
 } from "./observability/Services/BrowserTraceCollector.ts";
+import {
+  METRICS_AGGREGATED_PATH,
+  MetricsAggregator,
+  type MetricsAggregatorShape,
+} from "./observability/MetricsAggregator.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
 import {
   ProjectSetupScriptRunner,
@@ -333,6 +338,7 @@ const buildAppUnderTest = (options?: {
     projectionSnapshotQuery?: Partial<ProjectionSnapshotQueryShape>;
     checkpointDiffQuery?: Partial<CheckpointDiffQueryShape>;
     browserTraceCollector?: Partial<BrowserTraceCollectorShape>;
+    metricsAggregator?: Partial<MetricsAggregatorShape>;
     serverLifecycleEvents?: Partial<ServerLifecycleEventsShape>;
     serverRuntimeStartup?: Partial<ServerRuntimeStartupShape>;
     serverEnvironment?: Partial<ServerEnvironmentShape>;
@@ -723,6 +729,15 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provideMerge(makeAuthTestLayer()),
+      Layer.provide(
+        Layer.mock(MetricsAggregator)({
+          record: () => Effect.void,
+          recordAt: () => Effect.void,
+          rotate: Effect.void,
+          snapshot: Effect.succeed([]),
+          ...options?.layers?.metricsAggregator,
+        }),
+      ),
       Layer.provide(workspaceAndProjectServicesLayer),
       Layer.provideMerge(FetchHttpClient.layer),
       Layer.provide(layerConfig),
@@ -1289,6 +1304,52 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(response.status, 401);
       assertBrowserApiCorsHeaders(response.headers);
       assert.equal(body.error, "Authentication required.");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("serves authenticated aggregated metrics windows", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest({
+        layers: {
+          metricsAggregator: {
+            snapshot: Effect.succeed([
+              {
+                timestamp: "1970-01-01T00:01:00.000Z",
+                windowStart: "1970-01-01T00:00:00.000Z",
+                windowEnd: "1970-01-01T00:01:00.000Z",
+                windowStartMs: 0,
+                windowEndMs: 60_000,
+                methods: [
+                  {
+                    method: "server.getConfig",
+                    requestCount: 2,
+                    errorCount: 1,
+                    errorRate: 50,
+                    throughput: 2 / 60,
+                    p50LatencyMs: 10,
+                    p95LatencyMs: 25,
+                    p99LatencyMs: 25,
+                  },
+                ],
+              },
+            ]),
+          },
+        },
+      });
+
+      const response = yield* HttpClient.get(METRICS_AGGREGATED_PATH, {
+        headers: {
+          cookie: yield* getAuthenticatedSessionCookieHeader(),
+        },
+      });
+      const body = (yield* response.json) as ReadonlyArray<{
+        readonly methods: ReadonlyArray<{ readonly method: string; readonly errorRate: number }>;
+      }>;
+
+      assert.equal(response.status, 200);
+      assert.equal(body.length, 1);
+      assert.equal(body[0]?.methods[0]?.method, "server.getConfig");
+      assert.equal(body[0]?.methods[0]?.errorRate, 50);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -4,6 +4,7 @@ import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 
 import { ServerConfig } from "./config.ts";
 import {
+  aggregatedMetricsRouteLayer,
   attachmentsRouteLayer,
   otlpTracesProxyRouteLayer,
   projectFaviconRouteLayer,
@@ -11,6 +12,7 @@ import {
   staticAndDevRouteLayer,
   browserApiCorsLayer,
 } from "./http.ts";
+import { MetricsAggregatorLive } from "./observability/MetricsAggregator.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
@@ -276,6 +278,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(RepositoryIdentityResolverLive),
   Layer.provideMerge(ServerEnvironmentLive),
   Layer.provideMerge(AuthLayerLive),
+  Layer.provideMerge(MetricsAggregatorLive),
 );
 
 const RuntimeDependenciesLive = RuntimeCoreDependenciesLive.pipe(
@@ -304,6 +307,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   authPairingCredentialRouteLayer,
   authSessionRouteLayer,
   authWebSocketTokenRouteLayer,
+  aggregatedMetricsRouteLayer,
   attachmentsRouteLayer,
   orchestrationDispatchRouteLayer,
   orchestrationSnapshotRouteLayer,


### PR DESCRIPTION
/claim #856

## Summary
- add an Effect-based MetricsAggregator service for bucketed RPC observations and sliding-window aggregation
- compute per-method p50/p95/p99 latency, error rate, throughput, and bounded 60-window trend data
- record unary and streaming RPC completions into the aggregator and expose authenticated GET /metrics/aggregated
- add focused tests for percentile math, overlapping windows, rotation/buffer bounds, existing instrumentation, and the authenticated JSON route

## Demo
https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-856-metrics-demo.mp4

## Validation
- `npx -y bun@1.3.11 run --cwd apps/server test src/observability/MetricsAggregator.test.ts src/observability/RpcInstrumentation.test.ts`
- `npx -y bun@1.3.11 run --cwd apps/server test src/server.test.ts -t "serves authenticated aggregated metrics windows"`
- `npx -y bun@1.3.11 run --cwd apps/server typecheck`
- `npx -y bun@1.3.11 run fmt:check apps/server/src/observability/MetricsAggregator.ts apps/server/src/observability/MetricsAggregator.test.ts apps/server/src/observability/RpcInstrumentation.ts apps/server/src/observability/RpcInstrumentation.test.ts apps/server/src/http.ts apps/server/src/server.ts apps/server/src/server.test.ts apps/server/src/observability/.generation_meta.json`
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('t3code/apps/server/src/observability/.generation_meta.json','utf8')); console.log('generation metadata JSON OK')"`

## Lint note
- `npx -y bun@1.3.11 run lint apps/server/src/observability/MetricsAggregator.ts apps/server/src/observability/MetricsAggregator.test.ts apps/server/src/observability/RpcInstrumentation.ts apps/server/src/observability/RpcInstrumentation.test.ts apps/server/src/http.ts apps/server/src/server.ts apps/server/src/server.test.ts` currently stops before linting because the repo oxlint config cannot load `./oxlint-plugin-t3code/index.ts` through Node and throws `ERR_UNKNOWN_FILE_EXTENSION`.

## Metadata note
- `.generation_meta.json` contains safe public task context. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced in repository files.