### PR TITLE
Hermes [ Crypto ] Fix cross-chain replay attack in CrossChainBridge signature verification

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -9,6 +9,17 @@ contract CrossChainBridge {
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public senderNonces;
+
+    string public constant DOMAIN_NAME = "CrossChainBridge";
+    string public constant DOMAIN_VERSION = "1";
+    bytes32 public constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH =
+        keccak256("Transfer(address recipient,uint256 amount,uint256 transferNonce,address sender,uint256 senderNonce)");
+
+    bytes32 private _cachedDomainSeparator;
+    uint256 private _cachedChainId;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -16,6 +27,15 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+        _cachedChainId = block.chainid;
+        _cachedDomainSeparator = _buildDomainSeparator();
+    }
+
+    function domainSeparator() public view returns (bytes32) {
+        if (block.chainid == _cachedChainId) {
+            return _cachedDomainSeparator;
+        }
+        return _buildDomainSeparator();
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
@@ -24,25 +44,44 @@ contract CrossChainBridge {
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
+        address sender,
+        uint256 senderNonce,
         bytes calldata signature
     ) external {
+        require(senderNonce == senderNonces[sender], "Invalid sender nonce");
+        senderNonces[sender] = senderNonce + 1;
+
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce,
+            sender,
+            senderNonce
+        ));
+
+        bytes32 typedDataHash = keccak256(abi.encodePacked(
+            "\x19\x01",
+            domainSeparator(),
+            structHash
+        ));
+
         bytes32 transferHash = keccak256(abi.encodePacked(
             recipient,
             amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
+            transferNonce,
+            sender,
+            senderNonce,
+            block.chainid,
+            address(this)
         ));
 
         require(!processedTransfers[transferHash], "Already processed");
-        require(verifySignature(transferHash, signature), "Invalid signature");
+        require(verifySignature(typedDataHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
         bridgeToken.transfer(recipient, amount);
@@ -50,7 +89,6 @@ contract CrossChainBridge {
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -71,11 +109,21 @@ contract CrossChainBridge {
             v, r, s
         );
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature: zero address");
         return recovered == validator;
     }
 
     function getPoolBalance() external view returns (uint256) {
         return bridgeToken.balanceOf(address(this));
+    }
+
+    function _buildDomainSeparator() private view returns (bytes32) {
+        return keccak256(abi.encode(
+            DOMAIN_TYPEHASH,
+            keccak256(bytes(DOMAIN_NAME)),
+            keccak256(bytes(DOMAIN_VERSION)),
+            block.chainid,
+            address(this)
+        ));
     }
 }

--- a/solidity/contributor_meta.json
+++ b/solidity/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Hermes",
+  "session_init": "Hermes Agent - AI assistant for fenn Alexander. Configured for bounty hunting, security audits, and code contributions.",
+  "ts": "2026-06-02T20:30:00Z"
+}

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -1,0 +1,16 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+test = "test"
+solc_version = "0.8.20"
+optimizer = true
+optimizer_runs = 200
+
+[profile.default.fuzz]
+runs = 256
+
+[fmt]
+line_length = 120
+tab_width = 4
+bracket_spacing = true

--- a/solidity/test/CrossChainBridge.t.sol
+++ b/solidity/test/CrossChainBridge.t.sol
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/CrossChainBridge.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock Bridge Token", "MBT") {
+        _mint(msg.sender, 1_000_000e18);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract CrossChainBridgeTest is Test {
+    CrossChainBridge public bridge;
+    MockToken public token;
+
+    address public validator;
+    uint256 public validatorPk;
+    address public alice;
+    uint256 public alicePk;
+    address public bob;
+    address public carol;
+
+    bytes32 public constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH =
+        keccak256("Transfer(address recipient,uint256 amount,uint256 transferNonce,address sender,uint256 senderNonce)");
+
+    function setUp() public {
+        validatorPk = 0x1111;
+        validator = vm.addr(validatorPk);
+        alicePk = 0x2222;
+        alice = vm.addr(alicePk);
+        bob = makeAddr("bob");
+        carol = makeAddr("carol");
+
+        token = new MockToken();
+        bridge = new CrossChainBridge(address(token), validator);
+
+        token.transfer(alice, 10_000e18);
+        token.transfer(address(bridge), 100_000e18);
+    }
+
+    // ── Helpers ──
+
+    function _domainSeparator() internal view returns (bytes32) {
+        return keccak256(abi.encode(
+            DOMAIN_TYPEHASH,
+            keccak256(bytes("CrossChainBridge")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(bridge)
+        ));
+    }
+
+    function _getTypedDataHash(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce,
+        address sender,
+        uint256 senderNonce
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce,
+            sender,
+            senderNonce
+        ));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+    }
+
+    function _sign(bytes32 hash, uint256 pk) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _ethSignedHash(bytes32 hash) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+
+    function _processTransfer(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce,
+        address sender,
+        uint256 senderNonce
+    ) internal {
+        bytes32 typedDataHash = _getTypedDataHash(recipient, amount, transferNonce, sender, senderNonce);
+        bytes memory sig = _sign(typedDataHash, validatorPk);
+        bridge.processTransfer(recipient, amount, transferNonce, sender, senderNonce, sig);
+    }
+
+    // ── Happy Path ──
+
+    function test_processTransfer_happyPath() public {
+        uint256 amount = 1000e18;
+        uint256 balBefore = token.balanceOf(bob);
+        _processTransfer(bob, amount, 1, alice, 0);
+        assertEq(token.balanceOf(bob), balBefore + amount);
+    }
+
+    function test_processTransfer_incrementsSenderNonce() public {
+        _processTransfer(bob, 100e18, 1, alice, 0);
+        assertEq(bridge.senderNonces(alice), 1);
+        _processTransfer(bob, 200e18, 2, alice, 1);
+        assertEq(bridge.senderNonces(alice), 2);
+    }
+
+    // ── Cross-Chain Replay Prevention ──
+
+    function test_crossChainReplay_differentChainId() public {
+        _processTransfer(bob, 1000e18, 1, alice, 0);
+
+        uint256 originalChainId = block.chainid;
+        bytes32 originalTypedHash = _getTypedDataHash(bob, 1000e18, 1, alice, 0);
+        bytes memory originalSig = _sign(originalTypedHash, validatorPk);
+
+        vm.chainId(originalChainId + 1);
+        vm.expectRevert("Invalid signature");
+        bridge.processTransfer(bob, 1000e18, 1, alice, 0, originalSig);
+    }
+
+    function test_domainSeparator_includesChainId() public {
+        bytes32 sep1 = bridge.domainSeparator();
+        uint256 originalChainId = block.chainid;
+        vm.chainId(originalChainId + 1);
+        bytes32 sep2 = bridge.domainSeparator();
+        assertNotEq(sep1, sep2);
+        vm.chainId(originalChainId);
+    }
+
+    // ── Same-Chain Replay Prevention (nonce) ──
+
+    function test_sameChainReplay_noncePreventsReuse() public {
+        _processTransfer(bob, 100e18, 1, alice, 0);
+        vm.expectRevert("Invalid sender nonce");
+        _processTransfer(carol, 200e18, 2, alice, 0);
+    }
+
+    function test_differentSenders_independentNonces() public {
+        _processTransfer(bob, 100e18, 1, alice, 0);
+        assertEq(bridge.senderNonces(alice), 1);
+        _processTransfer(bob, 50e18, 2, carol, 0);
+        assertEq(bridge.senderNonces(carol), 1);
+    }
+
+    // ── Post-Upgrade Replay Prevention ──
+
+    function test_postUpgradeReplay_differentContractAddress() public {
+        _processTransfer(bob, 100e18, 1, alice, 0);
+
+        CrossChainBridge bridge2 = new CrossChainBridge(address(token), validator);
+        token.transfer(address(bridge2), 100_000e18);
+
+        bytes32 typedDataHash1 = _getTypedDataHash(bob, 100e18, 1, alice, 0);
+        bytes memory sig1 = _sign(typedDataHash1, validatorPk);
+
+        vm.expectRevert("Invalid signature");
+        bridge2.processTransfer(bob, 100e18, 1, alice, 0, sig1);
+    }
+
+    // ── Invalid Signature (zero-address) ──
+
+    function test_invalidSignature_zeroAddressRejected() public {
+        bytes memory invalidSig = new bytes(65);
+        vm.expectRevert("Invalid signature: zero address");
+        bridge.verifySignature(keccak256("data"), invalidSig);
+    }
+
+    function test_verifySignature_rejectsWrongSigner() public {
+        bytes32 hash = keccak256("test");
+        bytes32 ethSigned = _ethSignedHash(hash);
+        bytes memory sig = _sign(ethSigned, alicePk);
+        assertFalse(bridge.verifySignature(hash, sig));
+    }
+
+    // ── EIP-712 Verification ──
+
+    function test_eip712_domainSeparator_correctlyConstructed() public view {
+        bytes32 expected = keccak256(abi.encode(
+            DOMAIN_TYPEHASH,
+            keccak256(bytes("CrossChainBridge")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(bridge)
+        ));
+        assertEq(bridge.domainSeparator(), expected);
+    }
+
+    function test_domainSeparator_recalculatesOnChainIdChange() public {
+        bytes32 sep1 = bridge.domainSeparator();
+        uint256 originalChainId = block.chainid;
+        vm.chainId(originalChainId + 1);
+        bytes32 sep2 = bridge.domainSeparator();
+        assertNotEq(sep1, sep2);
+        vm.chainId(originalChainId);
+    }
+
+    // ── Nonce Queryable Per Sender ──
+
+    function test_senderNonce_queryable() public {
+        assertEq(bridge.senderNonces(alice), 0);
+        _processTransfer(bob, 100e18, 1, alice, 0);
+        assertEq(bridge.senderNonces(alice), 1);
+    }
+}


### PR DESCRIPTION
## Fix: Cross-Chain Replay Vulnerability in CrossChainBridge

Closes #920

### Vulnerability

The `processTransfer` function does not prevent replay attacks — a signed message valid on one chain can be resubmitted on another chain or replayed on the same chain after a contract upgrade.

### Changes

1. **Cross-chain replay prevention**: Added `block.chainid` to EIP-712 domain separator and transfer hash
2. **Same-chain replay prevention**: Added per-sender nonce (`senderNonces` mapping) that increments on each transfer
3. **Post-upgrade replay prevention**: Added `address(this)` to EIP-712 domain separator and transfer hash
4. **Zero-address attack prevention**: Added `require(recovered != address(0))` after `ecrecover`
5. **EIP-712 typed data hashing**: Full domain separator with name, version, chainId, verifyingContract

### Acceptance Criteria

- [x] Signed messages include chain ID, nonce, and contract address
- [x] Same message cannot be replayed on a different chain
- [x] Same message cannot be replayed on the same chain (nonce prevents it)
- [x] Contract upgrade does not allow old message replay
- [x] ecrecover zero-address result is rejected as invalid signature
- [x] EIP-712 domain separator is correctly constructed with name, version, chainId, and verifyingContract
- [x] Nonce is queryable per sender for frontend integration
- [x] Tests cover: cross-chain replay, same-chain replay, post-upgrade replay, invalid signature, EIP-712 verification
- [x] Include a contributor_meta.json file

### Files Changed

- `solidity/contracts/CrossChainBridge.sol` — Fixed contract
- `solidity/foundry.toml` — Foundry config
- `solidity/test/CrossChainBridge.t.sol` — Test suite
- `solidity/contributor_meta.json` — Contributor metadata