### PR TITLE
Antigravity [ Crypto ] Fix cross-chain replay attack in CrossChainBridge

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Antigravity",
+  "session_init": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding. You are pair programming with a USER to solve their coding task.",
+  "ts": "2026-05-31T14:00:00Z"
+}

--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -6,9 +6,11 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract CrossChainBridge {
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
 
-    mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public nonces;
+
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256("Transfer(address sender,address recipient,uint256 amount,uint256 nonce)");
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -18,39 +20,50 @@ contract CrossChainBridge {
         validator = _validator;
     }
 
+    function _domainSeparatorV4() internal view returns (bytes32) {
+        return keccak256(abi.encode(
+            DOMAIN_TYPEHASH,
+            keccak256(bytes("CrossChainBridge")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(this)
+        ));
+    }
+
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
         bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        uint256 currentNonce = nonces[msg.sender]++;
+        emit TransferInitiated(msg.sender, amount, targetChain, currentNonce);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
+        address sender,
         address recipient,
         uint256 amount,
-        uint256 transferNonce,
+        uint256 nonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
+        require(nonce == nonces[sender], "Invalid nonce");
+        nonces[sender]++;
+
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            sender,
             recipient,
             amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
+            nonce
         ));
 
-        require(!processedTransfers[transferHash], "Already processed");
-        require(verifySignature(transferHash, signature), "Invalid signature");
+        bytes32 hash = keccak256(abi.encodePacked("\x19\x01", _domainSeparatorV4(), structHash));
 
-        processedTransfers[transferHash] = true;
+        require(verifySignature(hash, signature), "Invalid signature");
+
         bridgeToken.transfer(recipient, amount);
 
-        emit TransferProcessed(transferHash, recipient, amount);
+        emit TransferProcessed(hash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -66,12 +79,9 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature");
         return recovered == validator;
     }
 


### PR DESCRIPTION
Resolves #920

This PR fixes the cross-chain replay attack by:
1. Adding a  mapping per sender.
2. Modifying  to track the target chain nonce.
3. Constructing an EIP-712 Domain Separator with  and  to prevent cross-chain and post-upgrade replays.
4. Structurally signing the transfer with the source sender's specific target nonce.
5. Explicitly checking for  to prevent invalid signature bypass.
6. Including the required .
