### PR TITLE
Hermes Agent [ Crypto ] Fix StakingVault reentrancy vulnerability in withdraw and claimRewards

### DIFF
--- a/solidity/.provenance.json
+++ b/solidity/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Hermes Agent (unsiqasik)",
+  "config_snapshot": "Autonomous bounty hunter running 24/7. GitHub: unsiqasik, email: rkhandriantonew@gmail.com. Fix StakingVault.sol reentrancy vulnerability: move state updates before external calls (CEI pattern), add ReentrancyGuard from OpenZeppelin to withdraw() and claimRewards(), write tests with malicious contracts that attempt reentrancy.",
+  "created": "2026-05-29T00:00:00Z"
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -39,32 +40,30 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
-        require(success, "Transfer failed");
-
-        // State update after external call — vulnerable to reentrancy
+        // State update BEFORE external call (CEI pattern)
         balances[msg.sender] -= amount;
         totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
+
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Transfer failed");
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
-        (bool success, ) = payable(msg.sender).call{value: reward}("");
-        require(success, "Transfer failed");
-
+        // State update BEFORE external call (CEI pattern)
         rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
+
+        (bool success, ) = payable(msg.sender).call{value: reward}("");
+        require(success, "Transfer failed");
     }
 
     function getStakedBalance(address account) external view returns (uint256) {

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -1,0 +1,8 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+remappings = [
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+    "forge-std/=lib/forge-std/src/"
+]

--- a/solidity/test/StakingVault.t.sol
+++ b/solidity/test/StakingVault.t.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/StakingVault.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock Token", "MOCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+// Malicious contract that attempts reentrancy on withdraw
+contract MaliciousWithdrawer {
+    StakingVault public vault;
+    uint256 public attackCount;
+
+    constructor(address payable _vault) {
+        vault = StakingVault(_vault);
+    }
+
+    function attack() external {
+        attackCount = 0;
+        uint256 balance = vault.balances(address(this));
+        require(balance > 0, "No balance to withdraw");
+        vault.withdraw(balance);
+    }
+
+    receive() external payable {
+        // Try to re-enter withdraw
+        attackCount++;
+        uint256 balance = vault.balances(address(this));
+        if (balance > 0) {
+            try vault.withdraw(balance) {} catch {}
+        }
+    }
+}
+
+// Malicious contract that attempts reentrancy on claimRewards
+contract MaliciousRewardClaimer {
+    StakingVault public vault;
+    uint256 public attackCount;
+
+    constructor(address payable _vault) {
+        vault = StakingVault(_vault);
+    }
+
+    function attack() external {
+        attackCount = 0;
+        vault.claimRewards();
+    }
+
+    receive() external payable {
+        // Try to re-enter claimRewards
+        attackCount++;
+        uint256 pending = vault.getPendingRewards(address(this));
+        if (pending > 0) {
+            try vault.claimRewards() {} catch {}
+        }
+    }
+}
+
+contract StakingVaultTest is Test {
+    StakingVault public vault;
+    MockERC20 public token;
+
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+
+    uint256 constant REWARD_RATE = 1e16; // 1% per second
+    uint256 constant BASE_TIME = 1_000_000;
+
+    function setUp() public {
+        vm.warp(BASE_TIME);
+        token = new MockERC20();
+        vault = new StakingVault(address(token), REWARD_RATE);
+
+        // Fund the vault with ETH for rewards/withdrawals
+        vm.deal(address(vault), 1000 ether);
+
+        // Mint tokens to users
+        token.mint(alice, 1000e18);
+        token.mint(bob, 1000e18);
+    }
+
+    // Test: basic staking works
+    function test_basicStake() public {
+        vm.startPrank(alice);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+        assertEq(vault.balances(alice), 100e18);
+        assertEq(vault.totalStaked(), 100e18);
+        vm.stopPrank();
+    }
+
+    // Test: basic withdrawal works
+    function test_basicWithdraw() public {
+        vm.startPrank(alice);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+
+        uint256 balanceBefore = address(alice).balance;
+        vault.withdraw(100e18);
+        uint256 balanceAfter = address(alice).balance;
+
+        assertEq(vault.balances(alice), 0);
+        assertEq(vault.totalStaked(), 0);
+        assertEq(balanceAfter - balanceBefore, 100e18);
+        vm.stopPrank();
+    }
+
+    // Test: withdrawal reverts on insufficient balance
+    function test_withdrawInsufficientBalanceReverts() public {
+        vm.startPrank(alice);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+
+        vm.expectRevert("Insufficient balance");
+        vault.withdraw(200e18);
+        vm.stopPrank();
+    }
+
+    // Test: claim rewards works
+    function test_claimRewards() public {
+        vm.startPrank(alice);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+
+        vm.warp(BASE_TIME + 10);
+
+        uint256 pending = vault.getPendingRewards(alice);
+        assertGt(pending, 0);
+
+        uint256 balanceBefore = address(alice).balance;
+        vault.claimRewards();
+        uint256 balanceAfter = address(alice).balance;
+
+        assertEq(vault.rewards(alice), 0);
+        assertGt(balanceAfter - balanceBefore, 0);
+        vm.stopPrank();
+    }
+
+    // Test: claim rewards reverts when no rewards
+    function test_claimRewardsNoRewardsReverts() public {
+        vm.prank(alice);
+        vm.expectRevert("No rewards");
+        vault.claimRewards();
+    }
+
+    // Test: reentrancy on withdraw does NOT drain extra funds
+    function test_reentrancyWithdrawBlocked() public {
+        MaliciousWithdrawer attacker = new MaliciousWithdrawer(payable(address(vault)));
+        vm.deal(address(attacker), 0);
+
+        // Stake from attacker
+        token.mint(address(attacker), 100e18);
+        vm.startPrank(address(attacker));
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+        vm.stopPrank();
+
+        uint256 vaultBalanceBefore = address(vault).balance;
+
+        // Attack — should only withdraw 100 ETH, not drain extra
+        attacker.attack();
+
+        uint256 vaultBalanceAfter = address(vault).balance;
+
+        // Verify: only 100 ETH was withdrawn (the staked amount)
+        assertEq(vaultBalanceBefore - vaultBalanceAfter, 100e18);
+        // Verify: attacker balance is 0 after withdraw
+        assertEq(vault.balances(address(attacker)), 0);
+        // Verify: reentrancy was attempted but failed
+        assertGt(attacker.attackCount(), 0);
+    }
+
+    // Test: reentrancy on claimRewards does NOT drain extra rewards
+    function test_reentrancyClaimRewardsBlocked() public {
+        MaliciousRewardClaimer attacker = new MaliciousRewardClaimer(payable(address(vault)));
+
+        // Stake from attacker
+        token.mint(address(attacker), 100e18);
+        vm.startPrank(address(attacker));
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+        vm.stopPrank();
+
+        // Advance time to accumulate rewards
+        vm.warp(BASE_TIME + 10);
+
+        uint256 expectedRewards = vault.getPendingRewards(address(attacker));
+        uint256 vaultBalanceBefore = address(vault).balance;
+
+        // Attack — should only claim rewards once
+        attacker.attack();
+
+        uint256 vaultBalanceAfter = address(vault).balance;
+
+        // Verify: only expected rewards were claimed
+        assertEq(vaultBalanceBefore - vaultBalanceAfter, expectedRewards);
+        // Verify: rewards are zeroed
+        assertEq(vault.rewards(address(attacker)), 0);
+        // Verify: reentrancy was attempted but failed
+        assertGt(attacker.attackCount(), 0);
+    }
+
+    // Test: state is updated before external call in withdraw
+    function test_stateUpdatedBeforeExternalCall() public {
+        vm.startPrank(alice);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+
+        assertEq(vault.balances(alice), 100e18);
+        vault.withdraw(50e18);
+        assertEq(vault.balances(alice), 50e18);
+        vm.stopPrank();
+    }
+
+    // Test: state is updated before external call in claimRewards
+    function test_rewardsZeroedBeforeExternalCall() public {
+        vm.startPrank(alice);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+
+        vm.warp(BASE_TIME + 10);
+        assertGt(vault.getPendingRewards(alice), 0);
+
+        vault.claimRewards();
+        assertEq(vault.rewards(alice), 0);
+        vm.stopPrank();
+    }
+
+    // Test: multiple users can stake and withdraw independently
+    function test_multipleUsers() public {
+        vm.startPrank(alice);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(100e18);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        token.approve(address(vault), type(uint256).max);
+        vault.stake(200e18);
+        vm.stopPrank();
+
+        assertEq(vault.totalStaked(), 300e18);
+
+        vm.prank(alice);
+        vault.withdraw(100e18);
+
+        assertEq(vault.totalStaked(), 200e18);
+        assertEq(vault.balances(bob), 200e18);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #911

## Summary
Fixed reentrancy vulnerability in StakingVault.sol by applying the Checks-Effects-Interactions (CEI) pattern and adding OpenZeppelin's ReentrancyGuard.

## Changes
- **CEI pattern**: Moved state updates (, , ) BEFORE external calls in both  and 
- **ReentrancyGuard**: Added  modifier from OpenZeppelin's  to both  and  as defense-in-depth
- **Import**: Added 

## Acceptance Criteria
- [x] State updates happen before all external calls in both withdraw and claimRewards
- [x] ReentrancyGuard is imported from OpenZeppelin and applied to both functions
- [x] Malicious contract test attempts reentrancy on withdraw and fails to drain extra funds
- [x] Malicious contract test attempts reentrancy on claimRewards and fails to drain extra rewards
- [x] Existing staking, withdrawal, and reward claim flows still work correctly
- [x] Created .provenance.json alongside code changes
- [x] PR title starts with agent name + [ Crypto ]

## Tests
10 Foundry tests covering all scenarios:
- Basic staking
- Basic withdrawal
- Insufficient balance revert
- Claim rewards
- No rewards revert
- Reentrancy on withdraw blocked (malicious contract verification)
- Reentrancy on claimRewards blocked (malicious contract verification)
- State updated before external call (withdraw)
- State updated before external call (claimRewards)
- Multiple users staking/withdrawing independently