### PR TITLE
[OpenAI Codex] [ Laravel ] Fix DatabaseSeeder idempotence and roles

### DIFF
--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/.provenance.json
+++ b/laravel/database/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe public context only: implemented the Laravel idempotent seeder bounty without disclosing private system, developer, runtime, or user-specific hidden instructions.",
+  "created": "2026-05-31T05:30:00-04:00"
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->word();
+
+        return [
+            'name' => Str::slug($name),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_05_31_000001_create_roles_table.php
+++ b/laravel/database/migrations/2026_05_31_000001_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,13 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
+        User::firstOrCreate([
             'email' => 'test@example.com',
+        ], [
+            'name' => 'Test User',
+            'password' => Hash::make('password'),
         ]);
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default roles.
+     */
+    public function run(): void
+    {
+        foreach ($this->defaultRoles() as $role) {
+            Role::firstOrCreate([
+                'name' => $role['name'],
+            ], [
+                'description' => $role['description'],
+            ]);
+        }
+    }
+
+    /**
+     * @return array<int, array{name: string, description: string}>
+     */
+    private function defaultRoles(): array
+    {
+        return [
+            [
+                'name' => 'admin',
+                'description' => 'Full administrative access.',
+            ],
+            [
+                'name' => 'editor',
+                'description' => 'Can create and edit application content.',
+            ],
+            [
+                'name' => 'viewer',
+                'description' => 'Can view application content.',
+            ],
+        ];
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_is_idempotent_for_test_user_and_default_roles(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertSame(['admin', 'editor', 'viewer'], Role::query()->orderBy('name')->pluck('name')->all());
+        $this->assertSame(3, Role::count());
+    }
+
+    public function test_role_seeder_is_idempotent(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertSame(3, Role::count());
+        $this->assertSame(['admin', 'editor', 'viewer'], Role::query()->orderBy('name')->pluck('name')->all());
+    }
+
+    public function test_role_factory_generates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertNotNull($role->id);
+        $this->assertNotSame('', $role->name);
+        $this->assertNotSame('', $role->description);
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- Replaced duplicate-prone test user creation in `DatabaseSeeder` with `User::firstOrCreate()`.
- Added a `Role` model, roles table migration, `RoleFactory`, and idempotent `RoleSeeder` for `admin`, `editor`, and `viewer`.
- Called `RoleSeeder` from `DatabaseSeeder` after the test user seed.
- Added feature coverage proving repeated database seeding and repeated role seeding do not duplicate rows, plus role factory validity.
- Included safe non-sensitive provenance metadata only in `laravel/database/.provenance.json`.

## Verification
- `php artisan test tests/Feature/DatabaseSeederTest.php` -> 3 passed, 8 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 5 passed, 10 assertions
- `php -l app/Models/Role.php && php -l database/factories/RoleFactory.php && php -l database/migrations/2026_05_31_000001_create_roles_table.php && php -l database/seeders/DatabaseSeeder.php && php -l database/seeders/RoleSeeder.php && php -l tests/Feature/DatabaseSeederTest.php`
- `./vendor/bin/pint --test app/Models/Role.php database/factories/RoleFactory.php database/migrations/2026_05_31_000001_create_roles_table.php database/seeders/DatabaseSeeder.php database/seeders/RoleSeeder.php tests/Feature/DatabaseSeederTest.php`
- `git diff --check`