### PR TITLE
[OpenAI Codex] [ FastAPI ] Fix duplicate operation ID generation

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Private system, developer, and runtime instructions are not disclosed. This submission was produced from the public issue requirements with safe non-sensitive attribution metadata only.",
+  "date": "2026-05-31T04:53:53-04:00"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -33,6 +33,7 @@ from fastapi.types import ModelNameMap
 from fastapi.utils import (
     deep_dict_update,
     generate_operation_id_for_path,
+    generate_unique_id_for_route,
     is_body_allowed_for_status_code,
 )
 from pydantic import BaseModel
@@ -233,6 +234,26 @@ def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:
     return route.name.replace("_", " ").title()
 
 
+def _get_operation_id_for_method(*, route: routing.APIRoute, method: str) -> str:
+    if route.operation_id:
+        return route.operation_id
+    if isinstance(route.generate_unique_id_function, DefaultPlaceholder):
+        return generate_unique_id_for_route(route, method)
+    return route.unique_id
+
+
+def _deduplicate_operation_id(operation_id: str, operation_ids: set[str]) -> str:
+    if operation_id not in operation_ids:
+        return operation_id
+
+    suffix = 2
+    unique_operation_id = f"{operation_id}_{suffix}"
+    while unique_operation_id in operation_ids:
+        suffix += 1
+        unique_operation_id = f"{operation_id}_{suffix}"
+    return unique_operation_id
+
+
 def get_openapi_operation_metadata(
     *, route: routing.APIRoute, method: str, operation_ids: set[str]
 ) -> dict[str, Any]:
@@ -242,7 +263,7 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
+    operation_id = _get_operation_id_for_method(route=route, method=method)
     if operation_id in operation_ids:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
         message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
@@ -250,6 +271,7 @@ def get_openapi_operation_metadata(
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        operation_id = _deduplicate_operation_id(operation_id, operation_ids)
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -86,18 +86,30 @@ def generate_operation_id_for_path(
         category=FastAPIDeprecationWarning,
         stacklevel=2,
     )
-    operation_id = f"{name}{path}"
-    operation_id = re.sub(r"\W", "_", operation_id)
-    operation_id = f"{operation_id}_{method.lower()}"
-    return operation_id
+    return _generate_operation_id(name=name, path=path, method=method)
+
+
+def _sanitize_operation_id(operation_id: str) -> str:
+    operation_id = re.sub(r"\W+", "_", operation_id.lower())
+    operation_id = re.sub(r"_+", "_", operation_id)
+    return operation_id.strip("_") or "operation"
+
+
+def _generate_operation_id(*, name: str, path: str, method: str) -> str:
+    path_part = path.strip("/")
+    raw_operation_id = f"{method.lower()}_{path_part}_{name}"
+    return _sanitize_operation_id(raw_operation_id)
+
+
+def generate_unique_id_for_route(route: "APIRoute", method: str) -> str:
+    return _generate_operation_id(
+        name=route.name, path=route.path_format, method=method
+    )
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    return generate_unique_id_for_route(route, sorted(route.methods)[0].lower())
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_operation_id_generation.py
+++ b/fastapi/tests/test_operation_id_generation.py
@@ -1,0 +1,101 @@
+import re
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+
+def test_default_operation_id_includes_method_path_and_name():
+    app = FastAPI()
+
+    @app.post("/api/v1/items/{item_id}/meta-data")
+    def update_item_metadata(item_id: str):
+        return {"item_id": item_id}
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    operation_id = schema["paths"]["/api/v1/items/{item_id}/meta-data"]["post"][
+        "operationId"
+    ]
+    assert operation_id == "post_api_v1_items_item_id_meta_data_update_item_metadata"
+    assert re.fullmatch(r"[a-z0-9_]+", operation_id)
+
+
+def test_default_operation_ids_are_unique_across_router_prefixes():
+    app = FastAPI()
+    api_v1 = APIRouter(prefix="/api/v1")
+    api_v2 = APIRouter(prefix="/api/v2")
+
+    @api_v1.get("/users", name="list_users")
+    def list_users_v1():
+        return []
+
+    @api_v2.get("/users", name="list_users")
+    def list_users_v2():
+        return []
+
+    app.include_router(api_v1)
+    app.include_router(api_v2)
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert (
+        schema["paths"]["/api/v1/users"]["get"]["operationId"]
+        == "get_api_v1_users_list_users"
+    )
+    assert (
+        schema["paths"]["/api/v2/users"]["get"]["operationId"]
+        == "get_api_v2_users_list_users"
+    )
+
+
+def test_default_operation_id_for_root_routes_is_consistent():
+    app = FastAPI()
+
+    @app.get("/")
+    def root():
+        return {"ok": True}
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert schema["paths"]["/"]["get"]["operationId"] == "get_root"
+
+
+def test_operation_id_collision_gets_numeric_suffix():
+    app = FastAPI()
+
+    @app.get("/reports/a-b", name="read_report")
+    def read_report_hyphen():
+        return {"report": "hyphen"}
+
+    @app.get("/reports/a_b", name="read_report")
+    def read_report_underscore():
+        return {"report": "underscore"}
+
+    with pytest.warns(UserWarning, match="Duplicate Operation ID"):
+        schema = app.openapi()
+
+    assert (
+        schema["paths"]["/reports/a-b"]["get"]["operationId"]
+        == "get_reports_a_b_read_report"
+    )
+    assert (
+        schema["paths"]["/reports/a_b"]["get"]["operationId"]
+        == "get_reports_a_b_read_report_2"
+    )
+
+
+def test_custom_generate_unique_id_function_is_unchanged():
+    def custom_generate_unique_id(route: APIRoute) -> str:
+        return f"custom_{route.name}"
+
+    app = FastAPI(generate_unique_id_function=custom_generate_unique_id)
+
+    @app.get("/items")
+    def read_items():
+        return []
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert schema["paths"]["/items"]["get"]["operationId"] == "custom_read_items"


### PR DESCRIPTION
/claim #764

Summary:
- Updated FastAPI default operation ID generation to use method + sanitized route path + route name.
- Generates method-specific OpenAPI operation IDs for default IDs so router prefixes and HTTP methods are represented.
- Adds numeric suffixing for post-sanitization collisions while preserving the existing duplicate warning.
- Keeps custom `generate_unique_id_function` behavior unchanged.
- Adds safe non-sensitive attribution metadata only.

Validation:
- `/tmp/codex-fastapi799-venv/bin/python -m pytest tests/test_operation_id_generation.py -q` -> 5 passed
- `/tmp/codex-fastapi799-venv/bin/python -m pytest tests/test_operation_id_generation.py tests/test_generate_unique_id_function.py -q` -> 13 passed
- `/tmp/codex-fastapi799-venv/bin/python -m ruff check fastapi/utils.py fastapi/openapi/utils.py tests/test_operation_id_generation.py` -> passed
- `/tmp/codex-fastapi799-venv/bin/python -m ruff format --check fastapi/utils.py fastapi/openapi/utils.py tests/test_operation_id_generation.py` -> passed
- `git diff --check` -> passed

Demo/proof:
- I could not attach a screen-recorded demo from this environment, so the PR includes focused executable tests for method/path/name formatting, router-prefix uniqueness, root routes, sanitized collision suffixing, and custom ID generator compatibility.

Security/privacy note:
- Private system/developer/runtime instructions are not included in repository files or PR text. The attribution file contains only safe public submission context.