### PR TITLE
[OpenAI Codex] [ Laravel ] Add failed job monitoring and summary

### DIFF
--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class LogFailedJob
+{
+    /**
+     * Handle the failed job event.
+     */
+    public function handle($event): void
+    {
+        $exception = $event->exception;
+
+        Log::error('Queue job failed', [
+            'connection' => $event->connectionName,
+            'queue' => $event->job->getQueue(),
+            'job_id' => $event->job->getJobId(),
+            'job' => $event->job->resolveName(),
+            'payload' => $event->job->payload(),
+            'exception_class' => $exception::class,
+            'exception_message' => $exception->getMessage(),
+            'exception_file' => $exception->getFile(),
+            'exception_line' => $exception->getLine(),
+            'exception_trace' => $this->formatTrace($exception),
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function formatTrace(Throwable $exception): array
+    {
+        return $exception->getTrace();
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, LogFailedJob::class);
     }
 }

--- a/laravel/config/queue.php
+++ b/laravel/config/queue.php
@@ -41,6 +41,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'max_tries' => (int) env('DB_QUEUE_MAX_TRIES', 3),
             'after_commit' => false,
         ],
 

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Safe public context only: implemented the Laravel failed-job monitoring bounty without disclosing private system, developer, runtime, or user-specific hidden instructions.",
+  "ts": "2026-05-31T05:36:00-04:00"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,42 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('queue:failed-summary', function () {
+    $failedTable = config('queue.failed.table', 'failed_jobs');
+    $failedJobs = DB::table($failedTable)->select('exception')->get();
+    $resolveExceptionClass = static function (string $exception): string {
+        $firstLine = trim(strtok($exception, "\n") ?: $exception);
+
+        if (preg_match('/^([A-Za-z_\\\\][A-Za-z0-9_\\\\]*)(?::|\\s)/', $firstLine, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return $firstLine !== '' ? $firstLine : 'Unknown';
+    };
+
+    if ($failedJobs->isEmpty()) {
+        $this->info('No failed jobs found.');
+
+        return 0;
+    }
+
+    $summary = $failedJobs
+        ->map(fn ($job) => [
+            'exception' => $resolveExceptionClass((string) $job->exception),
+        ])
+        ->countBy('exception')
+        ->sortKeys()
+        ->map(fn (int $count, string $exception) => [$exception, $count])
+        ->values()
+        ->all();
+
+    $this->table(['Exception', 'Count'], $summary);
+
+    return 0;
+})->purpose('Display failed queue jobs grouped by exception class');

--- a/laravel/tests/Feature/FailedJobMonitoringTest.php
+++ b/laravel/tests/Feature/FailedJobMonitoringTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use Exception;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+
+class FailedJobMonitoringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_failed_job_listener_logs_job_metadata(): void
+    {
+        $exception = new Exception('database is unavailable');
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('getQueue')->andReturn('emails');
+        $job->shouldReceive('getJobId')->andReturn('job-123');
+        $job->shouldReceive('resolveName')->andReturn('App\\Jobs\\SendEmail');
+        $job->shouldReceive('payload')->andReturn([
+            'displayName' => 'App\\Jobs\\SendEmail',
+            'attempts' => 3,
+        ]);
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Queue job failed', Mockery::on(function (array $context) use ($exception) {
+                return $context['connection'] === 'database'
+                    && $context['queue'] === 'emails'
+                    && $context['job_id'] === 'job-123'
+                    && $context['job'] === 'App\\Jobs\\SendEmail'
+                    && $context['payload']['attempts'] === 3
+                    && $context['exception_class'] === $exception::class
+                    && $context['exception_message'] === 'database is unavailable'
+                    && isset($context['exception_trace']);
+            }));
+
+        Event::dispatch(new JobFailed('database', $job, $exception));
+    }
+
+    public function test_failed_summary_command_groups_failed_jobs_by_exception_class(): void
+    {
+        $this->insertFailedJob('RuntimeException: first failure');
+        $this->insertFailedJob("RuntimeException: second failure\nStack trace:");
+        $this->insertFailedJob('InvalidArgumentException: bad payload');
+
+        $this->artisan('queue:failed-summary')
+            ->expectsTable(['Exception', 'Count'], [
+                ['InvalidArgumentException', 1],
+                ['RuntimeException', 2],
+            ])
+            ->assertExitCode(0);
+    }
+
+    public function test_database_queue_retry_configuration_is_set(): void
+    {
+        $this->assertSame(90, Config::get('queue.connections.database.retry_after'));
+        $this->assertSame(3, Config::get('queue.connections.database.max_tries'));
+    }
+
+    private function insertFailedJob(string $exception): void
+    {
+        DB::table('failed_jobs')->insert([
+            'uuid' => (string) Str::uuid(),
+            'connection' => 'database',
+            'queue' => 'default',
+            'payload' => '{}',
+            'exception' => $exception,
+            'failed_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
/claim #789

## Summary
- Added `App\Listeners\LogFailedJob` for `JobFailed` events, logging connection, queue, job id, resolved job name, payload, and full exception metadata.
- Registered the listener explicitly in `AppServiceProvider`.
- Added `queue:failed-summary`, grouping failed jobs by parsed exception class from `failed_jobs`.
- Set database queue `retry_after` to 90 seconds and added `max_tries` default of 3.
- Added feature tests for listener metadata logging, summary grouping, and queue config values.
- Included safe non-sensitive contributor metadata only in `laravel/contributor_meta.json`.

## Verification
- `php artisan test tests/Feature/FailedJobMonitoringTest.php` -> 3 passed, 10 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 5 passed, 12 assertions
- `php -l app/Listeners/LogFailedJob.php && php -l app/Providers/AppServiceProvider.php && php -l routes/console.php && php -l tests/Feature/FailedJobMonitoringTest.php && php -l config/queue.php`
- `./vendor/bin/pint --test app/Listeners/LogFailedJob.php app/Providers/AppServiceProvider.php routes/console.php tests/Feature/FailedJobMonitoringTest.php config/queue.php`
- `git diff --check`