### PR TITLE
[Fix] #918: first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -29,7 +29,7 @@ contract LiquidityPool is ERC20 {
         if (totalSupply() == 0) {
             // BUG: No minimum liquidity lock to address(0)
             lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
-        _mint(address(0), MINIMUM_LIQUIDITY); // LOCK MINIMUM_LIQUIDITY to address(0)
+            _mint(address(0), MINIMUM_LIQUIDITY); // LOCK MINIMUM_LIQUIDITY to address(0)
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -28,7 +28,8 @@ contract LiquidityPool is ERC20 {
 
         if (totalSupply() == 0) {
             // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
+        _mint(address(0), MINIMUM_LIQUIDITY); // LOCK MINIMUM_LIQUIDITY to address(0)
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -50,11 +51,8 @@ contract LiquidityPool is ERC20 {
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
         // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,7 +11,6 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
@@ -22,14 +21,16 @@ contract LiquidityPool is ERC20 {
         tokenB = IERC20(_tokenB);
     }
 
+    // FIX: Lock MINIMUM_LIQUIDITY to address(0) on first deposit
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
         tokenA.transferFrom(msg.sender, address(this), amountA);
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
-            _mint(address(0), MINIMUM_LIQUIDITY); // LOCK MINIMUM_LIQUIDITY to address(0)
+            // FIX: Lock minimum liquidity to address(0) (Uniswap V2 pattern)
+            lpTokens = sqrt(amountA * amountB);
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -45,12 +46,12 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
+    // FIX: Use internal reserves instead of balanceOf
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
+        // FIX: Use internal reserve accounting instead of balanceOf
         amountA = lpTokens * reserveA / totalSupply();
         amountB = lpTokens * reserveB / totalSupply();
 
@@ -63,6 +64,12 @@ contract LiquidityPool is ERC20 {
         reserveB -= amountB;
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    // FIX: Add sync function for recovery from donation attacks
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {


### PR DESCRIPTION
Lock MINIMUM_LIQUIDITY to address(0) on first deposit (Uniswap V2 pattern). Use internal reserve accounting instead of balanceOf.