### PR TITLE
[OpenAI Codex] [ Laravel ] Fix User model password cast rounds

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Safe public context only: implemented the Laravel bcrypt rounds bounty without disclosing private system, developer, runtime, or user-specific hidden instructions.",
+  "completed_at": "2026-05-31T05:20:00-04:00"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,22 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Hash raw passwords with the configured bcrypt rounds.
+     */
+    public function setPasswordAttribute(mixed $value): void
+    {
+        if ($value === null || (is_string($value) && Hash::isHashed($value))) {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value, [
+            'rounds' => (int) config('hashing.bcrypt.rounds'),
+        ]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,47 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Hash Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default hash driver used by the application.
+    | Bcrypt remains the default for password storage.
+    |
+    */
+
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bcrypt Options
+    |--------------------------------------------------------------------------
+    |
+    | The bcrypt work factor is read from the environment so password hashing
+    | can be tuned consistently across the model, factories, and tests.
+    |
+    */
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
+        'limit' => env('BCRYPT_LIMIT', null),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Argon Options
+    |--------------------------------------------------------------------------
+    */
+
+    'argon' => [
+        'memory' => env('ARGON_MEMORY', 65536),
+        'threads' => env('ARGON_THREADS', 1),
+        'time' => env('ARGON_TIME', 4),
+    ],
+
+    'rehash_on_login' => true,
+
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -14,8 +14,10 @@ class UserFactory extends Factory
 {
     /**
      * The current password being used by the factory.
+     *
+     * @var array<int, string>
      */
-    protected static ?string $password;
+    protected static array $passwords = [];
 
     /**
      * Define the model's default state.
@@ -28,9 +30,21 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::password(),
             'remember_token' => Str::random(10),
         ];
+    }
+
+    /**
+     * Get the cached factory password for the configured bcrypt rounds.
+     */
+    protected static function password(): string
+    {
+        $rounds = (int) config('hashing.bcrypt.rounds');
+
+        return static::$passwords[$rounds] ??= Hash::make('password', [
+            'rounds' => $rounds,
+        ]);
     }
 
     /**

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_password_hashing_respects_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 12]);
+
+        $user = new User;
+        $user->password = 'secret-password';
+
+        $this->assertSame(12, password_get_info($user->password)['options']['cost']);
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+    }
+
+    public function test_user_factory_generates_passwords_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 13]);
+
+        $user = User::factory()->make();
+
+        $this->assertSame(13, password_get_info($user->password)['options']['cost']);
+        $this->assertTrue(Hash::check('password', $user->password));
+    }
+
+    public function test_existing_bcrypt_hashes_are_preserved_for_legacy_verification(): void
+    {
+        $legacyHash = Hash::make('secret-password', ['rounds' => 10]);
+
+        $user = new User;
+        $user->password = $legacyHash;
+
+        $this->assertSame($legacyHash, $user->password);
+        $this->assertSame(10, password_get_info($user->password)['options']['cost']);
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+    }
+}


### PR DESCRIPTION
/claim #745

## Summary
- Replaced the generic `password => hashed` cast with an explicit `setPasswordAttribute` mutator that uses `config('hashing.bcrypt.rounds')`.
- Added the missing Laravel hashing config and updated `UserFactory` to cache generated passwords by configured bcrypt rounds.
- Added unit coverage for configured model hashing, factory hashing, and preserving existing bcrypt hashes for legacy `Hash::check()` compatibility.
- Included safe non-sensitive metadata only in `laravel/_meta.json`.

## Verification
- `php artisan test tests/Unit/UserPasswordHashingTest.php` -> 3 passed, 7 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 5 passed, 9 assertions
- `php -l app/Models/User.php && php -l database/factories/UserFactory.php && php -l config/hashing.php && php -l tests/Unit/UserPasswordHashingTest.php`
- `./vendor/bin/pint --test app/Models/User.php database/factories/UserFactory.php config/hashing.php tests/Unit/UserPasswordHashingTest.php`
- `git diff --check`