### PR TITLE
[ T3 Code ] Chillzyg: Fix ACP auth refresh retry

### DIFF
--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -9,6 +9,8 @@ import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
+import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization";
+import type * as RpcMessage from "effect/unstable/rpc/RpcMessage";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -22,11 +24,42 @@ import { makeInMemoryStdio } from "./_internal/stdio.ts";
 
 const InitializeRequest = jsonRpcRequest("initialize", AcpSchema.InitializeRequest);
 const InitializeResponse = jsonRpcResponse(AcpSchema.InitializeResponse);
+const AuthenticateRequest = jsonRpcRequest("authenticate", AcpSchema.AuthenticateRequest);
+const AuthenticateResponse = jsonRpcResponse(AcpSchema.AuthenticateResponse);
+const LogoutRequest = jsonRpcRequest("logout", AcpSchema.LogoutRequest);
+const LogoutResponse = jsonRpcResponse(AcpSchema.LogoutResponse);
+const PromptRequest = jsonRpcRequest("session/prompt", AcpSchema.PromptRequest);
+const PromptResponse = jsonRpcResponse(AcpSchema.PromptResponse);
+const decodeAuthenticateRequest = Schema.decodeEffect(Schema.fromJsonString(AuthenticateRequest));
+const decodeLogoutRequest = Schema.decodeEffect(Schema.fromJsonString(LogoutRequest));
+const decodePromptRequest = Schema.decodeEffect(Schema.fromJsonString(PromptRequest));
 const ExtRequest = jsonRpcRequest("x/test", Schema.Struct({ hello: Schema.String }));
 const ExtResponse = jsonRpcResponse(Schema.Struct({ ok: Schema.Boolean }));
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/acp-mock-peer.ts"),
 );
+const encoder = new TextEncoder();
+const protocolParser = RpcSerialization.ndJsonRpc().makeUnsafe();
+
+const encodeProtocolError = (id: string | number, error: AcpSchema.Error) => {
+  const encoded = protocolParser.encode({
+    _tag: "Exit",
+    requestId: String(id),
+    exit: {
+      _tag: "Failure",
+      cause: [
+        {
+          _tag: "Fail",
+          error,
+        },
+      ],
+    },
+  } satisfies RpcMessage.ResponseExitEncoded);
+  if (encoded === undefined) {
+    throw new Error("Expected encoded protocol error");
+  }
+  return typeof encoded === "string" ? encoder.encode(encoded) : encoded;
+};
 
 it.layer(NodeServices.layer)("effect-acp client", (it) => {
   const makeHandle = (env?: Record<string, string>) =>
@@ -443,6 +476,101 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
 
       yield* Fiber.join(initializeFiber);
       assert.deepEqual(yield* Fiber.join(extFiber), { ok: true });
+      yield* Scope.close(scope, Exit.void);
+    }),
+  );
+
+  it.effect("refreshes authentication once before replaying an expired session request", () =>
+    Effect.gen(function* () {
+      const expiredSessions = yield* Ref.make<Array<string>>([]);
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+      const acp = yield* AcpClient.make(stdio, {
+        onSessionExpired: (sessionId) =>
+          Ref.update(expiredSessions, (current) => [...current, sessionId]),
+      }).pipe(Effect.provideService(Scope.Scope, scope));
+
+      const authFiber = yield* acp.agent
+        .authenticate({
+          methodId: "cursor_login",
+          _meta: {
+            refreshToken: "refresh-1",
+          },
+        })
+        .pipe(Effect.forkScoped);
+
+      const authOutbound = yield* Queue.take(output);
+      const authenticateRequest = yield* decodeAuthenticateRequest(authOutbound);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: authenticateRequest.id,
+          result: {},
+        }),
+      );
+      yield* Fiber.join(authFiber);
+
+      const promptFiber = yield* acp.agent
+        .prompt({
+          sessionId: "expired-session",
+          prompt: [{ type: "text", text: "hello after expiry" }],
+        })
+        .pipe(Effect.forkScoped);
+
+      const firstPromptOutbound = yield* Queue.take(output);
+      const firstPromptRequest = yield* decodePromptRequest(firstPromptOutbound);
+      assert.equal(firstPromptRequest.params.sessionId, "expired-session");
+      yield* Queue.offer(
+        input,
+        encodeProtocolError(
+          firstPromptRequest.id,
+          AcpError.AcpRequestError.authRequired("401 Unauthorized").toProtocolError(),
+        ),
+      );
+
+      const logoutOutbound = yield* Queue.take(output);
+      const logoutRequest = yield* decodeLogoutRequest(logoutOutbound);
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(LogoutResponse, {
+          jsonrpc: "2.0",
+          id: logoutRequest.id,
+          result: {},
+        }),
+      );
+
+      const refreshAuthOutbound = yield* Queue.take(output);
+      const refreshAuthRequest = yield* decodeAuthenticateRequest(refreshAuthOutbound);
+      assert.equal(refreshAuthRequest.params.methodId, "cursor_login");
+      assert.equal(refreshAuthRequest.params._meta?.refreshToken, "refresh-1");
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(AuthenticateResponse, {
+          jsonrpc: "2.0",
+          id: refreshAuthRequest.id,
+          result: {},
+        }),
+      );
+
+      const retryPromptOutbound = yield* Queue.take(output);
+      const retryPromptRequest = yield* decodePromptRequest(retryPromptOutbound);
+      assert.equal(retryPromptRequest.params.sessionId, "expired-session");
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(PromptResponse, {
+          jsonrpc: "2.0",
+          id: retryPromptRequest.id,
+          result: {
+            stopReason: "end_turn",
+          },
+        }),
+      );
+
+      const promptResponse = yield* Fiber.join(promptFiber);
+      assert.equal(promptResponse.stopReason, "end_turn");
+      assert.deepEqual(yield* Ref.get(expiredSessions), ["expired-session"]);
+
       yield* Scope.close(scope, Exit.void);
     }),
   );

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -4,6 +4,8 @@ import * as Stdio from "effect/Stdio";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Schedule from "effect/Schedule";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import * as RpcServer from "effect/unstable/rpc/RpcServer";
@@ -26,6 +28,7 @@ export interface AcpClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
+  readonly onSessionExpired?: (sessionId: string) => Effect.Effect<void, never>;
 }
 
 type AcpClientRaw = {
@@ -306,6 +309,31 @@ interface BufferedNotificationHandler<A> {
   readonly pending: Array<A>;
 }
 
+const readMetaToken = (value: unknown) => {
+  if (typeof value !== "object" || value === null || !("_meta" in value)) {
+    return undefined;
+  }
+  const meta = (value as { readonly _meta?: unknown })._meta;
+  if (typeof meta !== "object" || meta === null) {
+    return undefined;
+  }
+  if ("refreshToken" in meta) {
+    return (meta as { readonly refreshToken?: unknown }).refreshToken;
+  }
+  if ("refresh_token" in meta) {
+    return (meta as { readonly refresh_token?: unknown }).refresh_token;
+  }
+  return undefined;
+};
+
+const sessionIdOf = (payload: unknown) => {
+  if (typeof payload !== "object" || payload === null || !("sessionId" in payload)) {
+    return undefined;
+  }
+  const sessionId = (payload as { readonly sessionId?: unknown }).sessionId;
+  return typeof sessionId === "string" ? sessionId : undefined;
+};
+
 export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpClientOptions = {},
@@ -330,6 +358,37 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   let unknownExtNotificationHandler:
     | ((method: string, params: unknown) => Effect.Effect<void, AcpError.AcpError>)
     | undefined;
+  let lastAuthenticatePayload: AcpSchema.AuthenticateRequest | undefined;
+  let refreshToken: unknown;
+  let authGeneration = 0;
+  const refreshSemaphore = yield* Semaphore.make(1);
+  const isAcpRequestError = Schema.is(AcpError.AcpRequestError);
+
+  const rememberAuthenticate = (
+    payload: AcpSchema.AuthenticateRequest,
+    response?: AcpSchema.AuthenticateResponse,
+  ) => {
+    lastAuthenticatePayload = payload;
+    const nextRefreshToken = readMetaToken(response) ?? readMetaToken(payload);
+    if (nextRefreshToken !== undefined) {
+      refreshToken = nextRefreshToken;
+    }
+    authGeneration++;
+  };
+
+  const isAuthExpiredError = (error: AcpError.AcpError) => {
+    if (!isAcpRequestError(error)) {
+      return false;
+    }
+    const message = error.errorMessage.toLowerCase();
+    return (
+      error.code === -32000 ||
+      message.includes("401") ||
+      message.includes("unauthorized") ||
+      message.includes("authentication") ||
+      message.includes("expired")
+    );
+  };
 
   const runNotificationHandlers = <A>(
     registration: BufferedNotificationHandler<A>,
@@ -456,6 +515,81 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     generateRequestId: () => nextRpcRequestId++ as never,
   }).pipe(Effect.provideService(RpcClient.Protocol, transport.clientProtocol));
 
+  const makeRefreshPayload = () => {
+    if (!lastAuthenticatePayload) {
+      return undefined;
+    }
+    if (refreshToken === undefined) {
+      return lastAuthenticatePayload;
+    }
+    const meta =
+      typeof lastAuthenticatePayload._meta === "object" && lastAuthenticatePayload._meta !== null
+        ? lastAuthenticatePayload._meta
+        : {};
+    return {
+      ...lastAuthenticatePayload,
+      _meta: {
+        ...meta,
+        refreshToken,
+      },
+    };
+  };
+
+  const refreshAuthentication = (
+    expiredSessionId: string | undefined,
+    observedGeneration: number,
+  ) =>
+    refreshSemaphore.withPermit(
+      Effect.suspend(() => {
+        if (authGeneration !== observedGeneration) {
+          return Effect.void;
+        }
+        const payload = makeRefreshPayload();
+        if (!payload) {
+          return Effect.fail(
+            AcpError.AcpRequestError.authRequired("Cannot refresh ACP session before authenticate"),
+          );
+        }
+        return Effect.gen(function* () {
+          if (expiredSessionId && options.onSessionExpired) {
+            yield* options.onSessionExpired(expiredSessionId);
+          }
+          yield* Effect.scoped(
+            Effect.acquireRelease(
+              callRpc(rpc[AGENT_METHODS.logout]({})).pipe(Effect.ignore),
+              () => Effect.void,
+            ),
+          );
+          const response = yield* callRpc(rpc[AGENT_METHODS.authenticate](payload));
+          rememberAuthenticate(payload, response);
+        });
+      }),
+    );
+
+  const withAuthRefresh = <A>(
+    payload: unknown,
+    request: () => Effect.Effect<A, AcpError.AcpError>,
+  ) =>
+    Effect.suspend(() => {
+      let shouldRetry = false;
+      const observedGeneration = authGeneration;
+      return request().pipe(
+        Effect.tapError((error) => {
+          if (!isAuthExpiredError(error) || shouldRetry || !lastAuthenticatePayload) {
+            shouldRetry = false;
+            return Effect.void;
+          }
+          shouldRetry = true;
+          return refreshAuthentication(sessionIdOf(payload), observedGeneration);
+        }),
+        Effect.retry({
+          schedule: Schedule.recurs(1),
+          times: 1,
+          while: (error) => isAuthExpiredError(error) && shouldRetry,
+        }),
+      );
+    });
+
   return AcpClient.of({
     raw: {
       notifications: transport.incoming,
@@ -464,18 +598,31 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     },
     agent: {
       initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
-      authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
+      authenticate: (payload) =>
+        callRpc(rpc[AGENT_METHODS.authenticate](payload)).pipe(
+          Effect.tap((response) => Effect.sync(() => rememberAuthenticate(payload, response))),
+        ),
       logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
-      closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      createSession: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_new](payload))),
+      loadSession: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_load](payload))),
+      listSessions: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_list](payload))),
+      forkSession: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_fork](payload))),
+      resumeSession: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_resume](payload))),
+      closeSession: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_close](payload))),
+      setSessionModel: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_set_model](payload))),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        withAuthRefresh(payload, () =>
+          callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
+        ),
+      prompt: (payload) =>
+        withAuthRefresh(payload, () => callRpc(rpc[AGENT_METHODS.session_prompt](payload))),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>


### PR DESCRIPTION
## Summary
- remember successful ACP authenticate payloads and refresh-token metadata
- add a one-shot auth-expiration recovery wrapper for session requests that calls `onSessionExpired`, runs logout cleanup, re-authenticates, and replays the failed request once
- cover the expired-session prompt path with an in-memory protocol regression test

## Verification
- `npx -y bun@1.3.11 run test --filter=effect-acp`
- `npx -y bun@1.3.11 run typecheck` from `packages/effect-acp`
- `npx -y bun@1.3.11 run fmt:check`
- `npx -y bun@1.3.11 run lint packages/effect-acp/src/client.ts packages/effect-acp/src/client.test.ts`
- `npx -y bun@1.3.11 run typecheck` from repo root

/claim #829