### PR TITLE
Manmohan Codex [ Crypto ] Fix SimpleSwap slippage protection

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -10,9 +10,17 @@ contract SimpleSwap {
     uint256 public reserveB;
     uint256 public fee; // basis points, e.g. 30 = 0.3%
 
-    event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
+    event Swap(
+        address indexed user,
+        address tokenIn,
+        uint256 amountIn,
+        uint256 amountOut
+    );
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_tokenA != address(0) && _tokenB != address(0), "Invalid token");
+        require(_tokenA != _tokenB, "Duplicate token");
+        require(_fee < 10000, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
@@ -25,11 +33,17 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
-        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Deadline expired");
+        require(
+            tokenIn == address(tokenA) || tokenIn == address(tokenB),
+            "Invalid token"
+        );
         require(amountIn > 0, "Amount must be > 0");
 
         bool isTokenA = tokenIn == address(tokenA);
@@ -37,15 +51,14 @@ contract SimpleSwap {
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
-        inputToken.transferFrom(msg.sender, address(this), amountIn);
+        amountOut = _getAmountOut(amountIn, reserveIn, reserveOut);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
 
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
-        outputToken.transfer(msg.sender, amountOut);
+        require(
+            inputToken.transferFrom(msg.sender, address(this), amountIn),
+            "Transfer in failed"
+        );
+        require(outputToken.transfer(msg.sender, amountOut), "Transfer out failed");
 
         if (isTokenA) {
             reserveA += amountIn;
@@ -59,11 +72,31 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(
+            tokenIn == address(tokenA) || tokenIn == address(tokenB),
+            "Invalid token"
+        );
+        require(amountIn > 0, "Amount must be > 0");
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
+        return _getAmountOut(amountIn, reserveIn, reserveOut);
+    }
+
+    function _getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) internal view returns (uint256) {
+        uint256 feeAmount = _calculateFee(amountIn);
         uint256 amountInAfterFee = amountIn - feeAmount;
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+    }
+
+    function _calculateFee(uint256 amountIn) internal view returns (uint256) {
+        if (fee == 0) {
+            return 0;
+        }
+        return (amountIn * fee + 9999) / 10000;
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Manmohan Codex",
+  "generation_context": "Public metadata only. Private runtime, system, developer, and user-specific instructions are intentionally excluded.",
+  "completed_at": "2026-05-30T06:22:47Z"
+}


### PR DESCRIPTION
/claim #913

## Summary
- Added `minAmountOut` and `deadline` parameters to `SimpleSwap.swap`.
- Reverts expired swaps with `Deadline expired` and insufficient output with `Slippage exceeded`.
- Made `swap` and `getAmountOut` share the same quote calculation path.
- Fixed small-amount basis-point fee precision by rounding fees up instead of truncating to zero.
- Added constructor token/fee validation and checked ERC20 transfer return values.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-913-simpleswap-slippage-demo

## Validation
- `npx --yes solc --base-path /Users/manmohan/bounty-work/Bounty-Hunters --include-path <temp>/node_modules --bin --output-dir <temp> solidity/contracts/SimpleSwap.sol`
- Deterministic math sanity check: `tinyFee(1, 30 bps) = 1`, exact quote for 1000 against 100000/50000 reserves at 30 bps = 493
- `git diff --check`

## Security note
- Private runtime/system instructions are not written to repository files or PR text; included metadata is intentionally non-sensitive public metadata only.