### PR TITLE
Manmohan Codex [ FastAPI ] Add concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Manmohan Codex",
+  "runtime_instructions": "Public metadata only. Private runtime, system, developer, and user-specific instructions are intentionally excluded.",
+  "timestamp": "2026-05-30T06:18:14Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,9 @@
-from collections.abc import AsyncGenerator
+import asyncio
+import inspect
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +14,78 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    """
+    Error raised when one or more concurrent tasks fail.
+    """
+
+    def __init__(
+        self,
+        failures: Sequence[BaseException],
+        partial_results: Sequence[Any],
+    ) -> None:
+        self.failures = list(failures)
+        self.partial_results = list(partial_results)
+        super().__init__(f"{len(self.failures)} concurrent task(s) failed")
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    """
+    Run awaitables concurrently with a concurrency limit.
+    """
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be greater than 0")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[_T | None] = [None] * len(coroutines)
+    completed = [False] * len(coroutines)
+    failures: list[BaseException] = []
+
+    async def run_one(index: int, coroutine: Awaitable[_T]) -> None:
+        started = False
+        try:
+            async with semaphore:
+                started = True
+                results[index] = await coroutine
+                completed[index] = True
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            failures.append(exc)
+        finally:
+            if not started and inspect.iscoroutine(coroutine):
+                coroutine.close()
+
+    tasks = [
+        asyncio.create_task(run_one(index, coroutine))
+        for index, coroutine in enumerate(coroutines)
+    ]
+    try:
+        runner = asyncio.gather(*tasks)
+        if timeout is None:
+            await runner
+        else:
+            await asyncio.wait_for(runner, timeout)
+    except TimeoutError as exc:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        failures.append(exc)
+
+    partial_results = [
+        result if is_complete else None
+        for result, is_complete in zip(results, completed, strict=True)
+    ]
+    if failures:
+        raise ConcurrencyError(failures, partial_results)
+    return cast(list[_T], results)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,139 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+def test_run_concurrently_preserves_order_and_limits_concurrency():
+    async def run_test():
+        active = 0
+        max_seen = 0
+
+        async def worker(value: int, delay: float) -> int:
+            nonlocal active, max_seen
+            active += 1
+            max_seen = max(max_seen, active)
+            await asyncio.sleep(delay)
+            active -= 1
+            return value
+
+        results = await run_concurrently(
+            [
+                worker(0, 0.03),
+                worker(1, 0.01),
+                worker(2, 0.02),
+                worker(3, 0.01),
+            ],
+            max_concurrency=2,
+        )
+        return results, max_seen
+
+    results, max_seen = asyncio.run(run_test())
+    assert results == [0, 1, 2, 3]
+    assert max_seen == 2
+
+
+def test_run_concurrently_with_one_runs_sequentially():
+    async def run_test():
+        active = 0
+        max_seen = 0
+
+        async def worker(value: int) -> int:
+            nonlocal active, max_seen
+            active += 1
+            max_seen = max(max_seen, active)
+            await asyncio.sleep(0)
+            active -= 1
+            return value
+
+        results = await run_concurrently(
+            [worker(1), worker(2), worker(3)],
+            max_concurrency=1,
+        )
+        return results, max_seen
+
+    results, max_seen = asyncio.run(run_test())
+    assert results == [1, 2, 3]
+    assert max_seen == 1
+
+
+def test_run_concurrently_allows_concurrency_above_task_count():
+    async def run_test():
+        active = 0
+        max_seen = 0
+
+        async def worker(value: int) -> int:
+            nonlocal active, max_seen
+            active += 1
+            max_seen = max(max_seen, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return value
+
+        results = await run_concurrently(
+            [worker(1), worker(2), worker(3)],
+            max_concurrency=10,
+        )
+        return results, max_seen
+
+    results, max_seen = asyncio.run(run_test())
+    assert results == [1, 2, 3]
+    assert max_seen == 3
+
+
+def test_run_concurrently_collects_all_failures():
+    async def run_test():
+        async def failing(message: str):
+            await asyncio.sleep(0)
+            raise RuntimeError(message)
+
+        async def passing():
+            await asyncio.sleep(0)
+            return "ok"
+
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(
+                [failing("first"), passing(), failing("second")],
+                max_concurrency=3,
+            )
+        return exc_info.value
+
+    error = asyncio.run(run_test())
+    assert [str(failure) for failure in error.failures] == ["first", "second"]
+    assert error.partial_results == [None, "ok", None]
+
+
+def test_run_concurrently_timeout_cancels_remaining_tasks():
+    async def run_test():
+        cancelled: list[bool] = []
+
+        async def fast():
+            return "done"
+
+        async def slow():
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                cancelled.append(True)
+                raise
+
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(
+                [fast(), slow()],
+                max_concurrency=2,
+                timeout=0.01,
+            )
+        return exc_info.value, cancelled
+
+    error, cancelled = asyncio.run(run_test())
+    assert any(isinstance(failure, TimeoutError) for failure in error.failures)
+    assert error.partial_results == ["done", None]
+    assert cancelled == [True]
+
+
+def test_run_concurrently_validates_max_concurrency():
+    async def run_test():
+        with pytest.raises(ValueError, match="max_concurrency"):
+            await run_concurrently([], max_concurrency=0)
+
+    asyncio.run(run_test())


### PR DESCRIPTION
/claim #803

## Summary
- Added `run_concurrently()` to `fastapi.concurrency` using `asyncio.Semaphore` for `max_concurrency` limiting.
- Preserves input-order results regardless of task completion order.
- Added `ConcurrencyError` carrying all task failures and partial results, including timeout cases.
- Timeout handling cancels unfinished tasks.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-803-run-concurrently-demo

## Validation
- `uv run pytest tests/test_concurrency.py -q` -> 6 passed
- `uv run ruff check fastapi/concurrency.py tests/test_concurrency.py`
- `uv run ruff format --check fastapi/concurrency.py tests/test_concurrency.py`
- `git diff --check`

## Security note
- Private runtime/system instructions are not written to repository files or PR text; included metadata is intentionally non-sensitive public metadata only.