### PR TITLE
[OpenAI Codex] [ FastAPI ] Fix jsonable_encoder bytes and memoryview encoding

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, and runtime instructions are not disclosed. This submission was produced from the public issue requirements with safe non-sensitive provenance metadata only.",
+  "timestamp": "2026-05-31T04:56:57-04:00"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -81,8 +82,15 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
         return float(dec_value)
 
 
+def _encode_bytes(value: bytes, bytes_encoding: str) -> str:
+    if bytes_encoding == "base64":
+        return base64.b64encode(value).decode("ascii")
+    if bytes_encoding == "hex":
+        return value.hex()
+    raise ValueError("bytes_encoding must be 'base64' or 'hex'")
+
+
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -215,6 +223,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding to use for bytes and memoryview objects. Supports "base64"
+            (the default) and "hex".
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -242,7 +259,7 @@ def jsonable_encoder(
         exclude = set(exclude)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     if isinstance(obj, BaseModel):
         obj_dict = obj.model_dump(
-            mode="json",
+            mode="python",
             include=include,
             exclude=exclude,
             by_alias=by_alias,
@@ -255,6 +272,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +287,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -276,6 +295,10 @@ def jsonable_encoder(
         return str(obj)
     if isinstance(obj, (str, int, float, type(None))):
         return obj
+    if isinstance(obj, bytes):
+        return _encode_bytes(obj, bytes_encoding)
+    if isinstance(obj, memoryview):
+        return _encode_bytes(obj.tobytes(), bytes_encoding)
     if isinstance(obj, PydanticUndefinedType):
         return None
     if isinstance(obj, dict):
@@ -302,6 +325,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +334,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +352,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +387,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -66,6 +66,10 @@ class ModelWithAlias(BaseModel):
     foo: str = Field(alias="Foo")
 
 
+class ModelWithBytes(BaseModel):
+    payload: bytes
+
+
 class ModelWithDefault(BaseModel):
     foo: str = ...  # type: ignore
     bar: str = "bar"
@@ -182,6 +186,43 @@ def test_encode_model_with_alias_raises():
 def test_encode_model_with_alias():
     model = ModelWithAlias(Foo="Bar")
     assert jsonable_encoder(model) == {"Foo": "Bar"}
+
+
+def test_encode_bytes_defaults_to_base64():
+    assert jsonable_encoder(b"\x00\xffhello") == "AP9oZWxsbw=="
+
+
+def test_encode_bytes_as_hex():
+    assert jsonable_encoder(b"\x00\xffhello", bytes_encoding="hex") == "00ff68656c6c6f"
+
+
+def test_encode_memoryview_defaults_to_base64():
+    assert jsonable_encoder(memoryview(b"hello")) == "aGVsbG8="
+
+
+def test_encode_memoryview_as_hex():
+    assert jsonable_encoder(memoryview(b"hello"), bytes_encoding="hex") == "68656c6c6f"
+
+
+def test_encode_nested_bytes_and_memoryview_uses_selected_encoding():
+    encoded = jsonable_encoder(
+        {"file": b"\x00\xff", "items": [memoryview(b"ok")]},
+        bytes_encoding="hex",
+    )
+
+    assert encoded == {"file": "00ff", "items": ["6f6b"]}
+
+
+def test_encode_model_with_bytes_uses_selected_encoding():
+    model = ModelWithBytes(payload=b"\x00\xff")
+
+    assert jsonable_encoder(model) == {"payload": "AP8="}
+    assert jsonable_encoder(model, bytes_encoding="hex") == {"payload": "00ff"}
+
+
+def test_encode_bytes_rejects_unknown_encoding():
+    with pytest.raises(ValueError, match="bytes_encoding must be 'base64' or 'hex'"):
+        jsonable_encoder(b"hello", bytes_encoding="utf-8")
 
 
 def test_encode_model_with_default():


### PR DESCRIPTION
/claim #759

Summary:
- Updated `jsonable_encoder` to encode raw `bytes` as base64 by default instead of decoding as UTF-8.
- Added `memoryview` support by converting to bytes before encoding.
- Added `bytes_encoding="hex"` and propagated it through recursive encoding for dicts, lists, dataclasses, and Pydantic models.
- Added safe non-sensitive provenance metadata only.

Validation:
- `/tmp/codex-fastapi799-venv/bin/python -m pytest tests/test_jsonable_encoder.py -q` -> 32 passed, 1 skipped
- `/tmp/codex-fastapi799-venv/bin/python -m ruff check fastapi/encoders.py tests/test_jsonable_encoder.py` -> passed
- `/tmp/codex-fastapi799-venv/bin/python -m ruff format --check fastapi/encoders.py tests/test_jsonable_encoder.py` -> passed
- `git diff --check` -> passed

Demo/proof:
- I could not attach a screen-recorded demo from this environment, so the PR includes executable tests covering bytes, memoryview, base64, hex, nested containers, Pydantic model fields, and invalid encoding rejection.

Security/privacy note:
- Private system/developer/runtime instructions are not included in repository files or PR text. The provenance file contains only safe public submission context.