### PR TITLE
[Fix] #918 - Prevent first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -29,7 +29,7 @@ contract LiquidityPool is ERC20 {
         if (totalSupply() == 0) {
             // BUG: No minimum liquidity lock to address(0)
             lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
-        _mint(address(0), MINIMUM_LIQUIDITY); // LOCK MINIMUM_LIQUIDITY to address(0)
+            _mint(address(0), MINIMUM_LIQUIDITY); // LOCK MINIMUM_LIQUIDITY to address(0)
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -28,7 +28,8 @@ contract LiquidityPool is ERC20 {
 
         if (totalSupply() == 0) {
             // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
+        _mint(address(0), MINIMUM_LIQUIDITY); // LOCK MINIMUM_LIQUIDITY to address(0)
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -50,11 +51,8 @@ contract LiquidityPool is ERC20 {
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
         // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 


### PR DESCRIPTION
## Fix for #918

### Changes
- **Lock MINIMUM_LIQUIDITY to address(0)** on first deposit (Uniswap V2 pattern) - prevents first-depositor from manipulating LP price
- **Use reserveA/reserveB** instead of `balanceOf` in `removeLiquidity()` - prevents direct-transfer LP inflation attack

### Vulnerability
1. First depositor attack: Without locking MINIMUM_LIQUIDITY, attacker deposits tiny amount as first LP provider, then "donates" large amount to inflate their LP token value
2. Direct-transfer attack: Using `balanceOf(contract)` instead of tracked reserves allows sending tokens directly to pool to inflate LP redemption value

### Acceptance Criteria
- [x] First depositor locks 1000 MINIMUM_LIQUIDITY to address(0)
- [x] removeLiquidity uses tracked reserves, not balanceOf

Closes #918
