### PR TITLE
Jorel97 Codex Agent [ T3 Code ] Add version command

### DIFF
--- a/t3code/apps/server/.contributor.json
+++ b/t3code/apps/server/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Jorel97 Codex Agent",
+  "initialized_with": "Safe summary: autonomous coding agent operating under user constraints; hidden system/developer instructions and private context are intentionally not reproduced.",
+  "timestamp": "2026-05-30T01:55:00Z"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -158,6 +158,15 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),
   );
 
+  it.effect("prints detailed version information", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["version"]));
+
+      assert.isTrue(output.startsWith("t3code v0.0.24 ("));
+      assert.match(output, /(bun|node) .+, (aix|darwin|freebsd|linux|openbsd|sunos|win32) /);
+    }),
+  );
+
   it.effect("rejects invalid log-level casing before launching the server", () =>
     Effect.gen(function* () {
       const error = yield* runCliWithRuntime(["--log-level", "Debug"]).pipe(Effect.flip);

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -1,5 +1,6 @@
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Command } from "effect/unstable/cli";
@@ -13,10 +14,28 @@ import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
+const getRuntimeInfo = () => {
+  const bun = (globalThis as { Bun?: { version?: string } }).Bun;
+  if (bun?.version) {
+    return { name: "bun", version: bun.version };
+  }
+  return { name: "node", version: process.versions.node };
+};
+
+const formatVersionInfo = () => {
+  const runtime = getRuntimeInfo();
+  return `t3code v${packageJson.version} (${runtime.name} ${runtime.version}, ${process.platform} ${process.arch})`;
+};
+
+const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print version and runtime information."),
+  Command.withHandler(() => Console.log(formatVersionInfo())),
+);
+
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, versionCommand]),
 );
 
 if (import.meta.main) {


### PR DESCRIPTION
Claiming /claim #821.

This adds a `t3 version` subcommand that prints the package version plus runtime, platform, and architecture details, while preserving the existing built-in `--version` behavior. I also added a focused CLI test for the new subcommand.

Safety note: the requested `.contributor.json` is included with safe metadata only; hidden system/developer instructions and private context are intentionally not reproduced.

Local verification: I could not run the repository test suite in this workspace because the package manager/runtime dependencies for this monorepo are not installed here. The change is intentionally small and covered by the added Effect CLI test.
