### PR TITLE
[ MintyAgnt ] [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/_generation.json
+++ b/solidity/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "MintyAgnt",
+  "pre_task_context": "redacted by contributor — fix first-depositor price manipulation in LiquidityPool per issue #918",
+  "timestamp": "2026-05-30T18:30:00Z"
+}

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,16 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
+    // Minimum liquidity permanently locked on the first deposit so that
+    // totalSupply can never be dust, which defeats first-depositor share
+    // price manipulation. OZ ERC20 forbids minting to address(0), so the
+    // shares are sent to a permanent dead address instead (same guarantee).
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
+    address public constant DEAD = 0x000000000000000000000000000000000000dEaD;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,8 +32,12 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            uint256 liquidity = sqrt(amountA * amountB);
+            require(liquidity > MINIMUM_LIQUIDITY, "Insufficient liquidity");
+            // Permanently lock MINIMUM_LIQUIDITY so the pool can never be
+            // drained to a tiny totalSupply that enables price manipulation.
+            _mint(DEAD, MINIMUM_LIQUIDITY);
+            lpTokens = liquidity - MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,27 +53,31 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // Use internal reserves, not balanceOf, so tokens donated directly to
+        // the pool cannot inflate withdrawal amounts.
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
 
         reserveA -= amountA;
         reserveB -= amountB;
 
+        tokenA.transfer(msg.sender, amountA);
+        tokenB.transfer(msg.sender, amountB);
+
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    // Force reserves to match actual balances after a direct token transfer.
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -1,0 +1,9 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+test = "test"
+cache_path = "cache"
+
+[profile.default.fuzz]
+runs = 256

--- a/solidity/test/LiquidityPool.t.sol
+++ b/solidity/test/LiquidityPool.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../contracts/LiquidityPool.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock", "MOCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract LiquidityPoolTest is Test {
+    LiquidityPool pool;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
+
+    address user1 = address(0x1111);
+    address user2 = address(0x2222);
+    address attacker = address(0xBEEF);
+
+    address constant DEAD = 0x000000000000000000000000000000000000dEaD;
+
+    event Sync(uint256 reserveA, uint256 reserveB);
+
+    function setUp() public {
+        tokenA = new MockERC20();
+        tokenB = new MockERC20();
+        pool = new LiquidityPool(address(tokenA), address(tokenB));
+
+        address[3] memory who = [user1, user2, attacker];
+        for (uint256 i = 0; i < who.length; i++) {
+            tokenA.mint(who[i], 10_000_000);
+            tokenB.mint(who[i], 10_000_000);
+            vm.startPrank(who[i]);
+            tokenA.approve(address(pool), type(uint256).max);
+            tokenB.approve(address(pool), type(uint256).max);
+            vm.stopPrank();
+        }
+    }
+
+    // First deposit locks MINIMUM_LIQUIDITY at the dead address and the
+    // depositor receives sqrt(amountA * amountB) - MINIMUM_LIQUIDITY.
+    function testFirstDepositLock() public {
+        vm.prank(user1);
+        uint256 lp = pool.addLiquidity(100_000, 100_000);
+
+        uint256 expectedTotal = 100_000; // sqrt(100_000 * 100_000)
+        assertEq(pool.balanceOf(DEAD), pool.MINIMUM_LIQUIDITY());
+        assertEq(lp, expectedTotal - pool.MINIMUM_LIQUIDITY());
+        assertEq(pool.balanceOf(user1), expectedTotal - pool.MINIMUM_LIQUIDITY());
+        assertEq(pool.totalSupply(), expectedTotal);
+    }
+
+    // The classic first-depositor attack (deposit dust, then inflate) is
+    // impossible: a sub-minimum first deposit reverts, and a donation after a
+    // real deposit does not change the LP shares a later depositor receives.
+    function testPriceManipulationAttempt() public {
+        // Dust first deposit can no longer bootstrap the pool.
+        vm.prank(attacker);
+        vm.expectRevert("Insufficient liquidity");
+        pool.addLiquidity(1, 1);
+
+        // Legitimate first deposit.
+        vm.prank(user1);
+        pool.addLiquidity(100_000, 100_000);
+
+        // Attacker donates directly to skew balances.
+        vm.prank(attacker);
+        tokenA.transfer(address(pool), 5_000_000);
+
+        // Second depositor's shares are computed from reserves, not balances,
+        // so the donation does not let the attacker steal value.
+        vm.prank(user2);
+        uint256 lp2 = pool.addLiquidity(100_000, 100_000);
+        assertEq(lp2, 100_000); // 100_000 * totalSupply / reserveA
+    }
+
+    // Tokens transferred directly to the pool do not inflate withdrawals,
+    // because removeLiquidity uses internal reserves instead of balanceOf.
+    function testDonationAttackViaTransfer() public {
+        vm.prank(user1);
+        uint256 lp = pool.addLiquidity(100_000, 100_000);
+
+        // Donate a large amount directly to the pool.
+        vm.prank(attacker);
+        tokenA.transfer(address(pool), 1_000_000);
+
+        // user1 withdraws everything they hold.
+        vm.prank(user1);
+        (uint256 outA, uint256 outB) = pool.removeLiquidity(lp);
+
+        // Withdrawal is proportional to reserves (99_000), not the inflated
+        // balance, so the donation is not extractable.
+        assertEq(outA, 99_000);
+        assertEq(outB, 99_000);
+    }
+
+    // sync() pulls reserves up to actual balances and emits Sync.
+    function testSyncRecovery() public {
+        vm.prank(user1);
+        pool.addLiquidity(100_000, 100_000);
+
+        vm.prank(attacker);
+        tokenA.transfer(address(pool), 50_000);
+
+        assertEq(pool.reserveA(), 100_000); // stale before sync
+
+        vm.expectEmit(false, false, false, true);
+        emit Sync(150_000, 100_000);
+        pool.sync();
+
+        assertEq(pool.reserveA(), 150_000);
+        assertEq(pool.reserveB(), 100_000);
+    }
+
+    // Subsequent deposits mint proportional LP tokens.
+    function testSubsequentDeposits() public {
+        vm.prank(user1);
+        pool.addLiquidity(100_000, 100_000);
+
+        vm.prank(user2);
+        uint256 lp2 = pool.addLiquidity(50_000, 50_000);
+
+        // 50_000 * totalSupply(100_000) / reserveA(100_000) = 50_000
+        assertEq(lp2, 50_000);
+        assertEq(pool.reserveA(), 150_000);
+        assertEq(pool.reserveB(), 150_000);
+    }
+
+    // Normal removeLiquidity returns reserves proportionally and updates them.
+    function testRemoveLiquidity() public {
+        vm.prank(user1);
+        uint256 lp = pool.addLiquidity(100_000, 100_000);
+
+        vm.prank(user1);
+        (uint256 outA, uint256 outB) = pool.removeLiquidity(lp);
+
+        assertEq(outA, 99_000);
+        assertEq(outB, 99_000);
+        // The 1_000 locked shares keep 1_000 of each reserve in the pool.
+        assertEq(pool.reserveA(), 1_000);
+        assertEq(pool.reserveB(), 1_000);
+        assertEq(pool.balanceOf(user1), 0);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #918

## Summary
Fixes first-depositor price manipulation in `LiquidityPool` by adding a Uniswap V2 style minimum-liquidity lock, switching `removeLiquidity` to use internal reserves instead of the manipulable `balanceOf`, and adding a `sync()` function to recover from direct token donations. All changes are covered by a Foundry test suite (6/6 passing locally).

## Changes
- **Minimum liquidity lock:** on the first deposit, `MINIMUM_LIQUIDITY` (1000) LP tokens are permanently locked so `totalSupply` can never be reduced to dust. The first depositor receives `sqrt(amountA * amountB) - MINIMUM_LIQUIDITY`.
- **`removeLiquidity` uses internal reserves:** withdrawals are now computed from `reserveA`/`reserveB`, so tokens transferred directly to the pool cannot inflate withdrawal amounts.
- **`sync()` added:** updates `reserveA`/`reserveB` to actual balances and emits a new `Sync(uint256 reserveA, uint256 reserveB)` event for donation recovery.

## Implementation note
OpenZeppelin's `ERC20._mint` reverts on a mint to `address(0)`, so a literal mint to `address(0)` would make the first `addLiquidity` call revert. The minimum liquidity is therefore locked to a permanent dead address (`0x000000000000000000000000000000000000dEaD`) instead. This is functionally equivalent for the security goal — those shares are unrecoverable and `totalSupply` can never drop to dust.

## Acceptance Criteria
- [x] First deposit locks `MINIMUM_LIQUIDITY` permanently (dead address, see note)
- [x] First depositor receives LP minus the locked amount
- [x] Subsequent deposits use the correct proportional formula
- [x] `removeLiquidity` uses internal reserves, not `balanceOf`
- [x] `sync()` updates reserves and emits a `Sync` event
- [x] Direct token transfers do not affect LP pricing
- [x] Tests cover first-deposit lock, manipulation attempt, donation attack, sync recovery, subsequent deposits, normal removal

## Test results
```
[PASS] testDonationAttackViaTransfer()
[PASS] testFirstDepositLock()
[PASS] testPriceManipulationAttempt()
[PASS] testRemoveLiquidity()
[PASS] testSubsequentDeposits()
[PASS] testSyncRecovery()
6 passed; 0 failed (forge test, OZ v5.1.0)
```

/claim #918
