### PR TITLE
Manmohan Codex [ Crypto ] Harden PriceOracle feed validation

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Manmohan Codex",
+  "initial_directives": "Public metadata only. Private runtime, system, developer, and user-specific instructions are intentionally excluded.",
+  "date": "2026-05-30T06:27:26Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,87 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(uint256 updatedAt);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+    function getLatestPrice() external returns (int256) {
+        (int256 price, uint256 updatedAt) = _readValidatedPrice(primaryFeed);
+        if (!_isStale(updatedAt)) {
+            emit PriceQueried(price, updatedAt);
+            return price;
+        }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        emit StalePrice(updatedAt);
 
-        return price;
+        (int256 fallbackPrice, uint256 fallbackUpdatedAt) = _readFreshPrice(fallbackFeed);
+        emit PriceQueried(fallbackPrice, fallbackUpdatedAt);
+        return fallbackPrice;
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        require(_maxStaleness > 0, "Invalid staleness");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setPrimaryFeed(address _primaryFeed) external onlyOwner {
+        require(_primaryFeed != address(0), "Invalid primary feed");
+        primaryFeed = AggregatorV3Interface(_primaryFeed);
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+    }
+
+    function _readFreshPrice(
+        AggregatorV3Interface feed
+    ) internal view returns (int256 price, uint256 updatedAt) {
+        (price, updatedAt) = _readValidatedPrice(feed);
+        require(!_isStale(updatedAt), "Stale price");
+    }
+
+    function _readValidatedPrice(
+        AggregatorV3Interface feed
+    ) internal view returns (int256 price, uint256 updatedAt) {
+        uint80 roundId;
+        int256 answer;
+        uint80 answeredInRound;
+        (
+            roundId,
+            answer,
+            ,
+            updatedAt,
+            answeredInRound
+        ) = feed.latestRoundData();
+
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(answer > 0, "Invalid price");
+        require(updatedAt <= block.timestamp, "Invalid timestamp");
+        return (answer, updatedAt);
+    }
+
+    function _isStale(uint256 updatedAt) internal view returns (bool) {
+        return block.timestamp - updatedAt >= MAX_STALENESS;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
     }
 }


### PR DESCRIPTION
/claim #915

## Summary
- Validates Chainlink round completeness with `answeredInRound >= roundId`.
- Rejects zero/negative prices and future timestamps with clear errors.
- Treats stale primary data as the fallback path, emits `StalePrice(updatedAt)`, and reverts if fallback data is also stale.
- Keeps `MAX_STALENESS` owner-configurable and adds owner controls for primary/fallback feeds.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-915-price-oracle-demo

## Validation
- `npx --yes solc --base-path /Users/manmohan/bounty-work/Bounty-Hunters --bin --output-dir <temp> solidity/contracts/PriceOracle.sol`
- `git diff --check`

## Security note
- Private runtime/system instructions are not written to repository files or PR text; included metadata is intentionally non-sensitive public metadata only.