### PR TITLE
[OpenAI Codex] [ Laravel ] Implement webhook delivery system

### DIFF
--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebhookController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json([
+            'data' => Webhook::query()
+                ->withCount('deliveries')
+                ->latest()
+                ->get(),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $webhook = Webhook::query()->create($this->validateWebhook($request));
+
+        return response()->json([
+            'data' => $webhook,
+        ], 201);
+    }
+
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json([
+            'data' => $webhook->load('deliveries'),
+        ]);
+    }
+
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $webhook->update($this->validateWebhook($request, updating: true));
+
+        return response()->json([
+            'data' => $webhook->refresh(),
+        ]);
+    }
+
+    public function destroy(Webhook $webhook): JsonResponse
+    {
+        $webhook->delete();
+
+        return response()->json(status: 204);
+    }
+
+    /**
+     * @return array{url?: string, secret?: string, events?: array<int, string>, active?: bool}
+     */
+    private function validateWebhook(Request $request, bool $updating = false): array
+    {
+        $required = $updating ? 'sometimes' : 'required';
+
+        $validated = $request->validate([
+            'url' => [$required, 'url', 'max:2048'],
+            'secret' => [$required, 'string', 'max:255'],
+            'events' => [$required, 'array', 'min:1'],
+            'events.*' => ['string', 'max:255'],
+            'active' => ['sometimes', 'boolean'],
+        ]);
+
+        if (! $updating) {
+            $validated['active'] ??= true;
+        }
+
+        return $validated;
+    }
+}

--- a/laravel/app/Jobs/DispatchWebhookJob.php
+++ b/laravel/app/Jobs/DispatchWebhookJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class DispatchWebhookJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = WebhookDispatcher::MAX_ATTEMPTS;
+
+    public function __construct(
+        public readonly int $deliveryId,
+    ) {}
+
+    public function handle(WebhookDispatcher $dispatcher): void
+    {
+        $delivery = WebhookDelivery::query()->findOrFail($this->deliveryId);
+
+        if ($delivery->delivered_at !== null) {
+            return;
+        }
+
+        $dispatcher->send($delivery);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return WebhookDispatcher::backoffSchedule();
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable(['url', 'secret', 'events', 'active'])]
+class Webhook extends Model
+{
+    /**
+     * @return HasMany<WebhookDelivery, $this>
+     */
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'events' => 'array',
+            'active' => 'boolean',
+        ];
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['webhook_id', 'event', 'payload', 'response_code', 'attempts', 'next_retry_at', 'delivered_at'])]
+class WebhookDelivery extends Model
+{
+    /**
+     * @return BelongsTo<Webhook, $this>
+     */
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'next_retry_at' => 'datetime',
+            'delivered_at' => 'datetime',
+        ];
+    }
+}

--- a/laravel/app/Services/.attribution.json
+++ b/laravel/app/Services/.attribution.json
@@ -1,0 +1,5 @@
+{
+    "tool": "OpenAI Codex",
+    "platform_config": "Safe public metadata only; private system, developer, and runtime instructions are intentionally not included.",
+    "date": "2026-05-31T09:35:00Z"
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Http;
+use JsonException;
+use RuntimeException;
+use Throwable;
+
+class WebhookDispatcher
+{
+    public const MAX_ATTEMPTS = 5;
+
+    /**
+     * @return Collection<int, WebhookDelivery>
+     */
+    public function dispatchEvent(string $event, array $payload): Collection
+    {
+        $deliveries = new Collection;
+
+        Webhook::query()
+            ->where('active', true)
+            ->get()
+            ->filter(fn (Webhook $webhook): bool => in_array($event, $webhook->events ?? [], true))
+            ->each(function (Webhook $webhook) use ($event, $payload, $deliveries): void {
+                $delivery = $webhook->deliveries()->create([
+                    'event' => $event,
+                    'payload' => $payload,
+                ]);
+
+                DispatchWebhookJob::dispatch($delivery->id);
+                $deliveries->push($delivery);
+            });
+
+        return $deliveries;
+    }
+
+    public function send(WebhookDelivery $delivery): WebhookDelivery
+    {
+        $delivery->loadMissing('webhook');
+
+        $attempts = $delivery->attempts + 1;
+        $body = $this->deliveryBody($delivery);
+        $signature = $this->signature($delivery->webhook, $body);
+
+        try {
+            $response = Http::withHeaders([
+                'Accept' => 'application/json',
+                'X-Webhook-Event' => $delivery->event,
+                'X-Webhook-Signature' => $signature,
+            ])->withBody($this->jsonEncode($body), 'application/json')
+                ->post($delivery->webhook->url);
+        } catch (Throwable $exception) {
+            $delivery->forceFill([
+                'attempts' => $attempts,
+                'response_code' => null,
+                'next_retry_at' => $this->nextRetryAtForAttempt($attempts),
+                'delivered_at' => null,
+            ])->save();
+
+            throw $exception;
+        }
+
+        $successful = $response->successful();
+
+        $delivery->forceFill([
+            'attempts' => $attempts,
+            'response_code' => $response->status(),
+            'next_retry_at' => $successful ? null : $this->nextRetryAtForAttempt($attempts),
+            'delivered_at' => $successful ? now() : null,
+        ])->save();
+
+        if (! $successful) {
+            throw new RuntimeException("Webhook delivery failed with status {$response->status()}.");
+        }
+
+        return $delivery;
+    }
+
+    public function signature(Webhook $webhook, array $body): string
+    {
+        return 'sha256='.hash_hmac('sha256', $this->jsonEncode($body), $webhook->secret);
+    }
+
+    public function deliveryBody(WebhookDelivery $delivery): array
+    {
+        return [
+            'event' => $delivery->event,
+            'payload' => $delivery->payload,
+        ];
+    }
+
+    public function retryDelayForAttempt(int $attempt): int
+    {
+        return 60 * (2 ** max(0, $attempt - 1));
+    }
+
+    public function nextRetryAtForAttempt(int $attempt, ?CarbonInterface $now = null): ?CarbonImmutable
+    {
+        if ($attempt >= self::MAX_ATTEMPTS) {
+            return null;
+        }
+
+        return CarbonImmutable::instance($now ?? now())
+            ->addSeconds($this->retryDelayForAttempt($attempt));
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public static function backoffSchedule(): array
+    {
+        return [60, 120, 240, 480, 960];
+    }
+
+    private function jsonEncode(array $body): string
+    {
+        try {
+            return json_encode($body, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Unable to encode webhook payload.', previous: $exception);
+        }
+    }
+}

--- a/laravel/database/migrations/2026_05_31_000002_create_webhooks_table.php
+++ b/laravel/database/migrations/2026_05_31_000002_create_webhooks_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url', 2048);
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true)->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/database/migrations/2026_05_31_000003_create_webhook_deliveries_table.php
+++ b/laravel/database/migrations/2026_05_31_000003_create_webhook_deliveries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event')->index();
+            $table->json('payload');
+            $table->unsignedSmallInteger('response_code')->nullable();
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable()->index();
+            $table->timestamp('delivered_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Http\Controllers\WebhookController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::apiResource('webhooks', WebhookController::class)
+    ->only(['index', 'store', 'show', 'update', 'destroy']);

--- a/laravel/tests/Feature/WebhookCrudTest.php
+++ b/laravel/tests/Feature/WebhookCrudTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Webhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebhookCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+    }
+
+    public function test_webhooks_can_be_created_listed_updated_and_deleted(): void
+    {
+        $createResponse = $this->postJson('/webhooks', [
+            'url' => 'https://example.test/webhook',
+            'secret' => 'secret-value',
+            'events' => ['user.created', 'invoice.paid'],
+        ]);
+
+        $createResponse
+            ->assertCreated()
+            ->assertJsonPath('data.url', 'https://example.test/webhook')
+            ->assertJsonPath('data.active', true);
+
+        $webhookId = $createResponse->json('data.id');
+
+        $this->assertDatabaseHas('webhooks', [
+            'id' => $webhookId,
+            'url' => 'https://example.test/webhook',
+            'active' => true,
+        ]);
+
+        $this->getJson('/webhooks')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $webhookId)
+            ->assertJsonPath('data.0.deliveries_count', 0);
+
+        $this->putJson("/webhooks/{$webhookId}", [
+            'active' => false,
+            'events' => ['invoice.paid'],
+        ])
+            ->assertOk()
+            ->assertJsonPath('data.active', false)
+            ->assertJsonPath('data.events.0', 'invoice.paid');
+
+        $this->deleteJson("/webhooks/{$webhookId}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('webhooks', [
+            'id' => $webhookId,
+        ]);
+    }
+
+    public function test_webhook_show_includes_delivery_history(): void
+    {
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.test/webhook',
+            'secret' => 'secret-value',
+            'events' => ['user.created'],
+        ]);
+
+        $webhook->deliveries()->create([
+            'event' => 'user.created',
+            'payload' => ['id' => 1],
+            'response_code' => 200,
+            'attempts' => 1,
+            'delivered_at' => now(),
+        ]);
+
+        $this->getJson("/webhooks/{$webhook->id}")
+            ->assertOk()
+            ->assertJsonPath('data.id', $webhook->id)
+            ->assertJsonPath('data.deliveries.0.event', 'user.created')
+            ->assertJsonPath('data.deliveries.0.response_code', 200);
+    }
+}

--- a/laravel/tests/Feature/WebhookDeliveryTest.php
+++ b/laravel/tests/Feature/WebhookDeliveryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Services\WebhookDispatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+use Tests\TestCase;
+
+class WebhookDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dispatch_event_creates_deliveries_for_active_matching_webhooks(): void
+    {
+        Queue::fake();
+
+        $matchingWebhook = Webhook::query()->create([
+            'url' => 'https://example.test/user',
+            'secret' => 'secret',
+            'events' => ['user.created'],
+        ]);
+
+        Webhook::query()->create([
+            'url' => 'https://example.test/inactive',
+            'secret' => 'secret',
+            'events' => ['user.created'],
+            'active' => false,
+        ]);
+
+        Webhook::query()->create([
+            'url' => 'https://example.test/other',
+            'secret' => 'secret',
+            'events' => ['invoice.paid'],
+        ]);
+
+        $deliveries = app(WebhookDispatcher::class)->dispatchEvent('user.created', ['id' => 1]);
+
+        $this->assertCount(1, $deliveries);
+        $this->assertDatabaseHas('webhook_deliveries', [
+            'webhook_id' => $matchingWebhook->id,
+            'event' => 'user.created',
+            'attempts' => 0,
+        ]);
+        Queue::assertPushed(DispatchWebhookJob::class, 1);
+    }
+
+    public function test_successful_delivery_posts_signed_json_and_stores_history(): void
+    {
+        Http::fake([
+            'https://example.test/webhook' => Http::response(['ok' => true], 202),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.test/webhook',
+            'secret' => 'secret',
+            'events' => ['user.created'],
+        ]);
+        $delivery = $webhook->deliveries()->create([
+            'event' => 'user.created',
+            'payload' => ['id' => 1],
+        ]);
+
+        app(WebhookDispatcher::class)->send($delivery);
+
+        $delivery->refresh();
+
+        $this->assertSame(1, $delivery->attempts);
+        $this->assertSame(202, $delivery->response_code);
+        $this->assertNotNull($delivery->delivered_at);
+        $this->assertNull($delivery->next_retry_at);
+
+        Http::assertSent(function ($request) use ($webhook): bool {
+            $body = [
+                'event' => 'user.created',
+                'payload' => ['id' => 1],
+            ];
+            $expectedSignature = app(WebhookDispatcher::class)->signature($webhook, $body);
+
+            return $request->url() === 'https://example.test/webhook'
+                && $request->method() === 'POST'
+                && $request->header('X-Webhook-Event')[0] === 'user.created'
+                && $request->header('X-Webhook-Signature')[0] === $expectedSignature
+                && $request->data() === $body;
+        });
+    }
+
+    public function test_failed_delivery_stores_response_and_next_retry_time(): void
+    {
+        Http::fake([
+            'https://example.test/webhook' => Http::response(['error' => true], 503),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.test/webhook',
+            'secret' => 'secret',
+            'events' => ['user.created'],
+        ]);
+        $delivery = $webhook->deliveries()->create([
+            'event' => 'user.created',
+            'payload' => ['id' => 1],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+
+        try {
+            app(WebhookDispatcher::class)->send($delivery);
+        } finally {
+            $delivery->refresh();
+
+            $this->assertSame(1, $delivery->attempts);
+            $this->assertSame(503, $delivery->response_code);
+            $this->assertNull($delivery->delivered_at);
+            $this->assertNotNull($delivery->next_retry_at);
+        }
+    }
+}

--- a/laravel/tests/Unit/WebhookDispatcherTest.php
+++ b/laravel/tests/Unit/WebhookDispatcherTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Carbon\CarbonImmutable;
+use Tests\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    public function test_it_generates_hmac_sha256_signature_for_json_body(): void
+    {
+        $webhook = new Webhook(['secret' => 'top-secret']);
+        $body = [
+            'event' => 'user.created',
+            'payload' => ['id' => 123, 'email' => 'dom@example.test'],
+        ];
+
+        $expectedBody = json_encode($body, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $expectedSignature = 'sha256='.hash_hmac('sha256', $expectedBody, 'top-secret');
+
+        $this->assertSame($expectedSignature, app(WebhookDispatcher::class)->signature($webhook, $body));
+    }
+
+    public function test_it_calculates_exponential_retry_timing(): void
+    {
+        $dispatcher = app(WebhookDispatcher::class);
+        $now = CarbonImmutable::parse('2026-05-31 09:00:00');
+
+        $this->assertSame([60, 120, 240, 480, 960], WebhookDispatcher::backoffSchedule());
+        $this->assertSame(60, $dispatcher->retryDelayForAttempt(1));
+        $this->assertSame(240, $dispatcher->retryDelayForAttempt(3));
+        $this->assertTrue($now->addSeconds(240)->equalTo($dispatcher->nextRetryAtForAttempt(3, $now)));
+        $this->assertNull($dispatcher->nextRetryAtForAttempt(5, $now));
+    }
+
+    public function test_it_builds_delivery_body_from_event_and_payload(): void
+    {
+        $delivery = new WebhookDelivery([
+            'event' => 'invoice.paid',
+            'payload' => ['invoice_id' => 99],
+        ]);
+
+        $this->assertSame([
+            'event' => 'invoice.paid',
+            'payload' => ['invoice_id' => 99],
+        ], app(WebhookDispatcher::class)->deliveryBody($delivery));
+    }
+}


### PR DESCRIPTION
/claim #754

## Summary
- Added `Webhook` and `WebhookDelivery` models with migrations, relationships, JSON casts, and delivery history fields.
- Added `WebhookDispatcher` to queue matching active webhooks, generate HMAC-SHA256 signatures, send signed JSON POST requests, and persist response codes, attempts, delivered timestamps, and retry timestamps.
- Added `DispatchWebhookJob` with five attempts and exponential backoff `[60, 120, 240, 480, 960]`.
- Added CRUD endpoints for listing, creating, showing, updating, and deleting webhooks.
- Added focused unit and feature tests for signatures, retry timing, CRUD, queue dispatching, successful delivery persistence, and failed retry scheduling.
- Included safe non-sensitive attribution metadata only in `laravel/app/Services/.attribution.json`.

## Verification
- `php artisan test tests/Unit/WebhookDispatcherTest.php tests/Feature/WebhookCrudTest.php tests/Feature/WebhookDeliveryTest.php` -> 8 passed, 37 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 10 passed, 39 assertions
- `php -l app/Models/Webhook.php && php -l app/Models/WebhookDelivery.php && php -l app/Services/WebhookDispatcher.php && php -l app/Jobs/DispatchWebhookJob.php && php -l app/Http/Controllers/WebhookController.php && php -l database/migrations/2026_05_31_000002_create_webhooks_table.php && php -l database/migrations/2026_05_31_000003_create_webhook_deliveries_table.php && php -l routes/web.php && php -l tests/Unit/WebhookDispatcherTest.php && php -l tests/Feature/WebhookCrudTest.php && php -l tests/Feature/WebhookDeliveryTest.php`
- `./vendor/bin/pint --test app/Models/Webhook.php app/Models/WebhookDelivery.php app/Services/WebhookDispatcher.php app/Jobs/DispatchWebhookJob.php app/Http/Controllers/WebhookController.php database/migrations/2026_05_31_000002_create_webhooks_table.php database/migrations/2026_05_31_000003_create_webhook_deliveries_table.php routes/web.php tests/Unit/WebhookDispatcherTest.php tests/Feature/WebhookCrudTest.php tests/Feature/WebhookDeliveryTest.php`
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan route:list --path=webhooks` -> 5 webhook CRUD routes
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan migrate --pretend --no-interaction`
- `git diff --check`
