### PR TITLE
Manmohan Codex [ Crypto ] Fix TokenVesting overflow and revocation

### DIFF
--- a/solidity/contracts/.audit.json
+++ b/solidity/contracts/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Manmohan Codex",
+  "environment_config": "Public metadata only. Private runtime, system, developer, and user-specific instructions are intentionally excluded.",
+  "completed_at": "2026-05-30T06:32:47Z"
+}

--- a/solidity/contracts/TokenVesting.sol
+++ b/solidity/contracts/TokenVesting.sol
@@ -26,6 +26,10 @@ contract TokenVesting {
         uint256 _cliffDuration,
         uint256 _vestingDuration
     ) {
+        require(_token != address(0), "Invalid token");
+        require(_beneficiary != address(0), "Invalid beneficiary");
+        require(_vestingDuration > 0, "Invalid duration");
+        require(_cliffDuration <= _vestingDuration, "Invalid cliff");
         token = IERC20(_token);
         beneficiary = _beneficiary;
         owner = msg.sender;
@@ -35,44 +39,48 @@ contract TokenVesting {
         duration = _vestingDuration;
     }
 
-    // BUG: Overflow risk for large allocations — totalAllocation * elapsed can exceed uint256
     function vestedAmount() public view returns (uint256) {
         if (block.timestamp < cliff) return 0;
-        if (block.timestamp >= start + duration) return totalAllocation;
 
         uint256 elapsed = block.timestamp - start;
-        // This multiplication can overflow for large totalAllocation values
-        return totalAllocation * elapsed / duration;
+        if (elapsed >= duration) return totalAllocation;
+
+        uint256 baseVested = (totalAllocation / duration) * elapsed;
+        uint256 remainderVested = ((totalAllocation % duration) * elapsed) / duration;
+        return baseVested + remainderVested;
     }
 
     function claimable() public view returns (uint256) {
+        if (revoked) return 0;
         return vestedAmount() - claimed;
     }
 
     function claim() external {
         require(msg.sender == beneficiary, "Not beneficiary");
+        require(!revoked, "Vesting revoked");
         uint256 amount = claimable();
         require(amount > 0, "Nothing to claim");
         claimed += amount;
-        token.transfer(beneficiary, amount);
+        require(token.transfer(beneficiary, amount), "Transfer failed");
         emit TokensClaimed(beneficiary, amount);
     }
 
-    // BUG: Incorrect unvested calculation during cliff period
     function revoke() external {
         require(msg.sender == owner, "Not owner");
         require(!revoked, "Already revoked");
         revoked = true;
 
         uint256 vested = vestedAmount();
-        // BUG: Should be totalAllocation - claimed, not totalAllocation - vested
-        // during cliff, vested is 0 but user may have claimed nothing
-        uint256 unvested = totalAllocation - vested;
+        uint256 beneficiaryAmount = vested > claimed ? vested - claimed : 0;
+        uint256 unvested = totalAllocation - claimed - beneficiaryAmount;
+        claimed += beneficiaryAmount;
 
-        if (vested > claimed) {
-            token.transfer(beneficiary, vested - claimed);
+        if (beneficiaryAmount > 0) {
+            require(token.transfer(beneficiary, beneficiaryAmount), "Transfer failed");
         }
-        token.transfer(owner, unvested);
+        if (unvested > 0) {
+            require(token.transfer(owner, unvested), "Transfer failed");
+        }
         emit VestingRevoked(beneficiary, unvested);
     }
 }


### PR DESCRIPTION
/claim #917

## Summary
- Replaced the overflow-prone `totalAllocation * elapsed / duration` vesting formula with quotient/remainder math.
- Uses `elapsed >= duration` instead of `start + duration` for completion checks.
- Blocks claims after revocation and checks ERC20 transfer return values.
- Corrects revoke accounting so the beneficiary receives vested-but-unclaimed tokens and the owner receives only truly unvested tokens, including during the cliff period.

## Demo
- https://github.com/ManmohanBuildsProducts/Bounty-Hunters/releases/tag/bounty-917-token-vesting-demo

## Validation
- `npx --yes solc --base-path /Users/manmohan/bounty-work/Bounty-Hunters --include-path <temp>/node_modules --bin --output-dir <temp> solidity/contracts/TokenVesting.sol`
- Deterministic math sanity check: 1B token 18-decimal allocation vests 500M at half duration and full allocation at end
- `git diff --check`

## Security note
- Private runtime/system instructions are not written to repository files or PR text; included metadata is intentionally non-sensitive public metadata only.