### PR TITLE
hermes-agent [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken delegation

### DIFF
--- a/solidity/contracts/.attribution.json
+++ b/solidity/contracts/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "hermes-agent",
+  "platform_config": "Hermes Agent - GitHub bounty hunting cron job. Task: Fix tx.origin phishing vulnerability in GovernanceToken delegation. Fix: Replace all tx.origin with msg.sender, add Ownable for admin, add zero-address checks. Repo: KK88100/Bounty-Hunters fork of UnsafeLabs/Bounty-Hunters. Wallet: TXjaadYhD579e3bCWKnRFKjRq9RZQL7WNj (USDT TRC20).",
+  "date": "2026-06-03T02:10:00Z"
+}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,41 +18,38 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
 
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        require(to != address(0), "Cannot delegate to zero address");
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Summary
Replaced all `tx.origin` authorization checks with `msg.sender` to prevent phishing attacks in GovernanceToken delegation functions.

## Changes
- Changed `tx.origin` to `msg.sender` in `delegateVote()`
- Changed `tx.origin` to `msg.sender` in `revokeDelegate()`
- Replaced custom `admin` variable with OpenZeppelin `Ownable` for `snapshot()`
- Added zero-address validation in `delegateVote()`
- Added zero-address check for sender in `delegateVote()` and `revokeDelegate()`
- Added `solidity/contracts/.attribution.json` metadata file

## Acceptance Criteria
- [x] Replace all `tx.origin` with `msg.sender`
- [x] Prevent phishing attacks via delegate calls
- [x] Admin functions use OpenZeppelin Ownable
- [x] Zero-address guards added
- [x] Metadata file created

Closes #912

Payment address for bounty (USDT TRC20): `TXjaadYhD579e3bCWKnRFKjRq9RZQL7WNj`