### PR TITLE
Codex [ Crypto ] Harden PriceOracle fallback validation

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initial_directives": "Redacted: contains private system/developer instructions. Public task context: harden PriceOracle staleness, fallback, round completeness, and price validation for UnsafeLabs/Bounty-Hunters issue #915.",
+  "date": "2026-05-29T00:00:00-06:00"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,21 +14,22 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed feed, uint256 updatedAt);
+    event FallbackFeedUpdated(address indexed fallbackFeed);
+    event MaxStalenessUpdated(uint256 maxStaleness);
 
     constructor(address _primaryFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
         (
             uint80 roundId,
             int256 price,
@@ -37,19 +38,66 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        _validateRound(roundId, price, updatedAt, answeredInRound);
 
-        return price;
+        if (!_isStale(updatedAt)) {
+            emit PriceQueried(price, updatedAt);
+            return price;
+        }
+
+        emit StalePrice(address(primaryFeed), updatedAt);
+        require(address(fallbackFeed) != address(0), "Fallback not set");
+
+        (
+            uint80 fallbackRoundId,
+            int256 fallbackPrice,
+            ,
+            uint256 fallbackUpdatedAt,
+            uint80 fallbackAnsweredInRound
+        ) = fallbackFeed.latestRoundData();
+
+        _validateRound(
+            fallbackRoundId,
+            fallbackPrice,
+            fallbackUpdatedAt,
+            fallbackAnsweredInRound
+        );
+        require(!_isStale(fallbackUpdatedAt), "Stale price");
+
+        emit PriceQueried(fallbackPrice, fallbackUpdatedAt);
+        return fallbackPrice;
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        emit FallbackFeedUpdated(_fallbackFeed);
+    }
+
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
+        require(_maxStaleness > 0, "Invalid staleness");
         MAX_STALENESS = _maxStaleness;
+        emit MaxStalenessUpdated(_maxStaleness);
+    }
+
+    function _validateRound(
+        uint80 roundId,
+        int256 price,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) internal view {
+        require(price > 0, "Invalid price");
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(updatedAt > 0 && updatedAt <= block.timestamp, "Invalid timestamp");
+    }
+
+    function _isStale(uint256 updatedAt) internal view returns (bool) {
+        return block.timestamp - updatedAt >= MAX_STALENESS;
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "unsafelabs-solidity-validation",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:price-oracle": "node test/priceOracle.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.0.0",
+    "ethers": "^6.0.0",
+    "ganache": "^7.0.0",
+    "solc": "^0.8.20"
+  }
+}

--- a/solidity/test/priceOracle.test.mjs
+++ b/solidity/test/priceOracle.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const externalModules = process.env.SOLIDITY_TEST_NODE_MODULES;
+const require = createRequire(
+  externalModules
+    ? path.join(externalModules, "package.json")
+    : import.meta.url
+);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const solidityDir = path.resolve(testDir, "..");
+
+const solc = require("solc");
+const ganache = require("ganache");
+const { ethers } = require("ethers");
+
+const priceOracleSource = fs.readFileSync(
+  path.join(solidityDir, "contracts", "PriceOracle.sol"),
+  "utf8"
+);
+
+const mockSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockAggregator {
+    uint8 public immutable decimals;
+    uint80 private roundId;
+    int256 private answer;
+    uint256 private startedAt;
+    uint256 private updatedAt;
+    uint80 private answeredInRound;
+
+    constructor(uint8 _decimals) {
+        decimals = _decimals;
+    }
+
+    function setRoundData(
+        uint80 _roundId,
+        int256 _answer,
+        uint256 _startedAt,
+        uint256 _updatedAt,
+        uint80 _answeredInRound
+    ) external {
+        roundId = _roundId;
+        answer = _answer;
+        startedAt = _startedAt;
+        updatedAt = _updatedAt;
+        answeredInRound = _answeredInRound;
+    }
+
+    function latestRoundData() external view returns (
+        uint80,
+        int256,
+        uint256,
+        uint256,
+        uint80
+    ) {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+}
+`;
+
+function compile() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "PriceOracle.sol": { content: priceOracleSource },
+      "MockAggregator.sol": { content: mockSource },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const errors = (output.errors ?? []).filter(
+    (error) => error.severity === "error"
+  );
+  assert.equal(errors.length, 0, errors.map((error) => error.formattedMessage).join("\n"));
+  return output.contracts;
+}
+
+async function deploy(factory, signer, ...args) {
+  const contract = await factory.connect(signer).deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function expectRejects(promise, expectedMessage) {
+  await assert.rejects(
+    promise,
+    (error) => String(error).includes(expectedMessage),
+    `Expected revert containing ${expectedMessage}`
+  );
+}
+
+async function run() {
+  const contracts = compile();
+  const provider = new ethers.BrowserProvider(
+    ganache.provider({ logging: { quiet: true } })
+  );
+  const [owner, attacker] = await Promise.all([
+    provider.getSigner(0),
+    provider.getSigner(1),
+  ]);
+
+  const oracleArtifact = contracts["PriceOracle.sol"].PriceOracle;
+  const mockArtifact = contracts["MockAggregator.sol"].MockAggregator;
+  const Oracle = new ethers.ContractFactory(
+    oracleArtifact.abi,
+    oracleArtifact.evm.bytecode.object,
+    owner
+  );
+  const Mock = new ethers.ContractFactory(
+    mockArtifact.abi,
+    mockArtifact.evm.bytecode.object,
+    owner
+  );
+
+  async function fixture() {
+    const primary = await deploy(Mock, owner, 8);
+    const fallback = await deploy(Mock, owner, 8);
+    const oracle = await deploy(Oracle, owner, await primary.getAddress());
+    await (await oracle.setFallbackFeed(await fallback.getAddress())).wait();
+    const now = BigInt((await provider.getBlock("latest")).timestamp);
+    return { primary, fallback, oracle, now };
+  }
+
+  {
+    const { primary, fallback, oracle, now } = await fixture();
+    await primary.setRoundData(10, 2000_00000000n, now, now, 10);
+    await fallback.setRoundData(11, 1900_00000000n, now, now, 11);
+    const price = await oracle.getLatestPrice.staticCall();
+    assert.equal(price, 2000_00000000n);
+  }
+
+  {
+    const { primary, fallback, oracle, now } = await fixture();
+    const staleTime = now - 7200n;
+    await primary.setRoundData(20, 1800_00000000n, staleTime, staleTime, 20);
+    await fallback.setRoundData(21, 1810_00000000n, now, now, 21);
+
+    const fallbackPrice = await oracle.getLatestPrice.staticCall();
+    assert.equal(fallbackPrice, 1810_00000000n);
+
+    const tx = await oracle.getLatestPrice();
+    const receipt = await tx.wait();
+    const staleEvent = receipt.logs
+      .map((log) => {
+        try {
+          return oracle.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .find((event) => event?.name === "StalePrice");
+
+    assert.ok(staleEvent, "StalePrice event was not emitted");
+    assert.equal(staleEvent.args.feed, await primary.getAddress());
+    assert.equal(staleEvent.args.updatedAt, staleTime);
+  }
+
+  {
+    const { primary, oracle, now } = await fixture();
+    await primary.setRoundData(30, 0, now, now, 30);
+    await expectRejects(oracle.getLatestPrice.staticCall(), "Invalid price");
+
+    await primary.setRoundData(31, -1, now, now, 31);
+    await expectRejects(oracle.getLatestPrice.staticCall(), "Invalid price");
+  }
+
+  {
+    const { primary, oracle, now } = await fixture();
+    await primary.setRoundData(40, 2000_00000000n, now, now, 39);
+    await expectRejects(oracle.getLatestPrice.staticCall(), "Incomplete round");
+  }
+
+  {
+    const { primary, fallback, oracle, now } = await fixture();
+    const staleTime = now - 7200n;
+    await primary.setRoundData(50, 2000_00000000n, staleTime, staleTime, 50);
+    await fallback.setRoundData(51, 1995_00000000n, staleTime, staleTime, 51);
+    await expectRejects(oracle.getLatestPrice.staticCall(), "Stale price");
+  }
+
+  {
+    const { primary, oracle, now } = await fixture();
+    await primary.setRoundData(60, 2000_00000000n, now - 120n, now - 120n, 60);
+    await (await oracle.setMaxStaleness(300)).wait();
+    assert.equal(await oracle.getLatestPrice.staticCall(), 2000_00000000n);
+    await expectRejects(
+      oracle.connect(attacker).setMaxStaleness.staticCall(300),
+      "Not owner"
+    );
+    await expectRejects(
+      oracle.setMaxStaleness.staticCall(0),
+      "Invalid staleness"
+    );
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
/claim #915

Summary:
- validate Chainlink round completeness, positive price, and sane timestamps before trusting oracle data
- treat stale primary prices as the only fallback path, emit StalePrice, and reject both-stale oracle data
- add owner-only fallback feed and max staleness controls plus focused Solidity/Ganache coverage

Demo video:
https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-915-demo.mp4

Validation:
- SOLIDITY_TEST_NODE_MODULES=../../tools/solidity-validation node solidity/test/priceOracle.test.mjs
- git diff --check
- JSON parse for solidity/contracts/.generation_meta.json and solidity/package.json