### PR TITLE
[OpenAI Codex] [ Laravel ] Add cache health checks

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+    "tool_name": "OpenAI Codex",
+    "boot_context": "Safe public metadata only; private system, developer, and runtime instructions are intentionally not included.",
+    "timestamp": "2026-05-31T09:30:00Z"
+}

--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status {--force : Ignore the cached health-check result}';
+
+    protected $description = 'Display the configured cache store health status';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $result = $healthCheck->check((bool) $this->option('force'));
+
+        $this->table(
+            ['Driver', 'Available', 'Latency (ms)'],
+            [[
+                $result['driver'],
+                $result['available'] ? 'yes' : 'no',
+                (string) $result['latency_ms'],
+            ]]
+        );
+
+        if (! $result['checked']) {
+            $this->warn('Cache health checks are disabled by configuration.');
+        }
+
+        if (! $result['available']) {
+            $this->error($result['error'] ?? 'Cache store is unavailable.');
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Http\JsonResponse;
+
+class HealthController extends Controller
+{
+    public function cache(CacheHealthCheck $healthCheck): JsonResponse
+    {
+        $result = $healthCheck->check();
+
+        return response()->json($result, $result['available'] ? 200 : 503);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +12,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(CacheHealthCheck::class);
     }
 
     /**

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use RuntimeException;
+use Throwable;
+
+class CacheHealthCheck
+{
+    private ?array $lastResult = null;
+
+    private ?float $lastCheckedAt = null;
+
+    public function __construct(
+        private readonly CacheFactory $cache,
+        private readonly ConfigRepository $config,
+    ) {}
+
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float, store: string, checked: bool, cached: bool, error?: string}
+     */
+    public function check(bool $force = false): array
+    {
+        $storeName = (string) $this->config->get('cache.default', 'default');
+        $driver = (string) $this->config->get("cache.stores.{$storeName}.driver", $storeName);
+
+        if (! (bool) $this->config->get('cache.health_check_enabled', true)) {
+            return [
+                'available' => true,
+                'driver' => $driver,
+                'latency_ms' => 0.0,
+                'store' => $storeName,
+                'checked' => false,
+                'cached' => false,
+            ];
+        }
+
+        if (! $force && $this->hasFreshCachedResult()) {
+            return [
+                ...$this->lastResult,
+                'cached' => true,
+            ];
+        }
+
+        $result = $this->probeStore($storeName, $driver);
+        $this->lastResult = $result;
+        $this->lastCheckedAt = microtime(true);
+
+        return $result;
+    }
+
+    private function hasFreshCachedResult(): bool
+    {
+        if ($this->lastResult === null || $this->lastCheckedAt === null) {
+            return false;
+        }
+
+        $interval = max(0, (int) $this->config->get('cache.health_check_interval', 300));
+
+        return $interval > 0 && (microtime(true) - $this->lastCheckedAt) < $interval;
+    }
+
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float, store: string, checked: bool, cached: bool, error?: string}
+     */
+    private function probeStore(string $storeName, string $driver): array
+    {
+        $startedAt = hrtime(true);
+
+        try {
+            $store = $this->cache->store($storeName);
+            $key = 'health:cache:'.bin2hex(random_bytes(8));
+            $value = bin2hex(random_bytes(16));
+
+            $store->put($key, $value, 30);
+
+            if ($store->get($key) !== $value) {
+                throw new RuntimeException('Cache store did not return the health check value.');
+            }
+
+            $store->forget($key);
+
+            return [
+                'available' => true,
+                'driver' => $driver,
+                'latency_ms' => $this->latencySince($startedAt),
+                'store' => $storeName,
+                'checked' => true,
+                'cached' => false,
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'available' => false,
+                'driver' => $driver,
+                'latency_ms' => $this->latencySince($startedAt),
+                'store' => $storeName,
+                'checked' => true,
+                'cached' => false,
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+
+    private function latencySince(int $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000, 3);
+    }
+}

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -19,6 +19,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Health Checks
+    |--------------------------------------------------------------------------
+    |
+    | These options control whether the application validates the configured
+    | cache store before reporting health, and how long a fresh result can be
+    | reused before probing the cache store again.
+    |
+    */
+
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => (int) env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Stores
     |--------------------------------------------------------------------------
     |

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/cache', [HealthController::class, 'cache']);

--- a/laravel/tests/Feature/CacheHealthEndpointTest.php
+++ b/laravel/tests/Feature/CacheHealthEndpointTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\CacheHealthCheck;
+use Mockery;
+use Tests\TestCase;
+
+class CacheHealthEndpointTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+    }
+
+    public function test_cache_health_endpoint_returns_ok_for_available_cache(): void
+    {
+        config()->set('cache.default', 'array');
+
+        $this->getJson('/health/cache')
+            ->assertOk()
+            ->assertJsonPath('available', true)
+            ->assertJsonPath('driver', 'array')
+            ->assertJsonPath('store', 'array')
+            ->assertJsonStructure([
+                'available',
+                'driver',
+                'latency_ms',
+                'store',
+                'checked',
+                'cached',
+            ]);
+    }
+
+    public function test_cache_health_endpoint_returns_service_unavailable_for_failed_cache(): void
+    {
+        $healthCheck = Mockery::mock(CacheHealthCheck::class);
+        $healthCheck->shouldReceive('check')->once()->andReturn([
+            'available' => false,
+            'driver' => 'redis',
+            'latency_ms' => 4.5,
+            'store' => 'redis',
+            'checked' => true,
+            'cached' => false,
+            'error' => 'redis offline',
+        ]);
+
+        $this->app->instance(CacheHealthCheck::class, $healthCheck);
+
+        $this->getJson('/health/cache')
+            ->assertStatus(503)
+            ->assertJsonPath('available', false)
+            ->assertJsonPath('driver', 'redis')
+            ->assertJsonPath('error', 'redis offline');
+    }
+}

--- a/laravel/tests/Feature/CacheStatusCommandTest.php
+++ b/laravel/tests/Feature/CacheStatusCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Support\Facades\Artisan;
+use Mockery;
+use Tests\TestCase;
+
+class CacheStatusCommandTest extends TestCase
+{
+    public function test_cache_status_command_outputs_driver_availability_and_latency(): void
+    {
+        $healthCheck = Mockery::mock(CacheHealthCheck::class);
+        $healthCheck->shouldReceive('check')->once()->with(false)->andReturn([
+            'available' => true,
+            'driver' => 'array',
+            'latency_ms' => 1.25,
+            'store' => 'array',
+            'checked' => true,
+            'cached' => false,
+        ]);
+
+        $this->app->instance(CacheHealthCheck::class, $healthCheck);
+
+        $exitCode = Artisan::call('cache:status');
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Driver', $output);
+        $this->assertStringContainsString('Available', $output);
+        $this->assertStringContainsString('Latency (ms)', $output);
+        $this->assertStringContainsString('array', $output);
+        $this->assertStringContainsString('yes', $output);
+        $this->assertStringContainsString('1.25', $output);
+    }
+
+    public function test_cache_status_command_returns_failure_when_cache_is_unavailable(): void
+    {
+        $healthCheck = Mockery::mock(CacheHealthCheck::class);
+        $healthCheck->shouldReceive('check')->once()->with(true)->andReturn([
+            'available' => false,
+            'driver' => 'redis',
+            'latency_ms' => 4.5,
+            'store' => 'redis',
+            'checked' => true,
+            'cached' => false,
+            'error' => 'redis offline',
+        ]);
+
+        $this->app->instance(CacheHealthCheck::class, $healthCheck);
+
+        $exitCode = Artisan::call('cache:status', ['--force' => true]);
+        $output = Artisan::output();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('redis', $output);
+        $this->assertStringContainsString('no', $output);
+        $this->assertStringContainsString('redis offline', $output);
+    }
+}

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    public function test_it_reports_the_active_cache_store_as_available(): void
+    {
+        config()->set('cache.default', 'array');
+
+        $result = app(CacheHealthCheck::class)->check(force: true);
+
+        $this->assertTrue($result['available']);
+        $this->assertTrue($result['checked']);
+        $this->assertFalse($result['cached']);
+        $this->assertSame('array', $result['driver']);
+        $this->assertIsFloat($result['latency_ms']);
+    }
+
+    public function test_it_respects_disabled_health_checks(): void
+    {
+        $config = new Repository([
+            'cache' => [
+                'default' => 'missing-store',
+                'health_check_enabled' => false,
+                'stores' => [
+                    'missing-store' => [
+                        'driver' => 'missing',
+                    ],
+                ],
+            ],
+        ]);
+
+        $cache = Mockery::mock(CacheFactory::class);
+        $cache->shouldNotReceive('store');
+
+        $result = (new CacheHealthCheck($cache, $config))->check();
+
+        $this->assertTrue($result['available']);
+        $this->assertFalse($result['checked']);
+        $this->assertSame('missing', $result['driver']);
+        $this->assertSame(0.0, $result['latency_ms']);
+    }
+
+    public function test_it_reuses_a_fresh_result_for_the_configured_interval(): void
+    {
+        $config = new Repository([
+            'cache' => [
+                'default' => 'array',
+                'health_check_enabled' => true,
+                'health_check_interval' => 300,
+                'stores' => [
+                    'array' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ]);
+
+        $storedValue = null;
+        $store = Mockery::mock();
+        $store->shouldReceive('put')
+            ->once()
+            ->withArgs(function (string $key, string $value, int $ttl) use (&$storedValue): bool {
+                $storedValue = $value;
+
+                return str_starts_with($key, 'health:cache:') && $ttl === 30;
+            })
+            ->andReturnTrue();
+        $store->shouldReceive('get')->once()->andReturnUsing(function () use (&$storedValue): ?string {
+            return $storedValue;
+        });
+        $store->shouldReceive('forget')->once()->andReturnTrue();
+
+        $cache = Mockery::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->once()->with('array')->andReturn($store);
+
+        $service = new CacheHealthCheck($cache, $config);
+
+        $first = $service->check();
+        $second = $service->check();
+
+        $this->assertTrue($first['available']);
+        $this->assertFalse($first['cached']);
+        $this->assertTrue($second['available']);
+        $this->assertTrue($second['cached']);
+    }
+
+    public function test_it_reports_unavailable_when_the_store_throws(): void
+    {
+        $config = new Repository([
+            'cache' => [
+                'default' => 'redis',
+                'health_check_enabled' => true,
+                'stores' => [
+                    'redis' => [
+                        'driver' => 'redis',
+                    ],
+                ],
+            ],
+        ]);
+
+        $cache = Mockery::mock(CacheFactory::class);
+        $cache->shouldReceive('store')->once()->with('redis')->andThrow(new RuntimeException('redis offline'));
+
+        $result = (new CacheHealthCheck($cache, $config))->check();
+
+        $this->assertFalse($result['available']);
+        $this->assertTrue($result['checked']);
+        $this->assertSame('redis', $result['driver']);
+        $this->assertSame('redis offline', $result['error']);
+        $this->assertIsFloat($result['latency_ms']);
+    }
+}


### PR DESCRIPTION
/claim #747

## Summary
- Added `App\Services\CacheHealthCheck` for the active cache store with availability, driver, store, latency, checked, cached, and error metadata.
- Added in-process reuse of fresh health results using `cache.health_check_interval`, plus a `cache.health_check_enabled` bypass.
- Added `cache:status` as an auto-discovered Artisan command with driver, availability, and latency output.
- Added `GET /health/cache` returning 200 for available cache stores and 503 for unavailable stores.
- Registered the health-check service as a singleton and included focused unit/feature tests.
- Included safe non-sensitive provenance metadata only in `laravel/_provenance.json`.

## Verification
- `php artisan test tests/Unit/CacheHealthCheckTest.php tests/Feature/CacheHealthEndpointTest.php tests/Feature/CacheStatusCommandTest.php` -> 8 passed, 52 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 10 passed, 54 assertions
- `php -l app/Services/CacheHealthCheck.php && php -l app/Http/Controllers/HealthController.php && php -l app/Console/Commands/CacheStatusCommand.php && php -l app/Providers/AppServiceProvider.php && php -l config/cache.php && php -l routes/web.php && php -l tests/Unit/CacheHealthCheckTest.php && php -l tests/Feature/CacheHealthEndpointTest.php && php -l tests/Feature/CacheStatusCommandTest.php`
- `./vendor/bin/pint --test app/Services/CacheHealthCheck.php app/Http/Controllers/HealthController.php app/Console/Commands/CacheStatusCommand.php app/Providers/AppServiceProvider.php config/cache.php routes/web.php tests/Unit/CacheHealthCheckTest.php tests/Feature/CacheHealthEndpointTest.php tests/Feature/CacheStatusCommandTest.php`
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') CACHE_STORE=array php artisan cache:status --force` -> driver `array`, available `yes`
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan route:list --path=health/cache` -> `GET|HEAD health/cache .. HealthController@cache`
- `git diff --check`
