### PR TITLE
Manmohan Codex [ FastAPI ] Add FastAPITestClient auth helpers

### DIFF
--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Safe public audit metadata only. Private system, developer, runtime, and user instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-30T05:07:00Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,36 @@
+import base64
+from typing import Any
+
 from starlette.testclient import TestClient as TestClient  # noqa
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> "FastAPITestClient":
+        self.headers["Authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(self, username: str, password: str) -> "FastAPITestClient":
+        credentials = base64.b64encode(f"{username}:{password}".encode()).decode(
+            "ascii"
+        )
+        self.headers["Authorization"] = f"Basic {credentials}"
+        return self
+
+    def reset_auth(self) -> "FastAPITestClient":
+        if "Authorization" in self.headers:
+            del self.headers["Authorization"]
+        return self
+
+    def ws_connect(self, url: str, **kwargs: Any) -> Any:
+        return self.websocket_connect(url, **kwargs)
+
+    def assert_status(
+        self, method: str, url: str, status_code: int, **kwargs: Any
+    ) -> Any:
+        response = self.request(method, url, **kwargs)
+        if response.status_code != status_code:
+            raise AssertionError(
+                f"Expected {method.upper()} {url} to return {status_code}, "
+                f"got {response.status_code}: {response.text}"
+            )
+        return response

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,107 @@
+import base64
+
+import pytest
+from fastapi import FastAPI, Header, Response, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+
+app = FastAPI()
+
+
+@app.get("/authorization")
+def read_authorization(
+    authorization: str | None = Header(default=None),
+) -> dict[str, str | None]:
+    return {"authorization": authorization}
+
+
+@app.get("/status/{status_code}")
+def read_status(status_code: int, response: Response) -> dict[str, int]:
+    response.status_code = status_code
+    return {"status_code": status_code}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    subprotocol = websocket.headers.get("sec-websocket-protocol")
+    selected_subprotocol = subprotocol.split(",")[0].strip() if subprotocol else None
+    await websocket.accept(subprotocol=selected_subprotocol)
+    await websocket.send_json(
+        {
+            "x-client": websocket.headers.get("x-client"),
+            "subprotocol": selected_subprotocol,
+        }
+    )
+    await websocket.close()
+
+
+def test_existing_testclient_export_is_unchanged() -> None:
+    client = TestClient(app)
+
+    response = client.get("/authorization")
+
+    assert response.json() == {"authorization": None}
+
+
+def test_authenticate_sets_bearer_token_for_following_requests() -> None:
+    client = FastAPITestClient(app)
+
+    client.authenticate("token-123")
+    response = client.get("/authorization")
+
+    assert response.json() == {"authorization": "Bearer token-123"}
+
+
+def test_authenticate_replaces_previous_token() -> None:
+    client = FastAPITestClient(app)
+
+    client.authenticate("old-token")
+    client.authenticate("new-token")
+    response = client.get("/authorization")
+
+    assert response.json() == {"authorization": "Bearer new-token"}
+
+
+def test_authenticate_basic_sets_encoded_credentials() -> None:
+    client = FastAPITestClient(app)
+
+    client.authenticate_basic("user", "pass")
+    response = client.get("/authorization")
+
+    expected = base64.b64encode(b"user:pass").decode("ascii")
+    assert response.json() == {"authorization": f"Basic {expected}"}
+
+
+def test_reset_auth_clears_authentication_state() -> None:
+    client = FastAPITestClient(app)
+
+    client.authenticate("token-123")
+    client.reset_auth()
+    response = client.get("/authorization")
+
+    assert response.json() == {"authorization": None}
+
+
+def test_ws_connect_accepts_custom_headers_and_subprotocols() -> None:
+    client = FastAPITestClient(app)
+
+    with client.ws_connect(
+        "/ws", headers={"x-client": "test"}, subprotocols=["chat"]
+    ) as session:
+        assert session.receive_json() == {"x-client": "test", "subprotocol": "chat"}
+
+
+def test_assert_status_returns_response_for_expected_status() -> None:
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("GET", "/status/201", 201)
+
+    assert response.status_code == 201
+
+
+def test_assert_status_raises_helpful_assertion_for_unexpected_status() -> None:
+    client = FastAPITestClient(app)
+
+    with pytest.raises(
+        AssertionError, match="Expected GET /status/404 to return 200, got 404"
+    ):
+        client.assert_status("GET", "/status/404", 200)


### PR DESCRIPTION
## Summary
- Adds an opt-in `FastAPITestClient` subclass while preserving the existing `TestClient` re-export and behavior.
- Adds `authenticate()` for Bearer auth, `authenticate_basic()` for HTTP Basic auth, and `reset_auth()`.
- Adds `ws_connect()` convenience wrapping Starlette WebSocket connections with custom headers/subprotocols.
- Adds `assert_status()` for one-call request/status assertions with useful failure output.

/claim #804

## Demo
- Demo video: https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/download/bounty-804-fastapi-testclient-demo/bounty-804-fastapi-testclient-demo.mp4

## Verification
- `uv run pytest tests/test_fastapi_testclient.py -q` - 8 passed
- `uv run ruff check fastapi/testclient.py tests/test_fastapi_testclient.py` - passed
- `uv run ruff format --check fastapi/testclient.py tests/test_fastapi_testclient.py` - passed
- `git diff --check` - passed

## Security / provenance
- Auth helpers only set local test-client headers; they do not log or persist token/password values.
- Adds safe public audit metadata only.
- Private system, developer, runtime, and user instructions are intentionally not copied into repository files or PR text.