### PR TITLE
Codex [ Crypto ] Harden LiquidityPool reserve accounting

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,12 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
+    uint256 public lockedLiquidity;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -23,12 +24,17 @@ contract LiquidityPool is ERC20 {
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(amountA > 0 && amountB > 0, "Invalid amounts");
+        require(tokenA.transferFrom(msg.sender, address(this), amountA), "Transfer A failed");
+        require(tokenB.transferFrom(msg.sender, address(this), amountB), "Transfer B failed");
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            uint256 initialLiquidity = sqrt(amountA * amountB);
+            require(initialLiquidity > MINIMUM_LIQUIDITY, "Insufficient initial liquidity");
+
+            lockedLiquidity = MINIMUM_LIQUIDITY;
+            lpTokens = initialLiquidity - MINIMUM_LIQUIDITY;
+            emit Transfer(address(0), address(0), MINIMUM_LIQUIDITY);
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -41,30 +47,46 @@ contract LiquidityPool is ERC20 {
         reserveA += amountA;
         reserveB += amountB;
 
+        emit Sync(reserveA, reserveB);
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
+        require(amountA > 0 && amountB > 0, "Insufficient output");
 
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
 
         reserveA -= amountA;
         reserveB -= amountB;
 
+        require(tokenA.transfer(msg.sender, amountA), "Transfer A failed");
+        require(tokenB.transfer(msg.sender, amountB), "Transfer B failed");
+
+        emit Sync(reserveA, reserveB);
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
+    }
+
+    function totalSupply() public view override returns (uint256) {
+        return super.totalSupply() + lockedLiquidity;
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        if (account == address(0)) {
+            return lockedLiquidity;
+        }
+
+        return super.balanceOf(account);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/contracts/_generation.json
+++ b/solidity/contracts/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "pre_task_context": "Redacted: contains private system/developer instructions. Public task context: implement minimum liquidity lock, reserve-based removals, and sync recovery for UnsafeLabs/Bounty-Hunters issue #918.",
+  "timestamp": "2026-05-29T00:00:00-06:00"
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "unsafelabs-solidity-validation",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:liquidity-pool": "node test/liquidityPool.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.0.0",
+    "ethers": "^6.0.0",
+    "ganache": "^7.0.0",
+    "solc": "^0.8.20"
+  }
+}

--- a/solidity/test/liquidityPool.test.mjs
+++ b/solidity/test/liquidityPool.test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const externalModules = process.env.SOLIDITY_TEST_NODE_MODULES;
+const require = createRequire(
+  externalModules
+    ? path.join(externalModules, "package.json")
+    : import.meta.url
+);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const solidityDir = path.resolve(testDir, "..");
+const repoRoot = path.resolve(solidityDir, "..");
+const externalRoot = externalModules
+  ? path.join(externalModules, "node_modules")
+  : path.join(solidityDir, "node_modules");
+
+const solc = require("solc");
+const ganache = require("ganache");
+const { ethers } = require("ethers");
+
+const poolSource = fs.readFileSync(
+  path.join(solidityDir, "contracts", "LiquidityPool.sol"),
+  "utf8"
+);
+
+const tokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+`;
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(repoRoot, importPath),
+    path.join(externalRoot, importPath),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+  return { error: `Import not found: ${importPath}` };
+}
+
+function compile() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "LiquidityPool.sol": { content: poolSource },
+      "MockToken.sol": { content: tokenSource },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(
+    solc.compile(JSON.stringify(input), { import: findImport })
+  );
+  const errors = (output.errors ?? []).filter(
+    (error) => error.severity === "error"
+  );
+  assert.equal(errors.length, 0, errors.map((error) => error.formattedMessage).join("\n"));
+  return output.contracts;
+}
+
+async function deploy(factory, signer, ...args) {
+  const contract = await factory.connect(signer).deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function expectRejects(promise, expectedMessage) {
+  await assert.rejects(
+    promise,
+    (error) => String(error).includes(expectedMessage),
+    `Expected revert containing ${expectedMessage}`
+  );
+}
+
+async function setup() {
+  const contracts = compile();
+  const provider = new ethers.BrowserProvider(
+    ganache.provider({ logging: { quiet: true } })
+  );
+  const [owner, providerAccount, donor] = await Promise.all([
+    provider.getSigner(0),
+    provider.getSigner(1),
+    provider.getSigner(2),
+  ]);
+
+  const tokenArtifact = contracts["MockToken.sol"].MockToken;
+  const poolArtifact = contracts["LiquidityPool.sol"].LiquidityPool;
+  const Token = new ethers.ContractFactory(
+    tokenArtifact.abi,
+    tokenArtifact.evm.bytecode.object,
+    owner
+  );
+  const Pool = new ethers.ContractFactory(
+    poolArtifact.abi,
+    poolArtifact.evm.bytecode.object,
+    owner
+  );
+
+  const tokenA = await deploy(Token, owner, "Token A", "A");
+  const tokenB = await deploy(Token, owner, "Token B", "B");
+  const pool = await deploy(Pool, owner, await tokenA.getAddress(), await tokenB.getAddress());
+  const amount = ethers.parseEther("100000");
+
+  for (const signer of [providerAccount, donor]) {
+    const address = await signer.getAddress();
+    await (await tokenA.mint(address, amount)).wait();
+    await (await tokenB.mint(address, amount)).wait();
+    await (await tokenA.connect(signer).approve(await pool.getAddress(), amount)).wait();
+    await (await tokenB.connect(signer).approve(await pool.getAddress(), amount)).wait();
+  }
+
+  return { providerAccount, donor, tokenA, tokenB, pool };
+}
+
+async function run() {
+  {
+    const { providerAccount, pool } = await setup();
+    await expectRejects(
+      pool.connect(providerAccount).addLiquidity.staticCall(1000, 1000),
+      "Insufficient initial liquidity"
+    );
+
+    const amount = ethers.parseEther("1000");
+    await (await pool.connect(providerAccount).addLiquidity(amount, amount)).wait();
+
+    assert.equal(await pool.balanceOf(ethers.ZeroAddress), 1000n);
+    assert.equal(await pool.lockedLiquidity(), 1000n);
+    assert.equal(await pool.totalSupply(), amount);
+    assert.equal(await pool.balanceOf(await providerAccount.getAddress()), amount - 1000n);
+  }
+
+  {
+    const { providerAccount, donor, tokenA, tokenB, pool } = await setup();
+    const poolAddress = await pool.getAddress();
+    const amount = ethers.parseEther("1000");
+    await (await pool.connect(providerAccount).addLiquidity(amount, amount)).wait();
+
+    const lpToBurn = (await pool.balanceOf(await providerAccount.getAddress())) / 2n;
+    const beforeDonation = await pool.connect(providerAccount).removeLiquidity.staticCall(lpToBurn);
+
+    await (await tokenA.connect(donor).transfer(poolAddress, ethers.parseEther("5000"))).wait();
+    assert.equal(await pool.reserveA(), amount);
+    assert.equal(await tokenA.balanceOf(poolAddress), ethers.parseEther("6000"));
+
+    const afterDonation = await pool.connect(providerAccount).removeLiquidity.staticCall(lpToBurn);
+    assert.equal(afterDonation[0], beforeDonation[0]);
+    assert.equal(afterDonation[1], beforeDonation[1]);
+
+    await (await pool.connect(providerAccount).removeLiquidity(lpToBurn)).wait();
+    assert.equal(await pool.reserveA(), amount - beforeDonation[0]);
+    assert.equal(await pool.reserveB(), amount - beforeDonation[1]);
+  }
+
+  {
+    const { providerAccount, donor, tokenA, tokenB, pool } = await setup();
+    const poolAddress = await pool.getAddress();
+    const amount = ethers.parseEther("1000");
+    await (await pool.connect(providerAccount).addLiquidity(amount, amount)).wait();
+
+    await (await tokenA.connect(donor).transfer(poolAddress, ethers.parseEther("250"))).wait();
+    await (await tokenB.connect(donor).transfer(poolAddress, ethers.parseEther("125"))).wait();
+    await (await pool.sync()).wait();
+
+    assert.equal(await pool.reserveA(), await tokenA.balanceOf(poolAddress));
+    assert.equal(await pool.reserveB(), await tokenB.balanceOf(poolAddress));
+  }
+
+  {
+    const { providerAccount, donor, pool } = await setup();
+    const amount = ethers.parseEther("1000");
+    await (await pool.connect(providerAccount).addLiquidity(amount, amount)).wait();
+    const supplyBefore = await pool.totalSupply();
+
+    await (await pool.connect(donor).addLiquidity(ethers.parseEther("100"), ethers.parseEther("100"))).wait();
+    assert.equal(await pool.totalSupply(), supplyBefore + ethers.parseEther("100"));
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
/claim #918

Summary:
- require a minimum initial liquidity and permanently account for the locked amount at address(0)
- mint the first provider only net liquidity after the lock
- calculate removals from internal reserves instead of token balances so direct donations do not skew LP withdrawals
- add sync() and Sync events for explicit reserve recovery
- add focused Solidity/Ganache tests for first-deposit lock, donation isolation, sync recovery, and proportional follow-up deposits

Demo video:
https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-918-demo.mp4

Validation:
- SOLIDITY_TEST_NODE_MODULES=../../tools/solidity-validation node solidity/test/liquidityPool.test.mjs
- git diff --check
- JSON parse for solidity/contracts/_generation.json and solidity/package.json