### PR TITLE
[ Hermes Agent ] [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken

### DIFF
--- a/solidity/contracts/.attribution.json
+++ b/solidity/contracts/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Hermes Agent",
+  "initialized_with": "Fix GovernanceToken tx.origin phishing vulnerability per issue #912: replace all tx.origin with msg.sender, add address(0) guards, use Ownable for admin functions",
+  "timestamp": "2026-06-04T12:20:00Z"
+}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,44 +18,51 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
 
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    /// @notice Delegate voting power to another address
+    /// @param to Address to delegate voting power to
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        require(to != address(0), "Cannot delegate to zero address");
+        require(to != msg.sender, "Cannot delegate to self");
+
+        address previousDelegate = delegates[msg.sender];
+        uint256 balance = balanceOf(msg.sender);
+
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balance;
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balance;
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    /// @notice Revoke delegation and return voting power
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    /// @notice Take a snapshot of token balances (admin only)
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 
+    /// @notice Get total voting power for an account (own balance + delegated)
     function getVotingPower(address account) public view returns (uint256) {
         return balanceOf(account) + delegatedPower[account];
     }


### PR DESCRIPTION
## Summary

Fixes tx.origin phishing vulnerability in GovernanceToken.sol as described in #912 (00 bounty).

## Changes

1. **Replaced all tx.origin with msg.sender**: Prevents phishing attacks where a malicious contract can delegate votes on behalf of users who interact with it.

2. **Added address(0) guards**: Both delegateVote and revokeDelegate now check msg.sender != address(0) as a defensive measure.

3. **Replaced admin with OpenZeppelin Ownable**: The snapshot() function now uses onlyOwner modifier instead of tx.origin == admin, providing proper access control.

4. **Added delegation target validation**: delegateVote now requires to != address(0) and to != msg.sender.

5. **Optimized balanceOf calls**: Cached balanceOf(msg.sender) in a local variable to avoid redundant external calls.

## Acceptance Criteria

- No usage of tx.origin remains in the contract
- All authorization checks use msg.sender
- onlyOwner modifier protects admin functions
- Delegated voting still works correctly through legitimate contract interactions

## Security Notes

- Solidity 0.8.x prevents integer underflow automatically
- No external calls in delegateVote/revokeDelegate means no reentrancy risk
- getVotingPower returns balanceOf + delegatedPower, which is safe for voting weight calculations

Fixes #912