### PR TITLE
Manmohan Codex [ T3 Code ] Standardize error types

### DIFF
--- a/t3code/apps/server/src/_meta.json
+++ b/t3code/apps/server/src/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Manmohan Codex",
+  "generation_context": "Public bounty metadata only. Private runtime, system, developer, credential, memory, and user-sensitive instructions are intentionally omitted.",
+  "completed_at": "2026-05-30T11:04:58+05:30"
+}

--- a/t3code/apps/server/src/bootstrap.ts
+++ b/t3code/apps/server/src/bootstrap.ts
@@ -4,18 +4,13 @@ import * as Net from "node:net";
 import * as readline from "node:readline";
 import type { Readable } from "node:stream";
 
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
-
-class BootstrapError extends Data.TaggedError("BootstrapError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+import { ConfigError, type ConfigError as BootstrapError } from "./errors.ts";
 
 export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function* <A, I>(
   schema: Schema.Codec<A, I>,
@@ -52,7 +47,7 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       }
       resume(
         Effect.fail(
-          new BootstrapError({
+          ConfigError({
             message: "Failed to read bootstrap envelope.",
             cause: error,
           }),
@@ -67,9 +62,12 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       } else {
         resume(
           Effect.fail(
-            new BootstrapError({
+            ConfigError({
               message: "Failed to decode bootstrap envelope.",
               cause: parsed.failure,
+              details: {
+                source: "bootstrap-envelope",
+              },
             }),
           ),
         );
@@ -97,7 +95,7 @@ const isFdReady = (fd: number) =>
   Effect.try({
     try: () => NFS.fstatSync(fd),
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to stat bootstrap fd.",
         cause: error,
       }),
@@ -136,7 +134,7 @@ const makeBootstrapInputStream = (fd: number) =>
       }
     },
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to duplicate bootstrap fd.",
         cause: error,
       }),

--- a/t3code/apps/server/src/cli/project.ts
+++ b/t3code/apps/server/src/cli/project.ts
@@ -5,7 +5,6 @@ import {
   type ClientOrchestrationCommand,
 } from "@t3tools/contracts";
 import * as Console from "effect/Console";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -41,6 +40,7 @@ import {
 import { WorkspacePathsLive } from "../workspace/Layers/WorkspacePaths.ts";
 import { WorkspacePaths } from "../workspace/Services/WorkspacePaths.ts";
 import { type CliAuthLocationFlags, projectLocationFlags, resolveCliAuthConfig } from "./config.ts";
+import { ValidationError, type ValidationError as ProjectCommandError } from "../errors.ts";
 
 type ProjectMutationTarget = {
   readonly id: ProjectId;
@@ -53,10 +53,6 @@ type ProjectCliDispatchCommand = Extract<
   ClientOrchestrationCommand,
   { type: "project.create" | "project.meta.update" | "project.delete" }
 >;
-
-class ProjectCommandError extends Data.TaggedError("ProjectCommandError")<{
-  readonly message: string;
-}> {}
 
 const ProjectCliRuntimeLive = Layer.mergeAll(
   WorkspacePathsLive,
@@ -128,7 +124,7 @@ const resolveProjectTitle = Effect.fn("resolveProjectTitle")(function* (
     if (trimmed.length > 0) {
       return trimmed;
     }
-    return yield* new ProjectCommandError({ message: "Project title cannot be empty." });
+    return yield* Effect.fail(ValidationError({ message: "Project title cannot be empty." }));
   }
 
   const path = yield* Path.Path;
@@ -142,7 +138,7 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
 }) {
   const trimmedIdentifier = input.identifier.trim();
   if (trimmedIdentifier.length === 0) {
-    return yield* new ProjectCommandError({ message: "Project identifier cannot be empty." });
+    return yield* Effect.fail(ValidationError({ message: "Project identifier cannot be empty." }));
   }
 
   const activeProjects = input.snapshot.projects.filter((project) => project.deletedAt === null);
@@ -169,9 +165,11 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
 
   const resolved = exactWorkspaceMatch;
   if (!resolved) {
-    return yield* new ProjectCommandError({
-      message: `No active project found for '${trimmedIdentifier}'.`,
-    });
+    return yield* Effect.fail(
+      ValidationError({
+        message: `No active project found for '${trimmedIdentifier}'.`,
+      }),
+    );
   }
 
   return {
@@ -191,7 +189,7 @@ const fetchLiveOrchestrationSnapshot = (origin: string, bearerToken: string) =>
       "2xx": decodeOrchestrationReadModelResponse,
       orElse: (response) =>
         readErrorMessageFromResponse(response).pipe(
-          Effect.flatMap((message) => Effect.fail(new ProjectCommandError({ message }))),
+          Effect.flatMap((message) => Effect.fail(ValidationError({ message }))),
         ),
     }),
   );
@@ -212,7 +210,7 @@ const dispatchLiveOrchestrationCommand = (
           "2xx": () => Effect.void,
           orElse: (response) =>
             readErrorMessageFromResponse(response).pipe(
-              Effect.flatMap((message) => Effect.fail(new ProjectCommandError({ message }))),
+              Effect.flatMap((message) => Effect.fail(ValidationError({ message }))),
             ),
         }),
       ),
@@ -337,9 +335,11 @@ const projectAddCommand = Command.make("add", {
           (project) => project.deletedAt === null && project.workspaceRoot === workspaceRoot,
         );
         if (existingProject) {
-          return yield* new ProjectCommandError({
-            message: `An active project already exists for '${workspaceRoot}'.`,
-          });
+          return yield* Effect.fail(
+            ValidationError({
+              message: `An active project already exists for '${workspaceRoot}'.`,
+            }),
+          );
         }
 
         const title = yield* resolveProjectTitle(workspaceRoot, Option.getOrUndefined(flags.title));

--- a/t3code/apps/server/src/errors.test.ts
+++ b/t3code/apps/server/src/errors.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import * as Match from "effect/Match";
+
+import {
+  AuthError,
+  ConfigError,
+  DatabaseError,
+  GitError,
+  NetworkError,
+  ValidationError,
+  errorToLog,
+  errorToResponse,
+  isServerError,
+  type ServerError,
+} from "./errors.ts";
+
+const timestamp = "2026-05-30T05:30:00.000Z";
+
+describe("server errors", () => {
+  it("constructs centralized tagged errors with timestamps and causes", () => {
+    const cause = new Error("token expired");
+    const error = AuthError({
+      message: "Authentication failed.",
+      cause,
+      timestamp,
+    });
+
+    expect(error._tag).toBe("AuthError");
+    expect(error.message).toBe("Authentication failed.");
+    expect(error.timestamp).toBe(timestamp);
+    expect(error.cause).toBe(cause);
+    expect(isServerError(error)).toBe(true);
+  });
+
+  it("maps every server error category to the expected HTTP status", () => {
+    const cases: ReadonlyArray<readonly [ServerError, number]> = [
+      [AuthError({ message: "auth", timestamp }), 401],
+      [ValidationError({ message: "validation", timestamp }), 400],
+      [DatabaseError({ message: "database", timestamp }), 500],
+      [NetworkError({ message: "network", timestamp }), 502],
+      [ConfigError({ message: "config", timestamp }), 500],
+      [GitError({ message: "git", timestamp }), 422],
+    ];
+
+    for (const [error, status] of cases) {
+      expect(errorToResponse(error)).toEqual({
+        status,
+        body: {
+          error: error._tag,
+          message: error.message,
+          timestamp,
+        },
+      });
+    }
+  });
+
+  it("formats structured logs with tag, message, stack, timestamp, and details", () => {
+    const cause = new Error("sqlite locked");
+    const error = DatabaseError({
+      message: "Persistence failed.",
+      cause,
+      details: {
+        operation: "write",
+      },
+      timestamp,
+    });
+
+    const log = errorToLog(error);
+
+    expect(log.tag).toBe("DatabaseError");
+    expect(log.message).toBe("Persistence failed.");
+    expect(log.timestamp).toBe(timestamp);
+    expect(log.stack).toContain("sqlite locked");
+    expect(log.cause).toBe("sqlite locked");
+    expect(log.details).toEqual({
+      operation: "write",
+    });
+  });
+
+  it("supports Effect.Match pattern matching on error tags", () => {
+    const matchMessage = (error: ServerError) =>
+      Match.valueTags(error, {
+        AuthError: () => "auth",
+        ValidationError: () => "validation",
+        DatabaseError: () => "database",
+        NetworkError: () => "network",
+        ConfigError: () => "config",
+        GitError: (error) => `git:${error.message}`,
+      });
+
+    expect(matchMessage(GitError({ message: "push rejected", timestamp }))).toBe(
+      "git:push rejected",
+    );
+  });
+});

--- a/t3code/apps/server/src/errors.ts
+++ b/t3code/apps/server/src/errors.ts
@@ -1,0 +1,159 @@
+import * as Data from "effect/Data";
+import * as DateTime from "effect/DateTime";
+import * as Match from "effect/Match";
+
+type ServerErrorTag =
+  | "AuthError"
+  | "ValidationError"
+  | "DatabaseError"
+  | "NetworkError"
+  | "ConfigError"
+  | "GitError";
+
+export type ServerErrorDetails = {
+  readonly name: ServerErrorTag;
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly timestamp: string;
+  readonly details?: unknown;
+};
+
+export type ServerError = Data.TaggedEnum<{
+  AuthError: ServerErrorDetails;
+  ValidationError: ServerErrorDetails;
+  DatabaseError: ServerErrorDetails;
+  NetworkError: ServerErrorDetails;
+  ConfigError: ServerErrorDetails;
+  GitError: ServerErrorDetails;
+}>;
+
+type ServerErrorInput = Omit<ServerErrorDetails, "name" | "timestamp"> & {
+  readonly timestamp?: string;
+};
+
+const ServerErrors = Data.taggedEnum<ServerError>();
+
+const nowIso = () => DateTime.formatIso(DateTime.nowUnsafe());
+
+const withErrorDetails = (name: ServerErrorTag, input: ServerErrorInput): ServerErrorDetails => ({
+  ...input,
+  name,
+  timestamp: input.timestamp ?? nowIso(),
+});
+
+export const AuthError = (input: ServerErrorInput) =>
+  ServerErrors.AuthError(withErrorDetails("AuthError", input));
+export type AuthError = Extract<ServerError, { readonly _tag: "AuthError" }>;
+
+export const ValidationError = (input: ServerErrorInput) =>
+  ServerErrors.ValidationError(withErrorDetails("ValidationError", input));
+export type ValidationError = Extract<ServerError, { readonly _tag: "ValidationError" }>;
+
+export const DatabaseError = (input: ServerErrorInput) =>
+  ServerErrors.DatabaseError(withErrorDetails("DatabaseError", input));
+export type DatabaseError = Extract<ServerError, { readonly _tag: "DatabaseError" }>;
+
+export const NetworkError = (input: ServerErrorInput) =>
+  ServerErrors.NetworkError(withErrorDetails("NetworkError", input));
+export type NetworkError = Extract<ServerError, { readonly _tag: "NetworkError" }>;
+
+export const ConfigError = (input: ServerErrorInput) =>
+  ServerErrors.ConfigError(withErrorDetails("ConfigError", input));
+export type ConfigError = Extract<ServerError, { readonly _tag: "ConfigError" }>;
+
+export const GitError = (input: ServerErrorInput) =>
+  ServerErrors.GitError(withErrorDetails("GitError", input));
+export type GitError = Extract<ServerError, { readonly _tag: "GitError" }>;
+
+export const isServerError = (value: unknown): value is ServerError =>
+  ServerErrors.$is("AuthError")(value) ||
+  ServerErrors.$is("ValidationError")(value) ||
+  ServerErrors.$is("DatabaseError")(value) ||
+  ServerErrors.$is("NetworkError")(value) ||
+  ServerErrors.$is("ConfigError")(value) ||
+  ServerErrors.$is("GitError")(value);
+
+export interface ServerErrorResponse {
+  readonly status: 400 | 401 | 422 | 500 | 502;
+  readonly body: {
+    readonly error: ServerError["_tag"];
+    readonly message: string;
+    readonly timestamp: string;
+  };
+}
+
+export const errorToResponse = (error: ServerError): ServerErrorResponse => {
+  const status = Match.valueTags(error, {
+    AuthError: () => 401 as const,
+    ValidationError: () => 400 as const,
+    DatabaseError: () => 500 as const,
+    NetworkError: () => 502 as const,
+    ConfigError: () => 500 as const,
+    GitError: () => 422 as const,
+  });
+
+  return {
+    status,
+    body: {
+      error: error._tag,
+      message: error.message,
+      timestamp: error.timestamp,
+    },
+  };
+};
+
+const stackFromCause = (cause: unknown): string | undefined => {
+  if (cause instanceof Error) {
+    return cause.stack;
+  }
+
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "stack" in cause &&
+    typeof cause.stack === "string"
+  ) {
+    return cause.stack;
+  }
+
+  return undefined;
+};
+
+const messageFromCause = (cause: unknown): string | undefined => {
+  if (cause instanceof Error) {
+    return cause.message;
+  }
+
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string"
+  ) {
+    return cause.message;
+  }
+
+  if (cause === undefined) {
+    return undefined;
+  }
+
+  return String(cause);
+};
+
+export interface ServerErrorLog {
+  readonly tag: ServerError["_tag"];
+  readonly message: string;
+  readonly timestamp: string;
+  readonly stack: string | undefined;
+  readonly cause: string | undefined;
+  readonly details: unknown;
+}
+
+export const errorToLog = (error: ServerError): ServerErrorLog => ({
+  tag: error._tag,
+  message: error.message,
+  timestamp: error.timestamp,
+  stack: stackFromCause(error.cause) ?? new Error(error.message).stack,
+  cause: messageFromCause(error.cause),
+  details: error.details,
+});

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,6 +1,5 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -28,6 +27,7 @@ import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolve
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
+import { ValidationError } from "./errors.ts";
 import {
   browserApiCorsAllowedHeaders,
   browserApiCorsAllowedMethods,
@@ -81,11 +81,6 @@ export const serverEnvironmentRouteLayer = HttpRouter.add(
   }),
 );
 
-class DecodeOtlpTraceRecordsError extends Data.TaggedError("DecodeOtlpTraceRecordsError")<{
-  readonly cause: unknown;
-  readonly bodyJson: OtlpTracer.TraceData;
-}> {}
-
 export const otlpTracesProxyRouteLayer = HttpRouter.add(
   "POST",
   OTLP_TRACES_PROXY_PATH,
@@ -100,7 +95,14 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),
-      catch: (cause) => new DecodeOtlpTraceRecordsError({ cause, bodyJson }),
+      catch: (cause) =>
+        ValidationError({
+          message: "Failed to decode browser OTLP traces.",
+          cause,
+          details: {
+            bodyJson,
+          },
+        }),
     }).pipe(
       Effect.flatMap((records) => browserTraceCollector.record(records)),
       Effect.catch((cause) =>


### PR DESCRIPTION
/claim #861

## Summary
- Add `t3code/apps/server/src/errors.ts` with centralized `Effect.Data.TaggedEnum` server errors for Auth, Validation, Database, Network, Config, and Git failures.
- Add `errorToResponse`, `errorToLog`, tag guards, and focused coverage for all status mappings, cause preservation, structured logging, and `Effect.Match` tag matching.
- Migrate existing error handling in `bootstrap.ts`, `http.ts`, and `cli/project.ts` to the centralized constructors.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-861-server-errors-demo

## Verification
- `npx -y bun@1.3.11 run --cwd apps/server test src/errors.test.ts src/http.test.ts`
- `npx -y bun@1.3.11 run --cwd apps/server typecheck`
- `npx -y bun@1.3.11 run fmt:check apps/server/src/_meta.json apps/server/src/errors.ts apps/server/src/errors.test.ts apps/server/src/bootstrap.ts apps/server/src/http.ts apps/server/src/cli/project.ts`
- `git diff --check`