### PR TITLE
OpenAI Codex [ T3 Code ] Add ChatView accessibility navigation

### DIFF
--- a/t3code/apps/web/src/components/.provenance.json
+++ b/t3code/apps/web/src/components/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Public task instructions loaded before this task: UnsafeLabs/Bounty-Hunters issue #852 acceptance criteria; t3code/AGENTS.md task requirements (bun fmt, bun lint, bun typecheck; use bun run test); repository contribution guidance requiring focused fixes, tests, and project style. Private system/developer instructions are intentionally not included.",
+  "created": "2026-06-04T17:15:04+08:00"
+}

--- a/t3code/apps/web/src/components/AppSidebarLayout.tsx
+++ b/t3code/apps/web/src/components/AppSidebarLayout.tsx
@@ -56,6 +56,9 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen>
       <Sidebar
+        id="chat-sidebar"
+        tabIndex={-1}
+        aria-label="Thread sidebar"
         side="left"
         collapsible="offcanvas"
         className="border-r border-border bg-card text-foreground"

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3552,6 +3552,29 @@ export default function ChatView(props: ChatViewProps) {
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {/* Messages Wrapper */}
           <div className="relative flex min-h-0 flex-1 flex-col">
+            <nav
+              aria-label="Chat skip links"
+              className="sr-only focus-within:not-sr-only focus-within:absolute focus-within:left-3 focus-within:top-3 focus-within:z-40 focus-within:flex focus-within:gap-2"
+            >
+              <a
+                href="#chat-sidebar"
+                className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Skip to sidebar
+              </a>
+              <a
+                href="#chat-messages"
+                className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Skip to messages
+              </a>
+              <a
+                href="#chat-composer"
+                className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Skip to composer
+              </a>
+            </nav>
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}
@@ -3577,6 +3600,7 @@ export default function ChatView(props: ChatViewProps) {
               workspaceRoot={activeWorkspaceRoot}
               skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
               onIsAtEndChange={onIsAtEndChange}
+              onReturnFocusToComposer={focusComposer}
             />
 
             {/* scroll to bottom pill — shown when user has scrolled away from the bottom */}
@@ -3584,10 +3608,11 @@ export default function ChatView(props: ChatViewProps) {
               <div className="pointer-events-none absolute bottom-1 left-1/2 z-30 flex -translate-x-1/2 justify-center py-1.5">
                 <button
                   type="button"
+                  aria-label="Scroll to latest message"
                   onClick={() => scrollToEnd(true)}
                   className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
                 >
-                  <ChevronDownIcon className="size-3.5" />
+                  <ChevronDownIcon className="size-3.5" aria-hidden="true" />
                   Scroll to bottom
                 </button>
               </div>
@@ -3603,7 +3628,12 @@ export default function ChatView(props: ChatViewProps) {
                 : "pb-[calc(env(safe-area-inset-bottom)+0.75rem)] sm:pb-[calc(env(safe-area-inset-bottom)+1rem)]",
             )}
           >
-            <div className="relative isolate">
+            <div
+              id="chat-composer"
+              className="relative isolate"
+              tabIndex={-1}
+              aria-label="Message composer"
+            >
               <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
               <div className="relative z-10">
                 <ChatComposer

--- a/t3code/apps/web/src/components/chat/.provenance.json
+++ b/t3code/apps/web/src/components/chat/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Public task instructions loaded before this task: UnsafeLabs/Bounty-Hunters issue #852 acceptance criteria; t3code/AGENTS.md task requirements (bun fmt, bun lint, bun typecheck; use bun run test); repository contribution guidance requiring focused fixes, tests, and project style. Private system/developer instructions are intentionally not included.",
+  "created": "2026-06-04T17:15:04+08:00"
+}

--- a/t3code/apps/web/src/components/chat/ComposerPrimaryActions.tsx
+++ b/t3code/apps/web/src/components/chat/ComposerPrimaryActions.tsx
@@ -105,6 +105,12 @@ export const ComposerPrimaryActions = memo(function ComposerPrimaryActions({
           size="sm"
           className={cn("rounded-full", compact ? "px-3" : "px-4")}
           {...pointerFocusProps}
+          aria-label={formatPendingPrimaryActionLabel({
+            compact,
+            isLastQuestion: pendingAction.isLastQuestion,
+            isResponding: pendingAction.isResponding,
+            questionIndex: pendingAction.questionIndex,
+          })}
           disabled={
             isEnvironmentUnavailable ||
             pendingAction.isResponding ||
@@ -146,6 +152,7 @@ export const ComposerPrimaryActions = memo(function ComposerPrimaryActions({
           size="sm"
           className={cn("rounded-full", compact ? "h-9 px-3 sm:h-8" : "h-9 px-4 sm:h-8")}
           {...pointerFocusProps}
+          aria-label={isConnecting || isSendBusy ? "Sending refinement" : "Refine plan"}
           disabled={isSendBusy || isConnecting || isEnvironmentUnavailable}
         >
           {isConnecting || isSendBusy ? "Sending..." : "Refine"}
@@ -160,6 +167,9 @@ export const ComposerPrimaryActions = memo(function ComposerPrimaryActions({
           size="sm"
           className="h-9 rounded-l-full rounded-r-none px-4 sm:h-8"
           {...pointerFocusProps}
+          aria-label={
+            isConnecting || isSendBusy ? "Sending implementation request" : "Implement plan"
+          }
           disabled={isSendBusy || isConnecting || isEnvironmentUnavailable}
         >
           {isConnecting || isSendBusy ? "Sending..." : "Implement"}

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.browser.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.browser.tsx
@@ -244,6 +244,74 @@ describe("MessagesTimeline", () => {
     }
   });
 
+  it("moves focus between message rows and returns focus intent to the composer", async () => {
+    const props = buildProps();
+    const onReturnFocusToComposer = vi.fn();
+    const screen = await render(
+      <MessagesTimeline
+        {...props}
+        onReturnFocusToComposer={onReturnFocusToComposer}
+        timelineEntries={[
+          buildUserTimelineEntry("First message."),
+          {
+            id: "entry-2",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: "message-2" as never,
+              role: "assistant" as const,
+              text: "Second message.",
+              createdAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    try {
+      const rows = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-timeline-keyboard-row="true"]'),
+      );
+      expect(rows).toHaveLength(2);
+
+      rows[0]?.focus();
+      expect(document.activeElement).toBe(rows[0]);
+
+      rows[0]?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ArrowDown" }));
+      expect(document.activeElement).toBe(rows[1]);
+
+      rows[1]?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ArrowUp" }));
+      expect(document.activeElement).toBe(rows[0]);
+
+      rows[0]?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+      expect(onReturnFocusToComposer).toHaveBeenCalledTimes(1);
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("expands a focused message row with Enter", async () => {
+    const screen = await render(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[buildUserTimelineEntry(buildLongUserMessageText())]}
+      />,
+    );
+
+    try {
+      const row = document.querySelector<HTMLElement>('[data-timeline-keyboard-row="true"]');
+      expect(row).not.toBeNull();
+
+      row?.focus();
+      row?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+
+      await expect.element(page.getByRole("button", { name: "Show less" })).toBeVisible();
+    } finally {
+      await screen.unmount();
+    }
+  });
+
   it("starts the newest long user prompt collapsed", async () => {
     const screen = await render(
       <MessagesTimeline

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -5,6 +5,7 @@ import {
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  resolveTimelineKeyboardNavigationIndex,
 } from "./MessagesTimeline.logic";
 
 describe("computeMessageDurationStart", () => {
@@ -201,6 +202,76 @@ describe("resolveAssistantMessageCopyState", () => {
       text: "Interim thought",
       visible: false,
     });
+  });
+});
+
+describe("resolveTimelineKeyboardNavigationIndex", () => {
+  it("moves between rows with arrow keys", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: 0,
+        key: "ArrowDown",
+        rowCount: 3,
+      }),
+    ).toBe(1);
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: 2,
+        key: "ArrowUp",
+        rowCount: 3,
+      }),
+    ).toBe(1);
+  });
+
+  it("keeps navigation within the available rows", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: 0,
+        key: "ArrowUp",
+        rowCount: 3,
+      }),
+    ).toBe(0);
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: 2,
+        key: "ArrowDown",
+        rowCount: 3,
+      }),
+    ).toBe(2);
+  });
+
+  it("supports jumping to the first or last row", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: 1,
+        key: "Home",
+        rowCount: 3,
+      }),
+    ).toBe(0);
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: 1,
+        key: "End",
+        rowCount: 3,
+      }),
+    ).toBe(2);
+  });
+
+  it("ignores unsupported keys and invalid row positions", () => {
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: 1,
+        key: "Enter",
+        rowCount: 3,
+      }),
+    ).toBeNull();
+    expect(
+      resolveTimelineKeyboardNavigationIndex({
+        currentIndex: -1,
+        key: "ArrowDown",
+        rowCount: 3,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -84,6 +84,33 @@ export function resolveAssistantMessageCopyState({
   };
 }
 
+export function resolveTimelineKeyboardNavigationIndex({
+  currentIndex,
+  key,
+  rowCount,
+}: {
+  currentIndex: number;
+  key: string;
+  rowCount: number;
+}): number | null {
+  if (rowCount <= 0 || currentIndex < 0 || currentIndex >= rowCount) {
+    return null;
+  }
+
+  switch (key) {
+    case "ArrowDown":
+      return Math.min(rowCount - 1, currentIndex + 1);
+    case "ArrowUp":
+      return Math.max(0, currentIndex - 1);
+    case "Home":
+      return 0;
+    case "End":
+      return rowCount - 1;
+    default:
+      return null;
+  }
+}
+
 function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<TimelineEntry>) {
   const lastAssistantMessageIdByResponseKey = new Map<string, string>();
   let nullTurnResponseIndex = 0;

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -133,6 +133,38 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('data-user-message-footer="true"');
   });
 
+  it("renders the messages container as a live log with focusable message rows", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildUserTimelineEntry("Please make this easier to navigate."),
+          {
+            id: "entry-2",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: MessageId.make("message-2"),
+              role: "assistant",
+              text: "Done.",
+              createdAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('id="chat-messages"');
+    expect(markup).toContain('role="log"');
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).toContain('role="listitem"');
+    expect(markup).toContain('data-timeline-keyboard-row="true"');
+    expect(markup).toContain('aria-label="User message: Please make this easier to navigate."');
+    expect(markup).toContain('aria-label="Assistant message: Done."');
+  });
+
   it("does not render collapse controls for short user messages", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
@@ -46,6 +47,7 @@ import {
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  resolveTimelineKeyboardNavigationIndex,
   type StableMessagesTimelineRowsState,
   type MessagesTimelineRow,
 } from "./MessagesTimeline.logic";
@@ -98,6 +100,7 @@ const TimelineRowActivityCtx = createContext<TimelineRowActivityState>(null!);
 const TIMELINE_LIST_HEADER = <div className="h-3 sm:h-4" />;
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const TIMELINE_KEYBOARD_ROW_SELECTOR = '[data-timeline-keyboard-row="true"]';
 
 // ---------------------------------------------------------------------------
 // Props (public API)
@@ -126,6 +129,7 @@ interface MessagesTimelineProps {
   workspaceRoot: string | undefined;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   onIsAtEndChange: (isAtEnd: boolean) => void;
+  onReturnFocusToComposer?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +159,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   workspaceRoot,
   skills = EMPTY_TIMELINE_SKILLS,
   onIsAtEndChange,
+  onReturnFocusToComposer,
 }: MessagesTimelineProps) {
   const rawRows = useMemo(
     () =>
@@ -242,6 +247,51 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [isRevertingCheckpoint, isWorking],
   );
 
+  const handleTimelineKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const target = event.target;
+      const rowElement =
+        target instanceof HTMLElement ? target.closest(TIMELINE_KEYBOARD_ROW_SELECTOR) : null;
+      if (!(rowElement instanceof HTMLElement) || !event.currentTarget.contains(rowElement)) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onReturnFocusToComposer?.();
+        return;
+      }
+
+      if (isInteractiveTimelineKeyboardTarget(target, rowElement)) {
+        return;
+      }
+
+      if (event.key === "Enter") {
+        if (clickFirstExpandableTimelineControl(rowElement)) {
+          event.preventDefault();
+        }
+        return;
+      }
+
+      const rowElements = Array.from(
+        event.currentTarget.querySelectorAll<HTMLElement>(TIMELINE_KEYBOARD_ROW_SELECTOR),
+      );
+      const currentIndex = rowElements.indexOf(rowElement);
+      const nextIndex = resolveTimelineKeyboardNavigationIndex({
+        currentIndex,
+        key: event.key,
+        rowCount: rowElements.length,
+      });
+      if (nextIndex === null || nextIndex === currentIndex) {
+        return;
+      }
+
+      event.preventDefault();
+      rowElements[nextIndex]?.focus();
+    },
+    [onReturnFocusToComposer],
+  );
+
   // Stable renderItem — no closure deps. Row components read shared state
   // from TimelineRowCtx, which propagates through LegendList's memo.
   const renderItem = useCallback(
@@ -255,7 +305,13 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   if (rows.length === 0 && !isWorking) {
     return (
-      <div className="flex h-full items-center justify-center">
+      <div
+        id="chat-messages"
+        className="flex h-full items-center justify-center"
+        role="log"
+        aria-live="polite"
+        aria-label="Conversation messages"
+      >
         <p className="text-sm text-muted-foreground/30">
           Send a message to start the conversation.
         </p>
@@ -266,21 +322,32 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   return (
     <TimelineRowCtx value={sharedState}>
       <TimelineRowActivityCtx value={activityState}>
-        <LegendList<MessagesTimelineRow>
-          ref={listRef}
-          data={rows}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          estimatedItemSize={90}
-          initialScrollAtEnd
-          maintainScrollAtEnd
-          maintainScrollAtEndThreshold={0.1}
-          maintainVisibleContentPosition
-          onScroll={handleScroll}
-          className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
-          ListHeaderComponent={TIMELINE_LIST_HEADER}
-          ListFooterComponent={TIMELINE_LIST_FOOTER}
-        />
+        <div
+          id="chat-messages"
+          className="h-full"
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions text"
+          aria-label="Conversation messages"
+          aria-busy={isWorking}
+          onKeyDown={handleTimelineKeyDown}
+        >
+          <LegendList<MessagesTimelineRow>
+            ref={listRef}
+            data={rows}
+            keyExtractor={keyExtractor}
+            renderItem={renderItem}
+            estimatedItemSize={90}
+            initialScrollAtEnd
+            maintainScrollAtEnd
+            maintainScrollAtEndThreshold={0.1}
+            maintainVisibleContentPosition
+            onScroll={handleScroll}
+            className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
+            ListHeaderComponent={TIMELINE_LIST_HEADER}
+            ListFooterComponent={TIMELINE_LIST_FOOTER}
+          />
+        </div>
       </TimelineRowActivityCtx>
     </TimelineRowCtx>
   );
@@ -300,12 +367,18 @@ type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["grouped
 type TimelineRow = MessagesTimelineRow;
 
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
+  const isMessageRow = row.kind === "message";
+
   return (
     <div
       className={cn(
-        "pb-4",
+        "pb-4 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
       )}
+      role={isMessageRow ? "listitem" : undefined}
+      aria-label={isMessageRow ? formatTimelineMessageRowLabel(row) : undefined}
+      tabIndex={isMessageRow ? 0 : undefined}
+      data-timeline-keyboard-row={isMessageRow ? "true" : undefined}
       data-timeline-row-id={row.id}
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
@@ -400,6 +473,7 @@ function RevertUserMessageButton({ messageId }: { messageId: MessageId }) {
       disabled={activity.isRevertingCheckpoint || activity.isWorking}
       onClick={() => ctx.onRevertUserMessage(messageId)}
       title="Revert to this message"
+      aria-label="Revert to this message"
     >
       <Undo2Icon className="size-3" />
     </Button>
@@ -929,6 +1003,42 @@ const UserMessageBody = memo(function UserMessageBody(props: {
     </div>
   );
 });
+
+function isInteractiveTimelineKeyboardTarget(
+  target: EventTarget | null,
+  rowElement: HTMLElement,
+): boolean {
+  if (!(target instanceof HTMLElement) || target === rowElement) {
+    return false;
+  }
+
+  return (
+    target.closest(
+      "button, a, input, select, textarea, [role='button'], [role='link'], [contenteditable='true']",
+    ) !== null
+  );
+}
+
+function clickFirstExpandableTimelineControl(rowElement: HTMLElement): boolean {
+  const expandableControl = rowElement.querySelector<HTMLButtonElement>("button[aria-expanded]");
+  if (!expandableControl || expandableControl.disabled) {
+    return false;
+  }
+
+  expandableControl.click();
+  return true;
+}
+
+function formatTimelineMessageRowLabel(row: Extract<TimelineRow, { kind: "message" }>): string {
+  const speaker =
+    row.message.role === "assistant"
+      ? "Assistant message"
+      : row.message.role === "user"
+        ? "User message"
+        : "System message";
+  const textPreview = (row.message.text ?? "").replace(/\s+/g, " ").trim().slice(0, 140);
+  return textPreview ? `${speaker}: ${textPreview}` : speaker;
+}
 
 // ---------------------------------------------------------------------------
 // Structural sharing — reuse old row references when data hasn't changed


### PR DESCRIPTION
## Summary

/claim #852

This PR implements focused ChatView accessibility coverage for the message timeline:

- Exposes the messages container as a polite live region with `role="log"` and `aria-live="polite"`.
- Marks message rows as focusable `role="listitem"` entries with useful accessible labels.
- Adds keyboard navigation for messages: Arrow Up/Down/Home/End move between messages, Enter activates the first expandable row action, and Escape returns focus to the composer.
- Adds skip links for sidebar, messages, and composer.
- Adds accessible labels for relevant composer/message controls without changing mouse or touch behavior.
- Includes safe `.provenance.json` metadata without copying private platform/system/developer instructions.

## Demo

Short demo video:

https://raw.githubusercontent.com/laoliLee222/Bounty-Hunters/codex-demo-artifacts-852-20260604181741/demo/chat-a11y-demo.webm

## Verification

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test --filter=@t3tools/web`
- `bun run test src/components/chat/MessagesTimeline.logic.test.ts src/components/chat/MessagesTimeline.test.tsx`
- `bun run test:browser src/components/chat/MessagesTimeline.browser.tsx`
- `git diff --check`
