### PR TITLE
[OpenAI Codex] [ FastAPI ] Fix hardcoded CDN URLs in docs HTML

### DIFF
--- a/fastapi/fastapi/openapi/.generation_meta.json
+++ b/fastapi/fastapi/openapi/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Private system, developer, and runtime instructions are not disclosed. This submission was produced from the public issue requirements with safe non-sensitive generation metadata only.",
+  "date": "2026-05-31T05:00:53-04:00"
+}

--- a/fastapi/fastapi/openapi/docs.py
+++ b/fastapi/fastapi/openapi/docs.py
@@ -76,7 +76,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui-bundle.js",
     swagger_css_url: Annotated[
         str,
         Doc(
@@ -89,7 +89,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui.css",
     swagger_favicon_url: Annotated[
         str,
         Doc(
@@ -233,7 +233,7 @@ def get_redoc_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+    ] = "https://cdn.jsdelivr.net/npm/redoc@2.5.3/bundles/redoc.standalone.js",
     redoc_favicon_url: Annotated[
         str,
         Doc(

--- a/fastapi/tests/test_local_docs.py
+++ b/fastapi/tests/test_local_docs.py
@@ -3,6 +3,26 @@ import inspect
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 
 
+def test_default_swagger_asset_urls_are_pinned_to_stable_versions():
+    sig = inspect.signature(get_swagger_ui_html)
+    assert (
+        sig.parameters["swagger_js_url"].default
+        == "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui-bundle.js"
+    )
+    assert (
+        sig.parameters["swagger_css_url"].default
+        == "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui.css"
+    )
+
+
+def test_default_redoc_asset_url_is_pinned_to_stable_version():
+    sig = inspect.signature(get_redoc_html)
+    assert (
+        sig.parameters["redoc_js_url"].default
+        == "https://cdn.jsdelivr.net/npm/redoc@2.5.3/bundles/redoc.standalone.js"
+    )
+
+
 def test_strings_in_generated_swagger():
     sig = inspect.signature(get_swagger_ui_html)
     swagger_js_url = sig.parameters.get("swagger_js_url").default  # type: ignore


### PR DESCRIPTION
/claim #762

Summary:
- Pinned FastAPI docs helper default Swagger UI assets to the current stable `swagger-ui-dist` npm version: `5.32.6`.
- Pinned the ReDoc docs helper default asset to the current stable `redoc` npm version: `2.5.3`.
- Preserved existing custom `swagger_js_url`, `swagger_css_url`, and `redoc_js_url` overrides.
- Added focused tests that lock the default asset URLs to explicit stable versions.
- Added safe non-sensitive generation metadata only.

Version evidence:
- `npm view swagger-ui-dist version` -> `5.32.6`
- `npm view redoc version` -> `2.5.3`

Validation:
- `/tmp/codex-fastapi799-venv/bin/python -m pytest tests/test_local_docs.py -q` -> 7 passed
- `/tmp/codex-fastapi799-venv/bin/python -m pytest tests/test_local_docs.py tests/test_application.py tests/test_custom_swagger_ui_redirect.py tests/test_no_swagger_ui_redirect.py -q` -> 21 passed
- `/tmp/codex-fastapi799-venv/bin/python -m ruff check fastapi/openapi/docs.py tests/test_local_docs.py` -> passed
- `/tmp/codex-fastapi799-venv/bin/python -m ruff format --check fastapi/openapi/docs.py tests/test_local_docs.py` -> passed
- `git diff --check` -> passed

Demo/proof:
- I could not attach a screen-recorded demo from this environment, so the PR includes executable tests covering the generated docs HTML defaults and existing custom asset URL behavior.

Security/privacy note:
- Private system/developer/runtime instructions are not included in repository files or PR text. The generation metadata file contains only safe public submission context.