### PR TITLE
[OpenAI Codex] [ FastAPI ] Add StreamingCSVResponse for large dataset exports

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,7 @@
+{
+  "agent": "OpenAI Codex",
+  "submitted_by": "Floofy6",
+  "issue": "UnsafeLabs/Bounty-Hunters#799",
+  "timestamp": "2026-05-31T04:46:15-04:00",
+  "session_init": "Private system, developer, and runtime instructions are not disclosed. This submission was produced from the public issue requirements with safe non-sensitive contributor metadata only."
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,5 +1,9 @@
+import csv
 import importlib
+import io
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from typing import Any, Protocol, cast
+from urllib.parse import quote
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
@@ -11,6 +15,8 @@ from starlette.responses import RedirectResponse as RedirectResponse  # noqa
 from starlette.responses import Response as Response  # noqa
 from starlette.responses import StreamingResponse as StreamingResponse  # noqa
 from typing_extensions import deprecated
+
+CSVRow = Mapping[str, Any] | Iterable[Any]
 
 
 class _UjsonModule(Protocol):
@@ -34,6 +40,87 @@ try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
 except ModuleNotFoundError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
+
+
+class StreamingCSVResponse(StreamingResponse):
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        rows: AsyncIterable[CSVRow],
+        *,
+        headers: Sequence[str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        response_headers: Mapping[str, str] | None = None,
+        background: Any = None,
+    ) -> None:
+        if len(delimiter) != 1:
+            raise ValueError("delimiter must be a single character")
+
+        csv_headers = tuple(headers or ())
+        http_headers = dict(response_headers or {})
+        http_headers.setdefault(
+            "content-disposition", self._content_disposition(filename)
+        )
+        super().__init__(
+            self._stream_rows(rows, csv_headers, delimiter),
+            status_code=status_code,
+            media_type=self.media_type,
+            headers=http_headers,
+            background=background,
+        )
+
+    @classmethod
+    async def _stream_rows(
+        cls,
+        rows: AsyncIterable[CSVRow],
+        headers: tuple[str, ...],
+        delimiter: str,
+    ) -> AsyncIterable[bytes]:
+        if headers:
+            yield cls._render_row(headers, delimiter)
+
+        async for row in rows:
+            yield cls._render_row(cls._row_values(row, headers), delimiter)
+
+    @staticmethod
+    def _row_values(row: CSVRow, headers: tuple[str, ...]) -> Iterable[Any]:
+        if isinstance(row, Mapping):
+            if headers:
+                return [row.get(header, "") for header in headers]
+            return row.values()
+
+        if isinstance(row, (str, bytes)):
+            return [row]
+
+        return row
+
+    @staticmethod
+    def _render_row(values: Iterable[Any], delimiter: str) -> bytes:
+        buffer = io.StringIO(newline="")
+        writer = csv.writer(buffer, delimiter=delimiter, lineterminator="\r\n")
+        writer.writerow(["" if value is None else value for value in values])
+        return buffer.getvalue().encode("utf-8")
+
+    @staticmethod
+    def _content_disposition(filename: str) -> str:
+        safe_filename = filename or "export.csv"
+        fallback_filename = safe_filename.encode("ascii", "ignore").decode("ascii")
+        fallback_filename = fallback_filename or "export.csv"
+        fallback_filename = (
+            fallback_filename.replace("\\", "_")
+            .replace("/", "_")
+            .replace('"', "_")
+            .replace("\r", "_")
+            .replace("\n", "_")
+        )
+        encoded_filename = quote(safe_filename, safe="")
+        return (
+            f'attachment; filename="{fallback_filename}"; '
+            f"filename*=utf-8''{encoded_filename}"
+        )
 
 
 @deprecated(

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,112 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+
+async def _empty_rows():
+    if False:
+        yield []
+
+
+def test_streaming_csv_response_headers_and_attachment():
+    app = FastAPI()
+
+    async def rows():
+        yield {"name": "Alice", "note": "hello"}
+        yield {"name": "Bob", "note": "bye"}
+
+    @app.get("/export")
+    def export():
+        return StreamingCSVResponse(
+            rows(), headers=["name", "note"], filename="users.csv"
+        )
+
+    response = TestClient(app).get("/export")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert 'filename="users.csv"' in response.headers["content-disposition"]
+    assert response.text == "name,note\r\nAlice,hello\r\nBob,bye\r\n"
+
+
+@pytest.mark.anyio
+async def test_streaming_csv_response_escapes_special_values_async():
+    async def rows():
+        yield ["a,b", 'quote "inside"', "line\nbreak"]
+
+    response = StreamingCSVResponse(rows())
+
+    body = b""
+    async for chunk in response.body_iterator:
+        body += chunk
+
+    assert body.decode() == '"a,b","quote ""inside""","line\nbreak"\r\n'
+
+
+def test_streaming_csv_response_custom_delimiter():
+    app = FastAPI()
+
+    async def rows():
+        yield ["alpha", "uses;delimiter"]
+
+    @app.get("/export")
+    def export():
+        return StreamingCSVResponse(rows(), delimiter=";")
+
+    response = TestClient(app).get("/export")
+
+    assert response.text == 'alpha;"uses;delimiter"\r\n'
+
+
+@pytest.mark.anyio
+async def test_streaming_csv_response_streams_lazily():
+    events: list[str] = []
+
+    async def rows():
+        for value in ["first", "second"]:
+            events.append(value)
+            yield [value]
+
+    response = StreamingCSVResponse(rows(), headers=["name"])
+    iterator = response.body_iterator
+
+    assert events == []
+    assert await anext(iterator) == b"name\r\n"
+    assert events == []
+    assert await anext(iterator) == b"first\r\n"
+    assert events == ["first"]
+    assert await anext(iterator) == b"second\r\n"
+    assert events == ["first", "second"]
+    with pytest.raises(StopAsyncIteration):
+        await anext(iterator)
+
+
+def test_streaming_csv_response_mapping_without_headers_uses_values():
+    app = FastAPI()
+
+    async def rows():
+        yield {"name": "Alice", "note": None}
+
+    @app.get("/export")
+    def export():
+        return StreamingCSVResponse(rows())
+
+    response = TestClient(app).get("/export")
+
+    assert response.text == "Alice,\r\n"
+
+
+def test_streaming_csv_response_sanitizes_filename_header():
+    response = StreamingCSVResponse(_empty_rows(), filename='unsafe/name"\r\n.csv')
+
+    assert (
+        response.headers["content-disposition"]
+        == 'attachment; filename="unsafe_name___.csv"; '
+        "filename*=utf-8''unsafe%2Fname%22%0D%0A.csv"
+    )
+
+
+def test_streaming_csv_response_rejects_multi_character_delimiter():
+    with pytest.raises(ValueError, match="delimiter must be a single character"):
+        StreamingCSVResponse(_empty_rows(), delimiter="::")


### PR DESCRIPTION
/claim #799

Summary:
- Added `StreamingCSVResponse` in `fastapi.responses` for async row streams.
- Supports optional CSV header rows, configurable attachment filename, and configurable delimiter.
- Uses Python `csv.writer` for RFC 4180-style escaping of commas, quotes, and newlines.
- Streams rows incrementally without materializing the full export.
- Adds safe non-sensitive contributor metadata only.

Validation:
- `/tmp/codex-fastapi799-venv/bin/python -m pytest tests/test_streaming_csv_response.py -q` -> 9 passed
- `/tmp/codex-fastapi799-venv/bin/python -m pytest tests/test_streaming_csv_response.py tests/test_deprecated_responses.py -q` -> 9 passed, 4 skipped
- `/tmp/codex-fastapi799-venv/bin/python -m ruff check fastapi/responses.py tests/test_streaming_csv_response.py` -> passed
- `/tmp/codex-fastapi799-venv/bin/python -m ruff format --check fastapi/responses.py tests/test_streaming_csv_response.py` -> passed
- `git diff --check` -> passed

Demo/proof:
- I could not attach a screen-recorded demo from this environment, so the PR includes focused executable tests covering headers, escaping, custom delimiters, lazy streaming, filename safety, and delimiter validation.

Security/privacy note:
- Private system/developer/runtime instructions are not included in repository files or PR text. The metadata file contains only safe public submission context.