### PR TITLE
Manmohan Codex [ FastAPI ] Fix validation error request context

### DIFF
--- a/fastapi/fastapi/_meta.json
+++ b/fastapi/fastapi/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Manmohan Codex",
+  "generation_context": "Public metadata only. Private runtime, system, developer, and user-specific instructions are intentionally excluded.",
+  "completed_at": "2026-05-30T06:10:12Z"
+}

--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
 from fastapi.utils import is_body_allowed_for_status_code
@@ -6,6 +9,21 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
+
+SENSITIVE_BODY_FIELDS = {"password", "secret", "token", "api_key"}
+
+
+def _redact_sensitive_body(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: "***REDACTED***"
+            if str(key).lower() in SENSITIVE_BODY_FIELDS
+            else _redact_sensitive_body(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_redact_sensitive_body(item) for item in value]
+    return value
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
@@ -20,9 +38,16 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
+    content: dict[str, Any] = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+    if request.app.debug and exc.body is not None:
+        content["body"] = jsonable_encoder(_redact_sensitive_body(exc.body))
     return JSONResponse(
         status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
+        content=content,
     )
 
 

--- a/fastapi/tests/test_request_validation_exception_context.py
+++ b/fastapi/tests/test_request_validation_exception_context.py
@@ -1,0 +1,69 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    name: str
+    count: int
+
+
+def create_app(*, debug: bool) -> FastAPI:
+    app = FastAPI(debug=debug)
+
+    @app.post("/items/{item_id}")
+    async def create_item(item_id: int, item: Item):
+        return {"item_id": item_id, "item": item}
+
+    return app
+
+
+def invalid_body() -> dict[str, object]:
+    return {
+        "name": "Widget",
+        "count": "not-an-int",
+        "password": "plain-password",
+        "nested": {
+            "secret": "nested-secret",
+            "visible": "kept",
+            "items": [
+                {"token": "nested-token"},
+                {"api_key": "nested-api-key", "value": 1},
+            ],
+        },
+    }
+
+
+def test_validation_error_includes_request_path_and_method_without_debug_body():
+    response = TestClient(create_app(debug=False)).post(
+        "/items/10", json=invalid_body()
+    )
+
+    assert response.status_code == 422
+    content = response.json()
+    assert content["path"] == "/items/10"
+    assert content["method"] == "POST"
+    assert "detail" in content
+    assert "body" not in content
+
+
+def test_validation_error_debug_body_redacts_sensitive_fields():
+    response = TestClient(create_app(debug=True)).post("/items/10", json=invalid_body())
+
+    assert response.status_code == 422
+    content = response.json()
+    assert content["path"] == "/items/10"
+    assert content["method"] == "POST"
+    assert content["body"] == {
+        "name": "Widget",
+        "count": "not-an-int",
+        "password": "***REDACTED***",
+        "nested": {
+            "secret": "***REDACTED***",
+            "visible": "kept",
+            "items": [
+                {"token": "***REDACTED***"},
+                {"api_key": "***REDACTED***", "value": 1},
+            ],
+        },
+    }


### PR DESCRIPTION
/claim #757

## Summary
- Added request `path` and `method` to default request validation error responses.
- Includes the received request body only when the FastAPI app is running with `debug=True`.
- Recursively redacts `password`, `secret`, `token`, and `api_key` fields from debug body echoes.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-757-validation-context-demo

## Validation
- `uv run pytest tests/test_request_validation_exception_context.py tests/test_exception_handlers.py tests/test_validation_error_context.py -q` -> 14 passed
- `uv run ruff check fastapi/exception_handlers.py tests/test_request_validation_exception_context.py`
- `uv run ruff format --check fastapi/exception_handlers.py tests/test_request_validation_exception_context.py`
- `git diff --check`

## Security note
- Private runtime/system instructions are not written to repository files or PR text; included metadata is intentionally non-sensitive public metadata only.