### PR TITLE
Codex [ T3 Code ] Standardize server error types with Effect.Data.TaggedEnum

### DIFF
--- a/t3code/apps/server/src/_meta.json
+++ b/t3code/apps/server/src/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex",
+  "generation_context": "Automated coding agent contribution for GitHub issue #861. Private system, developer, runtime, user, credential, and environment instructions are intentionally not included.",
+  "completed_at": "2026-05-30T09:35:00.000Z"
+}

--- a/t3code/apps/server/src/bootstrap.ts
+++ b/t3code/apps/server/src/bootstrap.ts
@@ -4,18 +4,15 @@ import * as Net from "node:net";
 import * as readline from "node:readline";
 import type { Readable } from "node:stream";
 
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
+import { ConfigError } from "./errors.ts";
 
-class BootstrapError extends Data.TaggedError("BootstrapError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+type BootstrapError = ConfigError;
 
 export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function* <A, I>(
   schema: Schema.Codec<A, I>,
@@ -52,7 +49,7 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       }
       resume(
         Effect.fail(
-          new BootstrapError({
+          ConfigError({
             message: "Failed to read bootstrap envelope.",
             cause: error,
           }),
@@ -67,7 +64,7 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       } else {
         resume(
           Effect.fail(
-            new BootstrapError({
+            ConfigError({
               message: "Failed to decode bootstrap envelope.",
               cause: parsed.failure,
             }),
@@ -97,7 +94,7 @@ const isFdReady = (fd: number) =>
   Effect.try({
     try: () => NFS.fstatSync(fd),
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to stat bootstrap fd.",
         cause: error,
       }),
@@ -136,7 +133,7 @@ const makeBootstrapInputStream = (fd: number) =>
       }
     },
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to duplicate bootstrap fd.",
         cause: error,
       }),

--- a/t3code/apps/server/src/errors.test.ts
+++ b/t3code/apps/server/src/errors.test.ts
@@ -1,0 +1,60 @@
+import * as Match from "effect/Match";
+import { describe, expect, it } from "vitest";
+
+import {
+  AuthError,
+  ConfigError,
+  DatabaseError,
+  GitError,
+  NetworkError,
+  type ServerError,
+  ValidationError,
+  errorToLog,
+  errorToResponse,
+} from "./errors.ts";
+
+describe("server errors", () => {
+  it("maps every server error tag to the expected HTTP status code", () => {
+    expect(errorToResponse(AuthError({ message: "missing token" })).status).toBe(401);
+    expect(errorToResponse(ValidationError({ message: "bad input" })).status).toBe(400);
+    expect(errorToResponse(DatabaseError({ message: "query failed" })).status).toBe(500);
+    expect(errorToResponse(NetworkError({ message: "upstream failed" })).status).toBe(502);
+    expect(errorToResponse(ConfigError({ message: "missing env" })).status).toBe(500);
+    expect(errorToResponse(GitError({ message: "rebase failed" })).status).toBe(422);
+  });
+
+  it("formats structured logs with tag, message, stack, timestamp, and cause chain", () => {
+    const cause = new Error("root cause");
+    const error = GitError({
+      message: "git command failed",
+      cause,
+      timestamp: "2026-05-30T00:00:00.000Z",
+    });
+
+    expect(errorToLog(error)).toMatchObject({
+      tag: "GitError",
+      message: "git command failed",
+      timestamp: "2026-05-30T00:00:00.000Z",
+      cause: {
+        message: "root cause",
+      },
+    });
+    expect(errorToLog(error).stack).toEqual(expect.any(String));
+  });
+
+  it("supports exhaustive pattern matching by error tag", () => {
+    const error: ServerError = ValidationError({ message: "missing project id" });
+
+    const matchServerError = Match.type<ServerError>().pipe(
+      Match.tag("AuthError", () => "auth"),
+      Match.tag("ConfigError", () => "config"),
+      Match.tag("DatabaseError", () => "database"),
+      Match.tag("GitError", () => "git"),
+      Match.tag("NetworkError", () => "network"),
+      Match.tag("ValidationError", () => "validation"),
+      Match.exhaustive,
+    );
+
+    expect(matchServerError(error)).toBe("validation");
+  });
+});

--- a/t3code/apps/server/src/errors.ts
+++ b/t3code/apps/server/src/errors.ts
@@ -1,0 +1,135 @@
+import * as Data from "effect/Data";
+import * as DateTime from "effect/DateTime";
+
+interface ServerErrorFields {
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly timestamp: string;
+}
+
+type ServerErrorVariants = {
+  readonly AuthError: ServerErrorFields;
+  readonly ConfigError: ServerErrorFields;
+  readonly DatabaseError: ServerErrorFields;
+  readonly GitError: ServerErrorFields;
+  readonly NetworkError: ServerErrorFields;
+  readonly ValidationError: ServerErrorFields;
+};
+
+export type ServerError = Data.TaggedEnum<ServerErrorVariants>;
+export type AuthError = Extract<ServerError, { readonly _tag: "AuthError" }>;
+export type ConfigError = Extract<ServerError, { readonly _tag: "ConfigError" }>;
+export type DatabaseError = Extract<ServerError, { readonly _tag: "DatabaseError" }>;
+export type GitError = Extract<ServerError, { readonly _tag: "GitError" }>;
+export type NetworkError = Extract<ServerError, { readonly _tag: "NetworkError" }>;
+export type ValidationError = Extract<ServerError, { readonly _tag: "ValidationError" }>;
+
+const ServerErrors = Data.taggedEnum<ServerError>();
+
+type ServerErrorInput = Omit<ServerErrorFields, "timestamp"> & {
+  readonly timestamp?: string;
+};
+
+function withTimestamp(input: ServerErrorInput): ServerErrorFields {
+  return {
+    ...input,
+    timestamp: input.timestamp ?? DateTime.formatIso(DateTime.nowUnsafe()),
+  };
+}
+
+export const AuthError = (input: ServerErrorInput): AuthError =>
+  ServerErrors.AuthError(withTimestamp(input));
+export const ConfigError = (input: ServerErrorInput): ConfigError =>
+  ServerErrors.ConfigError(withTimestamp(input));
+export const DatabaseError = (input: ServerErrorInput): DatabaseError =>
+  ServerErrors.DatabaseError(withTimestamp(input));
+export const GitError = (input: ServerErrorInput): GitError =>
+  ServerErrors.GitError(withTimestamp(input));
+export const NetworkError = (input: ServerErrorInput): NetworkError =>
+  ServerErrors.NetworkError(withTimestamp(input));
+export const ValidationError = (input: ServerErrorInput): ValidationError =>
+  ServerErrors.ValidationError(withTimestamp(input));
+
+export interface ServerErrorResponse {
+  readonly status: 400 | 401 | 422 | 500 | 502;
+  readonly body: {
+    readonly error: string;
+    readonly message: string;
+  };
+}
+
+export function errorToResponse(error: ServerError): ServerErrorResponse {
+  const status = ServerErrors.$match(error, {
+    AuthError: () => 401 as const,
+    ConfigError: () => 500 as const,
+    DatabaseError: () => 500 as const,
+    GitError: () => 422 as const,
+    NetworkError: () => 502 as const,
+    ValidationError: () => 400 as const,
+  });
+
+  return {
+    status,
+    body: {
+      error: error._tag,
+      message: error.message,
+    },
+  };
+}
+
+interface CauseLog {
+  readonly tag?: string;
+  readonly message: string;
+  readonly stack?: string;
+  readonly cause?: CauseLog;
+}
+
+export interface ServerErrorLog {
+  readonly tag: ServerError["_tag"];
+  readonly message: string;
+  readonly stack: string;
+  readonly timestamp: string;
+  readonly cause?: CauseLog;
+}
+
+function causeToLog(cause: unknown): CauseLog | undefined {
+  if (cause === undefined) {
+    return undefined;
+  }
+
+  if (cause instanceof Error) {
+    const result: CauseLog = {
+      message: cause.message,
+      ...(cause.stack ? { stack: cause.stack } : {}),
+    };
+    const nestedCause = causeToLog(cause.cause);
+    return nestedCause === undefined ? result : { ...result, cause: nestedCause };
+  }
+
+  if (typeof cause === "object" && cause !== null) {
+    const record = cause as Record<string, unknown>;
+    const tag = typeof record._tag === "string" ? record._tag : undefined;
+    const message = typeof record.message === "string" ? record.message : JSON.stringify(record);
+    const stack = typeof record.stack === "string" ? record.stack : undefined;
+    const result: CauseLog = {
+      ...(tag === undefined ? {} : { tag }),
+      message,
+      ...(stack === undefined ? {} : { stack }),
+    };
+    const nestedCause = causeToLog(record.cause);
+    return nestedCause === undefined ? result : { ...result, cause: nestedCause };
+  }
+
+  return { message: String(cause) };
+}
+
+export function errorToLog(error: ServerError): ServerErrorLog {
+  const result: ServerErrorLog = {
+    tag: error._tag,
+    message: error.message,
+    stack: new Error(error.message).stack ?? "",
+    timestamp: error.timestamp,
+  };
+  const cause = causeToLog(error.cause);
+  return cause === undefined ? result : { ...result, cause };
+}

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,6 +1,5 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -33,6 +32,7 @@ import {
   browserApiCorsAllowedMethods,
   browserApiCorsHeaders,
 } from "./httpCors.ts";
+import { ValidationError } from "./errors.ts";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
@@ -81,11 +81,6 @@ export const serverEnvironmentRouteLayer = HttpRouter.add(
   }),
 );
 
-class DecodeOtlpTraceRecordsError extends Data.TaggedError("DecodeOtlpTraceRecordsError")<{
-  readonly cause: unknown;
-  readonly bodyJson: OtlpTracer.TraceData;
-}> {}
-
 export const otlpTracesProxyRouteLayer = HttpRouter.add(
   "POST",
   OTLP_TRACES_PROXY_PATH,
@@ -100,7 +95,11 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),
-      catch: (cause) => new DecodeOtlpTraceRecordsError({ cause, bodyJson }),
+      catch: (cause) =>
+        ValidationError({
+          message: "Failed to decode browser OTLP traces.",
+          cause,
+        }),
     }).pipe(
       Effect.flatMap((records) => browserTraceCollector.record(records)),
       Effect.catch((cause) =>

--- a/t3code/apps/server/src/telemetry/Identify.ts
+++ b/t3code/apps/server/src/telemetry/Identify.ts
@@ -6,6 +6,7 @@ import * as Schema from "effect/Schema";
 import * as Crypto from "node:crypto";
 import { homedir } from "node:os";
 import { ServerConfig } from "../config.ts";
+import { ConfigError } from "../errors.ts";
 
 const CodexAuthJsonSchema = Schema.Struct({
   tokens: Schema.Struct({
@@ -17,16 +18,11 @@ const ClaudeJsonSchema = Schema.Struct({
   userID: Schema.String,
 });
 
-class IdentifyUserError extends Schema.TaggedErrorClass<IdentifyUserError>()("IdentifyUserError", {
-  message: Schema.String,
-  cause: Schema.optional(Schema.Defect),
-}) {}
-
 const hash = (value: string) =>
   Effect.try({
     try: () => Crypto.createHash("sha256").update(value).digest("hex"),
     catch: (error) =>
-      new IdentifyUserError({
+      ConfigError({
         message: "Failed to hash identifier",
         cause: error,
       }),


### PR DESCRIPTION
/claim #861

Summary:
- add a centralized server error ADT using effect/Data TaggedEnum
- add HTTP response and structured log mapping helpers with cause-chain support
- migrate bootstrap, OTLP trace decoding, and telemetry hashing failures to shared constructors
- add focused Vitest coverage and safe public metadata without private runtime/system/developer instructions

Verification:
- npx --yes bun@1.3.11 run test src/errors.test.ts (from t3code/apps/server)
- npx --yes bun@1.3.11 run typecheck
- npx --yes bun@1.3.11 run lint (passes with existing warnings)
- npx --yes bun@1.3.11 run fmt:check
- git diff --check
