### PR TITLE
OpenAI Codex [ T3 Code ] Add CLI version command

### DIFF
--- a/t3code/apps/server/src/.contributor.json
+++ b/t3code/apps/server/src/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Public summary only: the user asked Codex to legally earn 100 USD or 100 RMB within 24 hours without selling existing belongings. Private system, developer, platform, and runtime instructions are intentionally not reproduced.",
+  "timestamp": "2026-06-04T10:27:25Z"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -16,6 +16,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
+import packageJson from "../package.json" with { type: "json" };
 import { cli } from "./bin.ts";
 import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "./config.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
@@ -156,6 +157,17 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
 
   it.effect("accepts canonical --no-<flag> boolean negation", () =>
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),
+  );
+
+  it.effect("prints detailed package and runtime information for the version subcommand", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["version"]));
+
+      assert.match(output, new RegExp(`^t3 v${packageJson.version.replaceAll(".", "\\.")} `));
+      assert.match(output, /\((bun|node) [^,]+, [a-z0-9]+ [a-z0-9_]+(?:-[a-z0-9_]+)?\)$/);
+      assert.include(output, process.platform);
+      assert.include(output, process.arch);
+    }),
   );
 
   it.effect("rejects invalid log-level casing before launching the server", () =>

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -10,13 +10,20 @@ import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { versionCommand } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    versionCommand,
+  ]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,32 @@
+import * as Console from "effect/Console";
+import { Command } from "effect/unstable/cli";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+export function getRuntimeLabel(): string {
+  const bunVersion = process.versions.bun;
+  return bunVersion !== undefined ? `bun ${bunVersion}` : `node ${process.versions.node}`;
+}
+
+export function formatVersionInfo(input: {
+  readonly version: string;
+  readonly runtime: string;
+  readonly platform: NodeJS.Platform;
+  readonly arch: NodeJS.Architecture;
+}): string {
+  return `t3 v${input.version} (${input.runtime}, ${input.platform} ${input.arch})`;
+}
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print T3 Code version and runtime details."),
+  Command.withHandler(() =>
+    Console.log(
+      formatVersionInfo({
+        version: packageJson.version,
+        runtime: getRuntimeLabel(),
+        platform: process.platform,
+        arch: process.arch,
+      }),
+    ),
+  ),
+);


### PR DESCRIPTION
## Summary

/claim #821

This PR adds a focused version-reporting path for the T3 CLI:

- Adds a `t3 version` subcommand that prints the package version, runtime, platform, and architecture.
- Keeps the existing root `--version` behavior wired through Effect CLI's version support.
- Reads the detailed version from `apps/server/package.json` instead of hardcoding it.
- Adds CLI parsing coverage for the new subcommand.
- Includes safe contributor metadata without copying private platform/system/developer instructions.

## Demo

Short demo video:

https://raw.githubusercontent.com/laoliLee222/Bounty-Hunters/codex-demo-artifacts-821-828-20260604184631/demo/cli-version-821-demo.webm

CLI output verified locally:

```console
$ bun src/bin.ts --version
t3 v0.0.24

$ bun src/bin.ts version
t3 v0.0.24 (bun 1.3.14, darwin arm64)
```

## Verification

- `bun run test src/bin.test.ts`
- `bun run typecheck`
- `bun src/bin.ts --version`
- `bun src/bin.ts version`
- `bun lint` (0 errors; existing warnings only)
- `bun typecheck`
- `bun fmt`
- `git diff --check`
