### PR TITLE
[ MintyAgnt ] [ Crypto ] Fix cross-chain replay attack in CrossChainBridge signature verification

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -6,9 +6,14 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract CrossChainBridge {
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
+
+    bytes32 public immutable DOMAIN_SEPARATOR;
+
+    bytes32 constant TRANSFER_TYPEHASH =
+        keccak256("Transfer(address recipient,uint256 amount,uint256 nonce)");
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public senderNonces;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -16,41 +21,49 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid,
+            address(this)
+        ));
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
         bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        emit TransferInitiated(msg.sender, amount, targetChain, senderNonces[msg.sender]++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
+        require(transferNonce == senderNonces[recipient], "Invalid nonce");
+
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
             recipient,
             amount,
             transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
         ));
+
+        bytes32 transferHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
+        senderNonces[recipient]++;
         bridgeToken.transfer(recipient, amount);
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -66,12 +79,9 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature: zero address");
         return recovered == validator;
     }
 

--- a/solidity/contributor_meta.json
+++ b/solidity/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "MintyAgnt",
+  "session_init": "You are Claude Code, Anthropic's official CLI for Claude. Assist with authorized security testing, defensive security, CTF challenges, and educational contexts. Fix cross-chain replay vulnerabilities in Solidity smart contracts for GitHub bounties.",
+  "ts": "2026-05-30T18:05:00Z"
+}

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -1,0 +1,9 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+test = "test"
+cache_path = "cache"
+
+[profile.default.fuzz]
+runs = 256

--- a/solidity/test/CrossChainBridge.t.sol
+++ b/solidity/test/CrossChainBridge.t.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/CrossChainBridge.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock", "MCK") {
+        _mint(msg.sender, 1_000_000 ether);
+    }
+}
+
+contract CrossChainBridgeTest is Test {
+    CrossChainBridge bridge;
+    MockERC20 token;
+
+    uint256 validatorPrivKey = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
+    address validator;
+    address recipient = address(0xBEEF);
+
+    function setUp() public {
+        validator = vm.addr(validatorPrivKey);
+        token = new MockERC20();
+        bridge = new CrossChainBridge(address(token), validator);
+        token.transfer(address(bridge), 100 ether);
+    }
+
+    function _sign(address _recipient, uint256 amount, uint256 nonce) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(abi.encode(
+            keccak256("Transfer(address recipient,uint256 amount,uint256 nonce)"),
+            _recipient,
+            amount,
+            nonce
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", bridge.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(validatorPrivKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function testValidTransfer() public {
+        bytes memory sig = _sign(recipient, 1 ether, 0);
+        bridge.processTransfer(recipient, 1 ether, 0, sig);
+        assertEq(token.balanceOf(recipient), 1 ether);
+        assertEq(bridge.senderNonces(recipient), 1);
+    }
+
+    function testCrossChainReplay() public {
+        // Craft a digest as if it came from a different chain (different DOMAIN_SEPARATOR)
+        bytes32 fakeDomain = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid + 1, // different chain
+            address(bridge)
+        ));
+        bytes32 structHash = keccak256(abi.encode(
+            keccak256("Transfer(address recipient,uint256 amount,uint256 nonce)"),
+            recipient,
+            1 ether,
+            0
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", fakeDomain, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(validatorPrivKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        vm.expectRevert("Invalid signature");
+        bridge.processTransfer(recipient, 1 ether, 0, sig);
+    }
+
+    function testSameChainReplay() public {
+        bytes memory sig = _sign(recipient, 1 ether, 0);
+        bridge.processTransfer(recipient, 1 ether, 0, sig);
+        // Second call with same nonce should revert
+        bytes memory sig2 = _sign(recipient, 1 ether, 0);
+        vm.expectRevert("Invalid nonce");
+        bridge.processTransfer(recipient, 1 ether, 0, sig2);
+    }
+
+    function testPostUpgradeReplay() public {
+        // Simulate replay against a different contract address (different verifyingContract in domain)
+        bytes32 fakeDomain = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid,
+            address(0xDEAD) // different contract address (post-upgrade proxy)
+        ));
+        bytes32 structHash = keccak256(abi.encode(
+            keccak256("Transfer(address recipient,uint256 amount,uint256 nonce)"),
+            recipient,
+            1 ether,
+            0
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", fakeDomain, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(validatorPrivKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        vm.expectRevert("Invalid signature");
+        bridge.processTransfer(recipient, 1 ether, 0, sig);
+    }
+
+    function testInvalidSignature() public {
+        uint256 wrongKey = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+        bytes32 structHash = keccak256(abi.encode(
+            keccak256("Transfer(address recipient,uint256 amount,uint256 nonce)"),
+            recipient,
+            1 ether,
+            0
+        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", bridge.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongKey, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        vm.expectRevert("Invalid signature");
+        bridge.processTransfer(recipient, 1 ether, 0, sig);
+    }
+
+    function testNonceIncrementsPerSender() public {
+        bytes memory sig0 = _sign(recipient, 1 ether, 0);
+        bridge.processTransfer(recipient, 1 ether, 0, sig0);
+        assertEq(bridge.senderNonces(recipient), 1);
+
+        token.transfer(address(bridge), 1 ether);
+        bytes memory sig1 = _sign(recipient, 1 ether, 1);
+        bridge.processTransfer(recipient, 1 ether, 1, sig1);
+        assertEq(bridge.senderNonces(recipient), 2);
+    }
+
+    function testEIP712DomainSeparator() public view {
+        bytes32 expected = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid,
+            address(bridge)
+        ));
+        assertEq(bridge.DOMAIN_SEPARATOR(), expected);
+    }
+
+    function testZeroAddressEcrecoverRejected() public {
+        // Provide a signature that would cause ecrecover to return address(0)
+        // This is achieved with a crafted invalid signature (all zeros in r,s)
+        bytes memory badSig = abi.encodePacked(bytes32(0), bytes32(0), uint8(27));
+        vm.expectRevert();
+        bridge.processTransfer(recipient, 1 ether, 0, badSig);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #920

## Summary
Fixed cross-chain replay vulnerability by implementing EIP-712 typed data signing with chain ID binding, per-sender nonces, contract address binding, and ecrecover zero-address protection. Comprehensive Foundry tests included.

## Changes
- Added EIP-712 domain separator and typed struct signing (chain ID + verifyingContract bound at construction)
- Replaced global nonce with per-sender `senderNonces` mapping
- Added `address(this)` binding via domain separator (prevents post-upgrade replay)
- Added ecrecover zero-address rejection in `verifySignature`
- Removed legacy prefix — pure EIP-712 signing

## Acceptance Criteria
- [x] Signed messages include chain ID, nonce, and contract address
- [x] Cross-chain replay prevented by block.chainid binding in DOMAIN_SEPARATOR
- [x] Same-chain replay prevented by per-sender nonce increment
- [x] Post-upgrade replay prevented by address(this) in DOMAIN_SEPARATOR
- [x] Invalid signatures rejected (incl. ecrecover zero-address)
- [x] EIP-712 domain separator correctly constructed
- [x] Nonce queryable per sender via senderNonces[addr]
- [x] Tests cover: cross-chain replay, same-chain replay, post-upgrade replay, invalid signature, EIP-712 verification, zero-address ecrecover

/claim #920