### PR TITLE
OpenAI Codex [ T3 Code ] Add Prometheus metrics endpoint

### DIFF
--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -22,12 +22,14 @@ import {
   resolveAttachmentRelativePath,
 } from "./attachmentPaths.ts";
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
-import { resolveStaticDir, ServerConfig } from "./config.ts";
-import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
-import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
+import { SessionCredentialService } from "./auth/Services/SessionCredentialService.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
+import { resolveStaticDir, ServerConfig } from "./config.ts";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
+import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
+import { collectPrometheusMetrics } from "./observability/PrometheusMetrics.ts";
+import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import {
   browserApiCorsAllowedHeaders,
   browserApiCorsAllowedMethods,
@@ -66,6 +68,30 @@ const requireAuthenticatedRequest = Effect.gen(function* () {
   const serverAuth = yield* ServerAuth;
   yield* serverAuth.authenticateHttpRequest(request);
 });
+
+const readConnectedSessionCount = Effect.gen(function* () {
+  const sessions = yield* SessionCredentialService;
+  const activeSessions = yield* sessions.listActive();
+  return activeSessions.filter((session) => session.connected).length;
+}).pipe(Effect.catch(() => Effect.succeed(0)));
+
+export const metricsRouteLayer = HttpRouter.add(
+  "GET",
+  "/metrics",
+  Effect.gen(function* () {
+    if (process.env.METRICS_AUTH_DISABLED !== "true") {
+      yield* requireAuthenticatedRequest;
+    }
+
+    const activeSessions = yield* readConnectedSessionCount;
+    const metrics = yield* collectPrometheusMetrics({ activeSessions });
+    return HttpServerResponse.text(metrics, {
+      status: 200,
+      contentType: "text/plain; version=0.0.4; charset=utf-8",
+      headers: browserApiCorsHeaders,
+    });
+  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+);
 
 export const serverEnvironmentRouteLayer = HttpRouter.add(
   "GET",

--- a/t3code/apps/server/src/observability/.generation_meta.json
+++ b/t3code/apps/server/src/observability/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Public task context: paid OSS bounty implementation for UnsafeLabs/Bounty-Hunters issue #833. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "date": "2026-05-29T01:00:23Z"
+}

--- a/t3code/apps/server/src/observability/PrometheusMetrics.test.ts
+++ b/t3code/apps/server/src/observability/PrometheusMetrics.test.ts
@@ -1,0 +1,45 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Metric from "effect/Metric";
+
+import {
+  gitCommandsTotal,
+  metricAttributes,
+  rpcRequestDuration,
+  rpcRequestsTotal,
+} from "./Metrics.ts";
+import { collectPrometheusMetrics } from "./PrometheusMetrics.ts";
+
+describe("Prometheus metrics exposition", () => {
+  it.effect("formats required gauges, counters, and histograms", () =>
+    Effect.gen(function* () {
+      const method = "prometheus.test";
+      const operation = "prometheus-status";
+
+      yield* Metric.update(
+        Metric.withAttributes(rpcRequestsTotal, metricAttributes({ method })),
+        1,
+      );
+      yield* Metric.update(
+        Metric.withAttributes(rpcRequestDuration, metricAttributes({ method })),
+        Duration.millis(250),
+      );
+      yield* Metric.update(
+        Metric.withAttributes(gitCommandsTotal, metricAttributes({ operation })),
+        2,
+      );
+
+      const text = yield* collectPrometheusMetrics({ activeSessions: 2 });
+
+      assert.include(text, "# TYPE active_sessions gauge");
+      assert.include(text, "active_sessions 2");
+      assert.match(text, /memory_usage_bytes\{source="process_rss"\} \d+/);
+      assert.include(text, `rpc_requests_total{method="${method}"} 1`);
+      assert.include(text, `rpc_duration_seconds_bucket{le="+Inf",method="${method}"} 1`);
+      assert.include(text, `rpc_duration_seconds_sum{method="${method}"} 0.25`);
+      assert.include(text, `rpc_duration_seconds_count{method="${method}"} 1`);
+      assert.include(text, `git_operations_total{operation="${operation}"} 2`);
+    }),
+  );
+});

--- a/t3code/apps/server/src/observability/PrometheusMetrics.ts
+++ b/t3code/apps/server/src/observability/PrometheusMetrics.ts
@@ -1,0 +1,175 @@
+import * as Effect from "effect/Effect";
+import * as Metric from "effect/Metric";
+
+import { metricAttributes } from "./Metrics.ts";
+
+export const activeSessionsGauge = Metric.gauge("active_sessions", {
+  description: "Current connected server sessions.",
+});
+
+export const memoryUsageBytesGauge = Metric.gauge("memory_usage_bytes", {
+  description: "Current process RSS memory usage in bytes.",
+});
+
+const METRIC_NAME_ALIASES: Readonly<Record<string, string>> = {
+  t3_rpc_requests_total: "rpc_requests_total",
+  t3_rpc_request_duration: "rpc_duration_seconds",
+  t3_git_commands_total: "git_operations_total",
+};
+
+const METRIC_TYPE_BY_SNAPSHOT_TYPE: Readonly<Record<Metric.Metric.Type, string>> = {
+  Counter: "counter",
+  Frequency: "counter",
+  Gauge: "gauge",
+  Histogram: "histogram",
+  Summary: "summary",
+};
+
+function normalizeMetricName(name: string): string {
+  return METRIC_NAME_ALIASES[name] ?? name;
+}
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+function formatNumber(value: number | bigint): string {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  return String(value);
+}
+
+function metricUsesSeconds(name: string): boolean {
+  return name.endsWith("_seconds");
+}
+
+function normalizeMetricValue(name: string, value: number): number {
+  return metricUsesSeconds(name) ? value / 1_000 : value;
+}
+
+function normalizeAttributes(
+  name: string,
+  attributes: Readonly<Record<string, string>> | undefined,
+): Readonly<Record<string, string>> | undefined {
+  if (!attributes || !metricUsesSeconds(name)) {
+    return attributes;
+  }
+  const { time_unit: _timeUnit, ...rest } = attributes;
+  return rest;
+}
+
+function formatLabels(
+  attributes: Readonly<Record<string, string>> | undefined,
+  extra: Readonly<Record<string, string>> = {},
+): string {
+  const entries = [...Object.entries(attributes ?? {}), ...Object.entries(extra)].filter(
+    ([, value]) => value.length > 0,
+  );
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}="${escapeLabelValue(value)}"`)
+    .join(",")}}`;
+}
+
+function formatHelpAndType(snapshot: Metric.Metric.Snapshot, name: string): ReadonlyArray<string> {
+  const description = snapshot.description ? [`# HELP ${name} ${snapshot.description}`] : [];
+  return [...description, `# TYPE ${name} ${METRIC_TYPE_BY_SNAPSHOT_TYPE[snapshot.type]}`];
+}
+
+function formatCounter(snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Counter" }>) {
+  const name = normalizeMetricName(snapshot.id);
+  const attributes = normalizeAttributes(name, snapshot.attributes);
+  return [`${name}${formatLabels(attributes)} ${formatNumber(snapshot.state.count)}`];
+}
+
+function formatFrequency(
+  snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Frequency" }>,
+) {
+  const name = normalizeMetricName(snapshot.id);
+  const attributes = normalizeAttributes(name, snapshot.attributes);
+  return [
+    ...Array.from(snapshot.state.occurrences).map(
+      ([value, count]) => `${name}${formatLabels(attributes, { value })} ${count}`,
+    ),
+  ];
+}
+
+function formatGauge(snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Gauge" }>) {
+  const name = normalizeMetricName(snapshot.id);
+  const attributes = normalizeAttributes(name, snapshot.attributes);
+  return [`${name}${formatLabels(attributes)} ${formatNumber(snapshot.state.value)}`];
+}
+
+function formatHistogram(
+  snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Histogram" }>,
+) {
+  const name = normalizeMetricName(snapshot.id);
+  const attributes = normalizeAttributes(name, snapshot.attributes);
+  const buckets = snapshot.state.buckets.map(([boundary, count]) => {
+    const le = metricUsesSeconds(name) ? normalizeMetricValue(name, boundary) : boundary;
+    return `${name}_bucket${formatLabels(attributes, { le: formatNumber(le) })} ${count}`;
+  });
+  return [
+    ...buckets,
+    `${name}_bucket${formatLabels(attributes, { le: "+Inf" })} ${snapshot.state.count}`,
+    `${name}_sum${formatLabels(attributes)} ${formatNumber(
+      normalizeMetricValue(name, snapshot.state.sum),
+    )}`,
+    `${name}_count${formatLabels(attributes)} ${snapshot.state.count}`,
+  ];
+}
+
+function formatSummary(snapshot: Extract<Metric.Metric.Snapshot, { readonly type: "Summary" }>) {
+  const name = normalizeMetricName(snapshot.id);
+  const attributes = normalizeAttributes(name, snapshot.attributes);
+  return [
+    `${name}_count${formatLabels(attributes)} ${snapshot.state.count}`,
+    `${name}_sum${formatLabels(attributes)} ${formatNumber(snapshot.state.sum)}`,
+  ];
+}
+
+export function formatPrometheusMetrics(snapshots: ReadonlyArray<Metric.Metric.Snapshot>): string {
+  const emittedHeaders = new Set<string>();
+  const lines = snapshots.flatMap((snapshot) => {
+    const name = normalizeMetricName(snapshot.id);
+    const headers = emittedHeaders.has(name) ? [] : formatHelpAndType(snapshot, name);
+    emittedHeaders.add(name);
+
+    switch (snapshot.type) {
+      case "Counter":
+        return [...headers, ...formatCounter(snapshot)];
+      case "Frequency":
+        return [...headers, ...formatFrequency(snapshot)];
+      case "Gauge":
+        return [...headers, ...formatGauge(snapshot)];
+      case "Histogram":
+        return [...headers, ...formatHistogram(snapshot)];
+      case "Summary":
+        return [...headers, ...formatSummary(snapshot)];
+    }
+  });
+
+  return `${lines.join("\n")}\n`;
+}
+
+export const collectPrometheusMetrics = (input: { readonly activeSessions: number }) =>
+  Effect.gen(function* () {
+    yield* Metric.update(activeSessionsGauge, input.activeSessions);
+    yield* Metric.update(
+      Metric.withAttributes(memoryUsageBytesGauge, metricAttributes({ source: "process_rss" })),
+      process.memoryUsage().rss,
+    );
+    const snapshots = yield* Metric.snapshot;
+    return formatPrometheusMetrics(snapshots);
+  });
+
+export const collectPrometheusMetricsWithDefaults = collectPrometheusMetrics({
+  activeSessions: 0,
+});

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -924,6 +924,28 @@ const assertBrowserApiCorsHeaders = (headers: Headers) => {
 };
 const crossOriginClientOrigin = "http://remote-client.test:3773";
 
+const withMetricsAuthEnv = <A, E, R>(value: string | undefined, effect: Effect.Effect<A, E, R>) => {
+  const previous = process.env.METRICS_AUTH_DISABLED;
+  return Effect.sync(() => {
+    if (value === undefined) {
+      delete process.env.METRICS_AUTH_DISABLED;
+    } else {
+      process.env.METRICS_AUTH_DISABLED = value;
+    }
+  }).pipe(
+    Effect.andThen(effect),
+    Effect.ensuring(
+      Effect.sync(() => {
+        if (previous === undefined) {
+          delete process.env.METRICS_AUTH_DISABLED;
+        } else {
+          process.env.METRICS_AUTH_DISABLED = previous;
+        }
+      }),
+    ),
+  );
+};
+
 const getWsServerUrl = (
   pathname = "",
   options?: { authenticated?: boolean; credential?: string },
@@ -1065,6 +1087,38 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assertBrowserApiCorsHeaders(response.headers);
       assert.deepEqual(body, testEnvironmentDescriptor);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("serves Prometheus metrics when metrics auth is disabled", () =>
+    withMetricsAuthEnv(
+      "true",
+      Effect.gen(function* () {
+        yield* buildAppUnderTest();
+
+        const url = yield* getHttpServerUrl("/metrics");
+        const response = yield* Effect.promise(() => fetch(url));
+        const text = yield* Effect.promise(() => response.text());
+
+        assert.equal(response.status, 200);
+        assert.include(response.headers.get("content-type") ?? "", "text/plain");
+        assert.include(text, "# TYPE active_sessions gauge");
+        assert.include(text, "# TYPE memory_usage_bytes gauge");
+      }),
+    ).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("requires auth for Prometheus metrics by default", () =>
+    withMetricsAuthEnv(
+      undefined,
+      Effect.gen(function* () {
+        yield* buildAppUnderTest();
+
+        const url = yield* getHttpServerUrl("/metrics");
+        const response = yield* Effect.promise(() => fetch(url));
+
+        assert.equal(response.status, 401);
+      }),
+    ).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
   it.effect("reports unauthenticated session state without requiring auth", () =>

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -5,6 +5,7 @@ import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 import { ServerConfig } from "./config.ts";
 import {
   attachmentsRouteLayer,
+  metricsRouteLayer,
   otlpTracesProxyRouteLayer,
   projectFaviconRouteLayer,
   serverEnvironmentRouteLayer,
@@ -305,6 +306,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   authSessionRouteLayer,
   authWebSocketTokenRouteLayer,
   attachmentsRouteLayer,
+  metricsRouteLayer,
   orchestrationDispatchRouteLayer,
   orchestrationSnapshotRouteLayer,
   otlpTracesProxyRouteLayer,


### PR DESCRIPTION
/claim #833

## Summary
- Added a Prometheus exposition helper for Effect.Metric snapshots, including counters, gauges, histograms, summaries, and label escaping.
- Registered authenticated `GET /metrics`, with auth skipped only when `METRICS_AUTH_DISABLED=true`.
- Exposed the required metrics: `active_sessions`, `memory_usage_bytes`, `rpc_requests_total`, `rpc_duration_seconds`, and `git_operations_total`.
- Added focused tests for metrics formatting, counter/histogram output, and endpoint auth behavior.

## Demo
- Video: https://github.com/Davidrsdiaz/Bounty-Hunters/releases/download/bounty-demo-videos-2026-05-28/bounty-833-prometheus-demo.mp4
- SHA-256: `54cf037ace3d2af07c9581ba2f36c0be4af72a3d4429d3b2a1d0a208623aec7a`

## Validation
- `npx -y bun@1.3.11 run --cwd apps/server test src/observability/PrometheusMetrics.test.ts src/server.test.ts` - 68 passed
- `npx -y bun@1.3.11 run --cwd apps/server typecheck` - passed
- `npx -y bun@1.3.11 run fmt:check apps/server/src/observability/PrometheusMetrics.ts apps/server/src/observability/PrometheusMetrics.test.ts apps/server/src/http.ts apps/server/src/server.ts apps/server/src/server.test.ts apps/server/src/observability/.generation_meta.json` - passed
- `node -e "JSON.parse(require('node:fs').readFileSync('apps/server/src/observability/.generation_meta.json','utf8'))" && git diff --check` - passed
- `npx -y bun@1.3.11 run lint apps/server/src/observability/PrometheusMetrics.ts apps/server/src/observability/PrometheusMetrics.test.ts apps/server/src/http.ts apps/server/src/server.ts apps/server/src/server.test.ts` - blocked by existing repo oxlint plugin loader: `ERR_UNKNOWN_FILE_EXTENSION` for `oxlint-plugin-t3code/index.ts`

Note: `.generation_meta.json` includes public task metadata only; hidden system/developer/runtime/private session instructions and credentials are intentionally not reproduced.