### PR TITLE
Manmohan Codex [ T3 Code ] Add checkpoint pruning

### DIFF
--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -7,6 +7,7 @@ import { Command } from "effect/unstable/cli";
 import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
+import { checkpointCommand } from "./cli/checkpoint.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
@@ -16,7 +17,13 @@ const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    checkpointCommand,
+  ]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/checkpointing/Layers/CheckpointPruner.test.ts
+++ b/t3code/apps/server/src/checkpointing/Layers/CheckpointPruner.test.ts
@@ -1,0 +1,89 @@
+import {
+  CheckpointRef,
+  MessageId,
+  ThreadId,
+  TurnId,
+  type OrchestrationCheckpointSummary,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import { describe, expect, it } from "vitest";
+
+import {
+  CHECKPOINT_RETENTION_DAY_MS,
+  DEFAULT_MINIMUM_CHECKPOINTS_PER_THREAD,
+  selectPrunableCheckpoints,
+} from "../Services/CheckpointPruner.ts";
+
+const nowEpochMillis = Date.UTC(2026, 4, 30, 0, 0, 0);
+const cutoffEpochMillis = nowEpochMillis - 7 * CHECKPOINT_RETENTION_DAY_MS;
+const threadId = ThreadId.make("thread-prune");
+
+function iso(daysAgo: number): string {
+  return DateTime.formatIso(
+    DateTime.makeUnsafe(nowEpochMillis - daysAgo * CHECKPOINT_RETENTION_DAY_MS),
+  );
+}
+
+function checkpoint(turn: number, daysAgo: number): OrchestrationCheckpointSummary {
+  return {
+    turnId: TurnId.make(`turn-${turn}`),
+    checkpointTurnCount: turn,
+    checkpointRef: CheckpointRef.make(`refs/t3/checkpoints/thread-prune/turn/${turn}`),
+    status: "ready",
+    files: [
+      {
+        path: `file-${turn}.ts`,
+        kind: "modified",
+        additions: turn,
+        deletions: 0,
+      },
+    ],
+    assistantMessageId: MessageId.make(`assistant-${turn}`),
+    completedAt: iso(daysAgo),
+  };
+}
+
+describe("selectPrunableCheckpoints", () => {
+  it("removes checkpoints older than retention while preserving the three newest per thread", () => {
+    const prunable = selectPrunableCheckpoints({
+      threadId,
+      cutoffEpochMillis,
+      checkpoints: [
+        checkpoint(1, 30),
+        checkpoint(2, 29),
+        checkpoint(3, 28),
+        checkpoint(4, 27),
+        checkpoint(5, 26),
+      ],
+    });
+
+    expect(prunable.map((entry) => entry.checkpointTurnCount)).toEqual([1, 2]);
+  });
+
+  it("does not prune checkpoints newer than the retention cutoff", () => {
+    const prunable = selectPrunableCheckpoints({
+      threadId,
+      cutoffEpochMillis,
+      checkpoints: [checkpoint(1, 5), checkpoint(2, 4), checkpoint(3, 3), checkpoint(4, 2)],
+    });
+
+    expect(prunable).toEqual([]);
+  });
+
+  it("allows callers to raise the minimum preservation count", () => {
+    const prunable = selectPrunableCheckpoints({
+      threadId,
+      cutoffEpochMillis,
+      minimumCheckpointsPerThread: DEFAULT_MINIMUM_CHECKPOINTS_PER_THREAD + 1,
+      checkpoints: [
+        checkpoint(1, 30),
+        checkpoint(2, 29),
+        checkpoint(3, 28),
+        checkpoint(4, 27),
+        checkpoint(5, 26),
+      ],
+    });
+
+    expect(prunable.map((entry) => entry.checkpointTurnCount)).toEqual([1]);
+  });
+});

--- a/t3code/apps/server/src/checkpointing/Layers/CheckpointPruner.ts
+++ b/t3code/apps/server/src/checkpointing/Layers/CheckpointPruner.ts
@@ -1,0 +1,179 @@
+import * as Clock from "effect/Clock";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Metric from "effect/Metric";
+
+import { CheckpointStore } from "../Services/CheckpointStore.ts";
+import {
+  CHECKPOINT_RETENTION_DAY_MS,
+  CheckpointPruner,
+  DEFAULT_CHECKPOINT_RETENTION_DAYS,
+  DEFAULT_MINIMUM_CHECKPOINTS_PER_THREAD,
+  selectPrunableCheckpoints,
+  type CheckpointPruneCandidate,
+  type CheckpointPruneResult,
+  type CheckpointPrunerShape,
+} from "../Services/CheckpointPruner.ts";
+import {
+  checkpointPruneBytesFreed,
+  checkpointPruneDuration,
+  checkpointPruneSnapshotsDeleted,
+  metricAttributes,
+} from "../../observability/Metrics.ts";
+import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProjectionCheckpointRepository } from "../../persistence/Services/ProjectionCheckpoints.ts";
+
+const groupCandidatesByWorkspace = (
+  candidates: ReadonlyArray<CheckpointPruneCandidate & { readonly cwd: string }>,
+) => {
+  const grouped = new Map<string, Array<CheckpointPruneCandidate & { readonly cwd: string }>>();
+  for (const candidate of candidates) {
+    const existing = grouped.get(candidate.cwd) ?? [];
+    existing.push(candidate);
+    grouped.set(candidate.cwd, existing);
+  }
+  return grouped;
+};
+
+const make = Effect.gen(function* () {
+  const snapshotQuery = yield* ProjectionSnapshotQuery;
+  const checkpointStore = yield* CheckpointStore;
+  const checkpointRepository = yield* ProjectionCheckpointRepository;
+
+  const prune: CheckpointPrunerShape["prune"] = Effect.fn("CheckpointPruner.prune")(function* (
+    input = {},
+  ) {
+    const startedAt = yield* Clock.currentTimeNanos;
+    const retentionDays = Math.max(0, input.retentionDays ?? DEFAULT_CHECKPOINT_RETENTION_DAYS);
+    const minimumCheckpointsPerThread = Math.max(
+      0,
+      input.minimumCheckpointsPerThread ?? DEFAULT_MINIMUM_CHECKPOINTS_PER_THREAD,
+    );
+    const nowEpochMillis = input.nowEpochMillis ?? DateTime.toEpochMillis(yield* DateTime.now);
+    const cutoffEpochMillis = nowEpochMillis - retentionDays * CHECKPOINT_RETENTION_DAY_MS;
+    const snapshotExit = yield* Effect.exit(snapshotQuery.getSnapshot());
+
+    if (Exit.isFailure(snapshotExit)) {
+      yield* Effect.logWarning("checkpoint pruning skipped: failed to load projection snapshot", {
+        cause: snapshotExit.cause,
+      });
+      const endedAt = yield* Clock.currentTimeNanos;
+      return {
+        retentionDays,
+        minimumCheckpointsPerThread,
+        cutoffEpochMillis,
+        threadsScanned: 0,
+        workspacesScanned: 0,
+        snapshotsDeleted: 0,
+        metadataRowsCleared: 0,
+        estimatedBytesFreed: 0,
+        durationMs: Number((endedAt - startedAt) / 1_000_000n),
+        failures: 1,
+      } satisfies CheckpointPruneResult;
+    }
+
+    const snapshot = snapshotExit.value;
+    const projectWorkspaceById = new Map(
+      snapshot.projects.map((project) => [project.id, project.workspaceRoot] as const),
+    );
+    const candidates = snapshot.threads.flatMap((thread) => {
+      const cwd = thread.worktreePath ?? projectWorkspaceById.get(thread.projectId);
+      if (cwd === undefined) {
+        return [];
+      }
+      return selectPrunableCheckpoints({
+        threadId: thread.id,
+        checkpoints: thread.checkpoints,
+        cutoffEpochMillis,
+        minimumCheckpointsPerThread,
+      }).map((candidate) => ({ ...candidate, cwd }));
+    });
+    const candidatesByWorkspace = groupCandidatesByWorkspace(candidates);
+    const deletedCandidates: Array<CheckpointPruneCandidate & { readonly cwd: string }> = [];
+    let failures = 0;
+
+    for (const [cwd, workspaceCandidates] of candidatesByWorkspace) {
+      const deleteExit = yield* Effect.exit(
+        checkpointStore.deleteCheckpointRefs({
+          cwd,
+          checkpointRefs: workspaceCandidates.map((candidate) => candidate.checkpointRef),
+        }),
+      );
+      if (Exit.isSuccess(deleteExit)) {
+        deletedCandidates.push(...workspaceCandidates);
+      } else {
+        failures += 1;
+        yield* Effect.logWarning("checkpoint pruning failed to delete checkpoint refs", {
+          cwd,
+          refs: workspaceCandidates.map((candidate) => candidate.checkpointRef),
+          cause: deleteExit.cause,
+        });
+      }
+    }
+
+    let metadataRowsCleared = 0;
+    if (deletedCandidates.length > 0) {
+      const clearExit = yield* Effect.exit(
+        checkpointRepository.deleteByCheckpointRefs({
+          checkpointRefs: deletedCandidates.map((candidate) => candidate.checkpointRef),
+        }),
+      );
+      if (Exit.isSuccess(clearExit)) {
+        metadataRowsCleared = deletedCandidates.length;
+      } else {
+        failures += 1;
+        yield* Effect.logWarning("checkpoint pruning failed to clear projection metadata", {
+          refs: deletedCandidates.map((candidate) => candidate.checkpointRef),
+          cause: clearExit.cause,
+        });
+      }
+    }
+
+    const endedAt = yield* Clock.currentTimeNanos;
+    const duration = Duration.nanos(endedAt - startedAt);
+    const estimatedBytesFreed = deletedCandidates.reduce(
+      (sum, candidate) => sum + candidate.estimatedBytes,
+      0,
+    );
+    yield* Metric.update(checkpointPruneSnapshotsDeleted, deletedCandidates.length);
+    yield* Metric.update(checkpointPruneBytesFreed, estimatedBytesFreed);
+    yield* Metric.update(
+      Metric.withAttributes(
+        checkpointPruneDuration,
+        metricAttributes({ outcome: failures === 0 ? "success" : "partial_failure" }),
+      ),
+      duration,
+    );
+    yield* Effect.logInfo("checkpoint pruning complete", {
+      retentionDays,
+      minimumCheckpointsPerThread,
+      threadsScanned: snapshot.threads.length,
+      workspacesScanned: candidatesByWorkspace.size,
+      snapshotsDeleted: deletedCandidates.length,
+      metadataRowsCleared,
+      estimatedBytesFreed,
+      durationMs: Duration.toMillis(duration),
+      failures,
+    });
+
+    return {
+      retentionDays,
+      minimumCheckpointsPerThread,
+      cutoffEpochMillis,
+      threadsScanned: snapshot.threads.length,
+      workspacesScanned: candidatesByWorkspace.size,
+      snapshotsDeleted: deletedCandidates.length,
+      metadataRowsCleared,
+      estimatedBytesFreed,
+      durationMs: Duration.toMillis(duration),
+      failures,
+    } satisfies CheckpointPruneResult;
+  });
+
+  return { prune } satisfies CheckpointPrunerShape;
+});
+
+export const CheckpointPrunerLive = Layer.effect(CheckpointPruner, make);

--- a/t3code/apps/server/src/checkpointing/Services/CheckpointPruner.ts
+++ b/t3code/apps/server/src/checkpointing/Services/CheckpointPruner.ts
@@ -1,0 +1,111 @@
+import {
+  CheckpointRef,
+  type OrchestrationCheckpointSummary,
+  type ThreadId,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import type * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+export const DEFAULT_CHECKPOINT_RETENTION_DAYS = 7;
+export const DEFAULT_MINIMUM_CHECKPOINTS_PER_THREAD = 3;
+export const CHECKPOINT_RETENTION_DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface CheckpointPruneInput {
+  readonly retentionDays?: number;
+  readonly minimumCheckpointsPerThread?: number;
+  readonly nowEpochMillis?: number;
+}
+
+export interface CheckpointPruneResult {
+  readonly retentionDays: number;
+  readonly minimumCheckpointsPerThread: number;
+  readonly cutoffEpochMillis: number;
+  readonly threadsScanned: number;
+  readonly workspacesScanned: number;
+  readonly snapshotsDeleted: number;
+  readonly metadataRowsCleared: number;
+  readonly estimatedBytesFreed: number;
+  readonly durationMs: number;
+  readonly failures: number;
+}
+
+export interface CheckpointPruneCandidate {
+  readonly threadId: ThreadId;
+  readonly checkpointTurnCount: number;
+  readonly checkpointRef: CheckpointRef;
+  readonly completedAt: string;
+  readonly estimatedBytes: number;
+}
+
+export interface SelectPrunableCheckpointsInput {
+  readonly threadId: ThreadId;
+  readonly checkpoints: ReadonlyArray<OrchestrationCheckpointSummary>;
+  readonly cutoffEpochMillis: number;
+  readonly minimumCheckpointsPerThread?: number;
+}
+
+const checkpointCompletedAtEpochMillis = (
+  checkpoint: Pick<OrchestrationCheckpointSummary, "completedAt">,
+) =>
+  DateTime.make(checkpoint.completedAt).pipe(
+    Option.match({
+      onNone: () => Number.NaN,
+      onSome: DateTime.toEpochMillis,
+    }),
+  );
+
+const estimateCheckpointBytes = (checkpoint: OrchestrationCheckpointSummary): number =>
+  new TextEncoder().encode(
+    JSON.stringify({
+      checkpointRef: checkpoint.checkpointRef,
+      status: checkpoint.status,
+      files: checkpoint.files,
+      assistantMessageId: checkpoint.assistantMessageId,
+    }),
+  ).byteLength;
+
+export function selectPrunableCheckpoints(
+  input: SelectPrunableCheckpointsInput,
+): ReadonlyArray<CheckpointPruneCandidate> {
+  const minimumCheckpointsPerThread =
+    input.minimumCheckpointsPerThread ?? DEFAULT_MINIMUM_CHECKPOINTS_PER_THREAD;
+  const sortedCheckpoints = [...input.checkpoints].sort((left, right) => {
+    if (left.checkpointTurnCount !== right.checkpointTurnCount) {
+      return left.checkpointTurnCount - right.checkpointTurnCount;
+    }
+    return checkpointCompletedAtEpochMillis(left) - checkpointCompletedAtEpochMillis(right);
+  });
+  const preservedRefs = new Set(
+    sortedCheckpoints
+      .slice(Math.max(0, sortedCheckpoints.length - minimumCheckpointsPerThread))
+      .map((checkpoint) => checkpoint.checkpointRef),
+  );
+
+  return sortedCheckpoints
+    .filter((checkpoint) => {
+      if (preservedRefs.has(checkpoint.checkpointRef)) {
+        return false;
+      }
+      const completedAtEpochMillis = checkpointCompletedAtEpochMillis(checkpoint);
+      return Number.isFinite(completedAtEpochMillis)
+        ? completedAtEpochMillis < input.cutoffEpochMillis
+        : false;
+    })
+    .map((checkpoint) => ({
+      threadId: input.threadId,
+      checkpointTurnCount: checkpoint.checkpointTurnCount,
+      checkpointRef: checkpoint.checkpointRef,
+      completedAt: checkpoint.completedAt,
+      estimatedBytes: estimateCheckpointBytes(checkpoint),
+    }));
+}
+
+export interface CheckpointPrunerShape {
+  readonly prune: (input?: CheckpointPruneInput) => Effect.Effect<CheckpointPruneResult>;
+}
+
+export class CheckpointPruner extends Context.Service<CheckpointPruner, CheckpointPrunerShape>()(
+  "t3/checkpointing/Services/CheckpointPruner",
+) {}

--- a/t3code/apps/server/src/checkpointing/_meta.json
+++ b/t3code/apps/server/src/checkpointing/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Manmohan Codex",
+  "generation_context": "Public bounty metadata only. Private runtime, system, developer, credential, memory, and user-sensitive instructions are intentionally omitted.",
+  "completed_at": "2026-05-30T11:13:48+05:30"
+}

--- a/t3code/apps/server/src/cli/checkpoint.ts
+++ b/t3code/apps/server/src/cli/checkpoint.ts
@@ -1,0 +1,124 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as References from "effect/References";
+import { Command, Flag, GlobalFlag } from "effect/unstable/cli";
+
+import { CheckpointPrunerLive } from "../checkpointing/Layers/CheckpointPruner.ts";
+import { CheckpointStoreLive } from "../checkpointing/Layers/CheckpointStore.ts";
+import {
+  CheckpointPruner,
+  type CheckpointPruneResult,
+} from "../checkpointing/Services/CheckpointPruner.ts";
+import { ServerConfig } from "../config.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "../orchestration/Layers/ProjectionSnapshotQuery.ts";
+import { ProjectionCheckpointRepositoryLive } from "../persistence/Layers/ProjectionCheckpoints.ts";
+import { layerConfig as SqlitePersistenceLayerLive } from "../persistence/Layers/Sqlite.ts";
+import { RepositoryIdentityResolverLive } from "../project/Layers/RepositoryIdentityResolver.ts";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import { type CliServerFlags, resolveServerConfig, sharedServerLocationFlags } from "./config.ts";
+
+const retentionDaysFlag = Flag.integer("days").pipe(
+  Flag.withDescription("Delete checkpoints older than this many days."),
+  Flag.withDefault(7),
+);
+
+const minimumKeepFlag = Flag.integer("keep").pipe(
+  Flag.withDescription("Minimum recent checkpoints to keep per thread."),
+  Flag.withDefault(3),
+);
+
+const CheckpointCliRuntimeLive = CheckpointPrunerLive.pipe(
+  Layer.provide(
+    Layer.mergeAll(
+      ProjectionCheckpointRepositoryLive,
+      OrchestrationProjectionSnapshotQueryLive.pipe(Layer.provide(RepositoryIdentityResolverLive)),
+      CheckpointStoreLive.pipe(Layer.provide(VcsDriverRegistry.layer)),
+    ),
+  ),
+  Layer.provideMerge(SqlitePersistenceLayerLive),
+  Layer.provideMerge(VcsProcess.layer),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const runCheckpointPrune = (flags: {
+  readonly baseDir: CliServerFlags["baseDir"];
+  readonly devUrl: CliServerFlags["devUrl"];
+  readonly days: number;
+  readonly keep: number;
+}) =>
+  Effect.gen(function* () {
+    const logLevel = yield* GlobalFlag.LogLevel;
+    const config = yield* resolveServerConfig(
+      {
+        mode: Option.none(),
+        port: Option.none(),
+        host: Option.none(),
+        baseDir: flags.baseDir,
+        cwd: Option.none(),
+        devUrl: flags.devUrl,
+        noBrowser: Option.none(),
+        bootstrapFd: Option.none(),
+        autoBootstrapProjectFromCwd: Option.none(),
+        logWebSocketEvents: Option.none(),
+        tailscaleServeEnabled: Option.none(),
+        tailscaleServePort: Option.none(),
+      },
+      logLevel,
+      {
+        startupPresentation: "headless",
+        forceAutoBootstrapProjectFromCwd: false,
+      },
+    );
+    const pruneEffect = Effect.gen(function* () {
+      const pruner = yield* CheckpointPruner;
+      return yield* pruner.prune({
+        retentionDays: flags.days,
+        minimumCheckpointsPerThread: flags.keep,
+      });
+    }).pipe(
+      Effect.provide(
+        CheckpointCliRuntimeLive.pipe(
+          Layer.provide(Layer.succeed(ServerConfig, config)),
+          Layer.provide(Layer.succeed(References.MinimumLogLevel, config.logLevel)),
+        ),
+      ),
+    ) as Effect.Effect<CheckpointPruneResult>;
+    const result = yield* pruneEffect;
+
+    yield* Console.log(
+      [
+        `Deleted ${result.snapshotsDeleted} checkpoint snapshot(s).`,
+        `Cleared ${result.metadataRowsCleared} projection row(s).`,
+        `Scanned ${result.threadsScanned} thread(s) across ${result.workspacesScanned} workspace(s).`,
+        `Estimated bytes freed: ${result.estimatedBytesFreed}.`,
+        `Duration: ${result.durationMs}ms.`,
+        result.failures > 0 ? `Failures: ${result.failures}.` : "Failures: 0.",
+      ].join("\n"),
+    );
+  });
+
+const checkpointPruneCommand = Command.make("prune", {
+  ...sharedServerLocationFlags,
+  days: retentionDaysFlag,
+  keep: minimumKeepFlag,
+}).pipe(
+  Command.withDescription("Prune old checkpoint snapshots while preserving recent snapshots."),
+  Command.withHandler(runCheckpointPrune),
+);
+
+const checkpointCommandWithRuntime = Command.make("checkpoint").pipe(
+  Command.withDescription("Manage checkpoint snapshots."),
+  Command.withSubcommands([checkpointPruneCommand]),
+);
+
+export const checkpointCommand = checkpointCommandWithRuntime as Command.Command<
+  "checkpoint",
+  {},
+  {},
+  never,
+  never
+>;

--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -66,6 +66,21 @@ export const gitCommandDuration = Metric.timer("t3_git_command_duration", {
   description: "Git command execution duration.",
 });
 
+export const checkpointPruneSnapshotsDeleted = Metric.counter(
+  "t3_checkpoint_prune_snapshots_deleted",
+  {
+    description: "Checkpoint snapshots deleted by retention pruning.",
+  },
+);
+
+export const checkpointPruneBytesFreed = Metric.counter("t3_checkpoint_prune_bytes_freed", {
+  description: "Estimated checkpoint metadata bytes freed by retention pruning.",
+});
+
+export const checkpointPruneDuration = Metric.timer("t3_checkpoint_prune_duration", {
+  description: "Checkpoint pruning run duration.",
+});
+
 export const terminalSessionsTotal = Metric.counter("t3_terminal_sessions_total", {
   description: "Total terminal sessions started.",
 });

--- a/t3code/apps/server/src/persistence/Layers/ProjectionCheckpoints.ts
+++ b/t3code/apps/server/src/persistence/Layers/ProjectionCheckpoints.ts
@@ -1,4 +1,4 @@
-import { OrchestrationCheckpointFile } from "@t3tools/contracts";
+import { CheckpointRef, OrchestrationCheckpointFile } from "@t3tools/contracts";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import * as Effect from "effect/Effect";
@@ -9,6 +9,7 @@ import * as Struct from "effect/Struct";
 
 import { toPersistenceDecodeError, toPersistenceSqlError } from "../Errors.ts";
 import {
+  DeleteByCheckpointRefsInput,
   DeleteByThreadIdInput,
   GetByThreadAndTurnCountInput,
   ListByThreadIdInput,
@@ -148,6 +149,22 @@ const makeProjectionCheckpointRepository = Effect.gen(function* () {
       `,
   });
 
+  const deleteProjectionCheckpointRowByRef = SqlSchema.void({
+    Request: Schema.Struct({
+      checkpointRef: CheckpointRef,
+    }),
+    execute: ({ checkpointRef }) =>
+      sql`
+        UPDATE projection_turns
+        SET
+          checkpoint_turn_count = NULL,
+          checkpoint_ref = NULL,
+          checkpoint_status = NULL,
+          checkpoint_files_json = '[]'
+        WHERE checkpoint_ref = ${checkpointRef}
+      `,
+  });
+
   const upsertCheckpointRow = (row: Schema.Schema.Type<typeof ProjectionCheckpointDbRowSchema>) =>
     sql.withTransaction(
       clearCheckpointConflict({
@@ -203,11 +220,28 @@ const makeProjectionCheckpointRepository = Effect.gen(function* () {
       ),
     );
 
+  const deleteByCheckpointRefs: ProjectionCheckpointRepositoryShape["deleteByCheckpointRefs"] = (
+    input,
+  ) =>
+    Effect.forEach(
+      input.checkpointRefs,
+      (checkpointRef) => deleteProjectionCheckpointRowByRef({ checkpointRef }),
+      { discard: true },
+    ).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProjectionCheckpointRepository.deleteByCheckpointRefs:query",
+          "ProjectionCheckpointRepository.deleteByCheckpointRefs:encodeRequest",
+        ),
+      ),
+    );
+
   return {
     upsert,
     listByThreadId,
     getByThreadAndTurnCount,
     deleteByThreadId,
+    deleteByCheckpointRefs,
   } satisfies ProjectionCheckpointRepositoryShape;
 });
 

--- a/t3code/apps/server/src/persistence/Services/ProjectionCheckpoints.ts
+++ b/t3code/apps/server/src/persistence/Services/ProjectionCheckpoints.ts
@@ -51,6 +51,11 @@ export const DeleteByThreadIdInput = Schema.Struct({
 });
 export type DeleteByThreadIdInput = typeof DeleteByThreadIdInput.Type;
 
+export const DeleteByCheckpointRefsInput = Schema.Struct({
+  checkpointRefs: Schema.Array(CheckpointRef),
+});
+export type DeleteByCheckpointRefsInput = typeof DeleteByCheckpointRefsInput.Type;
+
 /**
  * ProjectionCheckpointRepositoryShape - Service API for projected checkpoints.
  */
@@ -83,6 +88,15 @@ export interface ProjectionCheckpointRepositoryShape {
    */
   readonly deleteByThreadId: (
     input: DeleteByThreadIdInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  /**
+   * Clear projected checkpoint metadata for specific filesystem checkpoint refs.
+   *
+   * Used by retention pruning after backing refs have been removed.
+   */
+  readonly deleteByCheckpointRefs: (
+    input: DeleteByCheckpointRefsInput,
   ) => Effect.Effect<void, ProjectionRepositoryError>;
 }
 

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
 import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 
 import { ServerConfig } from "./config.ts";
@@ -15,6 +16,7 @@ import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
+import { ProjectionCheckpointRepositoryLive } from "./persistence/Layers/ProjectionCheckpoints.ts";
 import { ServerLifecycleEventsLive } from "./serverLifecycleEvents.ts";
 import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService.ts";
 import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionDirectory.ts";
@@ -25,7 +27,12 @@ import { ProviderServiceLive } from "./provider/Layers/ProviderService.ts";
 import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReaper.ts";
 import { OpenCodeRuntimeLive } from "./provider/opencodeRuntime.ts";
 import { CheckpointDiffQueryLive } from "./checkpointing/Layers/CheckpointDiffQuery.ts";
+import { CheckpointPrunerLive } from "./checkpointing/Layers/CheckpointPruner.ts";
 import { CheckpointStoreLive } from "./checkpointing/Layers/CheckpointStore.ts";
+import {
+  CheckpointPruner,
+  DEFAULT_CHECKPOINT_RETENTION_DAYS,
+} from "./checkpointing/Services/CheckpointPruner.ts";
 import * as AzureDevOpsCli from "./sourceControl/AzureDevOpsCli.ts";
 import * as BitbucketApi from "./sourceControl/BitbucketApi.ts";
 import * as GitHubCli from "./sourceControl/GitHubCli.ts";
@@ -213,6 +220,28 @@ const CheckpointingLayerLive = Layer.empty.pipe(
   Layer.provideMerge(CheckpointStoreLive.pipe(Layer.provide(VcsDriverRegistryLayerLive))),
 );
 
+const CheckpointPruningSchedulerLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const pruner = yield* CheckpointPruner;
+    yield* Effect.forkScoped(
+      pruner
+        .prune({
+          retentionDays: DEFAULT_CHECKPOINT_RETENTION_DAYS,
+        })
+        .pipe(
+          Effect.repeat(Schedule.fixed("1 hour")),
+          Effect.catchCause((cause) =>
+            Effect.logWarning("checkpoint pruning scheduler stopped", { cause }),
+          ),
+        ),
+    );
+  }),
+);
+
+const CheckpointPruningLayerLive = CheckpointPruningSchedulerLive.pipe(
+  Layer.provide(CheckpointPrunerLive),
+);
+
 const TerminalLayerLive = TerminalManagerLive.pipe(Layer.provide(PtyAdapterLive));
 
 const WorkspaceEntriesLayerLive = WorkspaceEntriesLive.pipe(
@@ -241,9 +270,14 @@ const ProviderRuntimeLayerLive = ProviderSessionReaperLive.pipe(
   Layer.provideMerge(OrchestrationLayerLive),
 );
 
-const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
+const RuntimeCoreCheckpointDependenciesLive = ReactorLayerLive.pipe(
   // Core Services
+  Layer.provideMerge(CheckpointPruningLayerLive),
   Layer.provideMerge(CheckpointingLayerLive),
+  Layer.provideMerge(ProjectionCheckpointRepositoryLive),
+);
+
+const RuntimeCoreDependenciesLive = RuntimeCoreCheckpointDependenciesLive.pipe(
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
   Layer.provideMerge(GitLayerLive),
   Layer.provideMerge(VcsLayerLive),


### PR DESCRIPTION
/claim #838

## Summary
- Add a checkpoint pruning service that selects stale checkpoints by retention cutoff while preserving the newest checkpoints per thread.
- Delete backing checkpoint refs by workspace and clear projected checkpoint metadata for deleted refs.
- Add `t3 checkpoint prune --days --keep` for manual pruning and wire a non-blocking hourly runtime pruning layer.
- Add pruning metrics for deleted snapshots, estimated bytes freed, and duration.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-838-checkpoint-pruning-demo

## Verification
- `npx -y bun@1.3.11 run --cwd apps/server typecheck`
- `npx -y bun@1.3.11 run --cwd apps/server test src/checkpointing/Layers/CheckpointPruner.test.ts src/bin.test.ts`
- `npx -y bun@1.3.11 run --cwd apps/server test src/orchestration/Layers/CheckpointReactor.test.ts`
- `npx -y bun@1.3.11 run fmt:check apps/server/src/checkpointing/Services/CheckpointPruner.ts apps/server/src/checkpointing/Layers/CheckpointPruner.ts apps/server/src/checkpointing/Layers/CheckpointPruner.test.ts apps/server/src/checkpointing/_meta.json apps/server/src/persistence/Services/ProjectionCheckpoints.ts apps/server/src/persistence/Layers/ProjectionCheckpoints.ts apps/server/src/observability/Metrics.ts apps/server/src/orchestration/Layers/CheckpointReactor.ts apps/server/src/cli/checkpoint.ts apps/server/src/bin.ts apps/server/src/server.ts`
- `git diff --check`