### PR TITLE
Fix #5450

### DIFF
--- a/t3code/apps/server/src/git/GitManager.ts
+++ b/t3code/apps/server/src/git/GitManager.ts
@@ -20,6 +20,7 @@ import {
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
   GitPullRequestRefInput,
+  GitRebaseStateResult,
   GitResolvePullRequestResult,
   GitRunStackedActionInput,
   GitRunStackedActionResult,
@@ -80,6 +81,15 @@ export interface GitManagerShape {
   readonly preparePullRequestThread: (
     input: GitPreparePullRequestThreadInput,
   ) => Effect.Effect<GitPreparePullRequestThreadResult, GitManagerServiceError>;
+  readonly getRebaseState: (
+    cwd: string,
+  ) => Effect.Effect<GitRebaseStateResult, GitManagerServiceError>;
+  readonly abortRebase: (
+    cwd: string,
+  ) => Effect.Effect<GitRebaseStateResult, GitManagerServiceError>;
+  readonly continueRebase: (
+    cwd: string,
+  ) => Effect.Effect<GitRebaseStateResult, GitManagerServiceError>;
   readonly runStackedAction: (
     input: GitRunStackedActionInput,
     options?: GitRunStackedActionOptions,
@@ -1553,6 +1563,22 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     }).pipe(Effect.ensuring(invalidateStatus(input.cwd)));
   });
 
+  const getRebaseState: GitManagerShape["getRebaseState"] = Effect.fn("getRebaseState")(
+    function* (cwd) {
+      return yield* gitCore.getRebaseState(cwd);
+    },
+  );
+
+  const abortRebase: GitManagerShape["abortRebase"] = Effect.fn("abortRebase")(function* (cwd) {
+    return yield* gitCore.abortRebase(cwd).pipe(Effect.ensuring(invalidateStatus(cwd)));
+  });
+
+  const continueRebase: GitManagerShape["continueRebase"] = Effect.fn("continueRebase")(
+    function* (cwd) {
+      return yield* gitCore.continueRebase(cwd).pipe(Effect.ensuring(invalidateStatus(cwd)));
+    },
+  );
+
   const runFeatureBranchStep = Effect.fn("runFeatureBranchStep")(function* (
     modelSelection: ModelSelection,
     cwd: string,
@@ -1777,6 +1803,9 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     invalidateStatus,
     resolvePullRequest,
     preparePullRequestThread,
+    getRebaseState,
+    abortRebase,
+    continueRebase,
     runStackedAction,
   } satisfies GitManagerShape;
 });

--- a/t3code/apps/server/src/git/GitWorkflowService.ts
+++ b/t3code/apps/server/src/git/GitWorkflowService.ts
@@ -17,6 +17,7 @@ import {
   type GitPreparePullRequestThreadInput,
   type GitPreparePullRequestThreadResult,
   type GitPullRequestRefInput,
+  type GitRebaseStateResult,
   type VcsPullResult,
   type VcsRemoveWorktreeInput,
   type GitResolvePullRequestResult,
@@ -56,6 +57,15 @@ export interface GitWorkflowServiceShape {
   readonly preparePullRequestThread: (
     input: GitPreparePullRequestThreadInput,
   ) => Effect.Effect<GitPreparePullRequestThreadResult, GitManagerServiceError>;
+  readonly getRebaseState: (
+    cwd: string,
+  ) => Effect.Effect<GitRebaseStateResult, GitManagerServiceError>;
+  readonly abortRebase: (
+    cwd: string,
+  ) => Effect.Effect<GitRebaseStateResult, GitManagerServiceError>;
+  readonly continueRebase: (
+    cwd: string,
+  ) => Effect.Effect<GitRebaseStateResult, GitManagerServiceError>;
   readonly listRefs: (input: VcsListRefsInput) => Effect.Effect<VcsListRefsResult, GitCommandError>;
   readonly createWorktree: (
     input: VcsCreateWorktreeInput,
@@ -284,6 +294,18 @@ export const make = Effect.fn("makeGitWorkflowService")(function* () {
       "GitWorkflowService.preparePullRequestThread",
       gitManager.preparePullRequestThread,
     ),
+    getRebaseState: (cwd) =>
+      ensureGit("GitWorkflowService.getRebaseState", cwd).pipe(
+        Effect.andThen(gitManager.getRebaseState(cwd)),
+      ),
+    abortRebase: (cwd) =>
+      ensureGit("GitWorkflowService.abortRebase", cwd).pipe(
+        Effect.andThen(gitManager.abortRebase(cwd)),
+      ),
+    continueRebase: (cwd) =>
+      ensureGit("GitWorkflowService.continueRebase", cwd).pipe(
+        Effect.andThen(gitManager.continueRebase(cwd)),
+      ),
     listRefs: (input) =>
       detectGitRepositoryForCommand("GitWorkflowService.listRefs", input.cwd).pipe(
         Effect.flatMap((isGitRepository) =>

--- a/t3code/apps/server/src/vcs/GitVcsDriver.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriver.ts
@@ -11,6 +11,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   GitCommandError,
+  type GitRebaseStateResult,
   VcsProcessExitError,
   type VcsSwitchRefInput,
   type VcsSwitchRefResult,
@@ -185,6 +186,9 @@ export interface GitVcsDriverShape {
   ) => Effect.Effect<string | null, GitCommandError>;
   readonly listRefs: (input: VcsListRefsInput) => Effect.Effect<VcsListRefsResult, GitCommandError>;
   readonly pullCurrentBranch: (cwd: string) => Effect.Effect<VcsPullResult, GitCommandError>;
+  readonly getRebaseState: (cwd: string) => Effect.Effect<GitRebaseStateResult, GitCommandError>;
+  readonly abortRebase: (cwd: string) => Effect.Effect<GitRebaseStateResult, GitCommandError>;
+  readonly continueRebase: (cwd: string) => Effect.Effect<GitRebaseStateResult, GitCommandError>;
   readonly createWorktree: (
     input: VcsCreateWorktreeInput,
   ) => Effect.Effect<VcsCreateWorktreeResult, GitCommandError>;

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -57,6 +57,21 @@ const git = (
     return result.stdout.trim();
   });
 
+const gitAllowNonZero = (
+  cwd: string,
+  args: ReadonlyArray<string>,
+): Effect.Effect<GitVcsDriver.ExecuteGitResult, GitCommandError, GitVcsDriver.GitVcsDriver> =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.GitVcsDriver;
+    return yield* driver.execute({
+      operation: "GitVcsDriver.test.gitAllowNonZero",
+      cwd,
+      args,
+      allowNonZeroExit: true,
+      timeoutMs: 10_000,
+    });
+  });
+
 const initRepoWithCommit = (
   cwd: string,
 ): Effect.Effect<
@@ -127,6 +142,64 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.equal(status.aheadCount, 0);
         assert.equal(status.behindCount, 0);
         assert.equal(status.aheadOfDefaultCount, 1);
+      }),
+    );
+
+    it.effect("detects conflicted files while a rebase is stopped", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        yield* writeTextFile(cwd, "conflict.txt", "base\n");
+        yield* git(cwd, ["add", "conflict.txt"]);
+        yield* git(cwd, ["commit", "-m", "add conflict base"]);
+        yield* git(cwd, ["checkout", "-b", "feature/rebase-conflict"]);
+        yield* writeTextFile(cwd, "conflict.txt", "feature\n");
+        yield* git(cwd, ["commit", "-am", "feature change"]);
+        yield* git(cwd, ["checkout", initialBranch]);
+        yield* writeTextFile(cwd, "conflict.txt", "main\n");
+        yield* git(cwd, ["commit", "-am", "main change"]);
+        yield* git(cwd, ["checkout", "feature/rebase-conflict"]);
+
+        const rebase = yield* gitAllowNonZero(cwd, ["rebase", initialBranch]);
+        assert.notEqual(rebase.exitCode, 0);
+
+        const state = yield* driver.getRebaseState(cwd);
+        assert.equal(state.inProgress, true);
+        assert.deepStrictEqual(state.conflictedFiles, ["conflict.txt"]);
+
+        const aborted = yield* driver.abortRebase(cwd);
+        assert.deepStrictEqual(aborted, { inProgress: false, conflictedFiles: [] });
+      }),
+    );
+
+    it.effect("continues a stopped rebase after conflicts are resolved", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        yield* writeTextFile(cwd, "conflict.txt", "base\n");
+        yield* git(cwd, ["add", "conflict.txt"]);
+        yield* git(cwd, ["commit", "-m", "add conflict base"]);
+        yield* git(cwd, ["checkout", "-b", "feature/rebase-continue"]);
+        yield* writeTextFile(cwd, "conflict.txt", "feature\n");
+        yield* git(cwd, ["commit", "-am", "feature change"]);
+        yield* git(cwd, ["checkout", initialBranch]);
+        yield* writeTextFile(cwd, "conflict.txt", "main\n");
+        yield* git(cwd, ["commit", "-am", "main change"]);
+        yield* git(cwd, ["checkout", "feature/rebase-continue"]);
+
+        const rebase = yield* gitAllowNonZero(cwd, ["rebase", initialBranch]);
+        assert.notEqual(rebase.exitCode, 0);
+
+        yield* writeTextFile(cwd, "conflict.txt", "feature\n");
+        yield* git(cwd, ["add", "conflict.txt"]);
+
+        const continued = yield* driver.continueRebase(cwd);
+        assert.deepStrictEqual(continued, { inProgress: false, conflictedFiles: [] });
+        assert.equal(yield* git(cwd, ["log", "-1", "--pretty=%s"]), "feature change");
       }),
     );
 

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -136,6 +136,13 @@ function parsePorcelainPath(line: string): string | null {
   return filePath.length > 0 ? filePath : null;
 }
 
+function parseRebaseConflictedFiles(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/g)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
 function parseBranchLine(line: string): { name: string; current: boolean } | null {
   const trimmed = line.trim();
   if (trimmed.length === 0) return null;
@@ -1586,6 +1593,77 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     };
   });
 
+  const getRebaseState: GitVcsDriver.GitVcsDriverShape["getRebaseState"] = Effect.fn(
+    "getRebaseState",
+  )(function* (cwd) {
+    const gitPathExists = (name: string) =>
+      runGitStdout("GitVcsDriver.getRebaseState.gitPath", cwd, [
+        "rev-parse",
+        "--git-path",
+        name,
+      ]).pipe(
+        Effect.map((stdout) => stdout.trim()),
+        Effect.flatMap((gitPath) => {
+          if (gitPath.length === 0) return Effect.succeed(false);
+          const filePath = path.isAbsolute(gitPath) ? gitPath : path.resolve(cwd, gitPath);
+          return fileSystem.exists(filePath).pipe(Effect.catch(() => Effect.succeed(false)));
+        }),
+      );
+    const [hasRebaseHead, hasRebaseMerge, hasRebaseApply] = yield* Effect.all(
+      [gitPathExists("REBASE_HEAD"), gitPathExists("rebase-merge"), gitPathExists("rebase-apply")],
+      { concurrency: "unbounded" },
+    );
+    const inProgress = hasRebaseHead && (hasRebaseMerge || hasRebaseApply);
+    if (!inProgress) {
+      return {
+        inProgress: false,
+        conflictedFiles: [],
+      };
+    }
+
+    const conflictedFiles = yield* runGitStdout(
+      "GitVcsDriver.getRebaseState.conflictedFiles",
+      cwd,
+      ["diff", "--name-only", "--diff-filter=U"],
+    ).pipe(Effect.map(parseRebaseConflictedFiles));
+    return {
+      inProgress,
+      conflictedFiles,
+    };
+  });
+
+  const abortRebase: GitVcsDriver.GitVcsDriverShape["abortRebase"] = Effect.fn("abortRebase")(
+    function* (cwd) {
+      const state = yield* getRebaseState(cwd);
+      if (!state.inProgress) {
+        return state;
+      }
+      yield* executeGit("GitVcsDriver.abortRebase", cwd, ["rebase", "--abort"], {
+        timeoutMs: 30_000,
+        fallbackErrorMessage: "git rebase --abort failed",
+      });
+      return yield* getRebaseState(cwd);
+    },
+  );
+
+  const continueRebase: GitVcsDriver.GitVcsDriverShape["continueRebase"] = Effect.fn(
+    "continueRebase",
+  )(function* (cwd) {
+    yield* executeGit(
+      "GitVcsDriver.continueRebase",
+      cwd,
+      ["-c", "core.editor=true", "rebase", "--continue"],
+      {
+        env: {
+          GIT_EDITOR: "true",
+        },
+        timeoutMs: 30_000,
+        fallbackErrorMessage: "git rebase --continue failed",
+      },
+    );
+    return yield* getRebaseState(cwd);
+  });
+
   const readRangeContext: GitVcsDriver.GitVcsDriverShape["readRangeContext"] = Effect.fn(
     "readRangeContext",
   )(function* (cwd, baseRef) {
@@ -2123,6 +2201,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     commit,
     pushCurrentBranch,
     pullCurrentBranch,
+    getRebaseState,
+    abortRebase,
+    continueRebase,
     readRangeContext,
     readConfigValue,
     listRefs,

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -1066,6 +1066,24 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
               .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             { "rpc.aggregate": "git" },
           ),
+        [WS_METHODS.gitGetRebaseState]: (input) =>
+          observeRpcEffect(WS_METHODS.gitGetRebaseState, gitWorkflow.getRebaseState(input.cwd), {
+            "rpc.aggregate": "git",
+          }),
+        [WS_METHODS.gitAbortRebase]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitAbortRebase,
+            gitWorkflow.abortRebase(input.cwd).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "git" },
+          ),
+        [WS_METHODS.gitContinueRebase]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitContinueRebase,
+            gitWorkflow
+              .continueRebase(input.cwd)
+              .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "git" },
+          ),
         [WS_METHODS.vcsListRefs]: (input) =>
           observeRpcEffect(WS_METHODS.vcsListRefs, gitWorkflow.listRefs(input), {
             "rpc.aggregate": "vcs",

--- a/t3code/apps/web/src/environmentApi.ts
+++ b/t3code/apps/web/src/environmentApi.ts
@@ -42,6 +42,9 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
     git: {
       resolvePullRequest: rpcClient.git.resolvePullRequest,
       preparePullRequestThread: rpcClient.git.preparePullRequestThread,
+      getRebaseState: rpcClient.git.getRebaseState,
+      abortRebase: rpcClient.git.abortRebase,
+      continueRebase: rpcClient.git.continueRebase,
     },
     orchestration: {
       dispatchCommand: rpcClient.orchestration.dispatchCommand,

--- a/t3code/apps/web/src/environments/runtime/connection.test.ts
+++ b/t3code/apps/web/src/environments/runtime/connection.test.ts
@@ -88,6 +88,9 @@ function createTestClient() {
       runStackedAction: vi.fn(async () => ({}) as any),
       resolvePullRequest: vi.fn(async () => undefined),
       preparePullRequestThread: vi.fn(async () => undefined),
+      getRebaseState: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
+      abortRebase: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
+      continueRebase: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
     },
   } as unknown as WsRpcClient;
 

--- a/t3code/apps/web/src/environments/runtime/service.savedEnvironments.test.ts
+++ b/t3code/apps/web/src/environments/runtime/service.savedEnvironments.test.ts
@@ -214,6 +214,9 @@ function createClient() {
       init: vi.fn(async () => undefined),
       resolvePullRequest: vi.fn(async () => undefined),
       preparePullRequestThread: vi.fn(async () => undefined),
+      getRebaseState: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
+      abortRebase: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
+      continueRebase: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
     },
   };
 }

--- a/t3code/apps/web/src/lib/gitReactQuery.ts
+++ b/t3code/apps/web/src/lib/gitReactQuery.ts
@@ -24,6 +24,8 @@ export const gitQueryKeys = {
     ["git", "refs", environmentId ?? null, cwd] as const,
   branchSearch: (environmentId: EnvironmentId | null, cwd: string | null, query: string) =>
     ["git", "refs", environmentId ?? null, cwd, "search", query] as const,
+  rebaseState: (environmentId: EnvironmentId | null, cwd: string | null) =>
+    ["git", "rebase-state", environmentId ?? null, cwd] as const,
 };
 
 export const gitMutationKeys = {
@@ -37,6 +39,10 @@ export const gitMutationKeys = {
     ["git", "mutation", "pull", environmentId ?? null, cwd] as const,
   preparePullRequestThread: (environmentId: EnvironmentId | null, cwd: string | null) =>
     ["git", "mutation", "prepare-pull-request-thread", environmentId ?? null, cwd] as const,
+  abortRebase: (environmentId: EnvironmentId | null, cwd: string | null) =>
+    ["git", "mutation", "abort-rebase", environmentId ?? null, cwd] as const,
+  continueRebase: (environmentId: EnvironmentId | null, cwd: string | null) =>
+    ["git", "mutation", "continue-rebase", environmentId ?? null, cwd] as const,
   publishRepository: (environmentId: EnvironmentId | null, cwd: string | null) =>
     ["git", "mutation", "publish-repository", environmentId ?? null, cwd] as const,
 };
@@ -124,6 +130,27 @@ export function gitResolvePullRequestQueryOptions(input: {
     staleTime: 30_000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
+  });
+}
+
+export function gitRebaseStateQueryOptions(input: {
+  environmentId: EnvironmentId | null;
+  cwd: string | null;
+  enabled?: boolean;
+}) {
+  return queryOptions({
+    queryKey: gitQueryKeys.rebaseState(input.environmentId, input.cwd),
+    queryFn: async () => {
+      if (!input.cwd || !input.environmentId) {
+        throw new Error("Git rebase state is unavailable.");
+      }
+      const api = ensureEnvironmentApi(input.environmentId);
+      return api.git.getRebaseState({ cwd: input.cwd });
+    },
+    enabled: input.environmentId !== null && input.cwd !== null && (input.enabled ?? true),
+    staleTime: 2_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
 }
 
@@ -227,6 +254,54 @@ export function gitPullMutationOptions(input: {
     },
     onSuccess: async () => {
       await invalidateGitBranchQueries(input.queryClient, input.environmentId, input.cwd);
+    },
+  });
+}
+
+export function gitAbortRebaseMutationOptions(input: {
+  environmentId: EnvironmentId | null;
+  cwd: string | null;
+  queryClient: QueryClient;
+}) {
+  return mutationOptions({
+    mutationKey: gitMutationKeys.abortRebase(input.environmentId, input.cwd),
+    mutationFn: async () => {
+      if (!input.cwd || !input.environmentId) throw new Error("Git rebase abort is unavailable.");
+      const api = ensureEnvironmentApi(input.environmentId);
+      return api.git.abortRebase({ cwd: input.cwd });
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        invalidateGitBranchQueries(input.queryClient, input.environmentId, input.cwd),
+        input.queryClient.invalidateQueries({
+          queryKey: gitQueryKeys.rebaseState(input.environmentId, input.cwd),
+        }),
+      ]);
+    },
+  });
+}
+
+export function gitContinueRebaseMutationOptions(input: {
+  environmentId: EnvironmentId | null;
+  cwd: string | null;
+  queryClient: QueryClient;
+}) {
+  return mutationOptions({
+    mutationKey: gitMutationKeys.continueRebase(input.environmentId, input.cwd),
+    mutationFn: async () => {
+      if (!input.cwd || !input.environmentId) {
+        throw new Error("Git rebase continue is unavailable.");
+      }
+      const api = ensureEnvironmentApi(input.environmentId);
+      return api.git.continueRebase({ cwd: input.cwd });
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        invalidateGitBranchQueries(input.queryClient, input.environmentId, input.cwd),
+        input.queryClient.invalidateQueries({
+          queryKey: gitQueryKeys.rebaseState(input.environmentId, input.cwd),
+        }),
+      ]);
     },
   });
 }

--- a/t3code/apps/web/src/lib/gitStatusState.test.ts
+++ b/t3code/apps/web/src/lib/gitStatusState.test.ts
@@ -109,6 +109,9 @@ function createRegisteredGitStatusClient(environmentId: EnvironmentId) {
       runStackedAction: vi.fn(async () => ({}) as any),
       resolvePullRequest: vi.fn(async () => undefined),
       preparePullRequestThread: vi.fn(async () => undefined),
+      getRebaseState: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
+      abortRebase: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
+      continueRebase: vi.fn(async () => ({ inProgress: false, conflictedFiles: [] })),
     },
     server: {
       getConfig: vi.fn(async () => ({

--- a/t3code/apps/web/src/localApi.test.ts
+++ b/t3code/apps/web/src/localApi.test.ts
@@ -81,6 +81,9 @@ const rpcClientMock = {
     runStackedAction: vi.fn(),
     resolvePullRequest: vi.fn(),
     preparePullRequestThread: vi.fn(),
+    getRebaseState: vi.fn(),
+    abortRebase: vi.fn(),
+    continueRebase: vi.fn(),
   },
   server: {
     getConfig: vi.fn(),

--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -111,6 +111,9 @@ export interface WsRpcClient {
     readonly preparePullRequestThread: RpcUnaryMethod<
       typeof WS_METHODS.gitPreparePullRequestThread
     >;
+    readonly getRebaseState: RpcUnaryMethod<typeof WS_METHODS.gitGetRebaseState>;
+    readonly abortRebase: RpcUnaryMethod<typeof WS_METHODS.gitAbortRebase>;
+    readonly continueRebase: RpcUnaryMethod<typeof WS_METHODS.gitContinueRebase>;
   };
   readonly server: {
     readonly getConfig: RpcUnaryNoArgMethod<typeof WS_METHODS.serverGetConfig>;
@@ -245,6 +248,12 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
         transport.request((client) => client[WS_METHODS.gitResolvePullRequest](input)),
       preparePullRequestThread: (input) =>
         transport.request((client) => client[WS_METHODS.gitPreparePullRequestThread](input)),
+      getRebaseState: (input) =>
+        transport.request((client) => client[WS_METHODS.gitGetRebaseState](input)),
+      abortRebase: (input) =>
+        transport.request((client) => client[WS_METHODS.gitAbortRebase](input)),
+      continueRebase: (input) =>
+        transport.request((client) => client[WS_METHODS.gitContinueRebase](input)),
     },
     server: {
       getConfig: () => transport.request((client) => client[WS_METHODS.serverGetConfig]({})),

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -153,6 +153,11 @@ export const GitPreparePullRequestThreadInput = Schema.Struct({
 });
 export type GitPreparePullRequestThreadInput = typeof GitPreparePullRequestThreadInput.Type;
 
+export const GitRebaseInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type GitRebaseInput = typeof GitRebaseInput.Type;
+
 export const VcsRemoveWorktreeInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   path: TrimmedNonEmptyStringSchema,
@@ -274,6 +279,12 @@ export const GitPreparePullRequestThreadResult = Schema.Struct({
   worktreePath: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
 });
 export type GitPreparePullRequestThreadResult = typeof GitPreparePullRequestThreadResult.Type;
+
+export const GitRebaseStateResult = Schema.Struct({
+  inProgress: Schema.Boolean,
+  conflictedFiles: Schema.Array(TrimmedNonEmptyStringSchema),
+});
+export type GitRebaseStateResult = typeof GitRebaseStateResult.Type;
 
 export const VcsSwitchRefResult = Schema.Struct({
   refName: Schema.NullOr(TrimmedNonEmptyStringSchema),

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -4,6 +4,8 @@ import type {
   VcsCreateRefInput,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
+  GitRebaseInput,
+  GitRebaseStateResult,
   GitPullRequestRefInput,
   VcsCreateWorktreeInput,
   VcsCreateWorktreeResult,
@@ -543,6 +545,9 @@ export interface EnvironmentApi {
     preparePullRequestThread: (
       input: GitPreparePullRequestThreadInput,
     ) => Promise<GitPreparePullRequestThreadResult>;
+    getRebaseState: (input: GitRebaseInput) => Promise<GitRebaseStateResult>;
+    abortRebase: (input: GitRebaseInput) => Promise<GitRebaseStateResult>;
+    continueRebase: (input: GitRebaseInput) => Promise<GitRebaseStateResult>;
   };
   orchestration: {
     dispatchCommand: (command: ClientOrchestrationCommand) => Promise<{ sequence: number }>;

--- a/t3code/packages/contracts/src/rpc.ts
+++ b/t3code/packages/contracts/src/rpc.ts
@@ -24,6 +24,8 @@ import {
   GitManagerServiceError,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
+  GitRebaseInput,
+  GitRebaseStateResult,
   VcsPullInput,
   GitPullRequestRefInput,
   VcsPullResult,
@@ -127,6 +129,9 @@ export const WS_METHODS = {
   gitRunStackedAction: "git.runStackedAction",
   gitResolvePullRequest: "git.resolvePullRequest",
   gitPreparePullRequestThread: "git.preparePullRequestThread",
+  gitGetRebaseState: "git.getRebaseState",
+  gitAbortRebase: "git.abortRebase",
+  gitContinueRebase: "git.continueRebase",
 
   // Terminal methods
   terminalOpen: "terminal.open",
@@ -325,6 +330,24 @@ export const WsGitPreparePullRequestThreadRpc = Rpc.make(WS_METHODS.gitPreparePu
   error: GitManagerServiceError,
 });
 
+export const WsGitGetRebaseStateRpc = Rpc.make(WS_METHODS.gitGetRebaseState, {
+  payload: GitRebaseInput,
+  success: GitRebaseStateResult,
+  error: GitManagerServiceError,
+});
+
+export const WsGitAbortRebaseRpc = Rpc.make(WS_METHODS.gitAbortRebase, {
+  payload: GitRebaseInput,
+  success: GitRebaseStateResult,
+  error: GitManagerServiceError,
+});
+
+export const WsGitContinueRebaseRpc = Rpc.make(WS_METHODS.gitContinueRebase, {
+  payload: GitRebaseInput,
+  success: GitRebaseStateResult,
+  error: GitManagerServiceError,
+});
+
 export const WsVcsListRefsRpc = Rpc.make(WS_METHODS.vcsListRefs, {
   payload: VcsListRefsInput,
   success: VcsListRefsResult,
@@ -498,6 +521,9 @@ export const WsRpcGroup = RpcGroup.make(
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,
   WsGitPreparePullRequestThreadRpc,
+  WsGitGetRebaseStateRpc,
+  WsGitAbortRebaseRpc,
+  WsGitContinueRebaseRpc,
   WsVcsListRefsRpc,
   WsVcsCreateWorktreeRpc,
   WsVcsRemoveWorktreeRpc,


### PR DESCRIPTION
## Fix #5450\n\nImplemented the rebase resolution fix in the VCS driver.\n\nChanged:\n- [GitVcsDriverCore.ts](/tmp/bounty-Bounty-Hunters_5450-1sn_7ro7/repo/t3code/apps/server/src/vcs/GitVcsDriverCore.ts:1596): rebase state now requires  plus active  or , avoiding false positives after Git leaves stale .\n- [GitVcsDriverCore.ts](/tmp/bounty-Bounty-Hunters_5450-1sn_7ro7/repo/t3code/apps/server/src/vcs/GitVcsDriverCore.ts:1649):  runs non-interactiv\n\n---\n*Auto-generated bounty fix*