### PR TITLE
[promptpolish-ai] [ Crypto ] Fix cross-chain replay attack in CrossChainBridge signature verification

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex (promptpolish-ai)",
+  "session_init": "You are Codex running on o-series model through a local all-model shim. Be a helpful, direct coding collaborator.",
+  "ts": "2026-06-03T22:50:00Z"
+}

--- a/knowledge-base/context.json
+++ b/knowledge-base/context.json
@@ -9,7 +9,7 @@
       "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software enginering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
       "context_window": [
         "README.md — Project overview and contribution guidelines",
-        "CONTRIBUTING.md — Step-by-step instructions for submitting pull reuqests",
+        "CONTRIBUTING.md — Step-by-step instructions for submitting pull requests",
         "python/tls_handshake.py — TLS 1.2 handshake state machine implementation",
         "english/haikus.md — Collection of original haikus with TODO placeholders",
         "knowledge-base/context.json — This file"
@@ -21,12 +21,12 @@
       "agent_name": "Hermes Agent with Codex GPT 5.5",
       "agent_version": "0.48.2",
       "timestamp": "2026-05-14T11:15:00Z",
-      "system_prompt": "You are an intelligent programer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specifed. Do not modify files outside the scope of the isue.",
+      "system_prompt": "You are an intelligent programmer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specified. Do not modify files outside the scope of the issue.",
       "context_window": [
-        "README.md — Project overview and repository struture",
+        "README.md — Project overview and repository structure",
         "CONTRIBUTING.md — Pull request submission guidelines",
         "python/tls_handshake.py — TLS handshake implementation with known bugs",
-        "clankers.json — Database of tracked bot acounts and PR statistics",
+        "clankers.json — Database of tracked bot accounts and PR statistics",
         "knowledge-base/context.json — This file"
       ],
       "working_directory": "/Users/worker/projects/Bounty-Hunters",

--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -6,8 +6,23 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract CrossChainBridge {
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
 
+    // EIP-712 domain separator
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "Transfer(address recipient,uint256 amount,uint256 nonce)"
+    );
+
+    bytes32 public domainSeparator;
+    string public constant NAME = "CrossChainBridge";
+    string public constant VERSION = "1";
+
+    // Per-sender nonce to prevent same-chain replay
+    mapping(address => uint256) public senderNonces;
+
+    // Combined hash includes chain ID + contract address → prevents cross-chain & post-upgrade replay
     mapping(bytes32 => bool) public processedTransfers;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
@@ -16,41 +31,63 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+        domainSeparator = keccak256(
+            abi.encode(
+                DOMAIN_TYPEHASH,
+                keccak256(bytes(NAME)),
+                keccak256(bytes(VERSION)),
+                block.chainid,
+                address(this)
+            )
+        );
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
         bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        emit TransferInitiated(msg.sender, amount, targetChain, senderNonces[msg.sender]++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
+    // EIP-712 structured message hash: chainId + contract + nonce → prevents all replay types
+    function _buildTransferHash(address recipient, uint256 amount, uint256 senderNonce) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                TRANSFER_TYPEHASH,
+                recipient,
+                amount,
+                senderNonce
+            )
+        );
+        return keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                domainSeparator,
+                structHash
+            )
+        );
+    }
+
     function processTransfer(
         address recipient,
         uint256 amount,
-        uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        uint256 senderNonce = senderNonces[recipient];
+
+        bytes32 transferHash = _buildTransferHash(recipient, amount, senderNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
+        senderNonces[recipient] = senderNonce + 1;
+
         bridgeToken.transfer(recipient, amount);
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    // EIP-712 typed data signing with ecrecover zero-address check
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -66,13 +103,17 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        // Reject zero-address from ecrecover (invalid signature)
+        require(recovered != address(0), "Invalid signature: zero address");
+
         return recovered == validator;
+    }
+
+    // Query per-sender nonce for frontend integration
+    function getSenderNonce(address sender) external view returns (uint256) {
+        return senderNonces[sender];
     }
 
     function getPoolBalance() external view returns (uint256) {


### PR DESCRIPTION
## Summary

Fixed cross-chain replay attack in the CrossChainBridge contract by implementing EIP-712 typed data signing with chain ID, contract address, and per-sender nonce binding.

## Changes

- Added EIP-712 domain separator with name, version, chainId, and verifyingContract
- Added per-sender nonce tracking to prevent same-chain replay
- Included block.chainid and contract address in signed message hash
- Added ecrecover zero-address rejection
- Nonce is queryable per sender via getSenderNonce()

## Acceptance Criteria

- ✅ Signed messages include chain ID, nonce, and contract address
- ✅ Same message cannot be replayed on different chain
- ✅ Same message cannot be replayed on same chain (nonce prevents it)
- ✅ Contract upgrade does not allow replay (contract address in hash + EIP-712 domain separator)
- ✅ ecrecover zero-address rejected
- ✅ EIP-712 domain separator correctly constructed
- ✅ Nonce queryable per sender

## Related

- Closes #920
- Closes #611 (typos in context.json for priority queue)

/claim #920