### PR TITLE
Add T3 Code Playwright E2E coverage

### DIFF
--- a/t3code/apps/web/package.json
+++ b/t3code/apps/web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
+    "test:e2e": "playwright test",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:browser:install": "playwright install --with-deps chromium"
   },
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@effect/language-service": "catalog:",
+    "@playwright/test": "^1.58.2",
     "@rolldown/plugin-babel": "^0.2.0",
     "@tailwindcss/vite": "^4.0.0",
     "@tanstack/router-plugin": "^1.161.0",

--- a/t3code/apps/web/playwright.config.ts
+++ b/t3code/apps/web/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report" }]],
+  use: {
+    baseURL: "http://127.0.0.1:4177",
+    trace: "on-first-retry",
+    video: process.env.PLAYWRIGHT_DEMO_VIDEO ? "on" : "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "bun run dev --host 127.0.0.1 --port 4177",
+    cwd: ".",
+    env: {
+      VITE_HOSTED_APP_CHANNEL: "latest",
+    },
+    url: "http://127.0.0.1:4177",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/t3code/apps/web/tests/e2e/app-shell.spec.ts
+++ b/t3code/apps/web/tests/e2e/app-shell.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test";
+
+test("loads the hosted-static app shell", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveTitle(/T3 Code/);
+  await expect(page.getByText("Connect an environment to get started")).toBeVisible();
+  await expect(page.getByTestId("command-palette-trigger")).toBeVisible();
+});

--- a/t3code/apps/web/tests/e2e/command-palette.spec.ts
+++ b/t3code/apps/web/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test("opens and filters the command palette", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByTestId("command-palette-trigger").click();
+  await expect(page.getByTestId("command-palette")).toBeVisible();
+
+  const searchInput = page.getByRole("combobox", {
+    name: "Search commands, projects, and threads...",
+  });
+  await searchInput.fill("settings");
+
+  await expect(page.getByRole("option", { name: "Open settings" })).toBeVisible();
+});

--- a/t3code/apps/web/tests/e2e/sidebar-navigation.spec.ts
+++ b/t3code/apps/web/tests/e2e/sidebar-navigation.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("navigates from the sidebar into settings sections", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Settings" }).click();
+  await expect(page).toHaveURL(/\/settings\/general$/);
+  await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Keybindings" }).click();
+  await expect(page).toHaveURL(/\/settings\/keybindings$/);
+  await expect(page.getByRole("heading", { name: "Keybindings" })).toBeVisible();
+});

--- a/t3code/bun.lock
+++ b/t3code/bun.lock
@@ -116,6 +116,7 @@
       },
       "devDependencies": {
         "@effect/language-service": "catalog:",
+        "@playwright/test": "^1.58.2",
         "@rolldown/plugin-babel": "^0.2.0",
         "@tailwindcss/vite": "^4.0.0",
         "@tanstack/router-plugin": "^1.161.0",
@@ -719,6 +720,8 @@
     "@pierre/diffs": ["@pierre/diffs@1.1.20", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-lLi+3sLCm3QDd5/aLO9pw+WbF6UzhrkWm2oTZ5WZJTGemOyUNRJ4DDhcEKmVusu4C4bXx9Nssh6fF+wQcapb5w=="],
 
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -2156,6 +2159,8 @@
 
     "@pierre/diffs/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
+    "@playwright/test/playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
     "@rolldown/plugin-babel/rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -2265,6 +2270,8 @@
     "@pierre/diffs/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
 
     "@pierre/diffs/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@playwright/test/playwright/playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "@rolldown/plugin-babel/rolldown/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 


### PR DESCRIPTION
/claim #847

## Summary
- Add a focused Playwright E2E config for the T3 Code web app that starts Vite in hosted-static mode.
- Cover app shell loading, command palette open/filter behavior, and sidebar navigation into settings sections.
- Add an opt-in `PLAYWRIGHT_DEMO_VIDEO=1` switch for generating demo videos without recording by default.

## Validation
- `npx --yes -p node@24.13.1 -p bun@1.3.11 bun run --cwd apps/web test:e2e` -> 3 passed
- `npx --yes -p node@24.13.1 -p bun@1.3.11 bun run --cwd apps/web typecheck` -> passed
- `npx --yes -p node@24.13.1 -p bun@1.3.11 bun run fmt:check apps/web/package.json apps/web/playwright.config.ts apps/web/tests/e2e/app-shell.spec.ts apps/web/tests/e2e/command-palette.spec.ts apps/web/tests/e2e/sidebar-navigation.spec.ts` -> passed
- `git diff --check` -> passed

## Demo
- Short demo video: https://github.com/orenodinner/bounty-demo-assets/raw/master/bounty-hunters-847/command-palette-settings-demo.webm
- Generated with `PLAYWRIGHT_DEMO_VIDEO=1` for the command palette/settings flow.
