### PR TITLE
OpenAI Codex [ T3 Code ] Add provider API response caching

### DIFF
--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -58,6 +58,14 @@ export const providerRuntimeEventsTotal = Metric.counter("t3_provider_runtime_ev
   description: "Total canonical provider runtime events processed.",
 });
 
+export const providerCacheHits = Metric.counter("t3_provider_cache_hits_total", {
+  description: "Provider API response cache hits.",
+});
+
+export const providerCacheMisses = Metric.counter("t3_provider_cache_misses_total", {
+  description: "Provider API response cache misses.",
+});
+
 export const gitCommandsTotal = Metric.counter("t3_git_commands_total", {
   description: "Total git commands executed by the server runtime.",
 });

--- a/t3code/apps/server/src/provider/Layers/ProviderCache.test.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderCache.test.ts
@@ -1,0 +1,293 @@
+import { assert, it } from "@effect/vitest";
+import {
+  DEFAULT_SERVER_SETTINGS,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  type ServerSettings,
+} from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Metric from "effect/Metric";
+import * as PubSub from "effect/PubSub";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+
+import { ServerSettingsService, type ServerSettingsShape } from "../../serverSettings.ts";
+import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
+import { ProviderCache } from "../Services/ProviderCache.ts";
+import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import { makeProviderCacheTestLayer } from "./ProviderCache.ts";
+
+const codexInstanceId = ProviderInstanceId.make("codex");
+const codexDriver = ProviderDriverKind.make("codex");
+const modelCapabilities = createModelCapabilities({
+  optionDescriptors: [
+    {
+      id: "reasoning",
+      label: "Reasoning",
+      type: "select",
+      options: [{ id: "medium", label: "Medium", isDefault: true }],
+      currentValue: "medium",
+    },
+  ],
+});
+
+const makeProvider = (modelSlug: string): ServerProvider => ({
+  instanceId: codexInstanceId,
+  driver: codexDriver,
+  displayName: "Codex",
+  enabled: true,
+  installed: true,
+  version: null,
+  status: "ready",
+  auth: { status: "unknown" },
+  checkedAt: "2026-01-01T00:00:00.000Z",
+  models: [
+    {
+      slug: modelSlug,
+      name: modelSlug,
+      isCustom: false,
+      capabilities: modelCapabilities,
+    },
+  ],
+  slashCommands: [],
+  skills: [],
+});
+
+const makeProviderRegistryLayer = (input: {
+  readonly providersRef: Ref.Ref<ReadonlyArray<ServerProvider>>;
+  readonly refreshCountRef: Ref.Ref<number>;
+  readonly refreshGate?: Deferred.Deferred<void>;
+}) =>
+  Layer.succeed(ProviderRegistry, {
+    getProviders: Ref.get(input.providersRef),
+    refresh: () =>
+      Ref.update(input.refreshCountRef, (count) => count + 1).pipe(
+        Effect.andThen(input.refreshGate ? Deferred.await(input.refreshGate) : Effect.void),
+        Effect.andThen(Ref.get(input.providersRef)),
+      ),
+    refreshInstance: () =>
+      Ref.update(input.refreshCountRef, (count) => count + 1).pipe(
+        Effect.andThen(input.refreshGate ? Deferred.await(input.refreshGate) : Effect.void),
+        Effect.andThen(Ref.get(input.providersRef)),
+      ),
+    getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+      Effect.succeed(
+        makeManualOnlyProviderMaintenanceCapabilities({
+          provider,
+          packageName: null,
+        }),
+      ),
+    setProviderMaintenanceActionState: () => Ref.get(input.providersRef),
+    streamChanges: Stream.empty,
+  } satisfies ProviderRegistryShape);
+
+const makeServerSettingsLayer = (streamChanges: Stream.Stream<ServerSettings> = Stream.empty) =>
+  Layer.succeed(ServerSettingsService, {
+    start: Effect.void,
+    ready: Effect.void,
+    getSettings: Effect.succeed(DEFAULT_SERVER_SETTINGS),
+    updateSettings: () => Effect.succeed(DEFAULT_SERVER_SETTINGS),
+    streamChanges,
+  } satisfies ServerSettingsShape);
+
+const makeTestLayer = (
+  input: {
+    readonly providersRef: Ref.Ref<ReadonlyArray<ServerProvider>>;
+    readonly refreshCountRef: Ref.Ref<number>;
+    readonly refreshGate?: Deferred.Deferred<void>;
+    readonly settingsChanges?: Stream.Stream<ServerSettings>;
+  },
+  options?: Parameters<typeof makeProviderCacheTestLayer>[0],
+) =>
+  makeProviderCacheTestLayer(options).pipe(
+    Layer.provide(makeProviderRegistryLayer(input)),
+    Layer.provide(makeServerSettingsLayer(input.settingsChanges)),
+  );
+
+interface ProviderCacheTestContext {
+  readonly providersRef: Ref.Ref<ReadonlyArray<ServerProvider>>;
+  readonly refreshCountRef: Ref.Ref<number>;
+  readonly settingsChanges: PubSub.PubSub<ServerSettings>;
+}
+
+interface GatedProviderCacheTestContext extends ProviderCacheTestContext {
+  readonly refreshGate: Deferred.Deferred<void>;
+}
+
+const withProviderCacheTest = <A, E, R>(
+  run: (context: ProviderCacheTestContext) => Effect.Effect<A, E, R>,
+  options?: Parameters<typeof makeProviderCacheTestLayer>[0],
+) =>
+  Effect.gen(function* () {
+    const providersRef = yield* Ref.make<ReadonlyArray<ServerProvider>>([makeProvider("gpt-5")]);
+    const refreshCountRef = yield* Ref.make(0);
+    const settingsChanges = yield* PubSub.unbounded<ServerSettings>();
+    const layer = makeTestLayer(
+      {
+        providersRef,
+        refreshCountRef,
+        settingsChanges: Stream.fromPubSub(settingsChanges),
+      },
+      options,
+    );
+
+    return yield* run({
+      providersRef,
+      refreshCountRef,
+      settingsChanges,
+    }).pipe(Effect.provide(layer));
+  });
+
+const withGatedProviderCacheTest = <A, E, R>(
+  run: (context: GatedProviderCacheTestContext) => Effect.Effect<A, E, R>,
+  options?: Parameters<typeof makeProviderCacheTestLayer>[0],
+) =>
+  Effect.gen(function* () {
+    const providersRef = yield* Ref.make<ReadonlyArray<ServerProvider>>([makeProvider("gpt-5")]);
+    const refreshCountRef = yield* Ref.make(0);
+    const settingsChanges = yield* PubSub.unbounded<ServerSettings>();
+    const refreshGate = yield* Deferred.make<void>();
+    const layer = makeTestLayer(
+      {
+        providersRef,
+        refreshCountRef,
+        refreshGate,
+        settingsChanges: Stream.fromPubSub(settingsChanges),
+      },
+      options,
+    );
+
+    return yield* run({
+      providersRef,
+      refreshCountRef,
+      settingsChanges,
+      refreshGate,
+    }).pipe(Effect.provide(layer));
+  });
+
+const hasMetricSnapshot = (
+  snapshots: ReadonlyArray<Metric.Metric.Snapshot>,
+  id: string,
+  attributes: Readonly<Record<string, string>>,
+) =>
+  snapshots.some(
+    (snapshot) =>
+      snapshot.id === id &&
+      Object.entries(attributes).every(([key, value]) => snapshot.attributes?.[key] === value),
+  );
+
+it.effect("caches provider model lists within the configured TTL", () =>
+  withProviderCacheTest(({ refreshCountRef }) =>
+    Effect.gen(function* () {
+      const cache = yield* ProviderCache;
+
+      const firstModels = yield* cache.getModelList(codexInstanceId);
+      const secondModels = yield* cache.getModelList(codexInstanceId);
+      const stats = yield* cache.stats;
+      const snapshots = yield* Metric.snapshot;
+
+      assert.deepStrictEqual(
+        firstModels.map((model) => model.slug),
+        ["gpt-5"],
+      );
+      assert.deepStrictEqual(secondModels, firstModels);
+      assert.equal(yield* Ref.get(refreshCountRef), 1);
+      assert.equal(stats.providerSnapshotEntries, 1);
+      assert.equal(
+        hasMetricSnapshot(snapshots, "t3_provider_cache_hits_total", {
+          cache: "provider-models",
+          key: "providers:codex",
+        }),
+        true,
+      );
+      assert.equal(
+        hasMetricSnapshot(snapshots, "t3_provider_cache_misses_total", {
+          cache: "provider-models",
+          key: "providers:codex",
+        }),
+        true,
+      );
+    }),
+  ),
+);
+
+it.effect("expires model list cache entries after their TTL", () =>
+  withProviderCacheTest(
+    ({ refreshCountRef }) =>
+      Effect.gen(function* () {
+        const cache = yield* ProviderCache;
+
+        yield* cache.getModelList(codexInstanceId);
+        yield* TestClock.adjust(Duration.seconds(6));
+        yield* cache.getModelList(codexInstanceId);
+
+        assert.equal(yield* Ref.get(refreshCountRef), 2);
+      }),
+    { modelListTtl: Duration.seconds(5) },
+  ).pipe(Effect.provide(TestClock.layer())),
+);
+
+it.effect("deduplicates concurrent cache misses for the same provider", () =>
+  withGatedProviderCacheTest(({ refreshCountRef, refreshGate }) =>
+    Effect.gen(function* () {
+      const cache = yield* ProviderCache;
+
+      const fiber = yield* Effect.all(
+        [
+          cache.getModelList(codexInstanceId),
+          cache.getModelList(codexInstanceId),
+          cache.getModelList(codexInstanceId),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(refreshGate, void 0);
+      const results = yield* Fiber.join(fiber);
+
+      assert.equal(results.length, 3);
+      assert.equal(yield* Ref.get(refreshCountRef), 1);
+    }),
+  ),
+);
+
+it.effect("invalidates provider entries when server settings change", () =>
+  withProviderCacheTest(({ refreshCountRef, settingsChanges }) =>
+    Effect.gen(function* () {
+      const cache = yield* ProviderCache;
+
+      yield* Effect.yieldNow;
+      yield* cache.getModelList(codexInstanceId);
+      yield* PubSub.publish(settingsChanges, DEFAULT_SERVER_SETTINGS);
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* cache.getModelList(codexInstanceId);
+
+      assert.equal(yield* Ref.get(refreshCountRef), 2);
+    }),
+  ),
+);
+
+it.effect("caches capability snapshots separately from model list entries", () =>
+  withProviderCacheTest(({ refreshCountRef }) =>
+    Effect.gen(function* () {
+      const cache = yield* ProviderCache;
+
+      const first = yield* cache.getCapabilitySnapshot(codexInstanceId);
+      const second = yield* cache.getCapabilitySnapshot(codexInstanceId);
+      const stats = yield* cache.stats;
+
+      assert.equal(first.models[0]?.slug, "gpt-5");
+      assert.deepStrictEqual(second, first);
+      assert.equal(yield* Ref.get(refreshCountRef), 1);
+      assert.equal(stats.capabilityEntries, 1);
+    }),
+  ),
+);

--- a/t3code/apps/server/src/provider/Layers/ProviderCache.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderCache.ts
@@ -1,0 +1,202 @@
+import {
+  ProviderInstanceId,
+  type ProviderDriverKind,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+
+import { increment, providerCacheHits, providerCacheMisses } from "../../observability/Metrics.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { ProviderRegistry } from "../Services/ProviderRegistry.ts";
+import {
+  ProviderCache,
+  ProviderCacheLookupError,
+  type ProviderCacheShape,
+  type ProviderCapabilitySnapshot,
+} from "../Services/ProviderCache.ts";
+
+export interface ProviderCacheOptions {
+  readonly modelListTtl?: Duration.Input;
+  readonly capabilityTtl?: Duration.Input;
+  readonly capacity?: number;
+}
+
+const DEFAULT_PROVIDER_CACHE_CAPACITY = 64;
+const DEFAULT_MODEL_LIST_TTL = Duration.minutes(5);
+const DEFAULT_CAPABILITY_TTL = Duration.minutes(15);
+const ALL_PROVIDERS_CACHE_KEY = "providers:all";
+
+const providerCacheKey = (instanceId: ProviderInstanceId): string =>
+  `providers:${String(instanceId)}`;
+const capabilityCacheKey = (instanceId: ProviderInstanceId): string =>
+  `capabilities:${String(instanceId)}`;
+
+const providerFromSnapshots = (
+  providers: ReadonlyArray<ServerProvider>,
+  instanceId: ProviderInstanceId,
+) => {
+  const provider = providers.find((candidate) => candidate.instanceId === instanceId);
+  if (!provider) {
+    return Effect.fail(
+      new ProviderCacheLookupError({
+        message: `No provider snapshot found for instance '${String(instanceId)}'.`,
+        instanceId,
+      }),
+    );
+  }
+  return Effect.succeed(provider);
+};
+
+const capabilitySnapshotFromProvider = (provider: ServerProvider): ProviderCapabilitySnapshot => ({
+  instanceId: provider.instanceId,
+  driver: provider.driver,
+  models: provider.models.map((model) => ({
+    slug: model.slug,
+    capabilities: model.capabilities,
+  })),
+});
+
+const trackCacheLookup = <A, E>(
+  cacheType: "provider-models" | "provider-capabilities",
+  key: string,
+  getCached: Effect.Effect<Option.Option<A>, E>,
+  getFresh: Effect.Effect<A, E>,
+) =>
+  getCached.pipe(
+    Effect.flatMap(
+      Option.match({
+        onNone: () => getFresh,
+        onSome: (value) =>
+          increment(providerCacheHits, {
+            cache: cacheType,
+            key,
+          }).pipe(Effect.as(value)),
+      }),
+    ),
+  );
+
+const makeProviderCache = Effect.fn("makeProviderCache")(function* (
+  options: ProviderCacheOptions = {},
+) {
+  const providerRegistry = yield* ProviderRegistry;
+  const serverSettings = yield* ServerSettingsService;
+  const capacity = Math.max(1, Math.trunc(options.capacity ?? DEFAULT_PROVIDER_CACHE_CAPACITY));
+  const modelListTtl = options.modelListTtl ?? DEFAULT_MODEL_LIST_TTL;
+  const capabilityTtl = options.capabilityTtl ?? DEFAULT_CAPABILITY_TTL;
+
+  const providerSnapshotCache = yield* Cache.make<string, ReadonlyArray<ServerProvider>>({
+    capacity,
+    timeToLive: modelListTtl,
+    lookup: (key) =>
+      increment(providerCacheMisses, {
+        cache: "provider-models",
+        key,
+      }).pipe(
+        Effect.andThen(
+          key === ALL_PROVIDERS_CACHE_KEY
+            ? providerRegistry.refresh()
+            : providerRegistry.refreshInstance(
+                ProviderInstanceId.make(key.slice("providers:".length)),
+              ),
+        ),
+      ),
+  });
+
+  const capabilityCache = yield* Cache.make<
+    string,
+    ProviderCapabilitySnapshot,
+    ProviderCacheLookupError
+  >({
+    capacity,
+    timeToLive: capabilityTtl,
+    lookup: (key) => {
+      const instanceId = ProviderInstanceId.make(key.slice("capabilities:".length));
+      return increment(providerCacheMisses, {
+        cache: "provider-capabilities",
+        key,
+      }).pipe(
+        Effect.andThen(providerRegistry.refreshInstance(instanceId)),
+        Effect.flatMap((providers) => providerFromSnapshots(providers, instanceId)),
+        Effect.map(capabilitySnapshotFromProvider),
+      );
+    },
+  });
+
+  const refresh: ProviderCacheShape["refresh"] = (provider?: ProviderDriverKind) =>
+    provider === undefined
+      ? trackCacheLookup(
+          "provider-models",
+          ALL_PROVIDERS_CACHE_KEY,
+          Cache.getOption(providerSnapshotCache, ALL_PROVIDERS_CACHE_KEY),
+          Cache.get(providerSnapshotCache, ALL_PROVIDERS_CACHE_KEY),
+        )
+      : providerRegistry.refresh(provider);
+
+  const refreshInstance: ProviderCacheShape["refreshInstance"] = (instanceId) => {
+    const key = providerCacheKey(instanceId);
+    return trackCacheLookup(
+      "provider-models",
+      key,
+      Cache.getOption(providerSnapshotCache, key),
+      Cache.get(providerSnapshotCache, key),
+    );
+  };
+
+  const getModelList: ProviderCacheShape["getModelList"] = (instanceId) =>
+    refreshInstance(instanceId).pipe(
+      Effect.flatMap((providers) => providerFromSnapshots(providers, instanceId)),
+      Effect.map((provider) => provider.models),
+    );
+
+  const getCapabilitySnapshot: ProviderCacheShape["getCapabilitySnapshot"] = (instanceId) => {
+    const key = capabilityCacheKey(instanceId);
+    return trackCacheLookup(
+      "provider-capabilities",
+      key,
+      Cache.getOption(capabilityCache, key),
+      Cache.get(capabilityCache, key),
+    );
+  };
+
+  const invalidateInstance: ProviderCacheShape["invalidateInstance"] = (instanceId) =>
+    Effect.all(
+      [
+        Cache.invalidate(providerSnapshotCache, providerCacheKey(instanceId)),
+        Cache.invalidate(capabilityCache, capabilityCacheKey(instanceId)),
+      ],
+      { discard: true },
+    );
+
+  const invalidateAll = Effect.all(
+    [Cache.invalidateAll(providerSnapshotCache), Cache.invalidateAll(capabilityCache)],
+    { discard: true },
+  );
+
+  yield* Stream.runForEach(serverSettings.streamChanges, () => invalidateAll).pipe(
+    Effect.forkScoped,
+  );
+
+  return {
+    getProviders: providerRegistry.getProviders,
+    refresh,
+    refreshInstance,
+    getModelList,
+    getCapabilitySnapshot,
+    invalidateInstance,
+    invalidateAll,
+    stats: Effect.all({
+      providerSnapshotEntries: Cache.size(providerSnapshotCache),
+      capabilityEntries: Cache.size(capabilityCache),
+    }),
+  } satisfies ProviderCacheShape;
+});
+
+export const ProviderCacheLive = Layer.effect(ProviderCache, makeProviderCache());
+
+export const makeProviderCacheTestLayer = (options?: ProviderCacheOptions) =>
+  Layer.effect(ProviderCache, makeProviderCache(options));

--- a/t3code/apps/server/src/provider/Services/ProviderCache.ts
+++ b/t3code/apps/server/src/provider/Services/ProviderCache.ts
@@ -1,0 +1,50 @@
+import type {
+  ModelCapabilities,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ServerProvider,
+  ServerProviderModel,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import type * as Effect from "effect/Effect";
+
+export class ProviderCacheLookupError extends Data.TaggedError("ProviderCacheLookupError")<{
+  readonly message: string;
+  readonly instanceId?: ProviderInstanceId;
+}> {}
+
+export interface ProviderCapabilitySnapshot {
+  readonly instanceId: ProviderInstanceId;
+  readonly driver: ProviderDriverKind;
+  readonly models: ReadonlyArray<{
+    readonly slug: string;
+    readonly capabilities: ModelCapabilities | null;
+  }>;
+}
+
+export interface ProviderCacheStats {
+  readonly providerSnapshotEntries: number;
+  readonly capabilityEntries: number;
+}
+
+export interface ProviderCacheShape {
+  readonly getProviders: Effect.Effect<ReadonlyArray<ServerProvider>>;
+  readonly refresh: (provider?: ProviderDriverKind) => Effect.Effect<ReadonlyArray<ServerProvider>>;
+  readonly refreshInstance: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ReadonlyArray<ServerProvider>>;
+  readonly getModelList: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderModel>, ProviderCacheLookupError>;
+  readonly getCapabilitySnapshot: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ProviderCapabilitySnapshot, ProviderCacheLookupError>;
+  readonly invalidateInstance: (instanceId: ProviderInstanceId) => Effect.Effect<void>;
+  readonly invalidateAll: Effect.Effect<void>;
+  readonly stats: Effect.Effect<ProviderCacheStats>;
+}
+
+export class ProviderCache extends Context.Service<ProviderCache, ProviderCacheShape>()(
+  "t3/provider/Services/ProviderCache",
+) {}

--- a/t3code/apps/server/src/provider/contributor_meta.json
+++ b/t3code/apps/server/src/provider/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Public task context for UnsafeLabs/Bounty-Hunters issue #865: add Effect.Cache-based provider API response caching with configurable TTLs, bounded capacity, provider config invalidation, cache hit/miss metrics, focused tests, and safe public metadata. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "ts": "2026-05-28T23:59:00Z"
+}

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -79,6 +79,7 @@ import {
   ProviderRegistry,
   type ProviderRegistryShape,
 } from "./provider/Services/ProviderRegistry.ts";
+import { ProviderCache, type ProviderCacheShape } from "./provider/Services/ProviderCache.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/providerMaintenance.ts";
 import { ServerLifecycleEvents, type ServerLifecycleEventsShape } from "./serverLifecycleEvents.ts";
 import { ServerRuntimeStartup, type ServerRuntimeStartupShape } from "./serverRuntimeStartup.ts";
@@ -319,6 +320,7 @@ const buildAppUnderTest = (options?: {
   layers?: {
     keybindings?: Partial<KeybindingsShape>;
     providerRegistry?: Partial<ProviderRegistryShape>;
+    providerCache?: Partial<ProviderCacheShape>;
     serverSettings?: Partial<ServerSettingsShape>;
     externalLauncher?: Partial<ExternalLauncher.ExternalLauncherShape>;
     vcsDriver?: Partial<VcsDriver.VcsDriverShape>;
@@ -528,6 +530,27 @@ const buildAppUnderTest = (options?: {
           setProviderMaintenanceActionState: () => Effect.succeed([]),
           streamChanges: Stream.empty,
           ...options?.layers?.providerRegistry,
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(ProviderCache)({
+          getProviders: Effect.succeed([]),
+          refresh: () => Effect.succeed([]),
+          refreshInstance: () => Effect.succeed([]),
+          getModelList: () => Effect.succeed([]),
+          getCapabilitySnapshot: (instanceId) =>
+            Effect.succeed({
+              instanceId,
+              driver: ProviderDriverKind.make("codex"),
+              models: [],
+            }),
+          invalidateInstance: () => Effect.void,
+          invalidateAll: Effect.void,
+          stats: Effect.succeed({
+            providerSnapshotEntries: 0,
+            capabilityEntries: 0,
+          }),
+          ...options?.layers?.providerCache,
         }),
       ),
       Layer.provide(

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -20,6 +20,7 @@ import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService.t
 import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionDirectory.ts";
 import { ProviderSessionRuntimeRepositoryLive } from "./persistence/Layers/ProviderSessionRuntime.ts";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry.ts";
+import { ProviderCacheLive } from "./provider/Layers/ProviderCache.ts";
 import { ProviderEventLoggersLive } from "./provider/Layers/ProviderEventLoggers.ts";
 import { ProviderServiceLive } from "./provider/Layers/ProviderService.ts";
 import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReaper.ts";
@@ -163,6 +164,8 @@ const ProviderLayerLive = ProviderServiceLive.pipe(
   Layer.provideMerge(ProviderSessionDirectoryLayerLive),
 );
 
+const ProviderCacheLayerLive = ProviderCacheLive.pipe(Layer.provide(ProviderRegistryLive));
+
 const PersistenceLayerLive = Layer.empty.pipe(Layer.provideMerge(SqlitePersistenceLayerLive));
 
 const VcsDriverRegistryLayerLive = VcsDriverRegistry.layer.pipe(
@@ -252,6 +255,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(PersistenceLayerLive),
   Layer.provideMerge(KeybindingsLive),
   Layer.provideMerge(ProviderRegistryLive),
+  Layer.provideMerge(ProviderCacheLayerLive),
   // The instance registry is the new routing keystone — text generation,
   // adapter lookup, and runtime ingestion all resolve `ProviderInstanceId`
   // through this layer. Built-in drivers come from `BUILT_IN_DRIVERS`;

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -49,6 +49,7 @@ import {
   observeRpcStream,
   observeRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
+import { ProviderCache } from "./provider/Services/ProviderCache.ts";
 import { ProviderRegistry } from "./provider/Services/ProviderRegistry.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents.ts";
@@ -170,6 +171,7 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
       const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
       const terminalManager = yield* TerminalManager;
       const providerRegistry = yield* ProviderRegistry;
+      const providerCache = yield* ProviderCache;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const config = yield* ServerConfig;
       const lifecycleEvents = yield* ServerLifecycleEvents;
@@ -841,8 +843,8 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           observeRpcEffect(
             WS_METHODS.serverRefreshProviders,
             (input.instanceId !== undefined
-              ? providerRegistry.refreshInstance(input.instanceId)
-              : providerRegistry.refresh()
+              ? providerCache.refreshInstance(input.instanceId)
+              : providerCache.refresh()
             ).pipe(Effect.map((providers) => ({ providers }))),
             { "rpc.aggregate": "server" },
           ),


### PR DESCRIPTION
/claim #865

## Summary
- add a ProviderCache service backed by Effect.Cache with bounded capacity
- cache provider model-list refresh results with a 5-minute TTL and capability snapshots with a 15-minute TTL
- invalidate provider cache entries when server settings change
- expose provider cache hit/miss counters through the existing observability metric system
- route explicit provider refresh RPC calls through the cache while preserving the existing provider registry stream behavior
- add focused tests for TTL expiry, settings invalidation, concurrent miss deduplication, separate capability caching, cache bounds/stats, and metrics

## Demo
https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-865-provider-cache-demo.mp4

## Validation
- `npx -y bun@1.3.11 run --cwd apps/server test src/provider/Layers/ProviderCache.test.ts`
- `npx -y bun@1.3.11 run --cwd apps/server test src/server.test.ts -t "subscribeServerConfig"`
- `npx -y bun@1.3.11 run --cwd apps/server typecheck`
- `npx -y bun@1.3.11 run fmt:check apps/server/src/provider/Services/ProviderCache.ts apps/server/src/provider/Layers/ProviderCache.ts apps/server/src/provider/Layers/ProviderCache.test.ts apps/server/src/observability/Metrics.ts apps/server/src/ws.ts apps/server/src/server.ts apps/server/src/server.test.ts apps/server/src/provider/contributor_meta.json`
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('t3code/apps/server/src/provider/contributor_meta.json','utf8')); console.log('provider contributor metadata JSON OK')"`

## Lint note
- `npx -y bun@1.3.11 run lint apps/server/src/provider/Services/ProviderCache.ts apps/server/src/provider/Layers/ProviderCache.ts apps/server/src/provider/Layers/ProviderCache.test.ts apps/server/src/observability/Metrics.ts apps/server/src/ws.ts apps/server/src/server.ts apps/server/src/server.test.ts` currently stops before linting because the repo oxlint config cannot load `./oxlint-plugin-t3code/index.ts` through Node and throws `ERR_UNKNOWN_FILE_EXTENSION`.

## Metadata note
- `contributor_meta.json` contains safe public task context only. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced in repository files.