### PR TITLE
[OpenAI Codex] [ Laravel ] Add scheduled log cleanup command

### DIFF
--- a/laravel/routes/_generation.json
+++ b/laravel/routes/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Safe public context only: implemented the Laravel log cleanup bounty without disclosing private system, developer, runtime, or user-specific hidden instructions.",
+  "timestamp": "2026-05-31T05:26:00-04:00"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,67 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Delete log files older than this many days}', function () {
+    $days = (int) $this->option('days');
+
+    if ($days < 0) {
+        $this->error('The --days option must be zero or greater.');
+
+        return 1;
+    }
+
+    $formatBytes = static function (int $bytes): string {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $size = (float) $bytes;
+        $unitIndex = 0;
+
+        while ($size >= 1024 && $unitIndex < count($units) - 1) {
+            $size /= 1024;
+            $unitIndex++;
+        }
+
+        if ($unitIndex === 0) {
+            return $bytes.' '.$units[$unitIndex];
+        }
+
+        return rtrim(rtrim(number_format($size, 1), '0'), '.').' '.$units[$unitIndex];
+    };
+
+    $logPath = storage_path('logs');
+    $cutoffTimestamp = now()->subDays($days)->getTimestamp();
+    $deletedCount = 0;
+    $freedBytes = 0;
+
+    if (File::isDirectory($logPath)) {
+        foreach (File::files($logPath) as $file) {
+            if ($file->getExtension() !== 'log' || $file->getMTime() >= $cutoffTimestamp) {
+                continue;
+            }
+
+            $size = $file->getSize();
+
+            if (File::delete($file->getPathname())) {
+                $deletedCount++;
+                $freedBytes += $size;
+            }
+        }
+    }
+
+    $this->info(sprintf(
+        'Deleted %d log %s; freed %s.',
+        $deletedCount,
+        $deletedCount === 1 ? 'file' : 'files',
+        $formatBytes($freedBytes),
+    ));
+
+    return 0;
+})->purpose('Delete old Laravel log files');
+
+Schedule::command('logs:clear')->dailyAt('00:00');

--- a/laravel/tests/Feature/LogCleanupCommandTest.php
+++ b/laravel/tests/Feature/LogCleanupCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class LogCleanupCommandTest extends TestCase
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $createdLogFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdLogFiles as $path) {
+            File::delete($path);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_logs_clear_deletes_logs_older_than_default_retention(): void
+    {
+        $oldLog = $this->makeLogFile('codex-old-default.log', 8, str_repeat('a', 2048));
+        $freshLog = $this->makeLogFile('codex-fresh-default.log', 3, 'fresh');
+
+        $this->artisan('logs:clear')
+            ->expectsOutput('Deleted 1 log file; freed 2 KB.')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($freshLog);
+    }
+
+    public function test_logs_clear_days_option_overrides_default_retention(): void
+    {
+        $twentyDayLog = $this->makeLogFile('codex-retained-override.log', 20, 'keep me');
+
+        $this->artisan('logs:clear --days=30')
+            ->expectsOutput('Deleted 0 log files; freed 0 B.')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($twentyDayLog);
+    }
+
+    public function test_log_cleanup_is_scheduled_daily_at_midnight(): void
+    {
+        $event = collect($this->app->make(Schedule::class)->events())
+            ->first(fn ($event) => str_contains($event->command ?? '', 'logs:clear'));
+
+        $this->assertNotNull($event);
+        $this->assertSame('0 0 * * *', $event->getExpression());
+    }
+
+    private function makeLogFile(string $name, int $ageInDays, string $contents): string
+    {
+        $path = storage_path('logs/'.$name);
+
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+        touch($path, now()->subDays($ageInDays)->getTimestamp());
+
+        $this->createdLogFiles[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
/claim #753

## Summary
- Added a `logs:clear` closure Artisan command in `laravel/routes/console.php`.
- Supports `--days=7` by default and overrides such as `--days=30`.
- Deletes old `.log` files under `storage/logs`, reports deleted file count and human-readable freed space, and rejects negative retention windows.
- Scheduled the cleanup daily at midnight.
- Added feature coverage for default retention, `--days` override, and the daily midnight schedule.
- Included safe non-sensitive generation metadata only in `laravel/routes/_generation.json`.

## Verification
- `php artisan test tests/Feature/LogCleanupCommandTest.php` -> 3 passed, 9 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 5 passed, 11 assertions
- `php -l routes/console.php && php -l tests/Feature/LogCleanupCommandTest.php`
- `./vendor/bin/pint --test routes/console.php tests/Feature/LogCleanupCommandTest.php`
- `git diff --check`