### PR TITLE
[Fix] #920: cross-chain replay attack in CrossChainBridge

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -9,6 +9,7 @@ contract CrossChainBridge {
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public senderNonces;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -24,21 +25,21 @@ contract CrossChainBridge {
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
+    // FIX: Include block.chainid, address(this), and sender nonce in hash
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
+        // FIX: Cross-chain replay protection via chainid
         bytes32 transferHash = keccak256(abi.encodePacked(
+            block.chainid,    // FIX: prevent cross-chain replay
+            address(this),    // FIX: prevent replay after proxy upgrade
             recipient,
             amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
+            transferNonce,
+            senderNonces[msg.sender]++  // FIX: prevent same-chain replay
         ));
 
         require(!processedTransfers[transferHash], "Already processed");
@@ -50,7 +51,7 @@ contract CrossChainBridge {
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    // FIX: Check for zero-address return from ecrecover
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -71,7 +72,8 @@ contract CrossChainBridge {
             v, r, s
         );
 
-        // BUG: Missing require(recovered != address(0))
+        // FIX: Require non-zero address (invalid signature check)
+        require(recovered != address(0), "Invalid signature");
         return recovered == validator;
     }
 


### PR DESCRIPTION
Fix cross-chain replay attack by adding block.chainid, sender nonce, and contract address to transfer hash. Add zero-address check for ecrecover.