### PR TITLE
Manmohan Codex [ T3 Code ] Add runtime provider config validation

### DIFF
--- a/t3code/packages/contracts/src/.attribution.json
+++ b/t3code/packages/contracts/src/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Safe public provenance only. Private system, developer, runtime, and user instructions are intentionally not copied into repository files.",
+  "date": "2026-05-30T04:55:00Z"
+}

--- a/t3code/packages/contracts/src/index.ts
+++ b/t3code/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@ export * from "./ipc.ts";
 export * from "./terminal.ts";
 export * from "./provider.ts";
 export * from "./providerInstance.ts";
+export * from "./providerConfigValidation.ts";
 export * from "./providerRuntime.ts";
 export * from "./model.ts";
 export * from "./keybindings.ts";

--- a/t3code/packages/contracts/src/providerConfigValidation.test.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.test.ts
@@ -1,0 +1,111 @@
+import * as Result from "effect/Result";
+import { describe, expect, it } from "vitest";
+
+import { ProviderConfigError, validateProviderConfig } from "./providerConfigValidation.ts";
+
+describe("validateProviderConfig", () => {
+  it("accepts a valid provider config with API keys and HTTPS endpoints", () => {
+    const result = validateProviderConfig({
+      driver: "codex",
+      environment: [
+        { name: "OPENAI_API_KEY", value: "sk-valid123456", sensitive: true },
+        { name: "OPENAI_BASE_URL", value: "https://api.openai.com", sensitive: false },
+      ],
+      config: {
+        apiKey: "provider-key-123",
+        endpoint: "https://provider.example.com/v1",
+      },
+    });
+
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.success.driver).toBe("codex");
+    }
+  });
+
+  it("rejects empty and short API key values", () => {
+    const errors = expectValidationFailure(
+      validateProviderConfig({
+        driver: "codex",
+        environment: [{ name: "OPENAI_API_KEY", value: "", sensitive: true }],
+        config: { apiKey: "short" },
+      }),
+    );
+
+    expect(errors).toHaveLength(2);
+    expect(errors.map((error) => error.fieldName)).toEqual([
+      "environment.OPENAI_API_KEY",
+      "config.apiKey",
+    ]);
+    expect(errors.every((error) => error.expectedFormat.includes("at least 10"))).toBe(true);
+  });
+
+  it("rejects HTTP endpoint URLs with an HTTPS-specific error", () => {
+    const errors = expectValidationFailure(
+      validateProviderConfig({
+        driver: "codex",
+        environment: [
+          { name: "OPENAI_BASE_URL", value: "http://api.openai.com", sensitive: false },
+        ],
+      }),
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.fieldName).toBe("environment.OPENAI_BASE_URL");
+    expect(errors[0]?.detail).toContain("Use HTTPS");
+  });
+
+  it("rejects malformed endpoint URLs", () => {
+    const errors = expectValidationFailure(
+      validateProviderConfig({
+        driver: "codex",
+        config: { endpoint: "not a url" },
+      }),
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.fieldName).toBe("config.endpoint");
+    expect(errors[0]?.expectedFormat).toBe("valid HTTPS URL with a hostname");
+  });
+
+  it("returns all validation errors at once", () => {
+    const errors = expectValidationFailure(
+      validateProviderConfig({
+        driver: "codex",
+        environment: [
+          { name: "OPENAI_API_KEY", value: "short", sensitive: true },
+          { name: "OPENAI_BASE_URL", value: "http://api.openai.com", sensitive: false },
+        ],
+        config: {
+          endpoint: "not a url",
+          nested: { refreshToken: "" },
+        },
+      }),
+    );
+
+    expect(errors.map((error) => error.fieldName)).toEqual([
+      "environment.OPENAI_API_KEY",
+      "environment.OPENAI_BASE_URL",
+      "config.endpoint",
+      "config.nested.refreshToken",
+    ]);
+  });
+
+  it("maps schema decode failures to ProviderConfigError", () => {
+    const errors = expectValidationFailure(validateProviderConfig({ driver: "1bad" }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.fieldName).toBe("ProviderInstanceConfig");
+    expect(errors[0]?.expectedFormat).toBe("ProviderInstanceConfig envelope");
+  });
+});
+
+function expectValidationFailure(
+  result: ReturnType<typeof validateProviderConfig>,
+): ReadonlyArray<ProviderConfigError> {
+  if (Result.isFailure(result)) {
+    return result.failure;
+  }
+
+  throw new Error("Expected provider config validation to fail");
+}

--- a/t3code/packages/contracts/src/providerConfigValidation.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.ts
@@ -1,0 +1,218 @@
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+
+import { ProviderInstanceConfig } from "./providerInstance.ts";
+
+const API_KEY_EXPECTED_FORMAT = "non-empty API key string with at least 10 characters";
+const HTTPS_URL_EXPECTED_FORMAT = "valid HTTPS URL with a hostname";
+
+const decodeProviderInstanceConfig = Schema.decodeUnknownResult(ProviderInstanceConfig);
+
+export class ProviderConfigError extends Schema.TaggedErrorClass<ProviderConfigError>()(
+  "ProviderConfigError",
+  {
+    fieldName: Schema.String,
+    invalidValue: Schema.Unknown,
+    expectedFormat: Schema.String,
+    detail: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Invalid provider config field ${this.fieldName}: expected ${this.expectedFormat}`;
+  }
+}
+
+export function validateProviderConfig(
+  input: unknown,
+): Result.Result<ProviderInstanceConfig, ReadonlyArray<ProviderConfigError>> {
+  const decoded = decodeProviderInstanceConfig(input);
+  if (Result.isFailure(decoded)) {
+    return Result.fail([
+      new ProviderConfigError({
+        fieldName: "ProviderInstanceConfig",
+        invalidValue: input,
+        expectedFormat: "ProviderInstanceConfig envelope",
+        detail: String(decoded.failure),
+      }),
+    ]);
+  }
+
+  const errors: Array<ProviderConfigError> = [];
+  collectEnvironmentErrors(decoded.success.environment, errors);
+  collectConfigPayloadErrors(decoded.success.config, "config", errors, new WeakSet<object>());
+
+  return errors.length === 0 ? Result.succeed(decoded.success) : Result.fail(errors);
+}
+
+function collectEnvironmentErrors(
+  environment: ProviderInstanceConfig["environment"],
+  errors: Array<ProviderConfigError>,
+): void {
+  for (const variable of environment ?? []) {
+    if (variable.valueRedacted === true && variable.value === "") {
+      continue;
+    }
+
+    collectCandidateFieldErrors(
+      variable.name,
+      `environment.${variable.name}`,
+      variable.value,
+      errors,
+    );
+  }
+}
+
+function collectConfigPayloadErrors(
+  value: unknown,
+  path: string,
+  errors: Array<ProviderConfigError>,
+  seen: WeakSet<object>,
+): void {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return;
+    seen.add(value);
+
+    value.forEach((item, index) => {
+      collectConfigPayloadErrors(item, `${path}[${index}]`, errors, seen);
+    });
+    return;
+  }
+
+  if (!isRecord(value)) return;
+  if (seen.has(value)) return;
+  seen.add(value);
+
+  for (const [fieldName, fieldValue] of Object.entries(value)) {
+    const fieldPath = `${path}.${fieldName}`;
+    collectCandidateFieldErrors(fieldName, fieldPath, fieldValue, errors);
+    collectConfigPayloadErrors(fieldValue, fieldPath, errors, seen);
+  }
+}
+
+function collectCandidateFieldErrors(
+  fieldName: string,
+  fieldPath: string,
+  value: unknown,
+  errors: Array<ProviderConfigError>,
+): void {
+  if (isApiKeyField(fieldName)) {
+    validateApiKey(fieldPath, value, errors);
+    return;
+  }
+
+  if (isEndpointUrlField(fieldName)) {
+    validateHttpsUrl(fieldPath, value, errors);
+  }
+}
+
+function validateApiKey(
+  fieldName: string,
+  value: unknown,
+  errors: Array<ProviderConfigError>,
+): void {
+  if (typeof value !== "string") {
+    errors.push(
+      new ProviderConfigError({
+        fieldName,
+        invalidValue: value,
+        expectedFormat: API_KEY_EXPECTED_FORMAT,
+        detail: "API key fields must be strings.",
+      }),
+    );
+    return;
+  }
+
+  if (value.trim().length < 10) {
+    errors.push(
+      new ProviderConfigError({
+        fieldName,
+        invalidValue: value,
+        expectedFormat: API_KEY_EXPECTED_FORMAT,
+        detail: "API key fields cannot be empty or shorter than 10 characters.",
+      }),
+    );
+  }
+}
+
+function validateHttpsUrl(
+  fieldName: string,
+  value: unknown,
+  errors: Array<ProviderConfigError>,
+): void {
+  if (typeof value !== "string") {
+    errors.push(
+      new ProviderConfigError({
+        fieldName,
+        invalidValue: value,
+        expectedFormat: HTTPS_URL_EXPECTED_FORMAT,
+        detail: "Endpoint URL fields must be strings.",
+      }),
+    );
+    return;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(value);
+  } catch {
+    errors.push(
+      new ProviderConfigError({
+        fieldName,
+        invalidValue: value,
+        expectedFormat: HTTPS_URL_EXPECTED_FORMAT,
+        detail: "Endpoint URL fields must contain a parseable absolute URL.",
+      }),
+    );
+    return;
+  }
+
+  if (parsedUrl.protocol === "http:") {
+    errors.push(
+      new ProviderConfigError({
+        fieldName,
+        invalidValue: value,
+        expectedFormat: `${HTTPS_URL_EXPECTED_FORMAT}; use https:// instead of http://`,
+        detail: "HTTP endpoint URLs are not allowed. Use HTTPS.",
+      }),
+    );
+    return;
+  }
+
+  if (parsedUrl.protocol !== "https:" || parsedUrl.hostname.trim() === "") {
+    errors.push(
+      new ProviderConfigError({
+        fieldName,
+        invalidValue: value,
+        expectedFormat: HTTPS_URL_EXPECTED_FORMAT,
+        detail: "Endpoint URL fields must use https:// and include a hostname.",
+      }),
+    );
+  }
+}
+
+function isApiKeyField(fieldName: string): boolean {
+  const normalized = normalizeFieldName(fieldName);
+  return (
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("accesstoken") ||
+    normalized.endsWith("authtoken") ||
+    normalized.endsWith("bearertoken") ||
+    normalized.endsWith("refreshtoken") ||
+    normalized.endsWith("secret")
+  );
+}
+
+function isEndpointUrlField(fieldName: string): boolean {
+  const normalized = normalizeFieldName(fieldName);
+  return (
+    normalized.endsWith("endpoint") || normalized.endsWith("baseurl") || normalized.endsWith("url")
+  );
+}
+
+function normalizeFieldName(fieldName: string): string {
+  return fieldName.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- Adds `validateProviderConfig()` in `@t3tools/contracts` for ProviderInstanceConfig envelope validation.
- Adds typed `ProviderConfigError` failures with field name, invalid value, expected format, and detail.
- Validates API-key-like fields and endpoint/url-like fields across environment variables and opaque config payloads without making the generic config envelope lossy.
- Aggregates all validation errors instead of stopping at the first failure, and maps schema decode failures into ProviderConfigError.

/claim #825

## Demo
- Demo video: https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/download/bounty-825-provider-config-validation-demo/bounty-825-provider-config-validation-demo.mp4

## Verification
- `npx -y bun@1.3.11 run --cwd packages/contracts test src/providerConfigValidation.test.ts` - 6 passed
- `npx -y bun@1.3.11 run --cwd packages/contracts test` - 10 files, 148 tests passed
- `npx -y bun@1.3.11 run --cwd packages/contracts typecheck` - passed
- `npx -y bun@1.3.11 run typecheck` - 13 packages successful
- `npx -y bun@1.3.11 run fmt:check` - passed
- `npx -y bun@1.3.11 run lint` - 0 errors; existing unrelated warnings remain in web/test files outside this patch
- `git diff --check` - passed

## Security / provenance
- Adds safe public attribution metadata only.
- Private system, developer, runtime, and user instructions are intentionally not copied into repository files or PR text.