### PR TITLE
OpenAI Codex [ T3 Code ] Implement ACP client auth refresh

### DIFF
--- a/t3code/packages/effect-acp/src/.provenance.json
+++ b/t3code/packages/effect-acp/src/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Public task context for UnsafeLabs/Bounty-Hunters issue #829: implement automatic ACP client re-authentication for auth-expired responses with one serialized refresh attempt, refresh-token metadata handling, queued concurrent request replay, typed authentication failure, focused tests, and safe public provenance. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "created": "2026-05-29T00:25:00Z"
+}

--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -10,6 +10,7 @@ import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, assert } from "@effect/vitest";
@@ -22,11 +23,39 @@ import { makeInMemoryStdio } from "./_internal/stdio.ts";
 
 const InitializeRequest = jsonRpcRequest("initialize", AcpSchema.InitializeRequest);
 const InitializeResponse = jsonRpcResponse(AcpSchema.InitializeResponse);
+const AuthenticateRequest = jsonRpcRequest("authenticate", AcpSchema.AuthenticateRequest);
+const AuthenticateResponse = jsonRpcResponse(AcpSchema.AuthenticateResponse);
+const LogoutRequest = jsonRpcRequest("logout", AcpSchema.LogoutRequest);
+const LogoutResponse = jsonRpcResponse(AcpSchema.LogoutResponse);
+const PromptRequest = jsonRpcRequest("session/prompt", AcpSchema.PromptRequest);
+const PromptResponse = jsonRpcResponse(AcpSchema.PromptResponse);
 const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/acp-mock-peer.ts"),
 );
+const rpcParser = RpcSerialization.ndJsonRpc().makeUnsafe();
+
+const encodeRpcError = (id: string | number, error: AcpSchema.Error) =>
+  Effect.sync(() => {
+    const encoded = rpcParser.encode({
+      _tag: "Exit",
+      requestId: String(id),
+      exit: {
+        _tag: "Failure",
+        cause: [
+          {
+            _tag: "Fail",
+            error,
+          },
+        ],
+      },
+    });
+    if (encoded === undefined) {
+      throw new Error("Failed to encode ACP error response");
+    }
+    return typeof encoded === "string" ? new TextEncoder().encode(encoded) : encoded;
+  });
 
 it.layer(NodeServices.layer)("effect-acp client", (it) => {
   const makeHandle = (env?: Record<string, string>) =>
@@ -443,6 +472,193 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
 
       yield* Fiber.join(initializeFiber);
       assert.deepEqual(yield* Fiber.join(extFiber), { ok: true });
+      yield* Scope.close(scope, Exit.void);
+    }),
+  );
+
+  it.effect("reauthenticates once and replays concurrent requests after session expiry", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const expiredSessions = yield* Ref.make<ReadonlyArray<string>>([]);
+      const scope = yield* Scope.make();
+      const acp = yield* AcpClient.make(stdio, {
+        onSessionExpired: (sessionId) =>
+          Ref.update(expiredSessions, (current) => [...current, sessionId]),
+      }).pipe(Effect.provideService(Scope.Scope, scope));
+
+      const authFiber = yield* acp.agent
+        .authenticate({ methodId: "cursor_login" })
+        .pipe(Effect.forkScoped);
+      const authenticateRequest = yield* Schema.decodeEffect(
+        Schema.fromJsonString(AuthenticateRequest),
+      )(yield* Queue.take(output));
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: authenticateRequest.id,
+          result: {
+            _meta: {
+              accessToken: "access-1",
+              refreshToken: "refresh-1",
+            },
+          },
+        }),
+      );
+      yield* Fiber.join(authFiber);
+
+      const promptPayload = {
+        sessionId: "expired-session",
+        prompt: [{ type: "text" as const, text: "hello" }],
+      };
+      const firstPromptFiber = yield* acp.agent.prompt(promptPayload).pipe(Effect.forkScoped);
+      const secondPromptFiber = yield* acp.agent.prompt(promptPayload).pipe(Effect.forkScoped);
+      const decodePromptRequest = Schema.decodeEffect(Schema.fromJsonString(PromptRequest));
+      const firstPromptRequest = yield* decodePromptRequest(yield* Queue.take(output));
+      const secondPromptRequest = yield* decodePromptRequest(yield* Queue.take(output));
+
+      const expiredError = AcpError.AcpRequestError.authRequired("Session expired", {
+        sessionId: "expired-session",
+      }).toProtocolError();
+      yield* Queue.offer(input, yield* encodeRpcError(firstPromptRequest.id, expiredError));
+      yield* Queue.offer(input, yield* encodeRpcError(secondPromptRequest.id, expiredError));
+
+      const logoutRequest = yield* Schema.decodeEffect(Schema.fromJsonString(LogoutRequest))(
+        yield* Queue.take(output),
+      );
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(LogoutResponse, {
+          jsonrpc: "2.0",
+          id: logoutRequest.id,
+          result: {},
+        }),
+      );
+
+      const refreshRequest = yield* Schema.decodeEffect(Schema.fromJsonString(AuthenticateRequest))(
+        yield* Queue.take(output),
+      );
+      assert.equal(refreshRequest.params.methodId, "cursor_login");
+      assert.equal(refreshRequest.params._meta?.refreshToken, "refresh-1");
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: refreshRequest.id,
+          result: {
+            _meta: {
+              accessToken: "access-2",
+              refreshToken: "refresh-2",
+            },
+          },
+        }),
+      );
+
+      const replayedFirst = yield* decodePromptRequest(yield* Queue.take(output));
+      const replayedSecond = yield* decodePromptRequest(yield* Queue.take(output));
+      assert.deepEqual([replayedFirst.params.sessionId, replayedSecond.params.sessionId].sort(), [
+        "expired-session",
+        "expired-session",
+      ]);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(PromptResponse, {
+          jsonrpc: "2.0",
+          id: replayedFirst.id,
+          result: { stopReason: "end_turn" },
+        }),
+      );
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(PromptResponse, {
+          jsonrpc: "2.0",
+          id: replayedSecond.id,
+          result: { stopReason: "end_turn" },
+        }),
+      );
+
+      assert.equal((yield* Fiber.join(firstPromptFiber)).stopReason, "end_turn");
+      assert.equal((yield* Fiber.join(secondPromptFiber)).stopReason, "end_turn");
+      assert.deepEqual(yield* Ref.get(expiredSessions), ["expired-session"]);
+      yield* Scope.close(scope, Exit.void);
+    }),
+  );
+
+  it.effect("fails queued requests with a typed authentication error when refresh fails", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+      const acp = yield* AcpClient.make(stdio).pipe(Effect.provideService(Scope.Scope, scope));
+
+      const authFiber = yield* acp.agent
+        .authenticate({ methodId: "cursor_login" })
+        .pipe(Effect.forkScoped);
+      const authenticateRequest = yield* Schema.decodeEffect(
+        Schema.fromJsonString(AuthenticateRequest),
+      )(yield* Queue.take(output));
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: authenticateRequest.id,
+          result: {
+            _meta: {
+              refreshToken: "refresh-1",
+            },
+          },
+        }),
+      );
+      yield* Fiber.join(authFiber);
+
+      const promptFiber = yield* acp.agent
+        .prompt({
+          sessionId: "expired-session",
+          prompt: [{ type: "text", text: "hello" }],
+        })
+        .pipe(Effect.exit, Effect.forkScoped);
+      const promptRequest = yield* Schema.decodeEffect(Schema.fromJsonString(PromptRequest))(
+        yield* Queue.take(output),
+      );
+      yield* Queue.offer(
+        input,
+        yield* encodeRpcError(
+          promptRequest.id,
+          AcpError.AcpRequestError.authRequired("Token expired", {
+            sessionId: "expired-session",
+          }).toProtocolError(),
+        ),
+      );
+
+      const logoutRequest = yield* Schema.decodeEffect(Schema.fromJsonString(LogoutRequest))(
+        yield* Queue.take(output),
+      );
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(LogoutResponse, {
+          jsonrpc: "2.0",
+          id: logoutRequest.id,
+          result: {},
+        }),
+      );
+
+      const refreshRequest = yield* Schema.decodeEffect(Schema.fromJsonString(AuthenticateRequest))(
+        yield* Queue.take(output),
+      );
+      yield* Queue.offer(
+        input,
+        yield* encodeRpcError(
+          refreshRequest.id,
+          AcpError.AcpRequestError.authRequired("Refresh failed").toProtocolError(),
+        ),
+      );
+
+      const exit = yield* Fiber.join(promptFiber);
+      if (exit._tag !== "Failure") {
+        assert.fail("Expected prompt to fail when re-authentication fails");
+      }
+      const rendered = Cause.pretty(exit.cause);
+      assert.include(rendered, "AcpAuthenticationError");
+      assert.include(rendered, "ACP re-authentication failed after session expiry.");
       yield* Scope.close(scope, Exit.void);
     }),
   );

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -2,6 +2,9 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Stdio from "effect/Stdio";
 import * as Layer from "effect/Layer";
+import * as Deferred from "effect/Deferred";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
@@ -26,6 +29,7 @@ export interface AcpClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
+  readonly onSessionExpired?: (sessionId: string) => Effect.Effect<void, never>;
 }
 
 type AcpClientRaw = {
@@ -306,6 +310,103 @@ interface BufferedNotificationHandler<A> {
   readonly pending: Array<A>;
 }
 
+interface AuthTokenState {
+  readonly accessToken?: string;
+  readonly refreshToken?: string;
+}
+
+interface AuthSessionState {
+  readonly payload: AcpSchema.AuthenticateRequest;
+  readonly tokens: AuthTokenState;
+}
+
+interface AuthRefreshRequest {
+  readonly method: string;
+  readonly payload: unknown;
+  readonly authVersion: number;
+  readonly error: AcpError.AcpRequestError;
+}
+
+type AuthRefreshState =
+  | { readonly _tag: "Idle" }
+  | {
+      readonly _tag: "Refreshing";
+      readonly deferred: Deferred.Deferred<void, AcpError.AcpAuthenticationError>;
+    };
+
+const AUTH_REFRESH_SCHEDULE = Schedule.recurs(0);
+
+const hasRecordShape = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const firstString = (
+  record: Record<string, unknown> | undefined,
+  keys: ReadonlyArray<string>,
+): string | undefined => {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const extractAuthTokens = (response: AcpSchema.AuthenticateResponse): AuthTokenState => {
+  const metadata = hasRecordShape(response._meta) ? response._meta : undefined;
+  const accessToken = firstString(metadata, ["accessToken", "access_token"]);
+  const refreshToken = firstString(metadata, ["refreshToken", "refresh_token"]);
+  return {
+    ...(accessToken !== undefined ? { accessToken } : {}),
+    ...(refreshToken !== undefined ? { refreshToken } : {}),
+  };
+};
+
+const withRefreshToken = (
+  payload: AcpSchema.AuthenticateRequest,
+  refreshToken: string | undefined,
+): AcpSchema.AuthenticateRequest =>
+  refreshToken
+    ? {
+        ...payload,
+        _meta: {
+          ...(hasRecordShape(payload._meta) ? payload._meta : {}),
+          refreshToken,
+        },
+      }
+    : payload;
+
+const extractSessionId = (
+  payload: unknown,
+  error: AcpError.AcpRequestError,
+): string | undefined => {
+  if (hasRecordShape(payload) && typeof payload.sessionId === "string") {
+    return payload.sessionId;
+  }
+  if (hasRecordShape(error.data) && typeof error.data.sessionId === "string") {
+    return error.data.sessionId;
+  }
+  return undefined;
+};
+
+const isAuthExpiredError = (error: AcpError.AcpError): error is AcpError.AcpRequestError => {
+  if (error._tag !== "AcpRequestError") {
+    return false;
+  }
+  const message = error.errorMessage.toLowerCase();
+  return (
+    error.code === 401 ||
+    error.code === -32000 ||
+    message.includes("unauthorized") ||
+    message.includes("authentication required") ||
+    message.includes("session expired") ||
+    message.includes("token expired")
+  );
+};
+
 export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpClientOptions = {},
@@ -316,6 +417,9 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     sessionUpdate: { handlers: [], pending: [] },
     elicitationComplete: { handlers: [], pending: [] },
   };
+  const authStateRef = yield* Ref.make<AuthSessionState | undefined>(undefined);
+  const authVersionRef = yield* Ref.make(0);
+  const authRefreshStateRef = yield* Ref.make<AuthRefreshState>({ _tag: "Idle" });
   const extRequestHandlers = new Map<
     string,
     (params: unknown) => Effect.Effect<unknown, AcpError.AcpError>
@@ -456,6 +560,99 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     generateRequestId: () => nextRpcRequestId++ as never,
   }).pipe(Effect.provideService(RpcClient.Protocol, transport.clientProtocol));
 
+  const authenticateAndStore = (payload: AcpSchema.AuthenticateRequest) =>
+    callRpc(rpc[AGENT_METHODS.authenticate](payload)).pipe(
+      Effect.tap((response) =>
+        Ref.set(authStateRef, {
+          payload,
+          tokens: extractAuthTokens(response),
+        }),
+      ),
+      Effect.tap(() => Ref.update(authVersionRef, (version) => version + 1)),
+    );
+
+  const reauthenticate = Effect.fn("effect-acp/AcpClient.reauthenticate")(function* (
+    request: AuthRefreshRequest,
+  ) {
+    const currentVersion = yield* Ref.get(authVersionRef);
+    if (currentVersion !== request.authVersion) {
+      return;
+    }
+
+    const authState = yield* Ref.get(authStateRef);
+    const sessionId = extractSessionId(request.payload, request.error);
+    if (!authState) {
+      return yield* new AcpError.AcpAuthenticationError({
+        message: "ACP authentication expired but no prior authentication payload is available.",
+        ...(sessionId !== undefined ? { sessionId } : {}),
+        cause: request.error,
+      });
+    }
+
+    if (sessionId !== undefined && options.onSessionExpired) {
+      yield* options.onSessionExpired(sessionId);
+    }
+
+    const refreshPayload = withRefreshToken(authState.payload, authState.tokens.refreshToken);
+    return yield* Effect.acquireUseRelease(
+      Effect.succeed(authState),
+      () =>
+        callRpc(rpc[AGENT_METHODS.logout]({})).pipe(
+          Effect.ignore,
+          Effect.andThen(authenticateAndStore(refreshPayload)),
+          Effect.retry(AUTH_REFRESH_SCHEDULE),
+          Effect.asVoid,
+          Effect.mapError(
+            (error) =>
+              new AcpError.AcpAuthenticationError({
+                message: "ACP re-authentication failed after session expiry.",
+                ...(sessionId !== undefined ? { sessionId } : {}),
+                cause: error,
+              }),
+          ),
+        ),
+      () => Effect.void,
+    );
+  });
+
+  const refreshAuth = (request: AuthRefreshRequest) =>
+    Effect.gen(function* () {
+      const deferred = yield* Deferred.make<void, AcpError.AcpAuthenticationError>();
+      const awaitRefresh: Effect.Effect<void, AcpError.AcpAuthenticationError> = yield* Ref.modify(
+        authRefreshStateRef,
+        (state): [Effect.Effect<void, AcpError.AcpAuthenticationError>, AuthRefreshState] => {
+          if (state._tag === "Refreshing") {
+            return [Deferred.await(state.deferred), state] as const;
+          }
+          return [
+            reauthenticate(request).pipe(
+              Effect.tap(() => Deferred.succeed(deferred, void 0)),
+              Effect.tapError((error) => Deferred.fail(deferred, error)),
+              Effect.ensuring(Ref.set(authRefreshStateRef, { _tag: "Idle" })),
+            ),
+            { _tag: "Refreshing", deferred } satisfies AuthRefreshState,
+          ] as const;
+        },
+      );
+      return yield* awaitRefresh;
+    });
+
+  const withAuthRefresh = <A>(
+    method: string,
+    payload: unknown,
+    request: Effect.Effect<A, AcpError.AcpError>,
+  ) =>
+    Effect.gen(function* () {
+      const authVersion = yield* Ref.get(authVersionRef);
+      return yield* request.pipe(
+        Effect.catch((error: AcpError.AcpError) =>
+          isAuthExpiredError(error)
+            ? refreshAuth({ method, payload, authVersion, error }).pipe(Effect.andThen(request))
+            : Effect.fail(error),
+        ),
+      );
+    });
+
   return AcpClient.of({
     raw: {
       notifications: transport.incoming,
@@ -463,19 +660,69 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
       notify: transport.notify,
     },
     agent: {
-      initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
-      authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
-      logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
-      closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      initialize: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.initialize,
+          payload,
+          callRpc(rpc[AGENT_METHODS.initialize](payload)),
+        ),
+      authenticate: authenticateAndStore,
+      logout: (payload) =>
+        withAuthRefresh(AGENT_METHODS.logout, payload, callRpc(rpc[AGENT_METHODS.logout](payload))),
+      createSession: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_new,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_new](payload)),
+        ),
+      loadSession: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_load,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_load](payload)),
+        ),
+      listSessions: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_list,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_list](payload)),
+        ),
+      forkSession: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_fork,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_fork](payload)),
+        ),
+      resumeSession: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_resume,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_resume](payload)),
+        ),
+      closeSession: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_close,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_close](payload)),
+        ),
+      setSessionModel: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_set_model,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+        ),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        withAuthRefresh(
+          AGENT_METHODS.session_set_config_option,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
+        ),
+      prompt: (payload) =>
+        withAuthRefresh(
+          AGENT_METHODS.session_prompt,
+          payload,
+          callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        ),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>

--- a/t3code/packages/effect-acp/src/errors.ts
+++ b/t3code/packages/effect-acp/src/errors.ts
@@ -128,8 +128,18 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
   }
 }
 
+export class AcpAuthenticationError extends Schema.TaggedErrorClass<AcpAuthenticationError>()(
+  "AcpAuthenticationError",
+  {
+    message: Schema.String,
+    sessionId: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect),
+  },
+) {}
+
 export const AcpError = Schema.Union([
   AcpRequestError,
+  AcpAuthenticationError,
   AcpSpawnError,
   AcpProcessExitedError,
   AcpProtocolParseError,


### PR DESCRIPTION
/claim #829

## Summary
- Adds ACP client auth state that remembers the last authenticate payload and stores access-token and refresh-token metadata separately.
- Detects auth-expired ACP errors and runs one serialized re-authentication path, including `onSessionExpired(sessionId)` before refresh.
- Uses the stored refresh token in authenticate `_meta`, cleans up the previous session with a logout attempt, and replays the failed request after refresh.
- Queues concurrent auth-expired callers behind the same in-flight refresh and fails them with `AcpAuthenticationError` if refresh fails.
- Adds focused in-memory ACP RPC tests for concurrent replay and typed refresh failure.

## Demo
https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-829-acp-refresh-demo.mp4

## Validation
- `npx -y bun@1.3.11 run --cwd packages/effect-acp typecheck` - passed
- `npx -y bun@1.3.11 run --cwd packages/effect-acp test` - 18 passed
- `npx -y bun@1.3.11 run fmt:check packages/effect-acp/src/client.ts packages/effect-acp/src/errors.ts packages/effect-acp/src/client.test.ts packages/effect-acp/src/.provenance.json` - passed
- `git diff --check` - passed
- `node -e "JSON.parse(require('fs').readFileSync('t3code/packages/effect-acp/src/.provenance.json','utf8')); console.log('.provenance.json valid')"` - passed

## Lint note
- `npx -y bun@1.3.11 run lint packages/effect-acp/src/client.ts packages/effect-acp/src/errors.ts packages/effect-acp/src/client.test.ts` currently stops before linting because the repo oxlint config cannot load `./oxlint-plugin-t3code/index.ts` through Node and throws `ERR_UNKNOWN_FILE_EXTENSION`.

## Provenance note
- `.provenance.json` contains safe public task context only. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced in repository files or PR text.
