### PR TITLE
Manmohan Codex [ FastAPI ] Add dynamic CORS middleware

### DIFF
--- a/fastapi/fastapi/middleware/_generation.json
+++ b/fastapi/fastapi/middleware/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Manmohan Codex",
+  "pre_task_context": "Public bounty metadata only. Private runtime, system, developer, credential, and user-sensitive instructions are intentionally omitted.",
+  "timestamp": "2026-05-30T10:47:36+05:30"
+}

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,92 @@
+from collections.abc import Awaitable, Callable, Sequence
+from contextvars import ContextVar
+from inspect import isawaitable
+
+from starlette.datastructures import Headers
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+OriginValidator = Callable[[str], bool | Awaitable[bool]]
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        allow_origins: Sequence[str] = (),
+        allow_methods: Sequence[str] = ("GET",),
+        allow_headers: Sequence[str] = (),
+        allow_credentials: bool = False,
+        allow_origin_regex: str | None = None,
+        allow_private_network: bool = False,
+        expose_headers: Sequence[str] = (),
+        max_age: int | None = None,
+        allow_origin_func: OriginValidator | None = None,
+        cors_max_age: int = 600,
+    ) -> None:
+        self.allow_origin_func = allow_origin_func
+        self._origin_decision: ContextVar[tuple[str, bool] | None] = ContextVar(
+            "dynamic_cors_origin_decision",
+            default=None,
+        )
+
+        if max_age is not None:
+            cors_max_age = max_age
+
+        # A dynamic validator must be authoritative. Passing an empty static
+        # allow list prevents wildcard headers from bypassing callback denials.
+        static_allow_origins = () if allow_origin_func is not None else allow_origins
+        super().__init__(
+            app=app,
+            allow_origins=static_allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=allow_origin_regex,
+            allow_private_network=allow_private_network,
+            expose_headers=expose_headers,
+            max_age=cors_max_age,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.allow_origin_func is None or scope["type"] != "http":
+            await super().__call__(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+        if origin is None:
+            await super().__call__(scope, receive, send)
+            return
+
+        allowed = await self._resolve_origin(origin)
+        token = self._origin_decision.set((origin, allowed))
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            self._origin_decision.reset(token)
+
+    def is_allowed_origin(self, origin: str) -> bool:
+        if self.allow_origin_func is None:
+            return super().is_allowed_origin(origin)
+
+        decision = self._origin_decision.get()
+        if decision is not None and decision[0] == origin:
+            return decision[1]
+
+        result = self.allow_origin_func(origin)
+        if isawaitable(result):
+            raise RuntimeError(
+                "Async allow_origin_func must be evaluated during an ASGI request"
+            )
+
+        return bool(result)
+
+    async def _resolve_origin(self, origin: str) -> bool:
+        assert self.allow_origin_func is not None
+
+        result = self.allow_origin_func(origin)
+        if isawaitable(result):
+            result = await result
+
+        return bool(result)

--- a/fastapi/tests/test_dynamic_cors_middleware.py
+++ b/fastapi/tests/test_dynamic_cors_middleware.py
@@ -1,0 +1,119 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware, DynamicCORSMiddleware
+from fastapi.testclient import TestClient
+
+
+def create_app(**middleware_kwargs):
+    app = FastAPI()
+    app.add_middleware(DynamicCORSMiddleware, **middleware_kwargs)
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    return app
+
+
+def preflight_headers(origin: str):
+    return {
+        "Origin": origin,
+        "Access-Control-Request-Method": "GET",
+    }
+
+
+def test_dynamic_cors_sync_callback_allows_origin_and_sets_max_age():
+    calls: list[str] = []
+
+    def allow_origin(origin: str) -> bool:
+        calls.append(origin)
+        return origin == "https://allowed.example"
+
+    app = create_app(
+        allow_origin_func=allow_origin,
+        allow_methods=["GET"],
+        cors_max_age=123,
+    )
+    client = TestClient(app)
+
+    response = client.options(
+        "/",
+        headers=preflight_headers("https://allowed.example"),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-allow-origin"] == "https://allowed.example"
+    assert response.headers["access-control-max-age"] == "123"
+    assert calls == ["https://allowed.example"]
+
+
+def test_dynamic_cors_sync_callback_denies_origin_without_wildcard_leak():
+    app = create_app(
+        allow_origins=["*"],
+        allow_origin_func=lambda origin: False,
+        allow_methods=["GET"],
+    )
+    client = TestClient(app)
+
+    preflight = client.options(
+        "/",
+        headers=preflight_headers("https://denied.example"),
+    )
+    simple = client.get("/", headers={"Origin": "https://denied.example"})
+
+    assert preflight.status_code == 400, preflight.text
+    assert preflight.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in preflight.headers
+    assert simple.status_code == 200, simple.text
+    assert simple.json() == {"ok": True}
+    assert "access-control-allow-origin" not in simple.headers
+
+
+def test_dynamic_cors_async_callback_is_awaited():
+    async def allow_origin(origin: str) -> bool:
+        return origin.endswith(".example")
+
+    app = create_app(
+        allow_origin_func=allow_origin,
+        allow_methods=["GET"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Origin": "https://async.example"})
+
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-allow-origin"] == "https://async.example"
+
+
+def test_dynamic_cors_falls_back_to_static_origins_without_callback():
+    app = create_app(
+        allow_origins=["https://static.example"],
+        allow_methods=["GET"],
+    )
+    client = TestClient(app)
+
+    allowed = client.get("/", headers={"Origin": "https://static.example"})
+    denied = client.get("/", headers={"Origin": "https://other.example"})
+
+    assert allowed.status_code == 200, allowed.text
+    assert allowed.headers["access-control-allow-origin"] == "https://static.example"
+    assert denied.status_code == 200, denied.text
+    assert "access-control-allow-origin" not in denied.headers
+
+
+def test_existing_cors_middleware_export_is_unchanged():
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["https://existing.example"],
+        allow_methods=["GET"],
+    )
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    client = TestClient(app)
+    response = client.get("/", headers={"Origin": "https://existing.example"})
+
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-allow-origin"] == "https://existing.example"


### PR DESCRIPTION
/claim #763

## Summary
- Adds `DynamicCORSMiddleware` while preserving the existing `CORSMiddleware` re-export.
- Supports sync and async `allow_origin_func(origin)` callbacks per CORS request.
- Falls back to static `allow_origins` behavior when no callback is supplied.
- Adds `cors_max_age` for preflight `Access-Control-Max-Age` configuration.

## Demo
https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/download/bounty-763-dynamic-cors-demo/dynamic-cors-demo.mp4

## Verification
- `uv run pytest tests/test_dynamic_cors_middleware.py -q`
- `uv run pytest tests/test_dynamic_cors_middleware.py tests/test_tutorial/test_cors/test_tutorial001.py -q`
- `uv run ruff check fastapi/middleware/cors.py tests/test_dynamic_cors_middleware.py`
- `uv run ruff format --check fastapi/middleware/cors.py tests/test_dynamic_cors_middleware.py`
- `git diff --check`

## Metadata
Included safe public generation metadata next to the middleware. Private runtime/system/developer instructions and credentials are intentionally omitted.