### PR TITLE
OpenAI Codex [ T3 Code ] Add request body size limiting

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Public task context: paid OSS bounty implementation for UnsafeLabs/Bounty-Hunters issue #841. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "timestamp": "2026-05-29T00:51:50Z"
+}

--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,6 +1,28 @@
-import { describe, expect, it } from "vitest";
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import { assert, it as effectIt } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { describe, expect, it } from "vitest";
+import {
+  HttpBody,
+  HttpClient,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
+
+import {
+  DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+  FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES,
+  REQUEST_BODY_SIZE_LIMIT_HEADER,
+  makeRequestBodySizeLimitLayer,
+  parseContentLengthHeader,
+  resolveDevRedirectUrl,
+  resolveRequestBodySizeLimit,
+  isLoopbackHostname,
+} from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -24,4 +46,114 @@ describe("http dev routing", () => {
       "http://127.0.0.1:5173/pair?token=test-token",
     );
   });
+});
+
+describe("request body size limit policy", () => {
+  it("uses the regular default, file upload default, and per-route overrides", () => {
+    expect(
+      resolveRequestBodySizeLimit({
+        method: "POST",
+        url: "/api/observability/v1/traces",
+        headers: { "content-type": "application/json" },
+      }),
+    ).toEqual({
+      limitBytes: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+      routeKind: "default",
+    });
+
+    expect(
+      resolveRequestBodySizeLimit({
+        method: "POST",
+        url: "/api/files/upload",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    ).toEqual({
+      limitBytes: FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES,
+      routeKind: "file-upload",
+    });
+
+    expect(
+      resolveRequestBodySizeLimit(
+        {
+          method: "POST",
+          url: "/api/custom",
+          headers: { "content-type": "application/json" },
+        },
+        {
+          routeOverrides: [{ method: "POST", path: "/api/custom", limitBytes: 4 }],
+        },
+      ),
+    ).toEqual({
+      limitBytes: 4,
+      routeKind: "override",
+    });
+  });
+
+  it("parses valid Content-Length headers and ignores invalid values", () => {
+    expect(parseContentLengthHeader("42")).toBe(42);
+    expect(parseContentLengthHeader(" 42 ")).toBe(42);
+    expect(parseContentLengthHeader("4.2")).toBeUndefined();
+    expect(parseContentLengthHeader("invalid")).toBeUndefined();
+  });
+});
+
+effectIt.layer(NodeServices.layer)("request body size limit middleware", (it) => {
+  const routeLayer = HttpRouter.add(
+    "POST",
+    "/echo",
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const body = yield* request.text;
+      return HttpServerResponse.jsonUnsafe({ length: body.length });
+    }),
+  );
+
+  const serveEchoLayer = (limitBytes: number) =>
+    HttpRouter.serve(
+      routeLayer.pipe(
+        Layer.provide(
+          makeRequestBodySizeLimitLayer({
+            routeOverrides: [{ method: "POST", path: "/echo", limitBytes }],
+          }),
+        ),
+      ),
+      { disableListenLog: true, disableLogger: true },
+    );
+
+  it.effect("rejects a custom route body before the handler buffers it", () =>
+    Effect.gen(function* () {
+      yield* Layer.build(serveEchoLayer(4));
+
+      const response = yield* HttpClient.post("/echo", {
+        body: HttpBody.text("12345", "text/plain"),
+      });
+      const body = (yield* response.json) as {
+        readonly error: string;
+        readonly limit: number;
+        readonly received: number;
+      };
+
+      assert.equal(response.status, 413);
+      assert.equal(response.headers[REQUEST_BODY_SIZE_LIMIT_HEADER.toLowerCase()], "4");
+      assert.deepEqual(body, {
+        error: "Payload Too Large",
+        limit: 4,
+        received: 5,
+      });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("allows custom route bodies within the override", () =>
+    Effect.gen(function* () {
+      yield* Layer.build(serveEchoLayer(5));
+
+      const response = yield* HttpClient.post("/echo", {
+        body: HttpBody.text("12345", "text/plain"),
+      });
+      const body = (yield* response.json) as { readonly length: number };
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body, { length: 5 });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
 });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -38,6 +38,34 @@ const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
+const REQUEST_BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export const DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES = 10 * 1024 * 1024;
+export const FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES = 50 * 1024 * 1024;
+export const REQUEST_BODY_SIZE_LIMIT_HEADER = "X-Max-Body-Size";
+
+export interface RequestBodySizeLimitRouteOverride {
+  readonly method?: "*" | "POST" | "PUT" | "PATCH" | "DELETE";
+  readonly path: string;
+  readonly limitBytes: number;
+}
+
+export interface RequestBodySizeLimitOptions {
+  readonly defaultLimitBytes?: number;
+  readonly fileUploadLimitBytes?: number;
+  readonly routeOverrides?: ReadonlyArray<RequestBodySizeLimitRouteOverride>;
+}
+
+export interface ResolvedRequestBodySizeLimit {
+  readonly limitBytes: number;
+  readonly routeKind: "default" | "file-upload" | "override";
+}
+
+export interface RequestBodySizeLimitInput {
+  readonly method: string;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string | undefined>>;
+}
 
 export const browserApiCorsLayer = HttpRouter.cors({
   allowedMethods: [...browserApiCorsAllowedMethods],
@@ -60,6 +88,169 @@ export function resolveDevRedirectUrl(devUrl: URL, requestUrl: URL): string {
   redirectUrl.hash = requestUrl.hash;
   return redirectUrl.toString();
 }
+
+function resolveRequestPathname(url: string): string {
+  return new URL(url, "http://localhost").pathname;
+}
+
+function routeOverrideMatches(
+  override: RequestBodySizeLimitRouteOverride,
+  method: string,
+  pathname: string,
+): boolean {
+  if (override.method && override.method !== "*" && override.method !== method) {
+    return false;
+  }
+  if (override.path === "*") {
+    return true;
+  }
+  if (override.path.endsWith("/*")) {
+    const prefix = override.path.slice(0, -2);
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+  }
+  return pathname === override.path;
+}
+
+function isFileUploadRequest(pathname: string, headers: RequestBodySizeLimitInput["headers"]) {
+  const contentType = headers["content-type"]?.toLowerCase() ?? "";
+  return (
+    contentType.includes("multipart/form-data") ||
+    pathname.includes("/upload") ||
+    pathname.includes("/uploads") ||
+    pathname.startsWith(`${ATTACHMENTS_ROUTE_PREFIX}/upload`)
+  );
+}
+
+export function resolveRequestBodySizeLimit(
+  input: RequestBodySizeLimitInput,
+  options: RequestBodySizeLimitOptions = {},
+): ResolvedRequestBodySizeLimit | undefined {
+  const method = input.method.toUpperCase();
+  if (!REQUEST_BODY_METHODS.has(method)) {
+    return undefined;
+  }
+
+  const pathname = resolveRequestPathname(input.url);
+  const override = options.routeOverrides?.find((candidate) =>
+    routeOverrideMatches(candidate, method, pathname),
+  );
+  if (override) {
+    return { limitBytes: override.limitBytes, routeKind: "override" };
+  }
+
+  if (isFileUploadRequest(pathname, input.headers)) {
+    return {
+      limitBytes: options.fileUploadLimitBytes ?? FILE_UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES,
+      routeKind: "file-upload",
+    };
+  }
+
+  return {
+    limitBytes: options.defaultLimitBytes ?? DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+    routeKind: "default",
+  };
+}
+
+export function parseContentLengthHeader(contentLength: string | undefined): number | undefined {
+  if (!contentLength) {
+    return undefined;
+  }
+  const trimmed = contentLength.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function includesMaxBytesExceeded(value: unknown, seen = new Set<unknown>()): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  if (value instanceof Error && value.message.includes("maxBytes exceeded")) {
+    return true;
+  }
+  if (typeof value !== "object") {
+    return String(value).includes("maxBytes exceeded");
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    includesMaxBytesExceeded(record.cause, seen) ||
+    includesMaxBytesExceeded(record.reason, seen) ||
+    includesMaxBytesExceeded(record.error, seen)
+  );
+}
+
+function payloadTooLargeResponse(input: {
+  readonly limitBytes: number;
+  readonly receivedBytes: number;
+}) {
+  return HttpServerResponse.jsonUnsafe(
+    {
+      error: "Payload Too Large",
+      limit: input.limitBytes,
+      received: input.receivedBytes,
+    },
+    {
+      status: 413,
+      headers: {
+        ...browserApiCorsHeaders,
+        [REQUEST_BODY_SIZE_LIMIT_HEADER]: String(input.limitBytes),
+      },
+    },
+  );
+}
+
+export const makeRequestBodySizeLimitLayer = (options: RequestBodySizeLimitOptions = {}) =>
+  HttpRouter.middleware(
+    <E, R>(httpApp: Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const resolved = resolveRequestBodySizeLimit(
+          {
+            method: request.method,
+            url: request.url,
+            headers: request.headers,
+          },
+          options,
+        );
+        if (!resolved) {
+          return yield* httpApp;
+        }
+
+        const receivedBytes = parseContentLengthHeader(request.headers["content-length"]);
+        if (receivedBytes !== undefined && receivedBytes > resolved.limitBytes) {
+          return payloadTooLargeResponse({
+            limitBytes: resolved.limitBytes,
+            receivedBytes,
+          });
+        }
+
+        return yield* Effect.provideService(
+          httpApp,
+          HttpServerRequest.MaxBodySize,
+          FileSystem.Size(resolved.limitBytes),
+        ).pipe(
+          Effect.catch((cause) =>
+            includesMaxBytesExceeded(cause)
+              ? Effect.succeed(
+                  payloadTooLargeResponse({
+                    limitBytes: resolved.limitBytes,
+                    receivedBytes: receivedBytes ?? resolved.limitBytes + 1,
+                  }),
+                )
+              : Effect.fail(cause),
+          ),
+        );
+      }),
+    { global: true },
+  );
+
+export const requestBodySizeLimitLayer = makeRequestBodySizeLimitLayer();
 
 const requireAuthenticatedRequest = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -56,6 +56,7 @@ const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
 import type { ServerConfigShape } from "./config.ts";
 import { deriveServerPaths, ServerConfig } from "./config.ts";
 import { makeRoutesLayer } from "./server.ts";
+import { DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES, REQUEST_BODY_SIZE_LIMIT_HEADER } from "./http.ts";
 import { resolveAttachmentRelativePath } from "./attachmentPaths.ts";
 import {
   CheckpointDiffQuery,
@@ -1959,6 +1960,41 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         "content-type",
         "traceparent",
       ]);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("rejects browser OTLP trace payloads over the default request body limit", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const url = yield* getHttpServerUrl("/api/observability/v1/traces");
+      const cookie = yield* getAuthenticatedSessionCookieHeader();
+      const response = yield* Effect.promise(() =>
+        fetch(url, {
+          method: "POST",
+          headers: {
+            cookie,
+            "content-type": "application/json",
+          },
+          body: "x".repeat(DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES + 1),
+        }),
+      );
+      const body = (yield* Effect.promise(() => response.json())) as {
+        readonly error: string;
+        readonly limit: number;
+        readonly received: number;
+      };
+
+      assert.equal(response.status, 413);
+      assert.equal(
+        response.headers.get(REQUEST_BODY_SIZE_LIMIT_HEADER),
+        String(DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES),
+      );
+      assert.deepEqual(body, {
+        error: "Payload Too Large",
+        limit: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+        received: DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES + 1,
+      });
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -10,6 +10,7 @@ import {
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  requestBodySizeLimitLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -312,7 +313,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
-).pipe(Layer.provide(browserApiCorsLayer));
+).pipe(Layer.provide(Layer.mergeAll(browserApiCorsLayer, requestBodySizeLimitLayer)));
 
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {


### PR DESCRIPTION
/claim #841

## Summary
- Added a global Effect HTTP request body size limit layer for `apps/server` with a 10MB default for regular body-carrying requests.
- Added upload-style detection with a 50MB allowance plus configurable per-route override support.
- Oversized requests now return structured `413 Payload Too Large` JSON including `limit` and `received`, plus the required `X-Max-Body-Size` response header.
- Wired the layer into the server route stack and added focused policy, custom-route, and real server-route tests.

## Demo
- https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-841-body-limit-demo.mp4

## Validation
- `npx -y bun@1.3.11 run --cwd apps/server test src/http.test.ts src/server.test.ts` -> 73 passed
- `npx -y bun@1.3.11 run --cwd apps/server typecheck` -> passed
- `npx -y bun@1.3.11 run fmt:check apps/server/src/http.ts apps/server/src/http.test.ts apps/server/src/server.ts apps/server/src/server.test.ts apps/server/src/_provenance.json` -> passed
- `node -e "JSON.parse(require('fs').readFileSync('t3code/apps/server/src/_provenance.json','utf8'))" && git diff --check` -> passed

## Note
- `npx -y bun@1.3.11 run lint apps/server/src/http.ts apps/server/src/http.test.ts apps/server/src/server.ts apps/server/src/server.test.ts` is blocked by the existing repo oxlint plugin loader failure: `ERR_UNKNOWN_FILE_EXTENSION` for `oxlint-plugin-t3code/index.ts`.
- `_provenance.json` is included with public provenance. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.
