### PR TITLE
Codex GPT-5 [ Crypto ] Fix cross-chain bridge replay protection

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,53 +4,92 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    string public constant SIGNING_DOMAIN = "CrossChainBridge";
+    string public constant SIGNATURE_VERSION = "1";
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH =
+        keccak256("BridgeTransfer(address sourceSender,address recipient,uint256 amount,uint256 nonce)");
+
     IERC20 public bridgeToken;
     address public validator;
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public nonces;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
-    event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
+    event TransferProcessed(
+        bytes32 indexed transferHash,
+        address indexed sourceSender,
+        address indexed recipient,
+        uint256 amount
+    );
 
     constructor(address _bridgeToken, address _validator) {
+        require(_bridgeToken != address(0), "Invalid token");
+        require(_validator != address(0), "Invalid validator");
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
-        bridgeToken.transferFrom(msg.sender, address(this), amount);
+        require(bridgeToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
+        address sourceSender,
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(sourceSender != address(0), "Invalid source sender");
+        require(recipient != address(0), "Invalid recipient");
+        require(amount > 0, "Amount must be > 0");
+        require(transferNonce == nonces[sourceSender], "Invalid nonce");
+
+        bytes32 transferHash = getTransferHash(sourceSender, recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
-        bridgeToken.transfer(recipient, amount);
+        nonces[sourceSender] = transferNonce + 1;
+        require(bridgeToken.transfer(recipient, amount), "Transfer failed");
 
-        emit TransferProcessed(transferHash, recipient, amount);
+        emit TransferProcessed(transferHash, sourceSender, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes(SIGNING_DOMAIN)),
+            keccak256(bytes(SIGNATURE_VERSION)),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function getTransferHash(
+        address sourceSender,
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            sourceSender,
+            recipient,
+            amount,
+            transferNonce
+        ));
+
+        return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+    }
+
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -65,13 +104,15 @@ contract CrossChainBridge {
         }
 
         if (v < 27) v += 27;
+        if (v != 27 && v != 28) {
+            return false;
+        }
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        if (recovered == address(0)) {
+            return false;
+        }
         return recovered == validator;
     }
 

--- a/solidity/contributor_meta.json
+++ b/solidity/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex GPT-5",
+  "session_init": "Public task context only: rework UnsafeLabs/Bounty-Hunters issue #920 for CrossChainBridge replay protection. Private system, developer, runtime, environment, credential, and user-private instructions are intentionally not disclosed.",
+  "ts": "2026-06-03T04:10:00-06:00"
+}

--- a/solidity/tests/test_cross_chain_bridge.py
+++ b/solidity/tests/test_cross_chain_bridge.py
@@ -1,0 +1,299 @@
+from pathlib import Path
+
+import pytest
+from eth_abi import encode
+from eth_account import Account
+from eth_keys import keys
+from eth_tester import EthereumTester, PyEVMBackend
+from eth_utils import keccak, to_bytes, to_checksum_address
+from hexbytes import HexBytes
+from solcx import compile_standard, install_solc
+from web3 import EthereumTesterProvider, Web3
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "solidity" / "contracts" / "CrossChainBridge.sol"
+
+TOKEN_SOURCE = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract TestToken {
+    string public name = "Bridge Token";
+    string public symbol = "BRG";
+    uint8 public decimals = 18;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(uint256 supply) {
+        balanceOf[msg.sender] = supply;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+"""
+
+IERC20_SOURCE = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+"""
+
+DOMAIN_TYPE = "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+TRANSFER_TYPE = "BridgeTransfer(address sourceSender,address recipient,uint256 amount,uint256 nonce)"
+
+
+@pytest.fixture(scope="session")
+def compiled_contracts():
+    install_solc("0.8.20")
+    output = compile_standard(
+        {
+            "language": "Solidity",
+            "sources": {
+                "CrossChainBridge.sol": {"content": CONTRACT.read_text(encoding="utf-8")},
+                "@openzeppelin/contracts/token/ERC20/IERC20.sol": {"content": IERC20_SOURCE},
+                "TestToken.sol": {"content": TOKEN_SOURCE},
+            },
+            "settings": {
+                "evmVersion": "paris",
+                "outputSelection": {"*": {"*": ["abi", "evm.bytecode.object"]}},
+            },
+        },
+        solc_version="0.8.20",
+    )
+    return output["contracts"]
+
+
+@pytest.fixture()
+def bridge_chain(compiled_contracts):
+    tester = EthereumTester(PyEVMBackend())
+    w3 = Web3(EthereumTesterProvider(tester))
+    validator_account = Account.create()
+
+    token_def = compiled_contracts["TestToken.sol"]["TestToken"]
+    bridge_def = compiled_contracts["CrossChainBridge.sol"]["CrossChainBridge"]
+
+    token_contract = w3.eth.contract(
+        abi=token_def["abi"],
+        bytecode=token_def["evm"]["bytecode"]["object"],
+    )
+    token_tx = token_contract.constructor(10**24).transact({"from": w3.eth.accounts[0]})
+    token_address = w3.eth.wait_for_transaction_receipt(token_tx).contractAddress
+
+    bridge_contract = w3.eth.contract(
+        abi=bridge_def["abi"],
+        bytecode=bridge_def["evm"]["bytecode"]["object"],
+    )
+    bridge_tx = bridge_contract.constructor(
+        token_address,
+        validator_account.address,
+    ).transact({"from": w3.eth.accounts[0]})
+    bridge_address = w3.eth.wait_for_transaction_receipt(bridge_tx).contractAddress
+
+    token = w3.eth.contract(address=token_address, abi=token_def["abi"])
+    bridge = w3.eth.contract(address=bridge_address, abi=bridge_def["abi"])
+    token.functions.transfer(bridge_address, 1_000_000).transact({"from": w3.eth.accounts[0]})
+
+    return {
+        "w3": w3,
+        "token": token,
+        "bridge": bridge,
+        "bridge_def": bridge_def,
+        "validator": validator_account,
+    }
+
+
+def eip712_digest(chain_id, bridge_address, source_sender, recipient, amount, nonce):
+    domain_separator = keccak(
+        encode(
+            ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+            [
+                keccak(text=DOMAIN_TYPE),
+                keccak(text="CrossChainBridge"),
+                keccak(text="1"),
+                chain_id,
+                to_checksum_address(bridge_address),
+            ],
+        )
+    )
+    struct_hash = keccak(
+        encode(
+            ["bytes32", "address", "address", "uint256", "uint256"],
+            [
+                keccak(text=TRANSFER_TYPE),
+                to_checksum_address(source_sender),
+                to_checksum_address(recipient),
+                amount,
+                nonce,
+            ],
+        )
+    )
+    return keccak(b"\x19\x01" + domain_separator + struct_hash)
+
+
+def sign_hash(private_key, digest):
+    sig = keys.PrivateKey(to_bytes(private_key)).sign_msg_hash(HexBytes(digest))
+    return sig.r.to_bytes(32, "big") + sig.s.to_bytes(32, "big") + bytes([sig.v + 27])
+
+
+def test_valid_eip712_transfer_advances_source_sender_nonce(bridge_chain):
+    w3 = bridge_chain["w3"]
+    token = bridge_chain["token"]
+    bridge = bridge_chain["bridge"]
+    source_sender = w3.eth.accounts[2]
+    recipient = w3.eth.accounts[1]
+    amount = 1234
+    transfer_nonce = bridge.functions.nonces(source_sender).call()
+    digest = bridge.functions.getTransferHash(source_sender, recipient, amount, transfer_nonce).call()
+    signature = sign_hash(bridge_chain["validator"].key, digest)
+
+    assert bridge.functions.verifySignature(digest, signature).call() is True
+
+    bridge.functions.processTransfer(
+        source_sender, recipient, amount, transfer_nonce, signature
+    ).transact({"from": w3.eth.accounts[0]})
+
+    assert token.functions.balanceOf(recipient).call() == amount
+    assert bridge.functions.nonces(source_sender).call() == transfer_nonce + 1
+
+
+def test_cross_chain_replay_signature_is_rejected(bridge_chain):
+    w3 = bridge_chain["w3"]
+    bridge = bridge_chain["bridge"]
+    source_sender = w3.eth.accounts[2]
+    recipient = w3.eth.accounts[1]
+    wrong_chain_digest = eip712_digest(
+        w3.eth.chain_id + 1,
+        bridge.address,
+        source_sender,
+        recipient,
+        100,
+        0,
+    )
+    signature = sign_hash(bridge_chain["validator"].key, wrong_chain_digest)
+
+    assert bridge.functions.verifySignature(wrong_chain_digest, signature).call() is True
+
+    with pytest.raises(Exception, match="Invalid signature"):
+        bridge.functions.processTransfer(source_sender, recipient, 100, 0, signature).transact(
+            {"from": w3.eth.accounts[0]}
+        )
+
+
+def test_same_chain_replay_is_blocked_by_sender_nonce(bridge_chain):
+    w3 = bridge_chain["w3"]
+    bridge = bridge_chain["bridge"]
+    source_sender = w3.eth.accounts[2]
+    recipient = w3.eth.accounts[1]
+    digest = bridge.functions.getTransferHash(source_sender, recipient, 100, 0).call()
+    signature = sign_hash(bridge_chain["validator"].key, digest)
+
+    bridge.functions.processTransfer(source_sender, recipient, 100, 0, signature).transact(
+        {"from": w3.eth.accounts[0]}
+    )
+
+    with pytest.raises(Exception, match="Invalid nonce|Already processed"):
+        bridge.functions.processTransfer(source_sender, recipient, 100, 0, signature).transact(
+            {"from": w3.eth.accounts[0]}
+        )
+
+
+def test_redeployed_bridge_rejects_old_contract_signature(compiled_contracts, bridge_chain):
+    w3 = bridge_chain["w3"]
+    token = bridge_chain["token"]
+    first_bridge = bridge_chain["bridge"]
+    source_sender = w3.eth.accounts[2]
+    recipient = w3.eth.accounts[1]
+    digest = first_bridge.functions.getTransferHash(source_sender, recipient, 100, 0).call()
+    signature = sign_hash(bridge_chain["validator"].key, digest)
+
+    bridge_def = compiled_contracts["CrossChainBridge.sol"]["CrossChainBridge"]
+    factory = w3.eth.contract(
+        abi=bridge_def["abi"],
+        bytecode=bridge_def["evm"]["bytecode"]["object"],
+    )
+    second_tx = factory.constructor(
+        token.address,
+        bridge_chain["validator"].address,
+    ).transact({"from": w3.eth.accounts[0]})
+    second_address = w3.eth.wait_for_transaction_receipt(second_tx).contractAddress
+    second_bridge = w3.eth.contract(address=second_address, abi=bridge_def["abi"])
+    token.functions.transfer(second_address, 1_000_000).transact({"from": w3.eth.accounts[0]})
+
+    with pytest.raises(Exception, match="Invalid signature"):
+        second_bridge.functions.processTransfer(source_sender, recipient, 100, 0, signature).transact(
+            {"from": w3.eth.accounts[0]}
+        )
+
+
+def test_invalid_ecrecover_zero_address_signature_is_rejected(bridge_chain):
+    w3 = bridge_chain["w3"]
+    bridge = bridge_chain["bridge"]
+    source_sender = w3.eth.accounts[2]
+    recipient = w3.eth.accounts[1]
+    digest = bridge.functions.getTransferHash(source_sender, recipient, 100, 0).call()
+    invalid_signature = bytes(65)
+
+    assert bridge.functions.verifySignature(digest, invalid_signature).call() is False
+
+    with pytest.raises(Exception, match="Invalid signature"):
+        bridge.functions.processTransfer(source_sender, recipient, 100, 0, invalid_signature).transact(
+            {"from": w3.eth.accounts[0]}
+        )
+
+
+def test_domain_separator_matches_eip712_chain_and_contract(bridge_chain):
+    w3 = bridge_chain["w3"]
+    bridge = bridge_chain["bridge"]
+    expected = eip712_digest(
+        w3.eth.chain_id,
+        bridge.address,
+        w3.eth.accounts[2],
+        w3.eth.accounts[1],
+        100,
+        0,
+    )
+
+    assert bridge.functions.DOMAIN_SEPARATOR().call() == keccak(
+        encode(
+            ["bytes32", "bytes32", "bytes32", "uint256", "address"],
+            [
+                keccak(text=DOMAIN_TYPE),
+                keccak(text="CrossChainBridge"),
+                keccak(text="1"),
+                w3.eth.chain_id,
+                to_checksum_address(bridge.address),
+            ],
+        )
+    )
+    assert bridge.functions.getTransferHash(w3.eth.accounts[2], w3.eth.accounts[1], 100, 0).call() == expected
+
+
+def test_public_nonce_mapping_is_available_for_frontends():
+    source = CONTRACT.read_text(encoding="utf-8")
+
+    assert "mapping(address => uint256) public nonces" in source


### PR DESCRIPTION
/claim #920

## Issue
Closes #920

## Summary
Reworked CrossChainBridge transfer authorization around an EIP-712 domain separator and a typed BridgeTransfer payload. Signed transfers now bind source sender, recipient, amount, per-source-sender nonce, chain ID, and verifying contract, and signature recovery rejects zero-address recoveries.

## Acceptance criteria
- [x] Signed messages include chain ID, nonce, and contract address through the EIP-712 domain plus transfer struct
- [x] Same message cannot be replayed on a different chain; wrong-chain signatures are rejected
- [x] Same message cannot be replayed on the same chain; per-source-sender nonces are consumed after success
- [x] Contract upgrade/replacement cannot replay old messages; signatures are bound to verifyingContract
- [x] ecrecover zero-address return is invalid
- [x] EIP-712 domain separator uses name, version, chainId, and verifyingContract
- [x] Nonce is queryable per source sender through the public nonces mapping
- [x] Tests cover cross-chain replay, same-chain replay, post-upgrade/redeploy replay, invalid signature, and EIP-712 verification
- [x] contributor_meta.json included under solidity/ with public task metadata; private/system/runtime instructions are not disclosed

## Tests
- `python -m pytest ./solidity/tests/test_cross_chain_bridge.py -q` => 7 passed

## Demo
https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-920-demo.mp4