### PR TITLE
Manmohan Codex [ FastAPI ] Add HTTPBasic brute force protection

### DIFF
--- a/fastapi/fastapi/security/.generation_meta.json
+++ b/fastapi/fastapi/security/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Manmohan Codex",
+  "initial_directives": "Public metadata only. Private runtime, system, developer, and user-specific instructions are intentionally excluded.",
+  "date": "2026-05-30T06:02:25Z"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,10 @@
 import binascii
+import hashlib
+import math
+import secrets
+import time
 from base64 import b64decode
+from collections.abc import Callable
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +15,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -217,6 +222,188 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    """
+    HTTP Basic authentication with opt-in password verification and brute force
+    protection.
+    """
+
+    def __init__(
+        self,
+        *,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        realm: Annotated[
+            str | None,
+            Doc(
+                """
+                HTTP Basic authentication realm.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, authentication errors automatically cancel the request.
+                """
+            ),
+        ] = True,
+        max_attempts: Annotated[
+            int,
+            Doc(
+                """
+                Maximum failed attempts allowed per client IP inside the lockout
+                window.
+                """
+            ),
+        ] = 5,
+        window_seconds: Annotated[
+            int,
+            Doc(
+                """
+                Number of seconds failed attempts are counted for each client IP.
+                """
+            ),
+        ] = 60,
+        password_verifier: Annotated[
+            Callable[[HTTPBasicCredentials], bool] | None,
+            Doc(
+                """
+                Optional callback used to verify parsed HTTP Basic credentials.
+                When omitted, this class behaves like `HTTPBasic`.
+                """
+            ),
+        ] = None,
+    ):
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be greater than 0")
+        if window_seconds < 1:
+            raise ValueError("window_seconds must be greater than 0")
+        super().__init__(
+            scheme_name=scheme_name,
+            realm=realm,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self.password_verifier = password_verifier
+        self._failed_attempts: dict[str, list[float]] = {}
+
+    @staticmethod
+    def hash_password(
+        password: str, *, salt: bytes | None = None, iterations: int = 600_000
+    ) -> str:
+        """
+        Hash a password with PBKDF2-HMAC-SHA256 for use with `verify_password`.
+        """
+        if iterations < 1:
+            raise ValueError("iterations must be greater than 0")
+        salt = salt or secrets.token_bytes(16)
+        password_bytes = password.encode("utf-8")
+        digest = hashlib.pbkdf2_hmac("sha256", password_bytes, salt, iterations)
+        return f"pbkdf2_sha256${iterations}${salt.hex()}${digest.hex()}"
+
+    @staticmethod
+    def verify_password(password: str, password_hash: str) -> bool:
+        """
+        Verify a password hash using constant-time digest comparison.
+        """
+        try:
+            algorithm, iterations, salt_hex, digest_hex = password_hash.split("$", 3)
+            if algorithm != "pbkdf2_sha256":
+                return False
+            salt = bytes.fromhex(salt_hex)
+            expected = bytes.fromhex(digest_hex)
+            iteration_count = int(iterations)
+        except (TypeError, ValueError):
+            return False
+        if iteration_count < 1:
+            return False
+        actual = hashlib.pbkdf2_hmac(
+            "sha256", password.encode("utf-8"), salt, iteration_count
+        )
+        return secrets.compare_digest(actual, expected)
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _client_key(self, request: Request) -> str:
+        if request.client is None:
+            return "unknown"
+        return request.client.host
+
+    def _active_failures(self, client_key: str, now: float) -> list[float]:
+        attempts = [
+            attempt
+            for attempt in self._failed_attempts.get(client_key, [])
+            if now - attempt < self.window_seconds
+        ]
+        if attempts:
+            self._failed_attempts[client_key] = attempts
+        else:
+            self._failed_attempts.pop(client_key, None)
+        return attempts
+
+    def _retry_after(self, attempts: list[float], now: float) -> int:
+        if not attempts:
+            return self.window_seconds
+        remaining = self.window_seconds - (now - min(attempts))
+        return max(1, math.ceil(remaining))
+
+    def _lockout_error(self, retry_after: int) -> HTTPException:
+        return HTTPException(
+            status_code=HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many authentication attempts",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    def _record_failure(self, client_key: str, now: float) -> None:
+        attempts = self._active_failures(client_key, now)
+        attempts.append(now)
+        self._failed_attempts[client_key] = attempts
+
+    def _reset_failures(self, client_key: str) -> None:
+        self._failed_attempts.pop(client_key, None)
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        client_key = self._client_key(request)
+        now = self._now()
+        attempts = self._active_failures(client_key, now)
+        if len(attempts) >= self.max_attempts:
+            raise self._lockout_error(self._retry_after(attempts, now))
+
+        credentials = await super().__call__(request)
+        if credentials is None or self.password_verifier is None:
+            return credentials
+
+        if self.password_verifier(credentials):
+            self._reset_failures(client_key)
+            return credentials
+
+        self._record_failure(client_key, now)
+        if self.auto_error:
+            raise self.make_not_authenticated_error()
+        return None
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_security_http_basic_protection.py
+++ b/fastapi/tests/test_security_http_basic_protection.py
@@ -1,0 +1,152 @@
+import base64
+from collections.abc import Callable
+
+import fastapi.security.http as http_module
+import pytest
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+
+def basic_auth(username: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def create_protected_app() -> tuple[FastAPI, HTTPBasicWithProtection, dict[str, float]]:
+    password_hash = HTTPBasicWithProtection.hash_password(
+        "secret", salt=b"static-salt", iterations=1
+    )
+
+    def verifier(credentials: HTTPBasicCredentials) -> bool:
+        return (
+            credentials.username == "alice"
+            and HTTPBasicWithProtection.verify_password(
+                credentials.password, password_hash
+            )
+        )
+
+    security = HTTPBasicWithProtection(
+        max_attempts=2,
+        window_seconds=30,
+        password_verifier=verifier,
+    )
+    clock = {"now": 100.0}
+    security._now = lambda: clock["now"]  # type: ignore[method-assign]
+    app = FastAPI()
+
+    @app.get("/users/me")
+    async def read_current_user(
+        credentials: HTTPBasicCredentials = Security(security),
+    ):
+        return {"username": credentials.username}
+
+    return app, security, clock
+
+
+def test_failed_attempts_lock_out_client_ip():
+    app, _, _ = create_protected_app()
+    client = TestClient(app)
+
+    response = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    assert response.status_code == 401
+    response = client.get("/users/me", headers=basic_auth("alice", "still-wrong"))
+    assert response.status_code == 401
+
+    response = client.get("/users/me", headers=basic_auth("alice", "secret"))
+    assert response.status_code == 429
+    assert response.json() == {"detail": "Too many authentication attempts"}
+    assert response.headers["Retry-After"] == "30"
+
+
+def test_successful_authentication_resets_attempt_counter():
+    app, _, _ = create_protected_app()
+    client = TestClient(app)
+
+    response = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    assert response.status_code == 401
+    response = client.get("/users/me", headers=basic_auth("alice", "secret"))
+    assert response.status_code == 200
+    assert response.json() == {"username": "alice"}
+
+    response = client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    assert response.status_code == 401
+    response = client.get("/users/me", headers=basic_auth("alice", "wrong-again"))
+    assert response.status_code == 401
+    response = client.get("/users/me", headers=basic_auth("alice", "secret"))
+    assert response.status_code == 429
+
+
+def test_lockout_expires_after_window():
+    app, _, clock = create_protected_app()
+    client = TestClient(app)
+
+    client.get("/users/me", headers=basic_auth("alice", "wrong"))
+    client.get("/users/me", headers=basic_auth("alice", "wrong-again"))
+    response = client.get("/users/me", headers=basic_auth("alice", "secret"))
+    assert response.status_code == 429
+
+    clock["now"] = 131.0
+    response = client.get("/users/me", headers=basic_auth("alice", "secret"))
+    assert response.status_code == 200
+    assert response.json() == {"username": "alice"}
+
+
+def test_failed_attempts_are_scoped_per_ip():
+    app, _, _ = create_protected_app()
+    client_a = TestClient(app, client=("10.0.0.1", 50000))
+    client_b = TestClient(app, client=("10.0.0.2", 50000))
+
+    client_a.get("/users/me", headers=basic_auth("alice", "wrong"))
+    client_a.get("/users/me", headers=basic_auth("alice", "wrong-again"))
+    response = client_a.get("/users/me", headers=basic_auth("alice", "secret"))
+    assert response.status_code == 429
+
+    response = client_b.get("/users/me", headers=basic_auth("alice", "secret"))
+    assert response.status_code == 200
+    assert response.json() == {"username": "alice"}
+
+
+def test_without_verifier_behaves_like_http_basic():
+    security = HTTPBasicWithProtection(auto_error=False)
+    app = FastAPI()
+
+    @app.get("/users/me")
+    async def read_current_user(
+        credentials: HTTPBasicCredentials | None = Security(security),
+    ):
+        if credentials is None:
+            return {"anonymous": True}
+        return {"username": credentials.username, "password": credentials.password}
+
+    client = TestClient(app)
+    response = client.get("/users/me")
+    assert response.status_code == 200
+    assert response.json() == {"anonymous": True}
+
+    response = client.get("/users/me", headers=basic_auth("alice", "not-checked"))
+    assert response.status_code == 200
+    assert response.json() == {"username": "alice", "password": "not-checked"}
+
+
+def test_verify_password_uses_constant_time_compare(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[tuple[bytes, bytes]] = []
+    original_compare_digest: Callable[[bytes, bytes], bool] = (
+        http_module.secrets.compare_digest
+    )
+
+    def compare_digest_spy(actual: bytes, expected: bytes) -> bool:
+        calls.append((actual, expected))
+        return original_compare_digest(actual, expected)
+
+    monkeypatch.setattr(http_module.secrets, "compare_digest", compare_digest_spy)
+    password_hash = HTTPBasicWithProtection.hash_password(
+        "secret", salt=b"static-salt", iterations=1
+    )
+
+    assert HTTPBasicWithProtection.verify_password("secret", password_hash)
+    assert not HTTPBasicWithProtection.verify_password("wrong", password_hash)
+    assert not HTTPBasicWithProtection.verify_password("secret", "invalid")
+    assert len(calls) == 2


### PR DESCRIPTION
/claim #800

## Summary
- Added opt-in `HTTPBasicWithProtection` while preserving existing `HTTPBasic` behavior when no verifier is configured.
- Tracks failed credential attempts per client IP inside a configurable window, returns 429 with `Retry-After` on lockout, and resets counters after successful verification.
- Added PBKDF2-HMAC password hashing plus constant-time password verification helpers.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-800-httpbasic-protection-demo

## Validation
- `uv run pytest tests/test_security_http_basic_protection.py tests/test_security_http_basic_optional.py tests/test_security_http_basic_realm.py tests/test_security_http_basic_realm_description.py -q` -> 21 passed
- `uv run ruff check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py`
- `uv run ruff format --check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py`
- `git diff --check`

## Security note
- Private runtime/system instructions are not written to repository files or PR text; included metadata is intentionally non-sensitive public metadata only.