### PR TITLE
Codex [ Crypto ] Add EIP-712 bridge replay protection

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,53 +4,96 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    string public constant NAME = "CrossChainBridge";
+    string public constant VERSION = "1";
+
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "BridgeTransfer(address recipient,uint256 amount,uint256 nonce)"
+    );
+
     IERC20 public bridgeToken;
     address public validator;
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public nonces;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
 
     constructor(address _bridgeToken, address _validator) {
+        require(_bridgeToken != address(0), "Invalid token");
+        require(_validator != address(0), "Invalid validator");
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
-        bridgeToken.transferFrom(msg.sender, address(this), amount);
+        require(bridgeToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(recipient != address(0), "Invalid recipient");
+        require(amount > 0, "Amount must be > 0");
+        require(transferNonce == nonces[recipient], "Invalid nonce");
+
+        bytes32 transferHash = getTransferDigest(recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
-        bridgeToken.transfer(recipient, amount);
+        nonces[recipient] = transferNonce + 1;
+        require(bridgeToken.transfer(recipient, amount), "Transfer failed");
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    function domainSeparator() public view returns (bytes32) {
+        return keccak256(abi.encode(
+            DOMAIN_TYPEHASH,
+            keccak256(bytes(NAME)),
+            keccak256(bytes(VERSION)),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function getTransferStructHash(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce
+        ));
+    }
+
+    function getTransferDigest(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(
+            "\x19\x01",
+            domainSeparator(),
+            getTransferStructHash(recipient, amount, transferNonce)
+        ));
+    }
+
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -65,13 +108,11 @@ contract CrossChainBridge {
         }
 
         if (v < 27) v += 27;
+        require(v == 27 || v == 28, "Invalid signature");
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature");
         return recovered == validator;
     }
 

--- a/solidity/contracts/contributor_meta.json
+++ b/solidity/contracts/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex",
+  "session_init": "Redacted: contains private system/developer instructions. Public task context: implement EIP-712 replay protection for UnsafeLabs/Bounty-Hunters issue #920.",
+  "ts": "2026-05-29T00:00:00-06:00"
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "unsafelabs-solidity-validation",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:cross-chain-bridge": "node test/crossChainBridge.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.0.0",
+    "ethers": "^6.0.0",
+    "ganache": "^7.0.0",
+    "solc": "^0.8.20"
+  }
+}

--- a/solidity/test/crossChainBridge.test.mjs
+++ b/solidity/test/crossChainBridge.test.mjs
@@ -1,0 +1,280 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const externalModules = process.env.SOLIDITY_TEST_NODE_MODULES;
+const require = createRequire(
+  externalModules
+    ? path.join(externalModules, "package.json")
+    : import.meta.url
+);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const solidityDir = path.resolve(testDir, "..");
+const repoRoot = path.resolve(solidityDir, "..");
+const externalRoot = externalModules
+  ? path.join(externalModules, "node_modules")
+  : path.join(solidityDir, "node_modules");
+
+const solc = require("solc");
+const ganache = require("ganache");
+const { ethers } = require("ethers");
+
+const bridgeSource = fs.readFileSync(
+  path.join(solidityDir, "contracts", "CrossChainBridge.sol"),
+  "utf8"
+);
+
+const tokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Bridge Token", "BTK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+`;
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(repoRoot, importPath),
+    path.join(externalRoot, importPath),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+  return { error: `Import not found: ${importPath}` };
+}
+
+function compile() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "CrossChainBridge.sol": { content: bridgeSource },
+      "MockToken.sol": { content: tokenSource },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(
+    solc.compile(JSON.stringify(input), { import: findImport })
+  );
+  const errors = (output.errors ?? []).filter(
+    (error) => error.severity === "error"
+  );
+  assert.equal(errors.length, 0, errors.map((error) => error.formattedMessage).join("\n"));
+  return output.contracts;
+}
+
+async function deploy(factory, signer, ...args) {
+  const contract = await factory.connect(signer).deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function expectRejects(promise, expectedMessage) {
+  await assert.rejects(
+    promise,
+    (error) => String(error).includes(expectedMessage),
+    `Expected revert containing ${expectedMessage}`
+  );
+}
+
+function typedData(chainId, verifyingContract) {
+  return {
+    domain: {
+      name: "CrossChainBridge",
+      version: "1",
+      chainId,
+      verifyingContract,
+    },
+    types: {
+      BridgeTransfer: [
+        { name: "recipient", type: "address" },
+        { name: "amount", type: "uint256" },
+        { name: "nonce", type: "uint256" },
+      ],
+    },
+  };
+}
+
+async function setup(chainId = 31337) {
+  const contracts = compile();
+  const provider = new ethers.BrowserProvider(
+    ganache.provider({
+      chain: { chainId },
+      logging: { quiet: true },
+      wallet: { totalAccounts: 4 },
+    })
+  );
+  const [deployer, recipient] = await Promise.all([
+    provider.getSigner(0),
+    provider.getSigner(1),
+  ]);
+  const validator = ethers.Wallet.createRandom();
+
+  const tokenArtifact = contracts["MockToken.sol"].MockToken;
+  const bridgeArtifact = contracts["CrossChainBridge.sol"].CrossChainBridge;
+  const Token = new ethers.ContractFactory(
+    tokenArtifact.abi,
+    tokenArtifact.evm.bytecode.object,
+    deployer
+  );
+  const Bridge = new ethers.ContractFactory(
+    bridgeArtifact.abi,
+    bridgeArtifact.evm.bytecode.object,
+    deployer
+  );
+
+  const token = await deploy(Token, deployer);
+  const bridge = await deploy(
+    Bridge,
+    deployer,
+    await token.getAddress(),
+    validator.address
+  );
+  await (await token.mint(await bridge.getAddress(), ethers.parseEther("1000"))).wait();
+
+  return { provider, deployer, recipient, validator, token, bridge, Bridge };
+}
+
+async function signRelease(validator, bridge, recipient, amount, nonce) {
+  const network = await bridge.runner.provider.getNetwork();
+  const data = typedData(network.chainId, await bridge.getAddress());
+  return validator.signTypedData(data.domain, data.types, {
+    recipient,
+    amount,
+    nonce,
+  });
+}
+
+async function run() {
+  {
+    const { recipient, validator, token, bridge } = await setup();
+    const recipientAddress = await recipient.getAddress();
+    const amount = ethers.parseEther("12");
+    const nonce = await bridge.nonces(recipientAddress);
+    const signature = await signRelease(
+      validator,
+      bridge,
+      recipientAddress,
+      amount,
+      nonce
+    );
+
+    const digest = await bridge.getTransferDigest(recipientAddress, amount, nonce);
+    assert.equal(await bridge.verifySignature(digest, signature), true);
+
+    await (await bridge.processTransfer(recipientAddress, amount, nonce, signature)).wait();
+    assert.equal(await token.balanceOf(recipientAddress), amount);
+    assert.equal(await bridge.nonces(recipientAddress), nonce + 1n);
+
+    await expectRejects(
+      bridge.processTransfer.staticCall(recipientAddress, amount, nonce, signature),
+      "Invalid nonce"
+    );
+  }
+
+  {
+    const first = await setup(31337);
+    const second = await setup(31338);
+    const recipientAddress = await second.recipient.getAddress();
+    const amount = ethers.parseEther("3");
+    const signature = await signRelease(
+      first.validator,
+      first.bridge,
+      recipientAddress,
+      amount,
+      0
+    );
+
+    await expectRejects(
+      second.bridge.processTransfer.staticCall(
+        recipientAddress,
+        amount,
+        0,
+        signature
+      ),
+      "Invalid signature"
+    );
+  }
+
+  {
+    const { deployer, recipient, validator, token, bridge, Bridge } = await setup();
+    const replacement = await deploy(
+      Bridge,
+      deployer,
+      await token.getAddress(),
+      validator.address
+    );
+    await (await token.mint(await replacement.getAddress(), ethers.parseEther("1000"))).wait();
+
+    const recipientAddress = await recipient.getAddress();
+    const amount = ethers.parseEther("4");
+    const signature = await signRelease(
+      validator,
+      bridge,
+      recipientAddress,
+      amount,
+      0
+    );
+
+    await expectRejects(
+      replacement.processTransfer.staticCall(
+        recipientAddress,
+        amount,
+        0,
+        signature
+      ),
+      "Invalid signature"
+    );
+  }
+
+  {
+    const { recipient, bridge } = await setup();
+    const recipientAddress = await recipient.getAddress();
+    const amount = ethers.parseEther("1");
+    const badSignature = `0x${"00".repeat(65)}`;
+
+    await expectRejects(
+      bridge.processTransfer.staticCall(
+        recipientAddress,
+        amount,
+        0,
+        badSignature
+      ),
+      "Invalid signature"
+    );
+  }
+
+  {
+    const { provider, bridge } = await setup(42161);
+    const network = await provider.getNetwork();
+    const expected = ethers.TypedDataEncoder.hashDomain({
+      name: "CrossChainBridge",
+      version: "1",
+      chainId: network.chainId,
+      verifyingContract: await bridge.getAddress(),
+    });
+    assert.equal(await bridge.domainSeparator(), expected);
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
/claim #920

Summary:
- replace the ad hoc bridge release hash with an EIP-712 digest bound to name, version, chainId, and verifyingContract
- add queryable per-recipient nonces and require the exact next nonce before release processing
- reject zero-address ecrecover results and failed ERC20 transfers
- add focused Solidity/Ganache coverage for happy path, same-chain replay, cross-chain replay, replacement-contract replay, invalid signature, and domain separator behavior

Demo video:
https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-920-demo.mp4

Validation:
- SOLIDITY_TEST_NODE_MODULES=../../tools/solidity-validation node solidity/test/crossChainBridge.test.mjs
- git diff --check
- JSON parse for solidity/contracts/contributor_meta.json and solidity/package.json