### PR TITLE
Codex GPT-5 [ FastAPI ] Add rate-limited API key header

### DIFF
--- a/fastapi/.audit.json
+++ b/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "environment_config": "Public task context only: rework UnsafeLabs/Bounty-Hunters issue #768 for FastAPI API-key rate limiting and deprecated key warnings. Private system, developer, runtime, credential, and user-private instructions are intentionally not disclosed.",
+  "completed_at": "2026-06-03T04:55:00-06:00"
+}

--- a/fastapi/fastapi/security/.audit.json
+++ b/fastapi/fastapi/security/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "environment_config": "Public task context only: rework UnsafeLabs/Bounty-Hunters issue #768 for FastAPI API-key rate limiting and deprecated key warnings. Private system, developer, runtime, credential, and user-private instructions are intentionally not disclosed.",
+  "completed_at": "2026-06-03T04:55:00-06:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -1,6 +1,7 @@
 from .api_key import APIKeyCookie as APIKeyCookie
 from .api_key import APIKeyHeader as APIKeyHeader
 from .api_key import APIKeyQuery as APIKeyQuery
+from .api_key import APIKeyWithRateLimit as APIKeyWithRateLimit
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials

--- a/fastapi/fastapi/security/api_key.py
+++ b/fastapi/fastapi/security/api_key.py
@@ -1,3 +1,8 @@
+import math
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -5,7 +10,8 @@ from fastapi.openapi.models import APIKey, APIKeyIn
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.responses import Response
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class APIKeyBase(SecurityBase):
@@ -230,6 +236,158 @@ class APIKeyHeader(APIKeyBase):
     async def __call__(self, request: Request) -> str | None:
         api_key = request.headers.get(self.model.name)
         return self.check_api_key(api_key)
+
+
+class APIKeyWithRateLimit(APIKeyHeader):
+    """
+    API key authentication using a header with per-key in-memory rate limiting.
+    """
+
+    _TIME_WINDOWS = {
+        "second": 1,
+        "seconds": 1,
+        "minute": 60,
+        "minutes": 60,
+        "hour": 3600,
+        "hours": 3600,
+        "day": 86400,
+        "days": 86400,
+    }
+    _DEPRECATED_KEY_WARNING = '299 - "API key is deprecated and will be deactivated"'
+
+    def __init__(
+        self,
+        *,
+        name: Annotated[str, Doc("Header name.")],
+        rate_limit: Annotated[
+            str,
+            Doc(
+                """
+                Maximum requests per API key in a sliding window, for example
+                `100/minute` or `1000/hour`.
+                """
+            ),
+        ],
+        deprecated_keys: Annotated[
+            list[str] | None,
+            Doc(
+                """
+                Old API keys that should continue to authenticate but receive a
+                `Warning` response header.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if the header is not provided, `APIKeyWithRateLimit` will
+                automatically cancel the request and send the client an error.
+
+                If `auto_error` is set to `False`, when the header is not available,
+                instead of erroring out, the dependency result will be `None`.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            name=name,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.max_requests, self.window_seconds = self._parse_rate_limit(rate_limit)
+        self.deprecated_keys = set(deprecated_keys or [])
+        self._requests_by_key: dict[str, deque[float]] = {}
+        self._lock = threading.RLock()
+        self._time_func: Callable[[], float] = time.monotonic
+
+    @classmethod
+    def _parse_rate_limit(cls, rate_limit: str) -> tuple[int, int]:
+        limit, separator, unit = rate_limit.partition("/")
+        if not separator:
+            raise ValueError("rate_limit must use '<count>/<window>' format")
+        try:
+            max_requests = int(limit)
+        except ValueError as exc:
+            raise ValueError("rate_limit count must be an integer") from exc
+        if max_requests < 1:
+            raise ValueError("rate_limit count must be greater than 0")
+        window_seconds = cls._TIME_WINDOWS.get(unit.strip().lower())
+        if window_seconds is None:
+            raise ValueError("rate_limit window must be second, minute, hour, or day")
+        return max_requests, window_seconds
+
+    def _warning_headers(self, api_key: str) -> dict[str, str]:
+        if api_key in self.deprecated_keys:
+            return {"Warning": self._DEPRECATED_KEY_WARNING}
+        return {}
+
+    def _retry_after(self, now: float, timestamps: deque[float]) -> int:
+        if not timestamps:
+            return self.window_seconds
+        elapsed = now - timestamps[0]
+        remaining = self.window_seconds - elapsed
+        return max(1, math.ceil(remaining))
+
+    def _prune_expired(self, timestamps: deque[float], now: float) -> None:
+        while timestamps and now - timestamps[0] >= self.window_seconds:
+            timestamps.popleft()
+
+    def _record_request_or_raise(self, api_key: str) -> None:
+        now = self._time_func()
+        with self._lock:
+            timestamps = self._requests_by_key.setdefault(api_key, deque())
+            self._prune_expired(timestamps, now)
+            if len(timestamps) >= self.max_requests:
+                headers = {
+                    "Retry-After": str(self._retry_after(now, timestamps)),
+                    **self._warning_headers(api_key),
+                }
+                raise HTTPException(
+                    status_code=HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Rate limit exceeded",
+                    headers=headers,
+                )
+            timestamps.append(now)
+            expired_keys = []
+            for key, key_timestamps in self._requests_by_key.items():
+                self._prune_expired(key_timestamps, now)
+                if not key_timestamps:
+                    expired_keys.append(key)
+            for key in expired_keys:
+                del self._requests_by_key[key]
+
+    async def __call__(self, request: Request, response: Response) -> str | None:
+        api_key = request.headers.get(self.model.name)
+        checked_api_key = self.check_api_key(api_key)
+        if checked_api_key is None:
+            return None
+        self._record_request_or_raise(checked_api_key)
+        warning_headers = self._warning_headers(checked_api_key)
+        if warning_headers:
+            response.headers.update(warning_headers)
+        return checked_api_key
 
 
 class APIKeyCookie(APIKeyBase):

--- a/fastapi/tests/test_security_api_key_rate_limit.py
+++ b/fastapi/tests/test_security_api_key_rate_limit.py
@@ -1,0 +1,175 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import APIKeyHeader, APIKeyWithRateLimit
+from fastapi.testclient import TestClient
+
+
+def get_test_client(api_key: APIKeyWithRateLimit) -> TestClient:
+    app = FastAPI()
+
+    def get_current_key(key: str = Security(api_key)):
+        return key
+
+    @app.get("/items")
+    def read_items(key: str = Depends(get_current_key)):
+        return {"key": key}
+
+    return TestClient(app)
+
+
+def test_rate_limit_tracks_each_api_key_independently():
+    api_key = APIKeyWithRateLimit(name="key", rate_limit="2/minute")
+    client = get_test_client(api_key)
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    blocked = client.get("/items", headers={"key": "alpha"})
+    assert blocked.status_code == 429
+    assert blocked.headers["Retry-After"] == "60"
+
+    beta = client.get("/items", headers={"key": "beta"})
+    assert beta.status_code == 200
+    assert beta.json() == {"key": "beta"}
+
+
+def test_sliding_window_resets_expired_counts():
+    now = 1000.0
+    api_key = APIKeyWithRateLimit(name="key", rate_limit="1/minute")
+    api_key._time_func = lambda: now
+    client = get_test_client(api_key)
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    blocked = client.get("/items", headers={"key": "alpha"})
+    assert blocked.status_code == 429
+    assert blocked.headers["Retry-After"] == "60"
+
+    now += 60
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+
+
+def test_retry_after_uses_remaining_window_seconds():
+    now = 1000.0
+    api_key = APIKeyWithRateLimit(name="key", rate_limit="1/minute")
+    api_key._time_func = lambda: now
+    client = get_test_client(api_key)
+
+    assert client.get("/items", headers={"key": "alpha"}).status_code == 200
+    now += 17.2
+    blocked = client.get("/items", headers={"key": "alpha"})
+
+    assert blocked.status_code == 429
+    assert blocked.headers["Retry-After"] == "43"
+
+
+def test_deprecated_key_adds_warning_header_and_still_authenticates():
+    api_key = APIKeyWithRateLimit(
+        name="key",
+        rate_limit="2/minute",
+        deprecated_keys=["old-secret"],
+    )
+    client = get_test_client(api_key)
+
+    response = client.get("/items", headers={"key": "old-secret"})
+
+    assert response.status_code == 200
+    assert response.json() == {"key": "old-secret"}
+    assert (
+        response.headers["Warning"]
+        == '299 - "API key is deprecated and will be deactivated"'
+    )
+
+
+def test_current_key_has_no_warning_header():
+    api_key = APIKeyWithRateLimit(
+        name="key",
+        rate_limit="2/minute",
+        deprecated_keys=["old-secret"],
+    )
+    client = get_test_client(api_key)
+
+    response = client.get("/items", headers={"key": "current-secret"})
+
+    assert response.status_code == 200
+    assert "Warning" not in response.headers
+
+
+def test_deprecated_rate_limited_key_keeps_warning_header():
+    api_key = APIKeyWithRateLimit(
+        name="key",
+        rate_limit="1/minute",
+        deprecated_keys=["old-secret"],
+    )
+    client = get_test_client(api_key)
+
+    assert client.get("/items", headers={"key": "old-secret"}).status_code == 200
+    blocked = client.get("/items", headers={"key": "old-secret"})
+
+    assert blocked.status_code == 429
+    assert blocked.headers["Retry-After"] == "60"
+    assert (
+        blocked.headers["Warning"]
+        == '299 - "API key is deprecated and will be deactivated"'
+    )
+
+
+def test_in_memory_store_handles_concurrent_requests_safely():
+    api_key = APIKeyWithRateLimit(name="key", rate_limit="3/minute")
+    client = get_test_client(api_key)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        statuses = list(
+            executor.map(
+                lambda _: client.get("/items", headers={"key": "alpha"}).status_code,
+                range(10),
+            )
+        )
+
+    assert statuses.count(200) == 3
+    assert statuses.count(429) == 7
+
+
+def test_missing_key_preserves_api_key_header_behavior():
+    api_key = APIKeyWithRateLimit(name="key", rate_limit="2/minute")
+    client = get_test_client(api_key)
+
+    response = client.get("/items")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated"}
+    assert response.headers["WWW-Authenticate"] == "APIKey"
+
+
+def test_optional_missing_key_does_not_rate_limit():
+    app = FastAPI()
+    api_key = APIKeyWithRateLimit(name="key", rate_limit="1/minute", auto_error=False)
+
+    @app.get("/items")
+    def read_items(key: str | None = Security(api_key)):
+        return {"key": key}
+
+    client = TestClient(app)
+
+    assert client.get("/items").json() == {"key": None}
+    assert client.get("/items").json() == {"key": None}
+
+
+def test_invalid_rate_limit_configuration_is_rejected():
+    with pytest.raises(ValueError, match="format"):
+        APIKeyWithRateLimit(name="key", rate_limit="10")
+    with pytest.raises(ValueError, match="greater than 0"):
+        APIKeyWithRateLimit(name="key", rate_limit="0/minute")
+    with pytest.raises(ValueError, match="window"):
+        APIKeyWithRateLimit(name="key", rate_limit="10/month")
+
+
+def test_existing_api_key_header_export_and_behavior_are_unchanged():
+    api_key = APIKeyHeader(name="key")
+    client = get_test_client(api_key)  # type: ignore[arg-type]
+
+    response = client.get("/items", headers={"key": "secret"})
+
+    assert response.status_code == 200
+    assert response.json() == {"key": "secret"}


### PR DESCRIPTION
/claim #768

Closes #768

## Summary
- Added `APIKeyWithRateLimit`, extending `APIKeyHeader` directly in `fastapi/security/api_key.py`.
- Supports string rate limits such as `100/minute` and `1000/hour` using per-API-key sliding in-memory windows guarded by a lock.
- Returns `429 Too Many Requests` with `Retry-After` when a key exceeds its window.
- Supports `deprecated_keys` that continue to authenticate and add a `Warning` response header; active/current keys do not emit warnings.
- Kept existing `APIKeyHeader` behavior and exported the new class through `fastapi.security`.
- Added `.audit.json` metadata at the FastAPI root and security directory root without disclosing private runtime or credential context.

## Validation
- `python -m pytest ./tests/test_security_api_key_rate_limit.py -q` -> 11 passed
- `python -m pytest @tests -q` for all `test_security_api_key*.py` files -> 38 passed
- `python -m ruff check fastapi/security/api_key.py fastapi/security/__init__.py tests/test_security_api_key_rate_limit.py` -> passed
- `python -m ruff format --check fastapi/security/api_key.py fastapi/security/__init__.py tests/test_security_api_key_rate_limit.py` -> passed
- `python -m py_compile ./fastapi/security/api_key.py ./fastapi/security/__init__.py ./tests/test_security_api_key_rate_limit.py` -> passed
- `git diff --check` -> passed

## Demo
https://github.com/Jorel97/bounty-demo-assets/raw/main/unsafelabs/unsafelabs-768-demo.mp4