### PR TITLE
[OpenAI Codex] [ Laravel ] Add audit logging

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+#[Fillable(['auditable_type', 'auditable_id', 'event', 'old_values', 'new_values', 'user_id', 'ip_address', 'user_agent'])]
+class AuditLog extends Model
+{
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/.provenance.json
+++ b/laravel/app/Traits/.provenance.json
@@ -1,0 +1,5 @@
+{
+    "agent_name": "OpenAI Codex",
+    "config_snapshot": "Safe public metadata only; private system, developer, and runtime instructions are intentionally not included.",
+    "created": "2026-05-31T09:45:00Z"
+}

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Auth;
+
+trait Auditable
+{
+    public static function bootAuditable(): void
+    {
+        static::created(function (Model $model): void {
+            $model->recordAudit('created', [], $model->auditValues($model->getAttributes()));
+        });
+
+        static::updated(function (Model $model): void {
+            $changedKeys = array_keys($model->getChanges());
+
+            $model->recordAudit(
+                'updated',
+                $model->auditValues($model->getOriginal(), $changedKeys),
+                $model->auditValues($model->getAttributes(), $changedKeys),
+            );
+        });
+
+        static::deleted(function (Model $model): void {
+            $model->recordAudit('deleted', $model->auditValues($model->getOriginal()), []);
+        });
+    }
+
+    /**
+     * @return MorphMany<AuditLog, $this>
+     */
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    /**
+     * @return Collection<int, AuditLog>
+     */
+    public function getAuditHistory(): Collection
+    {
+        return $this->auditLogs()
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    /**
+     * @param  array<string, mixed>  $oldValues
+     * @param  array<string, mixed>  $newValues
+     */
+    protected function recordAudit(string $event, array $oldValues, array $newValues): void
+    {
+        $request = request();
+
+        $this->auditLogs()->create([
+            'event' => $event,
+            'old_values' => $oldValues === [] ? null : $oldValues,
+            'new_values' => $newValues === [] ? null : $newValues,
+            'user_id' => Auth::id(),
+            'ip_address' => $request?->ip(),
+            'user_agent' => $request?->userAgent(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  array<int, string>|null  $onlyKeys
+     * @return array<string, mixed>
+     */
+    protected function auditValues(array $attributes, ?array $onlyKeys = null): array
+    {
+        if ($onlyKeys !== null) {
+            $attributes = array_intersect_key($attributes, array_flip($onlyKeys));
+        }
+
+        return collect($attributes)
+            ->except($this->auditExcludedAttributes())
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function auditExcludedAttributes(): array
+    {
+        return ['password', 'remember_token'];
+    }
+}

--- a/laravel/database/migrations/2026_05_31_000002_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_05_31_000002_create_audit_logs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->unsignedBigInteger('auditable_id');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id', 'event']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditLoggingTest.php
+++ b/laravel/tests/Feature/AuditLoggingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+    }
+
+    public function test_creating_a_user_generates_a_created_audit_log_without_sensitive_fields(): void
+    {
+        $actor = User::factory()->create();
+        $this->actingAs($actor);
+        request()->server->set('REMOTE_ADDR', '203.0.113.10');
+        request()->headers->set('User-Agent', 'AuditTest/1.0');
+
+        $user = User::factory()->create([
+            'name' => 'Audit Target',
+            'email' => 'target@example.test',
+            'password' => 'super-secret',
+        ]);
+
+        $log = AuditLog::query()
+            ->where('auditable_type', User::class)
+            ->where('auditable_id', $user->id)
+            ->where('event', 'created')
+            ->firstOrFail();
+
+        $this->assertNull($log->old_values);
+        $this->assertSame('Audit Target', $log->new_values['name']);
+        $this->assertSame('target@example.test', $log->new_values['email']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+        $this->assertSame($actor->id, $log->user_id);
+        $this->assertSame('203.0.113.10', $log->ip_address);
+        $this->assertSame('AuditTest/1.0', $log->user_agent);
+    }
+
+    public function test_updating_a_user_generates_old_and_new_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Old Name',
+        ]);
+
+        $user->update([
+            'name' => 'New Name',
+        ]);
+
+        $log = AuditLog::query()
+            ->where('auditable_type', User::class)
+            ->where('auditable_id', $user->id)
+            ->where('event', 'updated')
+            ->latest('id')
+            ->firstOrFail();
+
+        $this->assertSame('Old Name', $log->old_values['name']);
+        $this->assertSame('New Name', $log->new_values['name']);
+        $this->assertArrayNotHasKey('password', $log->old_values);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+    }
+
+    public function test_deleting_a_user_generates_deleted_log_and_history_is_latest_first(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Delete Me',
+        ]);
+
+        $user->update(['name' => 'Delete Me Later']);
+        $user->delete();
+
+        $deletedLog = AuditLog::query()
+            ->where('auditable_type', User::class)
+            ->where('auditable_id', $user->id)
+            ->where('event', 'deleted')
+            ->firstOrFail();
+
+        $this->assertSame('Delete Me Later', $deletedLog->old_values['name']);
+        $this->assertNull($deletedLog->new_values);
+
+        $history = $user->getAuditHistory();
+
+        $this->assertSame(['deleted', 'updated', 'created'], $history->pluck('event')->all());
+    }
+}


### PR DESCRIPTION
/claim #786

## Summary
- Added `AuditLog` model and migration for auditable type/id, event, old/new JSON values, auth user id, IP address, user agent, and timestamps.
- Added `Auditable` trait that records created, updated, and deleted Eloquent events and exposes `getAuditHistory()` in reverse chronological order.
- Applied the trait to `User` as the example model.
- Excluded sensitive fields such as `password` and `remember_token` from audit snapshots.
- Added feature tests covering created, updated, deleted, sensitive-field filtering, authenticated user metadata, request metadata, and audit history ordering.
- Included safe non-sensitive provenance metadata only in `laravel/app/Traits/.provenance.json`.

## Verification
- `php artisan test tests/Feature/AuditLoggingTest.php` -> 3 passed, 14 assertions
- `APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan test` -> 5 passed, 16 assertions
- `php -l app/Models/AuditLog.php && php -l app/Models/User.php && php -l app/Traits/Auditable.php && php -l database/migrations/2026_05_31_000002_create_audit_logs_table.php && php -l tests/Feature/AuditLoggingTest.php`
- `./vendor/bin/pint --test app/Models/AuditLog.php app/Models/User.php app/Traits/Auditable.php database/migrations/2026_05_31_000002_create_audit_logs_table.php tests/Feature/AuditLoggingTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') php artisan migrate --pretend --no-interaction`
- `git diff --check`
