### PR TITLE
[ MintyAgnt ] [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/.generation_meta.json
+++ b/solidity/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "MintyAgnt",
+  "initial_directives": "Fix PriceOracle missing staleness check and fallback mechanism per issue #915",
+  "date": "2026-05-30T00:00:00Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,21 +14,19 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(uint256 primaryUpdatedAt);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
         (
             uint80 roundId,
             int256 price,
@@ -37,11 +35,33 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        bool primaryStale = block.timestamp - updatedAt >= MAX_STALENESS;
 
-        return price;
+        if (!primaryStale) {
+            require(answeredInRound >= roundId, "Incomplete round");
+            require(price > 0, "Invalid price");
+            emit PriceQueried(price, updatedAt);
+            return price;
+        }
+
+        emit StalePrice(updatedAt);
+
+        require(address(fallbackFeed) != address(0), "No fallback oracle");
+
+        (
+            uint80 fbRoundId,
+            int256 fbPrice,
+            ,
+            uint256 fbUpdatedAt,
+            uint80 fbAnsweredInRound
+        ) = fallbackFeed.latestRoundData();
+
+        require(block.timestamp - fbUpdatedAt < MAX_STALENESS, "Both oracles stale");
+        require(fbAnsweredInRound >= fbRoundId, "Fallback incomplete round");
+        require(fbPrice > 0, "Fallback invalid price");
+
+        emit PriceQueried(fbPrice, fbUpdatedAt);
+        return fbPrice;
     }
 
     function getDecimals() external view returns (uint8) {
@@ -51,5 +71,10 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
     }
 }

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+test = "test"

--- a/solidity/test/PriceOracle.t.sol
+++ b/solidity/test/PriceOracle.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/PriceOracle.sol";
+
+contract MockAggregator {
+    int256 public price;
+    uint256 public updatedAt;
+    uint80 public roundId;
+    uint80 public answeredInRound;
+
+    constructor(int256 _price, uint256 _updatedAt, uint80 _roundId, uint80 _answeredInRound) {
+        price = _price;
+        updatedAt = _updatedAt;
+        roundId = _roundId;
+        answeredInRound = _answeredInRound;
+    }
+
+    function latestRoundData() external view returns (
+        uint80, int256, uint256, uint256, uint80
+    ) {
+        return (roundId, price, 0, updatedAt, answeredInRound);
+    }
+
+    function decimals() external pure returns (uint8) { return 8; }
+
+    function setData(int256 _price, uint256 _updatedAt, uint80 _roundId, uint80 _answeredInRound) external {
+        price = _price;
+        updatedAt = _updatedAt;
+        roundId = _roundId;
+        answeredInRound = _answeredInRound;
+    }
+}
+
+contract PriceOracleTest is Test {
+    PriceOracle oracle;
+    MockAggregator primary;
+    MockAggregator fallback_;
+
+    function setUp() public {
+        primary = new MockAggregator(200000000000, block.timestamp, 1, 1);
+        fallback_ = new MockAggregator(199000000000, block.timestamp, 1, 1);
+        oracle = new PriceOracle(address(primary));
+        oracle.setFallbackFeed(address(fallback_));
+    }
+
+    function test_ValidPrice() public {
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 200000000000);
+    }
+
+    function test_StalePrice_FallsBackToSecondary() public {
+        primary.setData(200000000000, block.timestamp - 3601, 1, 1);
+        vm.expectEmit(true, false, false, false);
+        emit PriceOracle.StalePrice(block.timestamp - 3601);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, 199000000000);
+    }
+
+    function test_NegativePrice_Reverts() public {
+        primary.setData(-1, block.timestamp, 1, 1);
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    function test_ZeroPrice_Reverts() public {
+        primary.setData(0, block.timestamp, 1, 1);
+        vm.expectRevert("Invalid price");
+        oracle.getLatestPrice();
+    }
+
+    function test_IncompleteRound_Reverts() public {
+        primary.setData(200000000000, block.timestamp, 2, 1);
+        vm.expectRevert("Incomplete round");
+        oracle.getLatestPrice();
+    }
+
+    function test_BothOracles_Stale_Reverts() public {
+        primary.setData(200000000000, block.timestamp - 3601, 1, 1);
+        fallback_.setData(199000000000, block.timestamp - 3601, 1, 1);
+        vm.expectRevert("Both oracles stale");
+        oracle.getLatestPrice();
+    }
+
+    function test_SetMaxStaleness_OnlyOwner() public {
+        oracle.setMaxStaleness(7200);
+        assertEq(oracle.MAX_STALENESS(), 7200);
+    }
+
+    function test_SetMaxStaleness_NotOwner_Reverts() public {
+        vm.prank(address(0xdead));
+        vm.expectRevert("Not owner");
+        oracle.setMaxStaleness(7200);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #915

## Summary
- Added staleness check: reverts if `block.timestamp - updatedAt >= MAX_STALENESS`
- Added round completeness validation: `require(answeredInRound >= roundId)`
- Added non-positive price protection: `require(price > 0)`
- Added configurable fallback oracle (`setFallbackFeed`) queried when primary is stale
- Emits `StalePrice(primaryUpdatedAt)` event before falling back
- Reverts with `"Both oracles stale"` if fallback is also stale
- `MAX_STALENESS` remains owner-configurable via `setMaxStaleness`

## Acceptance Criteria
- [x] Stale prices (>1 hour) trigger fallback to secondary oracle
- [x] Zero or negative prices revert with clear error
- [x] Incomplete rounds are rejected
- [x] StalePrice event emitted with primary oracle's last update timestamp
- [x] Both oracles stale → revert with error message
- [x] MAX_STALENESS configurable by owner
- [x] Tests cover: valid price, stale price, negative price, zero price, incomplete round, both oracles stale, owner-only setMaxStaleness

/claim #915