### PR TITLE
Manmohan Codex [ FastAPI ] Add API key rate limiting

### DIFF
--- a/fastapi/fastapi/security/.audit.json
+++ b/fastapi/fastapi/security/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Safe public audit metadata only. Private system, developer, runtime, and user instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-30T05:15:00Z"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -1,6 +1,7 @@
 from .api_key import APIKeyCookie as APIKeyCookie
 from .api_key import APIKeyHeader as APIKeyHeader
 from .api_key import APIKeyQuery as APIKeyQuery
+from .api_key import APIKeyWithRateLimit as APIKeyWithRateLimit
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials

--- a/fastapi/fastapi/security/api_key.py
+++ b/fastapi/fastapi/security/api_key.py
@@ -1,3 +1,7 @@
+import math
+import time
+from collections.abc import Callable, Sequence
+from threading import Lock
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -5,7 +9,8 @@ from fastapi.openapi.models import APIKey, APIKeyIn
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.responses import Response
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class APIKeyBase(SecurityBase):
@@ -230,6 +235,147 @@ class APIKeyHeader(APIKeyBase):
     async def __call__(self, request: Request) -> str | None:
         api_key = request.headers.get(self.model.name)
         return self.check_api_key(api_key)
+
+
+class APIKeyWithRateLimit(APIKeyHeader):
+    """
+    API key authentication using a header with in-memory rate limiting.
+
+    This extends `APIKeyHeader` with an opt-in sliding-window rate limiter and
+    deprecated-key warning support.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: Annotated[str, Doc("Header name.")],
+        rate_limit: Annotated[
+            str,
+            Doc(
+                """
+                Sliding-window rate limit formatted as `<count>/<period>`, for example
+                `100/minute` or `1000/hour`.
+                """
+            ),
+        ],
+        deprecated_keys: Annotated[
+            Sequence[str] | None,
+            Doc(
+                """
+                Old API keys that should still authenticate but add a Warning response
+                header indicating that the key will be deactivated.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if the header is not provided, `APIKeyWithRateLimit` will
+                automatically cancel the request and send the client an error.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            name=name,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.rate_limit_count, self.rate_limit_window_seconds = self._parse_rate_limit(
+            rate_limit
+        )
+        self.deprecated_keys = set(deprecated_keys or ())
+        self._request_timestamps: dict[str, list[float]] = {}
+        self._lock = Lock()
+        self._time_provider: Callable[[], float] = time.monotonic
+
+    async def __call__(self, request: Request, response: Response) -> str | None:
+        api_key = self.check_api_key(request.headers.get(self.model.name))
+        if api_key is None:
+            return None
+
+        self._check_rate_limit(api_key)
+        if api_key in self.deprecated_keys:
+            response.headers["Warning"] = (
+                '299 - "API key is deprecated and will be deactivated"'
+            )
+        return api_key
+
+    @staticmethod
+    def _parse_rate_limit(rate_limit: str) -> tuple[int, int]:
+        try:
+            raw_count, raw_period = rate_limit.split("/", 1)
+            count = int(raw_count)
+        except ValueError as exc:
+            raise ValueError(
+                "rate_limit must be formatted as '<count>/<period>'"
+            ) from exc
+
+        if count <= 0:
+            raise ValueError("rate_limit count must be greater than 0")
+
+        periods = {
+            "second": 1,
+            "seconds": 1,
+            "minute": 60,
+            "minutes": 60,
+            "hour": 3600,
+            "hours": 3600,
+        }
+        period_seconds = periods.get(raw_period.strip().lower())
+        if period_seconds is None:
+            raise ValueError("rate_limit period must be one of: second, minute, hour")
+        return count, period_seconds
+
+    def _check_rate_limit(self, api_key: str) -> None:
+        now = self._time_provider()
+        window_start = now - self.rate_limit_window_seconds
+
+        with self._lock:
+            timestamps = [
+                timestamp
+                for timestamp in self._request_timestamps.get(api_key, [])
+                if timestamp > window_start
+            ]
+            self._request_timestamps[api_key] = timestamps
+
+            if len(timestamps) >= self.rate_limit_count:
+                oldest_timestamp = timestamps[0]
+                retry_after = max(
+                    1,
+                    math.ceil(
+                        self.rate_limit_window_seconds - (now - oldest_timestamp)
+                    ),
+                )
+                raise HTTPException(
+                    status_code=HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Rate limit exceeded",
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+            timestamps.append(now)
 
 
 class APIKeyCookie(APIKeyBase):

--- a/fastapi/tests/test_security_api_key_rate_limit.py
+++ b/fastapi/tests/test_security_api_key_rate_limit.py
@@ -1,0 +1,106 @@
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.security import APIKeyWithRateLimit
+from fastapi.testclient import TestClient
+
+
+def create_client(
+    rate_limit: str = "2/minute",
+    deprecated_keys: list[str] | None = None,
+) -> tuple[TestClient, APIKeyWithRateLimit]:
+    app = FastAPI()
+    api_key = APIKeyWithRateLimit(
+        name="key",
+        rate_limit=rate_limit,
+        deprecated_keys=deprecated_keys,
+    )
+
+    @app.get("/items")
+    def read_items(key: str = Depends(api_key)) -> dict[str, str]:
+        return {"key": key}
+
+    return TestClient(app), api_key
+
+
+def test_rate_limit_tracks_requests_per_api_key_independently() -> None:
+    client, security = create_client()
+    security._time_provider = lambda: 100.0
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+
+    limited = client.get("/items", headers={"key": "alpha"})
+    assert limited.status_code == 429
+    assert limited.json() == {"detail": "Rate limit exceeded"}
+
+    response = client.get("/items", headers={"key": "beta"})
+    assert response.status_code == 200
+    assert response.json() == {"key": "beta"}
+
+
+def test_rate_limit_includes_retry_after_seconds() -> None:
+    client, security = create_client()
+    now = 100.0
+    security._time_provider = lambda: now
+
+    client.get("/items", headers={"key": "alpha"})
+    client.get("/items", headers={"key": "alpha"})
+
+    now = 110.0
+    response = client.get("/items", headers={"key": "alpha"})
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "50"
+
+
+def test_rate_limit_window_resets_after_expired_counts() -> None:
+    client, security = create_client()
+    now = 100.0
+    security._time_provider = lambda: now
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+
+    now = 161.0
+    response = client.get("/items", headers={"key": "alpha"})
+
+    assert response.status_code == 200
+    assert response.json() == {"key": "alpha"}
+
+
+def test_deprecated_key_authenticates_with_warning_header() -> None:
+    client, security = create_client(deprecated_keys=["old-key"])
+    security._time_provider = lambda: 100.0
+
+    response = client.get("/items", headers={"key": "old-key"})
+
+    assert response.status_code == 200
+    assert response.json() == {"key": "old-key"}
+    assert response.headers["Warning"] == (
+        '299 - "API key is deprecated and will be deactivated"'
+    )
+
+
+def test_active_key_has_no_warning_header() -> None:
+    client, security = create_client(deprecated_keys=["old-key"])
+    security._time_provider = lambda: 100.0
+
+    response = client.get("/items", headers={"key": "new-key"})
+
+    assert response.status_code == 200
+    assert "Warning" not in response.headers
+
+
+def test_api_key_with_rate_limit_keeps_api_key_header_authentication_behavior() -> None:
+    client, _security = create_client()
+
+    response = client.get("/items")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated"}
+    assert response.headers["WWW-Authenticate"] == "APIKey"
+
+
+def test_invalid_rate_limit_format_is_rejected() -> None:
+    with pytest.raises(ValueError, match="rate_limit"):
+        APIKeyWithRateLimit(name="key", rate_limit="not-a-limit")


### PR DESCRIPTION
## Summary
- Adds `APIKeyWithRateLimit`, an opt-in `APIKeyHeader` extension with sliding-window in-memory rate limiting.
- Parses rate limits such as `2/minute`, `100/minute`, and `1000/hour`.
- Tracks counts independently per API key and guards the in-memory counter store with a lock.
- Returns `429 Too Many Requests` with `Retry-After` when the per-key limit is exceeded.
- Supports `deprecated_keys` that still authenticate but add a `Warning` response header.
- Exports `APIKeyWithRateLimit` from `fastapi.security`.

/claim #768

## Demo
- Demo video: https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/download/bounty-768-api-key-rate-limit-demo/bounty-768-api-key-rate-limit-demo.mp4

## Verification
- `uv run pytest tests/test_security_api_key_rate_limit.py -q` - 7 passed
- `uv run pytest tests/test_security_api_key_rate_limit.py tests/test_security_api_key_header.py -q` - 10 passed
- `uv run pytest tests/test_security_api_key*.py -q` - 34 passed
- `uv run ruff check fastapi/security/api_key.py fastapi/security/__init__.py tests/test_security_api_key_rate_limit.py` - passed
- `uv run ruff format --check fastapi/security/api_key.py fastapi/security/__init__.py tests/test_security_api_key_rate_limit.py` - passed
- `git diff --check` - passed

## Security / provenance
- Rate limiting is in-memory and opt-in; existing API key dependencies are unchanged.
- Adds safe public audit metadata only.
- Private system, developer, runtime, and user instructions are intentionally not copied into repository files or PR text.