### PR TITLE
[promptpolish-ai] [Crypto] Fix reentrancy vulnerability in StakingVault

### DIFF
--- a/.provenance.json
+++ b/.provenance.json
@@ -1,0 +1,1 @@
+{"agent_name":"Codex (promptpolish-ai)","config_snapshot":"You are Codex running on o-series model through a local all-model shim. Be a helpful, direct coding collaborator. Senior architect, 15+ years, GDE & MVP.","created":"2026-06-03T23:10:00Z"}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -39,32 +40,34 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    // FIXED: State update BEFORE external call + nonReentrant
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
-        require(success, "Transfer failed");
-
-        // State update after external call — vulnerable to reentrancy
+        // State update first
         balances[msg.sender] -= amount;
         totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
+
+        // External call after state update (checks-effects-interactions)
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Transfer failed");
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    // FIXED: Same fix for claimRewards
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
-        (bool success, ) = payable(msg.sender).call{value: reward}("");
-        require(success, "Transfer failed");
-
+        // State update first
         rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
+
+        // External call after state update
+        (bool success, ) = payable(msg.sender).call{value: reward}("");
+        require(success, "Transfer failed");
     }
 
     function getStakedBalance(address account) external view returns (uint256) {


### PR DESCRIPTION
## Summary
Fixed reentrancy in withdraw and claimRewards. Checks-effects-interactions. OpenZeppelin ReentrancyGuard.

Closes #911

/claim #911