### PR TITLE
Manmohan Codex [ T3 Code ] Add request body size limiting

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Manmohan Codex",
+  "boot_context": "Public bounty metadata only. Private runtime, system, developer, credential, memory, and user-sensitive instructions are intentionally omitted.",
+  "timestamp": "2026-05-30T10:55:30+05:30"
+}

--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+import {
+  DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+  MAX_BODY_SIZE_RESPONSE_HEADER,
+  UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES,
+  isLoopbackHostname,
+  makeRequestBodySizeLimitLayer,
+  parseContentLength,
+  resolveDevRedirectUrl,
+  resolveRequestBodySizeLimitBytes,
+} from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +36,117 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("http request body size limits", () => {
+  it("parses valid Content-Length headers and ignores invalid values", () => {
+    expect(parseContentLength("42")).toBe(42);
+    expect(parseContentLength(" 42 ")).toBe(42);
+    expect(parseContentLength(undefined)).toBeUndefined();
+    expect(parseContentLength("12.5")).toBeUndefined();
+    expect(parseContentLength("-1")).toBeUndefined();
+  });
+
+  it("uses the 10MB default, 50MB upload default, and per-route overrides", () => {
+    expect(resolveRequestBodySizeLimitBytes("/api/session")).toBe(
+      DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES,
+    );
+    expect(resolveRequestBodySizeLimitBytes("/api/files/upload")).toBe(
+      UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES,
+    );
+    expect(
+      resolveRequestBodySizeLimitBytes("/api/custom", [
+        {
+          path: "/api/custom",
+          limitBytes: 2048,
+        },
+      ]),
+    ).toBe(2048);
+  });
+
+  it("rejects oversized requests before the handler reads the body", async () => {
+    const appLayer = Layer.mergeAll(
+      HttpRouter.add(
+        "POST",
+        "/limited",
+        Effect.gen(function* () {
+          const request = yield* HttpServerRequest.HttpServerRequest;
+          const body = yield* request.text;
+          return HttpServerResponse.text(body);
+        }),
+      ),
+      makeRequestBodySizeLimitLayer([
+        {
+          path: "/limited",
+          limitBytes: 4,
+        },
+      ]),
+    );
+    const { handler, dispose } = HttpRouter.toWebHandler(appLayer, {
+      disableLogger: true,
+    });
+
+    try {
+      const response = await handler(
+        new Request("http://127.0.0.1/limited", {
+          method: "POST",
+          body: "12345",
+          headers: {
+            "content-length": "5",
+          },
+        }),
+      );
+
+      expect(response.status).toBe(413);
+      expect(response.headers.get(MAX_BODY_SIZE_RESPONSE_HEADER)).toBe("4");
+      await expect(response.json()).resolves.toEqual({
+        error: "Payload Too Large",
+        limit: 4,
+        received: 5,
+      });
+    } finally {
+      await dispose();
+    }
+  });
+
+  it("allows requests within the applicable route limit", async () => {
+    const appLayer = Layer.mergeAll(
+      HttpRouter.add(
+        "POST",
+        "/limited",
+        Effect.gen(function* () {
+          const request = yield* HttpServerRequest.HttpServerRequest;
+          const body = yield* request.text;
+          return HttpServerResponse.text(body);
+        }),
+      ),
+      makeRequestBodySizeLimitLayer([
+        {
+          path: "/limited",
+          limitBytes: 5,
+        },
+      ]),
+    );
+    const { handler, dispose } = HttpRouter.toWebHandler(appLayer, {
+      disableLogger: true,
+    });
+
+    try {
+      const response = await handler(
+        new Request("http://127.0.0.1/limited", {
+          method: "POST",
+          body: "12345",
+          headers: {
+            "content-length": "5",
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toBe("12345");
+    } finally {
+      await dispose();
+    }
   });
 });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -38,12 +38,123 @@ const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
+export const DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES = 10 * 1024 * 1024;
+export const UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES = 50 * 1024 * 1024;
+export const MAX_BODY_SIZE_RESPONSE_HEADER = "X-Max-Body-Size";
+
+export interface RequestBodySizeLimitOverride {
+  readonly path: string | RegExp;
+  readonly limitBytes: number;
+}
+
+export function parseContentLength(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+  if (!/^\d+$/.test(trimmedValue)) {
+    return undefined;
+  }
+
+  const contentLength = Number(trimmedValue);
+  return Number.isSafeInteger(contentLength) ? contentLength : undefined;
+}
+
+export function isUploadRequestPath(pathname: string): boolean {
+  const normalizedPathname = pathname.toLowerCase();
+  return (
+    normalizedPathname.includes("upload") ||
+    normalizedPathname.startsWith("/attachments/") ||
+    normalizedPathname.startsWith("/api/attachments/")
+  );
+}
+
+function requestBodySizeLimitOverrideMatches(
+  override: RequestBodySizeLimitOverride,
+  pathname: string,
+): boolean {
+  if (typeof override.path === "string") {
+    return override.path === pathname;
+  }
+
+  override.path.lastIndex = 0;
+  return override.path.test(pathname);
+}
+
+export function resolveRequestBodySizeLimitBytes(
+  pathname: string,
+  overrides: ReadonlyArray<RequestBodySizeLimitOverride> = [],
+): number {
+  const override = overrides.find((candidate) =>
+    requestBodySizeLimitOverrideMatches(candidate, pathname),
+  );
+  if (override) {
+    return override.limitBytes;
+  }
+
+  return isUploadRequestPath(pathname)
+    ? UPLOAD_REQUEST_BODY_SIZE_LIMIT_BYTES
+    : DEFAULT_REQUEST_BODY_SIZE_LIMIT_BYTES;
+}
+
+export function makePayloadTooLargeResponse(input: {
+  readonly limitBytes: number;
+  readonly receivedBytes: number;
+}) {
+  return HttpServerResponse.jsonUnsafe(
+    {
+      error: "Payload Too Large",
+      limit: input.limitBytes,
+      received: input.receivedBytes,
+    },
+    {
+      status: 413,
+      headers: {
+        ...browserApiCorsHeaders,
+        [MAX_BODY_SIZE_RESPONSE_HEADER]: String(input.limitBytes),
+      },
+    },
+  );
+}
 
 export const browserApiCorsLayer = HttpRouter.cors({
   allowedMethods: [...browserApiCorsAllowedMethods],
   allowedHeaders: [...browserApiCorsAllowedHeaders],
   maxAge: 600,
 });
+
+export const makeRequestBodySizeLimitLayer = (
+  overrides: ReadonlyArray<RequestBodySizeLimitOverride> = [],
+) =>
+  HttpRouter.middleware(
+    (handler) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const url = HttpServerRequest.toURL(request);
+        const pathname = Option.isSome(url)
+          ? url.value.pathname
+          : (request.url.split("?")[0] ?? "/");
+        const limitBytes = resolveRequestBodySizeLimitBytes(pathname, overrides);
+        const receivedBytes = parseContentLength(request.headers["content-length"]);
+
+        if (receivedBytes !== undefined && receivedBytes > limitBytes) {
+          return makePayloadTooLargeResponse({
+            limitBytes,
+            receivedBytes,
+          });
+        }
+
+        return yield* Effect.provideService(
+          handler,
+          HttpServerRequest.MaxBodySize,
+          FileSystem.Size(limitBytes),
+        );
+      }),
+    { global: true },
+  );
+
+export const requestBodySizeLimitLayer = makeRequestBodySizeLimitLayer();
 
 export function isLoopbackHostname(hostname: string): boolean {
   const normalizedHostname = hostname

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -10,6 +10,7 @@ import {
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  requestBodySizeLimitLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -312,7 +313,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
-).pipe(Layer.provide(browserApiCorsLayer));
+).pipe(Layer.provide(Layer.mergeAll(browserApiCorsLayer, requestBodySizeLimitLayer)));
 
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {


### PR DESCRIPTION
/claim #841

## Summary
- Adds a global request body size limit middleware to the T3 server HTTP router.
- Uses a 10 MB default for regular routes and 50 MB for upload-style paths.
- Supports per-route limit overrides through `makeRequestBodySizeLimitLayer`.
- Rejects oversized `Content-Length` requests with structured 413 JSON and `X-Max-Body-Size`.
- Sets Effect `MaxBodySize` for handlers that later read request bodies.

## Demo
https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/download/bounty-841-body-limit-demo/body-limit-demo.mp4

## Verification
- `npx -y bun@1.3.11 run --cwd apps/server test src/http.test.ts`
- `npx -y bun@1.3.11 run --cwd apps/server typecheck`
- `npx -y bun@1.3.11 run fmt:check apps/server/src/http.ts apps/server/src/http.test.ts apps/server/src/server.ts apps/server/src/_provenance.json`
- `git diff --check`

## Metadata
Included safe public provenance metadata. Private runtime/system/developer instructions and credentials are intentionally omitted.