### PR TITLE
OpenAI Codex [ Crypto ] Fix slippage and deadline in SimpleSwap

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -9,10 +9,12 @@ contract SimpleSwap {
     uint256 public reserveA;
     uint256 public reserveB;
     uint256 public fee; // basis points, e.g. 30 = 0.3%
+    uint256 private constant BASIS_POINTS = 10000;
 
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
+        require(_fee < BASIS_POINTS, "Invalid fee");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
         fee = _fee;
@@ -25,10 +27,13 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Transaction expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
@@ -37,14 +42,11 @@ contract SimpleSwap {
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
+        amountOut = _getAmountOut(amountIn, reserveIn, reserveOut);
+        require(amountOut >= minAmountOut, "Slippage exceeded");
+        require(amountOut < reserveOut, "Insufficient output reserve");
+
         inputToken.transferFrom(msg.sender, address(this), amountIn);
-
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-
-        // constant product formula: x * y = k
-        amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
-
         outputToken.transfer(msg.sender, amountOut);
 
         if (isTokenA) {
@@ -59,11 +61,18 @@ contract SimpleSwap {
     }
 
     function getAmountOut(address tokenIn, uint256 amountIn) external view returns (uint256) {
+        require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
-        return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+        return _getAmountOut(amountIn, reserveIn, reserveOut);
+    }
+
+    function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) internal view returns (uint256) {
+        require(amountIn > 0, "Amount must be > 0");
+        require(reserveIn > 0 && reserveOut > 0, "Insufficient liquidity");
+
+        uint256 amountInWithFee = amountIn * (BASIS_POINTS - fee);
+        return (reserveOut * amountInWithFee) / (reserveIn * BASIS_POINTS + amountInWithFee);
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "OpenAI Codex assisted this change. Private system, developer, and runtime instructions are intentionally not reproduced in this public repository.",
+  "completed_at": "2026-05-31T19:20:34Z"
+}


### PR DESCRIPTION
```text
OpenAI Codex public task summary: focused Solidity fix for SimpleSwap issue #913. Private system/developer/runtime instructions are not reproduced in this public PR.
```

/claim #913

Summary:
- added `minAmountOut` and `deadline` parameters to `SimpleSwap.swap`
- added explicit reverts for expired swaps and excessive slippage
- moved swap quote math into a shared helper used by both `swap` and `getAmountOut`
- changed the fee calculation to fixed-point basis-point math so small trades do not silently ignore fees
- added safe public metadata in `solidity/contracts/_meta.json`

Verification:
- compiled `solidity/contracts/SimpleSwap.sol` with `solc` 0.8.30 and OpenZeppelin contracts
- confirmed the ABI now exposes `swap(address tokenIn, uint256 amountIn, uint256 minAmountOut, uint256 deadline)`
- ran a local quote check showing the old small-trade fee path would round fee to zero while the new fixed-point path keeps fee precision

Security note:
- I intentionally did not paste private platform/system/developer instructions into repository files or this PR body. The metadata file contains only non-sensitive public provenance.