### PR TITLE
Manmohan Codex [ FastAPI ] Add OAuth2 refresh token helpers

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
+from .security import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/.provenance.json
+++ b/fastapi/fastapi/security/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Manmohan Codex",
+  "config_snapshot": "Public metadata only. Private runtime, system, developer, and user-specific instructions are intentionally excluded.",
+  "created": "2026-05-30T05:56:35Z"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,70 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    This is a dependency class to collect refresh-token form data for an OAuth2
+    refresh token flow.
+    """
+
+    def __init__(
+        self,
+        *,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 refresh token grant type. It must be the fixed string
+                "refresh_token".
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                The OAuth2 refresh token used to obtain a new access token.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                A single string with one or more scopes separated by spaces.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                If there's a `client_id`, it can be sent as part of the form fields.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                If there's a `client_secret`, it can be sent as part of the form
+                fields.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +606,74 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password bearer flow with an OpenAPI refresh URL.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        refresh_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new one.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                The OAuth2 scopes that would be required by the path operations that
+                use this dependency.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, missing or invalid bearer tokens automatically cancel the
+                request with a 401 response.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            tokenUrl=tokenUrl,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+            refreshUrl=refresh_url,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -1,0 +1,133 @@
+import pytest
+from fastapi import (
+    Depends,
+    FastAPI,
+    Security,
+)
+from fastapi import (
+    OAuth2PasswordBearerWithRefresh as FastAPIOAuth2PasswordBearerWithRefresh,
+)
+from fastapi import (
+    OAuth2RefreshRequestForm as FastAPIOAuth2RefreshRequestForm,
+)
+from fastapi.security import OAuth2PasswordBearerWithRefresh, OAuth2RefreshRequestForm
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="/token",
+    refresh_url="/token/refresh",
+    scopes={"items": "Read items"},
+    auto_error=False,
+)
+
+
+@app.get("/items/")
+async def read_items(token: str | None = Security(oauth2_scheme)):
+    if token is None:
+        return {"msg": "Create an account first"}
+    return {"token": token}
+
+
+@app.post("/token/refresh")
+async def refresh_token(form_data: OAuth2RefreshRequestForm = Depends()):
+    return {
+        "grant_type": form_data.grant_type,
+        "refresh_token": form_data.refresh_token,
+        "scopes": form_data.scopes,
+        "client_id": form_data.client_id,
+        "client_secret": form_data.client_secret,
+    }
+
+
+client = TestClient(app)
+
+
+def test_security_exports():
+    assert FastAPIOAuth2PasswordBearerWithRefresh is OAuth2PasswordBearerWithRefresh
+    assert FastAPIOAuth2RefreshRequestForm is OAuth2RefreshRequestForm
+
+
+def test_password_bearer_with_refresh_no_token():
+    response = client.get("/items/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"msg": "Create an account first"}
+
+
+def test_password_bearer_with_refresh_valid_token():
+    response = client.get("/items/", headers={"Authorization": "Bearer testtoken"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"token": "testtoken"}
+
+
+def test_password_bearer_with_refresh_rejects_wrong_scheme():
+    response = client.get("/items/", headers={"Authorization": "Basic testtoken"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"msg": "Create an account first"}
+
+
+def test_refresh_form_accepts_refresh_token_grant():
+    response = client.post(
+        "/token/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-secret",
+            "scope": "items profile",
+            "client_id": "client-a",
+            "client_secret": "secret-a",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-secret",
+        "scopes": ["items", "profile"],
+        "client_id": "client-a",
+        "client_secret": "secret-a",
+    }
+
+
+@pytest.mark.parametrize(
+    "grant_type",
+    [
+        pytest.param("password", id="password-grant"),
+        pytest.param("refresh_token_extra", id="refresh-token-suffix"),
+        pytest.param("extra_refresh_token", id="refresh-token-prefix"),
+    ],
+)
+def test_refresh_form_rejects_invalid_grant_type(grant_type: str):
+    response = client.post(
+        "/token/refresh",
+        data={"grant_type": grant_type, "refresh_token": "refresh-secret"},
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "string_pattern_mismatch",
+                "loc": ["body", "grant_type"],
+                "msg": "String should match pattern '^refresh_token$'",
+                "input": grant_type,
+                "ctx": {"pattern": "^refresh_token$"},
+            }
+        ]
+    }
+
+
+def test_openapi_schema_includes_refresh_url():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    security_scheme = response.json()["components"]["securitySchemes"][
+        "OAuth2PasswordBearerWithRefresh"
+    ]
+    assert security_scheme == {
+        "type": "oauth2",
+        "flows": {
+            "password": {
+                "scopes": {"items": "Read items"},
+                "tokenUrl": "/token",
+                "refreshUrl": "/token/refresh",
+            }
+        },
+    }


### PR DESCRIPTION
/claim #758

## Summary
- Added `OAuth2RefreshRequestForm` for refresh-token grant form handling with `grant_type=refresh_token` validation.
- Added `OAuth2PasswordBearerWithRefresh` as a drop-in password bearer helper that accepts `refresh_url` and emits OpenAPI `refreshUrl`.
- Exported the new helpers from `fastapi.security` and top-level `fastapi` per the issue request.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-758-oauth2-refresh-demo

## Validation
- `uv run pytest tests/test_security_oauth2_refresh.py tests/test_security_oauth2_password_bearer_optional.py tests/test_security_oauth2.py -q` -> 23 passed
- `uv run ruff check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py`
- `uv run ruff format --check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py`
- `git diff --check`

## Security note
- Private runtime/system instructions are not written to repository files or PR text; the included provenance metadata is intentionally non-sensitive public metadata only.