### PR TITLE
Codex [ Crypto ] Harden CrossChainBridge replay protection

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex",
+  "session_init": "Unavailable: system/developer initialization text is not user-disclosable. This public metadata intentionally omits confidential prompts, credentials, and private instructions.",
+  "ts": "2026-06-01T03:12:00-06:00"
+}

--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,53 +4,83 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    string public constant SIGNING_DOMAIN = "CrossChainBridge";
+    string public constant SIGNATURE_VERSION = "1";
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH =
+        keccak256("BridgeTransfer(address recipient,uint256 amount,uint256 nonce)");
+
     IERC20 public bridgeToken;
     address public validator;
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public nonces;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
 
     constructor(address _bridgeToken, address _validator) {
+        require(_bridgeToken != address(0), "Invalid token");
+        require(_validator != address(0), "Invalid validator");
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
-        bridgeToken.transferFrom(msg.sender, address(this), amount);
+        require(bridgeToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(recipient != address(0), "Invalid recipient");
+        require(amount > 0, "Amount must be > 0");
+        require(transferNonce == nonces[recipient], "Invalid nonce");
+
+        bytes32 transferHash = getTransferHash(recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
-        bridgeToken.transfer(recipient, amount);
+        nonces[recipient] = transferNonce + 1;
+        require(bridgeToken.transfer(recipient, amount), "Transfer failed");
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes(SIGNING_DOMAIN)),
+            keccak256(bytes(SIGNATURE_VERSION)),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function getTransferHash(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce
+        ));
+
+        return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+    }
+
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -65,13 +95,15 @@ contract CrossChainBridge {
         }
 
         if (v < 27) v += 27;
+        if (v != 27 && v != 28) {
+            return false;
+        }
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        if (recovered == address(0)) {
+            return false;
+        }
         return recovered == validator;
     }
 

--- a/solidity/tests/test_cross_chain_bridge.py
+++ b/solidity/tests/test_cross_chain_bridge.py
@@ -1,0 +1,229 @@
+from pathlib import Path
+
+import pytest
+from eth_account import Account
+from eth_abi import encode
+from eth_keys import keys
+from eth_tester import EthereumTester, PyEVMBackend
+from eth_utils import keccak, to_bytes, to_checksum_address
+from hexbytes import HexBytes
+from solcx import compile_standard, install_solc
+from web3 import EthereumTesterProvider, Web3
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "solidity" / "contracts" / "CrossChainBridge.sol"
+
+TOKEN_SOURCE = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract TestToken {
+    string public name = "Bridge Token";
+    string public symbol = "BRG";
+    uint8 public decimals = 18;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(uint256 supply) {
+        balanceOf[msg.sender] = supply;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+"""
+
+IERC20_SOURCE = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+"""
+
+
+@pytest.fixture(scope="session")
+def compiled_contracts():
+    install_solc("0.8.20")
+    output = compile_standard(
+        {
+            "language": "Solidity",
+            "sources": {
+                "CrossChainBridge.sol": {"content": CONTRACT.read_text(encoding="utf-8")},
+                "@openzeppelin/contracts/token/ERC20/IERC20.sol": {"content": IERC20_SOURCE},
+                "TestToken.sol": {"content": TOKEN_SOURCE},
+            },
+            "settings": {
+                "evmVersion": "paris",
+                "outputSelection": {"*": {"*": ["abi", "evm.bytecode.object"]}},
+            },
+        },
+        solc_version="0.8.20",
+    )
+    return output["contracts"]
+
+
+@pytest.fixture()
+def bridge_chain(compiled_contracts):
+    tester = EthereumTester(PyEVMBackend())
+    w3 = Web3(EthereumTesterProvider(tester))
+    validator_account = Account.create()
+
+    token_def = compiled_contracts["TestToken.sol"]["TestToken"]
+    bridge_def = compiled_contracts["CrossChainBridge.sol"]["CrossChainBridge"]
+
+    token_contract = w3.eth.contract(
+        abi=token_def["abi"],
+        bytecode=token_def["evm"]["bytecode"]["object"],
+    )
+    token_tx = token_contract.constructor(10**24).transact({"from": w3.eth.accounts[0]})
+    token_address = w3.eth.wait_for_transaction_receipt(token_tx).contractAddress
+
+    bridge_contract = w3.eth.contract(
+        abi=bridge_def["abi"],
+        bytecode=bridge_def["evm"]["bytecode"]["object"],
+    )
+    bridge_tx = bridge_contract.constructor(
+        token_address,
+        validator_account.address,
+    ).transact({"from": w3.eth.accounts[0]})
+    bridge_address = w3.eth.wait_for_transaction_receipt(bridge_tx).contractAddress
+
+    token = w3.eth.contract(address=token_address, abi=token_def["abi"])
+    bridge = w3.eth.contract(address=bridge_address, abi=bridge_def["abi"])
+    token.functions.transfer(bridge_address, 1_000_000).transact({"from": w3.eth.accounts[0]})
+
+    return {
+        "w3": w3,
+        "token": token,
+        "bridge": bridge,
+        "bridge_def": bridge_def,
+        "validator": validator_account,
+    }
+
+
+def sign_hash(private_key, digest):
+    sig = keys.PrivateKey(to_bytes(private_key)).sign_msg_hash(HexBytes(digest))
+    return sig.r.to_bytes(32, "big") + sig.s.to_bytes(32, "big") + bytes([sig.v + 27])
+
+
+def test_valid_eip712_transfer_advances_recipient_nonce(bridge_chain):
+    w3 = bridge_chain["w3"]
+    token = bridge_chain["token"]
+    bridge = bridge_chain["bridge"]
+    recipient = w3.eth.accounts[1]
+    amount = 1234
+    transfer_nonce = bridge.functions.nonces(recipient).call()
+    digest = bridge.functions.getTransferHash(recipient, amount, transfer_nonce).call()
+    signature = sign_hash(bridge_chain["validator"].key, digest)
+
+    assert bridge.functions.verifySignature(digest, signature).call() is True
+
+    bridge.functions.processTransfer(recipient, amount, transfer_nonce, signature).transact(
+        {"from": w3.eth.accounts[0]}
+    )
+
+    assert token.functions.balanceOf(recipient).call() == amount
+    assert bridge.functions.nonces(recipient).call() == transfer_nonce + 1
+
+
+def test_same_chain_replay_is_blocked_by_nonce(bridge_chain):
+    w3 = bridge_chain["w3"]
+    bridge = bridge_chain["bridge"]
+    recipient = w3.eth.accounts[1]
+    digest = bridge.functions.getTransferHash(recipient, 100, 0).call()
+    signature = sign_hash(bridge_chain["validator"].key, digest)
+
+    bridge.functions.processTransfer(recipient, 100, 0, signature).transact({"from": w3.eth.accounts[0]})
+
+    with pytest.raises(Exception, match="Invalid nonce|Already processed"):
+        bridge.functions.processTransfer(recipient, 100, 0, signature).transact({"from": w3.eth.accounts[0]})
+
+
+def test_redeployed_bridge_rejects_old_contract_signature(compiled_contracts, bridge_chain):
+    w3 = bridge_chain["w3"]
+    token = bridge_chain["token"]
+    first_bridge = bridge_chain["bridge"]
+    recipient = w3.eth.accounts[1]
+    digest = first_bridge.functions.getTransferHash(recipient, 100, 0).call()
+    signature = sign_hash(bridge_chain["validator"].key, digest)
+
+    bridge_def = compiled_contracts["CrossChainBridge.sol"]["CrossChainBridge"]
+    factory = w3.eth.contract(
+        abi=bridge_def["abi"],
+        bytecode=bridge_def["evm"]["bytecode"]["object"],
+    )
+    second_tx = factory.constructor(
+        token.address,
+        bridge_chain["validator"].address,
+    ).transact({"from": w3.eth.accounts[0]})
+    second_address = w3.eth.wait_for_transaction_receipt(second_tx).contractAddress
+    second_bridge = w3.eth.contract(address=second_address, abi=bridge_def["abi"])
+    token.functions.transfer(second_address, 1_000_000).transact({"from": w3.eth.accounts[0]})
+
+    with pytest.raises(Exception, match="Invalid signature"):
+        second_bridge.functions.processTransfer(recipient, 100, 0, signature).transact(
+            {"from": w3.eth.accounts[0]}
+        )
+
+
+def test_invalid_ecrecover_zero_address_signature_is_rejected(bridge_chain):
+    w3 = bridge_chain["w3"]
+    bridge = bridge_chain["bridge"]
+    recipient = w3.eth.accounts[1]
+    digest = bridge.functions.getTransferHash(recipient, 100, 0).call()
+    invalid_signature = bytes(65)
+
+    assert bridge.functions.verifySignature(digest, invalid_signature).call() is False
+
+    with pytest.raises(Exception, match="Invalid signature"):
+        bridge.functions.processTransfer(recipient, 100, 0, invalid_signature).transact(
+            {"from": w3.eth.accounts[0]}
+        )
+
+
+def test_domain_separator_binds_chain_and_verifying_contract(bridge_chain):
+    w3 = bridge_chain["w3"]
+    bridge = bridge_chain["bridge"]
+    expected = keccak(
+        encode(
+            ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+            [
+                keccak(text="EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak(text="CrossChainBridge"),
+                keccak(text="1"),
+                w3.eth.chain_id,
+                to_checksum_address(bridge.address),
+            ],
+        )
+    )
+
+    assert bridge.functions.DOMAIN_SEPARATOR().call() == expected
+
+
+def test_public_nonce_mapping_is_available_for_frontends():
+    source = CONTRACT.read_text(encoding="utf-8")
+
+    assert "mapping(address => uint256) public nonces" in source


### PR DESCRIPTION
## Issue
Fixes #920
/claim #920

## Summary
Hardened `CrossChainBridge` release signatures with an EIP-712 digest that binds each transfer to the current chain ID and bridge contract address. The bridge now uses a public per-recipient nonce, rejects invalid zero-address recoveries, and checks ERC20 transfer return values.

## Acceptance criteria
- [x] Signed messages include chain ID, nonce, and contract address through the EIP-712 domain and transfer struct
- [x] Same message cannot be replayed on a different chain because the chain ID is part of `DOMAIN_SEPARATOR()`
- [x] Same message cannot be replayed on the same chain because `nonces[recipient]` must match and advances after processing
- [x] Contract replacement/redeployment cannot replay an old message because `address(this)` is part of the verifying contract domain
- [x] `ecrecover` zero-address results are rejected as invalid signatures
- [x] EIP-712 domain separator is constructed from name, version, chainId, and verifyingContract
- [x] Nonce is queryable through the public `nonces(address)` mapping
- [x] Tests cover valid transfer, same-chain replay, replacement-contract replay, invalid signature handling, domain separator construction, and public nonce availability
- [x] Added public `contributor_meta.json` without confidential prompts or credentials

## Demo video
https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-920-demo.mp4

## Validation
```text
C:\Users\Juanr\Documents\Codex\2026-05-27\goal-generame-al-menos-200-usd\bounty-work\venvs\unsafelabs-920\Scripts\python.exe -m pytest solidity/tests/test_cross_chain_bridge.py -q
......                                                                   [100%]
6 passed, 1936 warnings in 5.21s

git diff --check
# pass
```