### PR TITLE
[ zhangjiayang6835-cyber ] [ T3 Code ] Fix turbo.json missing dependency graph for app builds

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,7 @@
+{
+  "description": "T3Code monorepo turbo configuration",
+  "changes": [
+    "Added missing dependency chains for apps/server#build: packages/shared, packages/effect-acp, packages/effect-codex-app-server",
+    "Added apps/desktop#build with dependsOn apps/web#build and apps/server#build"
+  ]
+}

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,19 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "apps/web#build": {
+      "dependsOn": [
+        "packages/contracts#build",
+        "packages/client-runtime#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "apps/server#build": {
+      "dependsOn": [
+        "packages/contracts#build"
+      ],
+      "outputs": ["dist/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -43,7 +43,17 @@
     },
     "apps/server#build": {
       "dependsOn": [
-        "packages/contracts#build"
+        "packages/contracts#build",
+        "packages/shared#build",
+        "packages/effect-acp#build",
+        "packages/effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "apps/desktop#build": {
+      "dependsOn": [
+        "apps/web#build",
+        "apps/server#build"
       ],
       "outputs": ["dist/**"]
     },


### PR DESCRIPTION
Fixes #828

## Changes
- Updated `apps/server#build` to depend on `packages/contracts#build`, `packages/shared#build`, `packages/effect-acp#build`, `packages/effect-codex-app-server#build`
- Added `apps/desktop#build` with dependencies on `apps/web#build` and `apps/server#build`
- Created `_meta.json` documenting the changes

## Dependency Chains
| Task | Depends On |
|------|-----------|
| apps/web#build | packages/contracts#build, packages/client-runtime#build |
| apps/server#build | packages/contracts#build, packages/shared#build, packages/effect-acp#build, packages/effect-codex-app-server#build |
| apps/desktop#build | apps/web#build, apps/server#build |
