### PR TITLE
Codex [ FastAPI ] Add rate limiting to API key auth

### DIFF
--- a/fastapi/.audit.json
+++ b/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Safe public audit metadata only. Private system, developer, runtime, and user instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-30T13:25:00Z"
+}

--- a/fastapi/fastapi/security/.audit.json
+++ b/fastapi/fastapi/security/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Safe public audit metadata only. Private system, developer, runtime, and user instructions are intentionally not copied into repository files.",
+  "completed_at": "2026-05-30T12:12:00Z"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -1,6 +1,7 @@
 from .api_key import APIKeyCookie as APIKeyCookie
 from .api_key import APIKeyHeader as APIKeyHeader
 from .api_key import APIKeyQuery as APIKeyQuery
+from .api_key import APIKeyWithRateLimit as APIKeyWithRateLimit
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials

--- a/fastapi/fastapi/security/api_key.py
+++ b/fastapi/fastapi/security/api_key.py
@@ -2,7 +2,7 @@ import math
 import time
 from collections.abc import Callable, Sequence
 from threading import Lock
-from typing import Annotated
+from typing import Annotated, cast
 
 from annotated_doc import Doc
 from fastapi.openapi.models import APIKey, APIKeyIn
@@ -245,6 +245,8 @@ class APIKeyWithRateLimit(APIKeyHeader):
     deprecated-key warning support without changing existing API key classes.
     """
 
+    deprecated_key_warning = '299 - "API key is deprecated and will be deactivated"'
+
     def __init__(
         self,
         *,
@@ -267,6 +269,16 @@ class APIKeyWithRateLimit(APIKeyHeader):
                 """
             ),
         ] = None,
+        max_tracked_keys: Annotated[
+            int,
+            Doc(
+                """
+                Maximum number of API key buckets retained in memory. When the limit is
+                reached, expired buckets are pruned first and the oldest remaining
+                bucket is evicted if necessary.
+                """
+            ),
+        ] = 10000,
         scheme_name: Annotated[
             str | None,
             Doc(
@@ -306,21 +318,27 @@ class APIKeyWithRateLimit(APIKeyHeader):
         self.rate_limit_count, self.rate_limit_window_seconds = self._parse_rate_limit(
             rate_limit
         )
+        if max_tracked_keys <= 0:
+            raise ValueError("max_tracked_keys must be greater than 0")
+        if isinstance(deprecated_keys, (str, bytes)):
+            raise TypeError("deprecated_keys must be a sequence of strings")
         self.deprecated_keys = set(deprecated_keys or ())
         self._request_timestamps: dict[str, list[float]] = {}
+        self.max_tracked_keys = max_tracked_keys
         self._lock = Lock()
         self._time_provider: Callable[[], float] = time.monotonic
 
-    async def __call__(self, request: Request, response: Response) -> str | None:
+    async def __call__(
+        self, request: Request, response: Response = cast(Response, None)
+    ) -> str | None:
         api_key = self.check_api_key(request.headers.get(self.model.name))
         if api_key is None:
             return None
 
-        self._check_rate_limit(api_key)
-        if api_key in self.deprecated_keys:
-            response.headers["Warning"] = (
-                '299 - "API key is deprecated and will be deactivated"'
-            )
+        warning_headers = self._warning_headers(api_key)
+        self._check_rate_limit(api_key, exception_headers=warning_headers)
+        if response is not None:
+            response.headers.update(warning_headers)
         return api_key
 
     @staticmethod
@@ -349,11 +367,15 @@ class APIKeyWithRateLimit(APIKeyHeader):
             raise ValueError("rate_limit period must be one of: second, minute, hour")
         return count, period_seconds
 
-    def _check_rate_limit(self, api_key: str) -> None:
-        now = self._time_provider()
-        window_start = now - self.rate_limit_window_seconds
-
+    def _check_rate_limit(
+        self, api_key: str, exception_headers: dict[str, str] | None = None
+    ) -> None:
         with self._lock:
+            now = self._time_provider()
+            window_start = now - self.rate_limit_window_seconds
+            if api_key not in self._request_timestamps:
+                self._prune_or_evict_key_bucket(window_start)
+
             timestamps = [
                 timestamp
                 for timestamp in self._request_timestamps.get(api_key, [])
@@ -364,15 +386,44 @@ class APIKeyWithRateLimit(APIKeyHeader):
             if len(timestamps) >= self.rate_limit_count:
                 retry_after = max(
                     1,
-                    math.ceil(self.rate_limit_window_seconds - (now - timestamps[0])),
+                    math.ceil(self.rate_limit_window_seconds - (now - min(timestamps))),
                 )
+                headers = {"Retry-After": str(retry_after)}
+                if exception_headers:
+                    headers.update(exception_headers)
                 raise HTTPException(
                     status_code=HTTP_429_TOO_MANY_REQUESTS,
                     detail="Rate limit exceeded",
-                    headers={"Retry-After": str(retry_after)},
+                    headers=headers,
                 )
 
             timestamps.append(now)
+
+    def _warning_headers(self, api_key: str) -> dict[str, str]:
+        if api_key not in self.deprecated_keys:
+            return {}
+        return {"Warning": self.deprecated_key_warning}
+
+    def _prune_or_evict_key_bucket(self, window_start: float) -> None:
+        if len(self._request_timestamps) < self.max_tracked_keys:
+            return
+
+        expired_keys = [
+            key
+            for key, timestamps in self._request_timestamps.items()
+            if not any(timestamp > window_start for timestamp in timestamps)
+        ]
+        for key in expired_keys:
+            del self._request_timestamps[key]
+
+        if len(self._request_timestamps) < self.max_tracked_keys:
+            return
+
+        oldest_key = min(
+            self._request_timestamps,
+            key=lambda key: min(self._request_timestamps[key], default=window_start),
+        )
+        del self._request_timestamps[oldest_key]
 
 
 class APIKeyCookie(APIKeyBase):

--- a/fastapi/fastapi/security/api_key.py
+++ b/fastapi/fastapi/security/api_key.py
@@ -1,3 +1,7 @@
+import math
+import time
+from collections.abc import Callable, Sequence
+from threading import Lock
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -5,7 +9,8 @@ from fastapi.openapi.models import APIKey, APIKeyIn
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.responses import Response
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class APIKeyBase(SecurityBase):
@@ -230,6 +235,144 @@ class APIKeyHeader(APIKeyBase):
     async def __call__(self, request: Request) -> str | None:
         api_key = request.headers.get(self.model.name)
         return self.check_api_key(api_key)
+
+
+class APIKeyWithRateLimit(APIKeyHeader):
+    """
+    API key authentication using a header with optional in-memory rate limiting.
+
+    This extends `APIKeyHeader` with a per-key sliding window limiter and
+    deprecated-key warning support without changing existing API key classes.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: Annotated[str, Doc("Header name.")],
+        rate_limit: Annotated[
+            str,
+            Doc(
+                """
+                Sliding-window rate limit formatted as `<count>/<period>`, for example
+                `100/minute` or `1000/hour`.
+                """
+            ),
+        ],
+        deprecated_keys: Annotated[
+            Sequence[str] | None,
+            Doc(
+                """
+                Old API keys that should still authenticate but add a Warning response
+                header indicating that the key will be deactivated.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if the header is not provided, `APIKeyWithRateLimit` will
+                automatically cancel the request and send the client an error.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            name=name,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.rate_limit_count, self.rate_limit_window_seconds = self._parse_rate_limit(
+            rate_limit
+        )
+        self.deprecated_keys = set(deprecated_keys or ())
+        self._request_timestamps: dict[str, list[float]] = {}
+        self._lock = Lock()
+        self._time_provider: Callable[[], float] = time.monotonic
+
+    async def __call__(self, request: Request, response: Response) -> str | None:
+        api_key = self.check_api_key(request.headers.get(self.model.name))
+        if api_key is None:
+            return None
+
+        self._check_rate_limit(api_key)
+        if api_key in self.deprecated_keys:
+            response.headers["Warning"] = (
+                '299 - "API key is deprecated and will be deactivated"'
+            )
+        return api_key
+
+    @staticmethod
+    def _parse_rate_limit(rate_limit: str) -> tuple[int, int]:
+        try:
+            raw_count, raw_period = rate_limit.split("/", 1)
+            count = int(raw_count.strip())
+        except ValueError as exc:
+            raise ValueError(
+                "rate_limit must be formatted as '<count>/<period>'"
+            ) from exc
+
+        if count <= 0:
+            raise ValueError("rate_limit count must be greater than 0")
+
+        periods = {
+            "second": 1,
+            "seconds": 1,
+            "minute": 60,
+            "minutes": 60,
+            "hour": 3600,
+            "hours": 3600,
+        }
+        period_seconds = periods.get(raw_period.strip().lower())
+        if period_seconds is None:
+            raise ValueError("rate_limit period must be one of: second, minute, hour")
+        return count, period_seconds
+
+    def _check_rate_limit(self, api_key: str) -> None:
+        now = self._time_provider()
+        window_start = now - self.rate_limit_window_seconds
+
+        with self._lock:
+            timestamps = [
+                timestamp
+                for timestamp in self._request_timestamps.get(api_key, [])
+                if timestamp > window_start
+            ]
+            self._request_timestamps[api_key] = timestamps
+
+            if len(timestamps) >= self.rate_limit_count:
+                retry_after = max(
+                    1,
+                    math.ceil(self.rate_limit_window_seconds - (now - timestamps[0])),
+                )
+                raise HTTPException(
+                    status_code=HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Rate limit exceeded",
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+            timestamps.append(now)
 
 
 class APIKeyCookie(APIKeyBase):

--- a/fastapi/tests/test_security_api_key_rate_limit.py
+++ b/fastapi/tests/test_security_api_key_rate_limit.py
@@ -1,0 +1,142 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.security import APIKeyWithRateLimit
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException
+
+
+def create_client(
+    rate_limit: str = "2/minute",
+    deprecated_keys: list[str] | None = None,
+    auto_error: bool = True,
+) -> tuple[TestClient, APIKeyWithRateLimit]:
+    app = FastAPI()
+    api_key = APIKeyWithRateLimit(
+        name="key",
+        rate_limit=rate_limit,
+        deprecated_keys=deprecated_keys,
+        auto_error=auto_error,
+    )
+
+    @app.get("/items")
+    def read_items(key: str | None = Depends(api_key)) -> dict[str, str | None]:
+        return {"key": key}
+
+    return TestClient(app), api_key
+
+
+def test_rate_limit_tracks_requests_per_api_key_independently() -> None:
+    client, security = create_client()
+    security._time_provider = lambda: 100.0
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+
+    limited = client.get("/items", headers={"key": "alpha"})
+    assert limited.status_code == 429
+    assert limited.json() == {"detail": "Rate limit exceeded"}
+
+    response = client.get("/items", headers={"key": "beta"})
+    assert response.status_code == 200
+    assert response.json() == {"key": "beta"}
+
+
+def test_rate_limit_includes_retry_after_seconds() -> None:
+    client, security = create_client()
+    now = 100.0
+    security._time_provider = lambda: now
+
+    client.get("/items", headers={"key": "alpha"})
+    client.get("/items", headers={"key": "alpha"})
+
+    now = 110.0
+    response = client.get("/items", headers={"key": "alpha"})
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "50"
+
+
+def test_rate_limit_window_resets_after_expired_counts() -> None:
+    client, security = create_client()
+    now = 100.0
+    security._time_provider = lambda: now
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+
+    now = 161.0
+    response = client.get("/items", headers={"key": "alpha"})
+
+    assert response.status_code == 200
+    assert response.json() == {"key": "alpha"}
+
+
+def test_rate_limit_store_handles_concurrent_requests_safely() -> None:
+    _client, security = create_client(rate_limit="20/minute")
+    security._time_provider = lambda: 100.0
+
+    def check_limit() -> bool:
+        try:
+            security._check_rate_limit("alpha")
+        except HTTPException as exc:
+            assert exc.status_code == 429
+            return False
+        return True
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _index: check_limit(), range(40)))
+
+    assert results.count(True) == 20
+    assert results.count(False) == 20
+
+
+def test_deprecated_key_authenticates_with_warning_header() -> None:
+    client, security = create_client(deprecated_keys=["old-key"])
+    security._time_provider = lambda: 100.0
+
+    response = client.get("/items", headers={"key": "old-key"})
+
+    assert response.status_code == 200
+    assert response.json() == {"key": "old-key"}
+    assert response.headers["Warning"] == (
+        '299 - "API key is deprecated and will be deactivated"'
+    )
+
+
+def test_active_key_has_no_warning_header() -> None:
+    client, security = create_client(deprecated_keys=["old-key"])
+    security._time_provider = lambda: 100.0
+
+    response = client.get("/items", headers={"key": "new-key"})
+
+    assert response.status_code == 200
+    assert "Warning" not in response.headers
+
+
+def test_api_key_with_rate_limit_keeps_api_key_header_authentication_behavior() -> None:
+    client, _security = create_client()
+
+    response = client.get("/items")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated"}
+    assert response.headers["WWW-Authenticate"] == "APIKey"
+
+
+def test_auto_error_false_returns_none_without_rate_limiting() -> None:
+    client, security = create_client(auto_error=False)
+    security._time_provider = lambda: 100.0
+
+    response = client.get("/items")
+
+    assert response.status_code == 200
+    assert response.json() == {"key": None}
+    assert security._request_timestamps == {}
+
+
+@pytest.mark.parametrize("rate_limit", ["0/minute", "not-a-limit", "10/day"])
+def test_invalid_rate_limit_format_is_rejected(rate_limit: str) -> None:
+    with pytest.raises(ValueError, match="rate_limit"):
+        APIKeyWithRateLimit(name="key", rate_limit=rate_limit)

--- a/fastapi/tests/test_security_api_key_rate_limit.py
+++ b/fastapi/tests/test_security_api_key_rate_limit.py
@@ -1,3 +1,4 @@
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -5,6 +6,7 @@ from fastapi import Depends, FastAPI
 from fastapi.security import APIKeyWithRateLimit
 from fastapi.testclient import TestClient
 from starlette.exceptions import HTTPException
+from starlette.requests import Request
 
 
 def create_client(
@@ -58,6 +60,18 @@ def test_rate_limit_includes_retry_after_seconds() -> None:
     assert response.headers["Retry-After"] == "50"
 
 
+def test_retry_after_uses_oldest_active_timestamp() -> None:
+    _client, security = create_client()
+    security._time_provider = lambda: 130.0
+    security._request_timestamps["alpha"] = [120.0, 100.0]
+
+    with pytest.raises(HTTPException) as exc_info:
+        security._check_rate_limit("alpha")
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers["Retry-After"] == "30"
+
+
 def test_rate_limit_window_resets_after_expired_counts() -> None:
     client, security = create_client()
     now = 100.0
@@ -92,6 +106,33 @@ def test_rate_limit_store_handles_concurrent_requests_safely() -> None:
     assert results.count(False) == 20
 
 
+def test_concurrent_requests_are_rate_limited_safely() -> None:
+    client, security = create_client(rate_limit="5/minute")
+    security._time_provider = lambda: 100.0
+
+    def request_status() -> int:
+        return client.get("/items", headers={"key": "alpha"}).status_code
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        statuses = list(executor.map(lambda _index: request_status(), range(10)))
+
+    assert statuses.count(200) == 5
+    assert statuses.count(429) == 5
+
+
+def test_rate_limit_store_is_bounded_for_arbitrary_api_keys() -> None:
+    _client, security = create_client(rate_limit="10/minute")
+    security.max_tracked_keys = 2
+    security._time_provider = lambda: 100.0
+
+    security._check_rate_limit("alpha")
+    security._check_rate_limit("beta")
+    security._check_rate_limit("gamma")
+
+    assert len(security._request_timestamps) == 2
+    assert "gamma" in security._request_timestamps
+
+
 def test_deprecated_key_authenticates_with_warning_header() -> None:
     client, security = create_client(deprecated_keys=["old-key"])
     security._time_provider = lambda: 100.0
@@ -100,6 +141,20 @@ def test_deprecated_key_authenticates_with_warning_header() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"key": "old-key"}
+    assert response.headers["Warning"] == (
+        '299 - "API key is deprecated and will be deactivated"'
+    )
+
+
+def test_deprecated_key_rate_limit_response_includes_warning_header() -> None:
+    client, security = create_client(rate_limit="1/minute", deprecated_keys=["old-key"])
+    security._time_provider = lambda: 100.0
+
+    assert client.get("/items", headers={"key": "old-key"}).status_code == 200
+    response = client.get("/items", headers={"key": "old-key"})
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "60"
     assert response.headers["Warning"] == (
         '299 - "API key is deprecated and will be deactivated"'
     )
@@ -136,7 +191,38 @@ def test_auto_error_false_returns_none_without_rate_limiting() -> None:
     assert security._request_timestamps == {}
 
 
+def test_api_key_with_rate_limit_can_be_called_with_request_only() -> None:
+    security = APIKeyWithRateLimit(name="key", rate_limit="2/minute")
+    security._time_provider = lambda: 100.0
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"key", b"alpha")],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "scheme": "http",
+        }
+    )
+
+    assert asyncio.run(security(request)) == "alpha"
+
+
 @pytest.mark.parametrize("rate_limit", ["0/minute", "not-a-limit", "10/day"])
 def test_invalid_rate_limit_format_is_rejected(rate_limit: str) -> None:
     with pytest.raises(ValueError, match="rate_limit"):
         APIKeyWithRateLimit(name="key", rate_limit=rate_limit)
+
+
+def test_invalid_max_tracked_keys_is_rejected() -> None:
+    with pytest.raises(ValueError, match="max_tracked_keys"):
+        APIKeyWithRateLimit(name="key", rate_limit="1/minute", max_tracked_keys=0)
+
+
+def test_deprecated_keys_rejects_single_string() -> None:
+    with pytest.raises(TypeError, match="deprecated_keys"):
+        APIKeyWithRateLimit(
+            name="key", rate_limit="1/minute", deprecated_keys="old-key"
+        )


### PR DESCRIPTION
/claim #768

Closes #768.

## Summary

Adds `APIKeyWithRateLimit`, an opt-in `APIKeyHeader` extension with per-key sliding-window rate limiting and deprecated-key warning support.

The existing `APIKeyHeader`, `APIKeyQuery`, and `APIKeyCookie` behavior is unchanged.

## Acceptance Criteria

- [x] Rate limiting tracks requests per API key independently
- [x] Sliding window resets expired counts
- [x] `429 Too Many Requests` responses include `Retry-After` in seconds
- [x] Deprecated keys authenticate successfully and add a `Warning` response header
- [x] Deprecated keys also include `Warning` on rate-limited `429` responses
- [x] Active keys not in `deprecated_keys` return no `Warning` header
- [x] In-memory request tracking is guarded with a lock and covered by direct and request-level concurrent access regression tests
- [x] In-memory tracking is bounded with `max_tracked_keys` to avoid unbounded growth from arbitrary key values
- [x] Retry-after timing is computed under the lock using the oldest active timestamp
- [x] Existing request-only callable behavior remains supported
- [x] Tests cover rate-limit enforcement, window reset, retry-after, deprecated-key warnings, active-key behavior, optional auth behavior, invalid configuration, bounded tracking, and concurrent access
- [x] Safe public audit metadata is included without publishing private runtime instructions

## Validation

```sh
/private/tmp/bounty-fastapi-venv/bin/python -m py_compile fastapi/fastapi/security/api_key.py fastapi/fastapi/security/__init__.py fastapi/tests/test_security_api_key_rate_limit.py
/private/tmp/bounty-fastapi-venv/bin/python -m pytest fastapi/tests/test_security_api_key_rate_limit.py fastapi/tests/test_security_api_key_header.py -q
/private/tmp/bounty-fastapi-venv/bin/python -m pytest fastapi/tests/test_security_api_key*.py -q
/private/tmp/bounty-fastapi-venv/bin/python -m ruff check fastapi/fastapi/security/api_key.py fastapi/fastapi/security/__init__.py fastapi/tests/test_security_api_key_rate_limit.py
/private/tmp/bounty-fastapi-venv/bin/python -m ruff format --check fastapi/fastapi/security/api_key.py fastapi/fastapi/security/__init__.py fastapi/tests/test_security_api_key_rate_limit.py
git diff --check
```

Results:
- Focused suite: 21 passed
- API-key suite: 45 passed
- Ruff check: passed
- Ruff format check: passed
- Diff whitespace check: passed

## Demo

Short demo video: https://github.com/adityawrk/Bounty-Hunters/releases/download/bounty-768-demo-20260530/unsafelabs-768-demo.mp4

The validation commands above demonstrate the behavior end-to-end with FastAPI `TestClient`, including successful requests, independent per-key throttling, `Retry-After`, deprecated-key warnings, bounded in-memory tracking, and concurrent request-level limit checks.

## Security / Audit Note

The requested audit artifact is included with safe public metadata only at both:
- `fastapi/.audit.json`
- `fastapi/fastapi/security/.audit.json`

Private system, developer, runtime, and user instructions are intentionally not copied into repository files or PR text. If the project needs a different sanitized provenance schema or path, I can adjust it without publishing private initialization payloads.
