### PR TITLE
Hermes Agent [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/.generation_meta.json
+++ b/solidity/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes Agent (unsiqasik)",
+  "initial_directives": "Autonomous bounty hunter. Fix PriceOracle.sol: add staleness check, fallback oracle, round completeness validation, zero/negative price checks, StalePrice event, configurable MAX_STALENESS. Write Foundry tests. Create .generation_meta.json.",
+  "date": "2026-05-29T00:00:00Z"
+}

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -1,0 +1,66 @@
+## Foundry
+
+**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+
+Foundry consists of:
+
+- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
+- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
+- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
+- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+
+## Documentation
+
+https://book.getfoundry.sh/
+
+## Usage
+
+### Build
+
+```shell
+$ forge build
+```
+
+### Test
+
+```shell
+$ forge test
+```
+
+### Format
+
+```shell
+$ forge fmt
+```
+
+### Gas Snapshots
+
+```shell
+$ forge snapshot
+```
+
+### Anvil
+
+```shell
+$ anvil
+```
+
+### Deploy
+
+```shell
+$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+```
+
+### Cast
+
+```shell
+$ cast <subcommand>
+```
+
+### Help
+
+```shell
+$ forge --help
+$ anvil --help
+$ cast --help
+```

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,21 +14,20 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(uint256 primaryUpdatedAt, uint256 timestamp);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
         (
             uint80 roundId,
             int256 price,
@@ -37,11 +36,33 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        // Check round completeness
+        require(answeredInRound >= roundId, "Round not complete");
+        // Check for zero/negative price
+        require(price > 0, "Invalid price");
+        // Check staleness
+        if (block.timestamp - updatedAt < MAX_STALENESS) {
+            return price;
+        }
 
-        return price;
+        // Primary is stale — try fallback
+        (
+            uint80 fallbackRoundId,
+            int256 fallbackPrice,
+            ,
+            uint256 fallbackUpdatedAt,
+            uint80 fallbackAnsweredInRound
+        ) = fallbackFeed.latestRoundData();
+
+        // Validate fallback oracle
+        require(fallbackAnsweredInRound >= fallbackRoundId, "Fallback round not complete");
+        require(fallbackPrice > 0, "Fallback invalid price");
+        require(block.timestamp - fallbackUpdatedAt < MAX_STALENESS, "Both oracles stale");
+
+        // Emit stale price event for monitoring
+        emit StalePrice(updatedAt, block.timestamp);
+
+        return fallbackPrice;
     }
 
     function getDecimals() external view returns (uint8) {

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/solidity/test/PriceOracle.t.sol
+++ b/solidity/test/PriceOracle.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/PriceOracle.sol";
+
+contract MockAggregator is AggregatorV3Interface {
+    uint80 internal _roundId;
+    int256 internal _answer;
+    uint256 internal _startedAt;
+    uint256 internal _updatedAt;
+    uint80 internal _answeredInRound;
+    uint8 internal _decimals;
+
+    function setRoundData(
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) external {
+        _roundId = roundId;
+        _answer = answer;
+        _startedAt = startedAt;
+        _updatedAt = updatedAt;
+        _answeredInRound = answeredInRound;
+    }
+
+    function setDecimals(uint8 decimals_) external {
+        _decimals = decimals_;
+    }
+
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        return (_roundId, _answer, _startedAt, _updatedAt, _answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+}
+
+contract PriceOracleTest is Test {
+    PriceOracle public oracle;
+    MockAggregator public primaryMock;
+    MockAggregator public fallbackMock;
+
+    uint256 constant BASE_TIME = 1_000_000;
+
+    function setUp() public {
+        vm.warp(BASE_TIME);
+        primaryMock = new MockAggregator();
+        fallbackMock = new MockAggregator();
+        oracle = new PriceOracle(address(primaryMock), address(fallbackMock));
+        primaryMock.setDecimals(8);
+        fallbackMock.setDecimals(8);
+    }
+
+    // Test: valid price from primary oracle
+    function test_validPriceFromPrimary() public {
+        primaryMock.setRoundData(1, 2000e8, BASE_TIME, BASE_TIME, 1);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2000e8);
+    }
+
+    // Test: zero price reverts
+    function test_zeroPriceReverts() public {
+        primaryMock.setRoundData(1, 0, BASE_TIME, BASE_TIME, 1);
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    // Test: negative price reverts
+    function test_negativePriceReverts() public {
+        primaryMock.setRoundData(1, -100, BASE_TIME, BASE_TIME, 1);
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    // Test: incomplete round reverts
+    function test_incompleteRoundReverts() public {
+        primaryMock.setRoundData(5, 2000e8, BASE_TIME, BASE_TIME, 3);
+        vm.expectRevert("Round not complete");
+        oracle.getLatestPrice();
+    }
+
+    // Test: stale price falls back to secondary oracle
+    function test_stalePriceFallsBackToSecondary() public {
+        uint256 staleTime = BASE_TIME - 7200;
+        primaryMock.setRoundData(1, 2000e8, staleTime, staleTime, 1);
+        fallbackMock.setRoundData(1, 2100e8, BASE_TIME, BASE_TIME, 1);
+
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2100e8);
+    }
+
+    // Test: stale price emits StalePrice event
+    function test_stalePriceEmitsEvent() public {
+        uint256 staleTime = BASE_TIME - 7200;
+        primaryMock.setRoundData(1, 2000e8, staleTime, staleTime, 1);
+        fallbackMock.setRoundData(1, 2100e8, BASE_TIME, BASE_TIME, 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit PriceOracle.StalePrice(staleTime, BASE_TIME);
+        oracle.getLatestPrice();
+    }
+
+    // Test: both oracles stale reverts
+    function test_bothOraclesStaleReverts() public {
+        uint256 staleTime = BASE_TIME - 7200;
+        primaryMock.setRoundData(1, 2000e8, staleTime, staleTime, 1);
+        fallbackMock.setRoundData(1, 2100e8, staleTime, staleTime, 1);
+
+        vm.expectRevert("Both oracles stale");
+        oracle.getLatestPrice();
+    }
+
+    // Test: fallback zero price reverts
+    function test_fallbackZeroPriceReverts() public {
+        uint256 staleTime = BASE_TIME - 7200;
+        primaryMock.setRoundData(1, 2000e8, staleTime, staleTime, 1);
+        fallbackMock.setRoundData(1, 0, BASE_TIME, BASE_TIME, 1);
+
+        vm.expectRevert("Fallback invalid price");
+        oracle.getLatestPrice();
+    }
+
+    // Test: fallback incomplete round reverts
+    function test_fallbackIncompleteRoundReverts() public {
+        uint256 staleTime = BASE_TIME - 7200;
+        primaryMock.setRoundData(1, 2000e8, staleTime, staleTime, 1);
+        fallbackMock.setRoundData(5, 2100e8, BASE_TIME, BASE_TIME, 3);
+
+        vm.expectRevert("Fallback round not complete");
+        oracle.getLatestPrice();
+    }
+
+    // Test: owner can set max staleness
+    function test_ownerCanSetMaxStaleness() public {
+        oracle.setMaxStaleness(7200);
+        assertEq(oracle.MAX_STALENESS(), 7200);
+    }
+
+    // Test: non-owner cannot set max staleness
+    function test_nonOwnerCannotSetMaxStaleness() public {
+        vm.prank(address(0xdead));
+        vm.expectRevert("Not owner");
+        oracle.setMaxStaleness(7200);
+    }
+
+    // Test: price just under staleness boundary returns primary
+    function test_priceJustUnderStaleness() public {
+        uint256 recentTime = BASE_TIME - 3599;
+        primaryMock.setRoundData(1, 2000e8, recentTime, recentTime, 1);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2000e8);
+    }
+
+    // Test: price at staleness boundary falls back
+    function test_priceAtStalenessBoundary() public {
+        uint256 staleTime = BASE_TIME - 3600;
+        primaryMock.setRoundData(1, 2000e8, staleTime, staleTime, 1);
+        fallbackMock.setRoundData(1, 2100e8, BASE_TIME, BASE_TIME, 1);
+
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 2100e8);
+    }
+
+    // Test: getDecimals returns primary feed decimals
+    function test_getDecimals() public {
+        uint8 dec = oracle.getDecimals();
+        assertEq(dec, 8);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #915

## Summary
Fixed PriceOracle.sol to validate Chainlink oracle responses for staleness, zero/negative prices, and round completeness. Added a fallback oracle mechanism with event emission.

## Changes
- **Round completeness check**: Verify `answeredInRound >= roundId` to reject incomplete rounds
- **Zero/negative price rejection**: `require(price > 0)` to reject invalid prices
- **Staleness check**: `require(block.timestamp - updatedAt < MAX_STALENESS)` with configurable threshold (default 3600s)
- **Fallback oracle**: Added secondary oracle address; queries it when primary returns stale data
- **StalePrice event**: Emitted when falling back to secondary oracle for monitoring
- **Both-oracle safety**: Reverts if both oracles return stale data instead of returning bad data
- **Owner-configurable MAX_STALENESS**: Owner can adjust the staleness threshold

## Acceptance Criteria
- [x] Stale prices (older than 1 hour) trigger fallback to secondary oracle
- [x] Zero or negative prices revert with clear error
- [x] Incomplete rounds are rejected
- [x] StalePrice event is emitted with the primary oracle's last update timestamp
- [x] If both oracles return stale data, the function reverts instead of returning bad data
- [x] MAX_STALENESS is configurable by the contract owner
- [x] Tests mock Chainlink responses for: valid price, stale price, negative price, incomplete round, both oracles stale
- [x] Created .generation_meta.json alongside code changes

## Tests
14 Foundry tests covering all scenarios:
- Valid price from primary
- Zero price revert
- Negative price revert
- Incomplete round revert
- Stale price fallback to secondary
- StalePrice event emission
- Both oracles stale revert
- Fallback zero price revert
- Fallback incomplete round revert
- Owner can set max staleness
- Non-owner cannot set max staleness
- Price just under staleness boundary
- Price at staleness boundary
- getDecimals