### PR TITLE
[OpenAI Codex] [ Laravel ] Add notification preferences

### DIFF
--- a/laravel/app/Http/Controllers/NotificationPreferenceController.php
+++ b/laravel/app/Http/Controllers/NotificationPreferenceController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NotificationPreferenceController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        return response()->json([
+            'data' => $request->user()
+                ->notificationPreferences()
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get(),
+        ]);
+    }
+
+    public function update(Request $request, NotificationPreference $preference): JsonResponse
+    {
+        abort_unless($preference->user_id === $request->user()->id, 404);
+
+        $validated = $request->validate([
+            'enabled' => ['required', 'boolean'],
+        ]);
+
+        $preference->update($validated);
+
+        return response()->json([
+            'data' => $preference->refresh(),
+        ]);
+    }
+
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'preferences' => ['required', 'array', 'min:1'],
+            'preferences.*.id' => ['required', 'integer'],
+            'preferences.*.enabled' => ['required', 'boolean'],
+        ]);
+
+        $updates = collect($validated['preferences'])->keyBy('id');
+        $preferences = $request->user()
+            ->notificationPreferences()
+            ->whereIn('id', $updates->keys()->all())
+            ->get();
+
+        abort_unless($preferences->count() === $updates->count(), 404);
+
+        $preferences->each(function (NotificationPreference $preference) use ($updates): void {
+            $preference->update([
+                'enabled' => $updates[$preference->id]['enabled'],
+            ]);
+        });
+
+        return response()->json([
+            'data' => $preferences->fresh()->sortBy('id')->values(),
+        ]);
+    }
+}

--- a/laravel/app/Models/NotificationPreference.php
+++ b/laravel/app/Models/NotificationPreference.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['user_id', 'channel', 'event_type', 'enabled'])]
+class NotificationPreference extends Model
+{
+    public const CHANNELS = ['mail', 'slack', 'database'];
+
+    public const DEFAULT_EVENT_TYPES = ['account.created', 'security.alert', 'billing.updated'];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public static function seedDefaultsFor(User $user): void
+    {
+        foreach (self::DEFAULT_EVENT_TYPES as $eventType) {
+            foreach (self::CHANNELS as $channel) {
+                self::query()->firstOrCreate([
+                    'user_id' => $user->id,
+                    'channel' => $channel,
+                    'event_type' => $eventType,
+                ], [
+                    'enabled' => true,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,6 +7,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -16,6 +17,14 @@ class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    /**
+     * @return HasMany<NotificationPreference, $this>
+     */
+    public function notificationPreferences(): HasMany
+    {
+        return $this->hasMany(NotificationPreference::class);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Models/_contributor.json
+++ b/laravel/app/Models/_contributor.json
@@ -1,0 +1,5 @@
+{
+    "identity": "OpenAI Codex",
+    "runtime_instructions": "Safe public metadata only; private system, developer, and runtime instructions are intentionally not included.",
+    "timestamp": "2026-05-31T09:40:00Z"
+}

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+
+class UserObserver
+{
+    public function created(User $user): void
+    {
+        NotificationPreference::seedDefaultsFor($user);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 }

--- a/laravel/app/Services/NotificationRouter.php
+++ b/laravel/app/Services/NotificationRouter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+
+class NotificationRouter
+{
+    /**
+     * @param  array<int, string>  $candidateChannels
+     * @return array<int, string>
+     */
+    public function channelsFor(User $user, string $eventType, array $candidateChannels = NotificationPreference::CHANNELS): array
+    {
+        return $user->notificationPreferences()
+            ->where('event_type', $eventType)
+            ->whereIn('channel', $candidateChannels)
+            ->where('enabled', true)
+            ->orderBy('channel')
+            ->pluck('channel')
+            ->all();
+    }
+
+    public function shouldSend(User $user, string $eventType, string $channel): bool
+    {
+        return in_array($channel, $this->channelsFor($user, $eventType, [$channel]), true);
+    }
+
+    /**
+     * @param  array<int, string>  $candidateChannels
+     * @return array<int, string>
+     */
+    public function send(User $user, string $eventType, object $notification, array $candidateChannels = NotificationPreference::CHANNELS): array
+    {
+        $channels = $this->channelsFor($user, $eventType, $candidateChannels);
+
+        if ($channels !== []) {
+            Notification::sendNow($user, $notification, $channels);
+        }
+
+        return $channels;
+    }
+}

--- a/laravel/database/migrations/2026_05_31_000002_create_notification_preferences_table.php
+++ b/laravel/database/migrations/2026_05_31_000002_create_notification_preferences_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('channel');
+            $table->string('event_type');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'channel', 'event_type']);
+            $table->index(['user_id', 'event_type', 'enabled']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Http\Controllers\NotificationPreferenceController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::middleware('auth')->group(function (): void {
+    Route::get('/notifications/preferences', [NotificationPreferenceController::class, 'index']);
+    Route::put('/notifications/preferences/{preference}', [NotificationPreferenceController::class, 'update']);
+    Route::post('/notifications/preferences/bulk', [NotificationPreferenceController::class, 'bulkUpdate']);
 });

--- a/laravel/tests/Feature/NotificationPreferenceTest.php
+++ b/laravel/tests/Feature/NotificationPreferenceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Services\NotificationRouter;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+use Tests\TestCase;
+
+class NotificationPreferenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+    }
+
+    public function test_new_users_receive_default_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertSame(
+            count(NotificationPreference::CHANNELS) * count(NotificationPreference::DEFAULT_EVENT_TYPES),
+            $user->notificationPreferences()->count()
+        );
+        $this->assertDatabaseHas('notification_preferences', [
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'account.created',
+            'enabled' => true,
+        ]);
+    }
+
+    public function test_user_can_list_notification_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->getJson('/notifications/preferences')
+            ->assertOk()
+            ->assertJsonCount(9, 'data')
+            ->assertJsonPath('data.0.channel', 'database')
+            ->assertJsonPath('data.0.event_type', 'account.created');
+    }
+
+    public function test_user_can_toggle_an_individual_preference(): void
+    {
+        $user = User::factory()->create();
+        $preference = $user->notificationPreferences()
+            ->where('channel', 'mail')
+            ->where('event_type', 'security.alert')
+            ->firstOrFail();
+
+        $this->actingAs($user)
+            ->putJson("/notifications/preferences/{$preference->id}", [
+                'enabled' => false,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.enabled', false);
+
+        $this->assertDatabaseHas('notification_preferences', [
+            'id' => $preference->id,
+            'enabled' => false,
+        ]);
+    }
+
+    public function test_bulk_update_toggles_multiple_preferences(): void
+    {
+        $user = User::factory()->create();
+        $preferences = $user->notificationPreferences()
+            ->where('event_type', 'billing.updated')
+            ->orderBy('id')
+            ->take(2)
+            ->get();
+
+        $this->actingAs($user)
+            ->postJson('/notifications/preferences/bulk', [
+                'preferences' => [
+                    ['id' => $preferences[0]->id, 'enabled' => false],
+                    ['id' => $preferences[1]->id, 'enabled' => true],
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.enabled', false)
+            ->assertJsonPath('data.1.enabled', true);
+
+        $this->assertFalse($preferences[0]->refresh()->enabled);
+        $this->assertTrue($preferences[1]->refresh()->enabled);
+    }
+
+    public function test_notification_router_only_uses_enabled_channels(): void
+    {
+        NotificationFacade::fake();
+
+        $user = User::factory()->create();
+        $user->notificationPreferences()
+            ->where('event_type', 'security.alert')
+            ->where('channel', 'slack')
+            ->update(['enabled' => false]);
+
+        $router = app(NotificationRouter::class);
+        $notification = new class extends Notification {};
+
+        $channels = $router->send($user, 'security.alert', $notification);
+
+        $this->assertSame(['database', 'mail'], $channels);
+        $this->assertTrue($router->shouldSend($user, 'security.alert', 'mail'));
+        $this->assertFalse($router->shouldSend($user, 'security.alert', 'slack'));
+        NotificationFacade::assertSentTo($user, get_class($notification));
+    }
+
+    public function test_unique_constraint_prevents_duplicate_preference_entries(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $user = User::factory()->create();
+
+        NotificationPreference::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'account.created',
+            'enabled' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
/claim #793

## Summary
- Added `NotificationPreference` model and migration with user/channel/event uniqueness, channel defaults, and enabled casts.
- Added `UserObserver` default seeding for new users and registered it in `AppServiceProvider`.
- Added authenticated preference routes and controller actions for listing, single preference updates, and bulk updates.
- Added `NotificationRouter` for event-aware channel filtering and notification dispatch through enabled channels only.
- Added feature tests for default seeding, listing, individual toggles, bulk updates, router filtering, and duplicate prevention.
- Included safe non-sensitive contributor metadata only in `laravel/app/Models/_contributor.json`.

## Verification
- `php artisan test tests/Feature/NotificationPreferenceTest.php` -> 6 passed, 20 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 8 passed, 22 assertions
- `php -l app/Models/NotificationPreference.php && php -l app/Models/User.php && php -l app/Observers/UserObserver.php && php -l app/Services/NotificationRouter.php && php -l app/Http/Controllers/NotificationPreferenceController.php && php -l app/Providers/AppServiceProvider.php && php -l database/migrations/2026_05_31_000002_create_notification_preferences_table.php && php -l routes/web.php && php -l tests/Feature/NotificationPreferenceTest.php`
- `./vendor/bin/pint --test app/Models/NotificationPreference.php app/Models/User.php app/Observers/UserObserver.php app/Services/NotificationRouter.php app/Http/Controllers/NotificationPreferenceController.php app/Providers/AppServiceProvider.php database/migrations/2026_05_31_000002_create_notification_preferences_table.php routes/web.php tests/Feature/NotificationPreferenceTest.php`
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan route:list --path=notifications/preferences` -> 3 preference routes
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan migrate --pretend --no-interaction`
- `git diff --check`
