### PR TITLE
Codex [ Crypto ] Harden YieldVault reward accounting

### DIFF
--- a/solidity/contracts/YieldVault.sol
+++ b/solidity/contracts/YieldVault.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract YieldVault {
+    uint256 public constant PRECISION = 1e18;
+
     IERC20 public rewardToken;
     IERC20 public stakingToken;
 
@@ -22,29 +24,34 @@ contract YieldVault {
     event Deposited(address indexed user, uint256 amount);
     event Withdrawn(address indexed user, uint256 amount);
     event RewardPaid(address indexed user, uint256 reward);
+    event RewardAdded(uint256 reward, uint256 duration);
 
     constructor(address _stakingToken, address _rewardToken) {
+        require(_stakingToken != address(0), "Invalid staking token");
+        require(_rewardToken != address(0), "Invalid reward token");
         stakingToken = IERC20(_stakingToken);
         rewardToken = IERC20(_rewardToken);
         rewardDistributor = msg.sender;
     }
 
-    // BUG: Does not cap at periodFinish — accrues phantom rewards after period ends
+    function lastTimeRewardApplicable() public view returns (uint256) {
+        return block.timestamp < periodFinish ? block.timestamp : periodFinish;
+    }
+
     function rewardPerToken() public view returns (uint256) {
         if (totalSupply == 0) return rewardPerTokenStored;
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / totalSupply
+            (lastTimeRewardApplicable() - lastUpdateTime) * rewardRate / totalSupply
         );
     }
 
-    // BUG: Uses uncapped rewardPerToken
     function earned(address account) public view returns (uint256) {
-        return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / 1e18 + rewards[account];
+        return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / PRECISION + rewards[account];
     }
 
     modifier updateReward(address account) {
         rewardPerTokenStored = rewardPerToken();
-        lastUpdateTime = block.timestamp;
+        lastUpdateTime = lastTimeRewardApplicable();
         if (account != address(0)) {
             rewards[account] = earned(account);
             userRewardPerTokenPaid[account] = rewardPerTokenStored;
@@ -56,7 +63,7 @@ contract YieldVault {
         require(amount > 0, "Cannot deposit 0");
         totalSupply += amount;
         balanceOf[msg.sender] += amount;
-        stakingToken.transferFrom(msg.sender, address(this), amount);
+        require(stakingToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
         emit Deposited(msg.sender, amount);
     }
 
@@ -64,7 +71,7 @@ contract YieldVault {
         require(amount > 0, "Cannot withdraw 0");
         totalSupply -= amount;
         balanceOf[msg.sender] -= amount;
-        stakingToken.transfer(msg.sender, amount);
+        require(stakingToken.transfer(msg.sender, amount), "Transfer failed");
         emit Withdrawn(msg.sender, amount);
     }
 
@@ -72,16 +79,19 @@ contract YieldVault {
         uint256 reward = rewards[msg.sender];
         if (reward > 0) {
             rewards[msg.sender] = 0;
-            rewardToken.transfer(msg.sender, reward);
+            require(rewardToken.transfer(msg.sender, reward), "Transfer failed");
             emit RewardPaid(msg.sender, reward);
         }
     }
 
-    // BUG: No access control — anyone can call
-    // BUG: Precision loss in rewardRate calculation
     function notifyRewardAmount(uint256 reward, uint256 duration) external updateReward(address(0)) {
-        rewardRate = reward / duration;
+        require(msg.sender == rewardDistributor, "Not distributor");
+        require(reward > 0, "Invalid reward");
+        require(duration > 0, "Invalid duration");
+
+        rewardRate = reward * PRECISION / duration;
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + duration;
+        emit RewardAdded(reward, duration);
     }
 }

--- a/solidity/contracts/_contributor.json
+++ b/solidity/contracts/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex",
+  "runtime_instructions": "Redacted: contains private system/developer instructions. Public task context: fix YieldVault phantom rewards, distributor access control, and reward precision for UnsafeLabs/Bounty-Hunters issue #914.",
+  "timestamp": "2026-05-29T00:00:00-06:00"
+}

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "unsafelabs-solidity-validation",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:yield-vault": "node test/yieldVault.test.mjs"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^5.0.0",
+    "ethers": "^6.0.0",
+    "ganache": "^7.0.0",
+    "solc": "^0.8.20"
+  }
+}

--- a/solidity/test/yieldVault.test.mjs
+++ b/solidity/test/yieldVault.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const externalModules = process.env.SOLIDITY_TEST_NODE_MODULES;
+const require = createRequire(
+  externalModules
+    ? path.join(externalModules, "package.json")
+    : import.meta.url
+);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const solidityDir = path.resolve(testDir, "..");
+const repoRoot = path.resolve(solidityDir, "..");
+const externalRoot = externalModules
+  ? path.join(externalModules, "node_modules")
+  : path.join(solidityDir, "node_modules");
+
+const solc = require("solc");
+const ganache = require("ganache");
+const { ethers } = require("ethers");
+
+const vaultSource = fs.readFileSync(
+  path.join(solidityDir, "contracts", "YieldVault.sol"),
+  "utf8"
+);
+
+const tokenSource = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+`;
+
+function findImport(importPath) {
+  const candidates = [
+    path.join(repoRoot, importPath),
+    path.join(externalRoot, importPath),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { contents: fs.readFileSync(candidate, "utf8") };
+    }
+  }
+  return { error: `Import not found: ${importPath}` };
+}
+
+function compile() {
+  const input = {
+    language: "Solidity",
+    sources: {
+      "YieldVault.sol": { content: vaultSource },
+      "MockToken.sol": { content: tokenSource },
+    },
+    settings: {
+      evmVersion: "paris",
+      outputSelection: {
+        "*": {
+          "*": ["abi", "evm.bytecode.object"],
+        },
+      },
+    },
+  };
+
+  const output = JSON.parse(
+    solc.compile(JSON.stringify(input), { import: findImport })
+  );
+  const errors = (output.errors ?? []).filter(
+    (error) => error.severity === "error"
+  );
+  assert.equal(errors.length, 0, errors.map((error) => error.formattedMessage).join("\n"));
+  return output.contracts;
+}
+
+async function deploy(factory, signer, ...args) {
+  const contract = await factory.connect(signer).deploy(...args);
+  await contract.waitForDeployment();
+  return contract;
+}
+
+async function expectRejects(promise, expectedMessage) {
+  await assert.rejects(
+    promise,
+    (error) => String(error).includes(expectedMessage),
+    `Expected revert containing ${expectedMessage}`
+  );
+}
+
+async function increase(provider, seconds) {
+  await provider.send("evm_increaseTime", [seconds]);
+  await provider.send("evm_mine", []);
+}
+
+async function setup() {
+  const contracts = compile();
+  const provider = new ethers.BrowserProvider(
+    ganache.provider({ logging: { quiet: true } })
+  );
+  const [owner, alice, bob] = await Promise.all([
+    provider.getSigner(0),
+    provider.getSigner(1),
+    provider.getSigner(2),
+  ]);
+
+  const tokenArtifact = contracts["MockToken.sol"].MockToken;
+  const vaultArtifact = contracts["YieldVault.sol"].YieldVault;
+  const Token = new ethers.ContractFactory(
+    tokenArtifact.abi,
+    tokenArtifact.evm.bytecode.object,
+    owner
+  );
+  const Vault = new ethers.ContractFactory(
+    vaultArtifact.abi,
+    vaultArtifact.evm.bytecode.object,
+    owner
+  );
+
+  const staking = await deploy(Token, owner, "Stake Token", "STK");
+  const reward = await deploy(Token, owner, "Reward Token", "RWD");
+  const vault = await deploy(Vault, owner, await staking.getAddress(), await reward.getAddress());
+
+  const stakeAmount = ethers.parseEther("10000");
+  const rewardAmount = ethers.parseEther("10000");
+  for (const signer of [alice, bob]) {
+    const address = await signer.getAddress();
+    await (await staking.mint(address, stakeAmount)).wait();
+    await (await staking.connect(signer).approve(await vault.getAddress(), stakeAmount)).wait();
+  }
+  await (await reward.mint(await vault.getAddress(), rewardAmount)).wait();
+
+  return { provider, owner, alice, bob, staking, reward, vault };
+}
+
+async function run() {
+  {
+    const { provider, owner, alice, vault } = await setup();
+    await (await vault.connect(alice).deposit(ethers.parseEther("100"))).wait();
+    await (await vault.connect(owner).notifyRewardAmount(ethers.parseEther("1000"), 1000)).wait();
+    await increase(provider, 100);
+
+    const earned = await vault.earned(await alice.getAddress());
+    assert.ok(
+      earned >= ethers.parseEther("99") && earned <= ethers.parseEther("103"),
+      `unexpected active accrual: ${earned}`
+    );
+  }
+
+  {
+    const { provider, owner, alice, bob, vault } = await setup();
+    await (await vault.connect(alice).deposit(ethers.parseEther("100"))).wait();
+    await (await vault.connect(owner).notifyRewardAmount(ethers.parseEther("1000"), 1000)).wait();
+    await increase(provider, 1500);
+
+    const earnedAtEnd = await vault.earned(await alice.getAddress());
+    const rptAtEnd = await vault.rewardPerToken();
+    await increase(provider, 500);
+    assert.equal(await vault.earned(await alice.getAddress()), earnedAtEnd);
+    assert.equal(await vault.rewardPerToken(), rptAtEnd);
+
+    await (await vault.connect(bob).deposit(ethers.parseEther("10"))).wait();
+    await increase(provider, 100);
+    assert.equal(await vault.earned(await bob.getAddress()), 0n);
+  }
+
+  {
+    const { owner, alice, vault } = await setup();
+    await expectRejects(
+      vault.connect(alice).notifyRewardAmount.staticCall(ethers.parseEther("1000"), 1000),
+      "Not distributor"
+    );
+    await expectRejects(
+      vault.connect(owner).notifyRewardAmount.staticCall(0, 1000),
+      "Invalid reward"
+    );
+    await expectRejects(
+      vault.connect(owner).notifyRewardAmount.staticCall(ethers.parseEther("1000"), 0),
+      "Invalid duration"
+    );
+  }
+
+  {
+    const { provider, owner, alice, vault } = await setup();
+    const reward = ethers.parseEther("1000");
+    const duration = 333n;
+    await (await vault.connect(alice).deposit(ethers.parseEther("1"))).wait();
+    await (await vault.connect(owner).notifyRewardAmount(reward, duration)).wait();
+    await increase(provider, Number(duration));
+
+    const earned = await vault.earned(await alice.getAddress());
+    const error = earned > reward ? earned - reward : reward - earned;
+    assert.ok(error * 10000n <= reward, `precision error too high: ${earned}`);
+  }
+
+  {
+    const { provider, owner, alice, reward, vault } = await setup();
+    const stake = ethers.parseEther("250");
+    await (await vault.connect(alice).deposit(stake)).wait();
+    await (await vault.connect(owner).notifyRewardAmount(ethers.parseEther("500"), 500)).wait();
+    await increase(provider, 250);
+
+    const beforeReward = await reward.balanceOf(await alice.getAddress());
+    await (await vault.connect(alice).claimReward()).wait();
+    assert.ok(await reward.balanceOf(await alice.getAddress()) > beforeReward);
+  }
+
+  {
+    const { alice, staking, vault } = await setup();
+    const stake = ethers.parseEther("250");
+    await (await vault.connect(alice).deposit(stake)).wait();
+    const beforeStake = await staking.balanceOf(await alice.getAddress());
+    assert.equal(await vault.balanceOf(await alice.getAddress()), stake);
+    assert.equal(await staking.balanceOf(await vault.getAddress()), stake);
+    await (await vault.connect(alice).withdraw(stake)).wait();
+    assert.equal(await staking.balanceOf(await alice.getAddress()), beforeStake + stake);
+    assert.equal(await vault.balanceOf(await alice.getAddress()), 0n);
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
/claim #914

Summary:
- add lastTimeRewardApplicable() and cap reward accrual at periodFinish
- make rewardPerToken() and earned() use the capped reward-per-token path
- restrict notifyRewardAmount() to the configured rewardDistributor
- use fixed-point reward-rate precision to reduce duration division loss
- keep deposit, withdrawal, and reward claim flows working with checked token transfers
- add focused Solidity/Ganache tests for active accrual, post-expiry freeze, unauthorized notify, precision, claim, and withdraw behavior

Demo video:
https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-914-demo.mp4

Validation:
- SOLIDITY_TEST_NODE_MODULES=../../tools/solidity-validation node solidity/test/yieldVault.test.mjs
- git diff --check
- JSON parse for solidity/contracts/_contributor.json and solidity/package.json