### PR TITLE
Codex [ Crypto ] Harden SimpleSwap slippage and deadline checks

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract SimpleSwap {
+    uint256 public constant FEE_DENOMINATOR = 10000;
+
     IERC20 public tokenA;
     IERC20 public tokenB;
     uint256 public reserveA;
@@ -13,39 +15,41 @@ contract SimpleSwap {
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_tokenA != address(0) && _tokenB != address(0), "Invalid token");
+        require(_tokenA != _tokenB, "Duplicate tokens");
+        require(_fee < FEE_DENOMINATOR, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(amountA > 0 && amountB > 0, "Invalid liquidity");
+        require(tokenA.transferFrom(msg.sender, address(this), amountA), "TokenA transfer failed");
+        require(tokenB.transferFrom(msg.sender, address(this), amountB), "TokenB transfer failed");
         reserveA += amountA;
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Deadline expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
         bool isTokenA = tokenIn == address(tokenA);
-        (IERC20 inputToken, IERC20 outputToken, uint256 reserveIn, uint256 reserveOut) = isTokenA
-            ? (tokenA, tokenB, reserveA, reserveB)
-            : (tokenB, tokenA, reserveB, reserveA);
+        IERC20 inputToken = isTokenA ? tokenA : tokenB;
+        IERC20 outputToken = isTokenA ? tokenB : tokenA;
 
-        inputToken.transferFrom(msg.sender, address(this), amountIn);
+        amountOut = _getAmountOut(tokenIn, amountIn);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
 
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
-        outputToken.transfer(msg.sender, amountOut);
+        require(inputToken.transferFrom(msg.sender, address(this), amountIn), "Input transfer failed");
+        require(outputToken.transfer(msg.sender, amountOut), "Output transfer failed");
 
         if (isTokenA) {
             reserveA += amountIn;
@@ -59,11 +63,29 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        return _getAmountOut(tokenIn, amountIn);
+    }
+
+    function _getAmountOut(address tokenIn, uint256 amountIn) internal view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
+        require(amountIn > 0, "Amount must be > 0");
+
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
+        require(reserveIn > 0 && reserveOut > 0, "Insufficient liquidity");
+
+        uint256 feeAmount = _calculateFee(amountIn);
         uint256 amountInAfterFee = amountIn - feeAmount;
+        require(amountInAfterFee > 0, "Amount too small after fee");
+
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+    }
+
+    function _calculateFee(uint256 amountIn) internal view returns (uint256) {
+        if (fee == 0) {
+            return 0;
+        }
+        return (amountIn * fee + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Public task context: paid OSS bounty implementation for UnsafeLabs/Bounty-Hunters issue #913. Hidden system, developer, runtime, credential, memory, and private session instructions are intentionally not reproduced.",
+  "completed_at": "2026-05-29T11:46:00Z"
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bounty-hunters-solidity",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/simpleSwap.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.3.0",
+    "ethers": "^6.14.4",
+    "ganache": "^7.9.2",
+    "solc": "^0.8.30"
+  }
+}

--- a/solidity/test/simpleSwap.test.mjs
+++ b/solidity/test/simpleSwap.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const requireFromTest = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const solidityRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(solidityRoot, "..");
+const fallbackModules = process.env.SOLIDITY_TEST_NODE_MODULES;
+
+function requirePackage(name) {
+  try {
+    return requireFromTest(name);
+  } catch (error) {
+    if (!fallbackModules) {
+      throw error;
+    }
+    const requireFromFallback = createRequire(path.join(fallbackModules, "package.json"));
+    return requireFromFallback(name);
+  }
+}
+
+const { ethers } = requirePackage("ethers");
+const ganachePackage = requirePackage("ganache");
+const ganache = ganachePackage.default ?? ganachePackage;
+const solc = requirePackage("solc");
+
+const mockTokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}
+`;
+
+function resolveImport(importPath) {
+  if (importPath.startsWith("@openzeppelin/")) {
+    const resolved = requireFromTest.resolve(importPath, { paths: [solidityRoot, fallbackModules].filter(Boolean) });
+    return { contents: readFileSync(resolved, "utf8") };
+  }
+
+  try {
+    return { contents: readFileSync(path.join(repoRoot, importPath), "utf8") };
+  } catch (error) {
+    return { error: `Unable to resolve ${importPath}: ${error.message}` };
+  }
+}
+
+function compileContracts() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "solidity/contracts/SimpleSwap.sol": {
+        content: readFileSync(path.join(solidityRoot, "contracts", "SimpleSwap.sol"), "utf8"),
+      },
+      "test/MockToken.sol": {
+        content: mockTokenSource,
+      },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input), { import: resolveImport }));
+  const errors = output.errors?.filter((error) => error.severity === "error") ?? [];
+  assert.deepEqual(errors, []);
+
+  return {
+    simpleSwap: output.contracts["solidity/contracts/SimpleSwap.sol"].SimpleSwap,
+    mockToken: output.contracts["test/MockToken.sol"].MockToken,
+  };
+}
+
+async function deploy(compiled, signer, args = []) {
+  const factory = new ethers.ContractFactory(
+    compiled.abi,
+    `0x${compiled.evm.bytecode.object}`,
+    signer,
+  );
+  const contract = await factory.deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function expectRevert(action, message) {
+  await assert.rejects(
+    action,
+    (error) => [
+      error.shortMessage,
+      error.message,
+      error.info?.error?.data?.reason,
+      error.info?.error?.message,
+    ].some((value) => String(value ?? "").includes(message)),
+  );
+}
+
+function feeRoundedUp(amountIn, feeBps) {
+  if (feeBps === 0n) {
+    return 0n;
+  }
+  return (amountIn * feeBps + 9999n) / 10000n;
+}
+
+function expectedAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+  const afterFee = amountIn - feeRoundedUp(amountIn, feeBps);
+  return (reserveOut * afterFee) / (reserveIn + afterFee);
+}
+
+const compiled = compileContracts();
+const ganacheProvider = ganache.provider({
+  chain: { chainId: 31337 },
+  logging: { quiet: true },
+  wallet: { deterministic: true },
+});
+const provider = new ethers.BrowserProvider(ganacheProvider);
+const owner = await provider.getSigner(0);
+const trader = await provider.getSigner(1);
+const ownerAddress = await owner.getAddress();
+const traderAddress = await trader.getAddress();
+
+const tokenA = await deploy(compiled.mockToken, owner, ["Token A", "TKA"]);
+const tokenB = await deploy(compiled.mockToken, owner, ["Token B", "TKB"]);
+const swap = await deploy(compiled.simpleSwap, owner, [
+  await tokenA.getAddress(),
+  await tokenB.getAddress(),
+  30,
+]);
+
+const reserveA = ethers.parseEther("1000");
+const reserveB = ethers.parseEther("500");
+await (await tokenA.mint(ownerAddress, reserveA)).wait();
+await (await tokenB.mint(ownerAddress, reserveB)).wait();
+await (await tokenA.approve(await swap.getAddress(), reserveA)).wait();
+await (await tokenB.approve(await swap.getAddress(), reserveB)).wait();
+await (await swap.addLiquidity(reserveA, reserveB)).wait();
+
+const amountIn = ethers.parseEther("10");
+await (await tokenA.mint(traderAddress, amountIn * 2n)).wait();
+await (await tokenA.connect(trader).approve(await swap.getAddress(), amountIn * 2n)).wait();
+
+const quote = await swap.getAmountOut(await tokenA.getAddress(), amountIn);
+assert.equal(quote, expectedAmountOut(amountIn, reserveA, reserveB, 30n));
+
+const latestBlock = await provider.getBlock("latest");
+const liveDeadline = BigInt(latestBlock.timestamp + 120);
+
+await expectRevert(
+  async () => {
+    const tx = await swap.connect(trader).swap(await tokenA.getAddress(), amountIn, quote + 1n, liveDeadline);
+    await tx.wait();
+  },
+  "Slippage exceeded",
+);
+
+await expectRevert(
+  async () => {
+    const tx = await swap.connect(trader).swap(await tokenA.getAddress(), amountIn, 0, liveDeadline - 121n);
+    await tx.wait();
+  },
+  "Deadline expired",
+);
+
+await (await swap.connect(trader).swap(await tokenA.getAddress(), amountIn, quote, liveDeadline)).wait();
+assert.equal(await tokenB.balanceOf(traderAddress), quote);
+
+await expectRevert(
+  async () => swap.getAmountOut(await tokenA.getAddress(), 1n),
+  "Amount too small after fee",
+);
+
+assert.equal(feeRoundedUp(34n, 30n), 1n);
+
+console.log("SimpleSwap slippage, deadline, and fee precision tests passed");


### PR DESCRIPTION
/claim #913

## Summary
- Adds `minAmountOut` and `deadline` to `SimpleSwap.swap` so stale swaps and excessive slippage revert before token transfers.
- Shares quote logic between `swap` and `getAmountOut`, with liquidity and tiny-trade checks.
- Rounds basis-point fees up for nonzero fees so small swaps cannot bypass the fee through integer truncation.
- Checks ERC20 transfer return values and rejects invalid liquidity/token setup.
- Adds the required safe `_meta.json` next to the Solidity contract changes.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-913-demo.mp4

## Validation
- `SOLIDITY_TEST_NODE_MODULES=... node solidity/test/simpleSwap.test.mjs` -> SimpleSwap slippage, deadline, and fee precision tests passed
- `solc-js` compile of `solidity/contracts/SimpleSwap.sol` with OpenZeppelin imports -> passed
- JSON parse of `solidity/contracts/_meta.json` and `solidity/package.json` -> passed
- `git diff --check` -> passed

Note: local Ganache printed a µWS native-binary compatibility warning and fell back to its NodeJS implementation; the contract test still passed.

Security note: `_meta.json` intentionally includes only public task context and does not reproduce hidden system, developer, runtime, credential, memory, or private session instructions.