### PR TITLE
Codex [ T3 Code ] Fix turbo build dependency graph

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Public task context: paid OSS bounty implementation for UnsafeLabs/Bounty-Hunters issue #828. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "completed_at": "2026-05-29T11:38:00Z"
+}

--- a/t3code/apps/desktop/turbo.jsonc
+++ b/t3code/apps/desktop/turbo.jsonc
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@t3tools/web#build", "t3#build"],
       "outputs": ["dist-electron/**"],
     },
     "dev": {

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,24 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/web#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/client-runtime#build"],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "@t3tools/web#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "@t3tools/desktop#build": {
+      "dependsOn": ["^build", "@t3tools/web#build", "t3#build"],
+      "outputs": ["dist-electron/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
﻿/claim #828

## Summary
- add package-specific Turbo build graph entries for the T3 web and server builds
- make the server build wait for the web client bundle it copies into `dist/client`
- make the desktop build wait for both web and server artifacts while preserving its transitive package build dependencies
- scope cache outputs to `dist/**` for web/server and `dist-electron/**` for desktop
- include safe public `_meta.json` provenance

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-828-demo.mp4

## Validation
- JSON parse for `turbo.json` and `_meta.json`
- `turbo run build --dry=json`
- Verified dry-run dependencies:
  - `@t3tools/web#build` -> `@t3tools/client-runtime#build`, `@t3tools/contracts#build`
  - `t3#build` -> `@t3tools/contracts#build`, `@t3tools/shared#build`, `@t3tools/web#build`, `effect-acp#build`, `effect-codex-app-server#build`
  - `@t3tools/desktop#build` -> includes `@t3tools/web#build` and `t3#build` plus direct package deps from `^build`
- `oxfmt --check turbo.json apps/desktop/turbo.jsonc _meta.json`
- `git diff --check`

Security note: `_meta.json` includes public provenance only; hidden system/developer/runtime/private instructions are intentionally not reproduced.
