### PR TITLE
OpenAI Codex [ T3 Code ] Add explicit Turbo build graph

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Public summary only: the user asked Codex to legally earn 100 USD or 100 RMB within 24 hours without selling existing belongings. Private system, developer, platform, and runtime instructions are intentionally not reproduced.",
+  "completed_at": "2026-06-04T10:40:00Z"
+}

--- a/t3code/apps/desktop/turbo.jsonc
+++ b/t3code/apps/desktop/turbo.jsonc
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@t3tools/web#build", "t3#build"],
       "outputs": ["dist-electron/**"],
     },
     "dev": {

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,40 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/contracts#build": {
+      "outputs": []
+    },
+    "@t3tools/shared#build": {
+      "dependsOn": ["@t3tools/contracts#build"],
+      "outputs": []
+    },
+    "@t3tools/client-runtime#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/shared#build"],
+      "outputs": []
+    },
+    "effect-acp#build": {
+      "outputs": []
+    },
+    "effect-codex-app-server#build": {
+      "outputs": []
+    },
+    "@t3tools/web#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "@t3tools/client-runtime#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
## Summary

/claim #828

This PR makes the T3 Code Turbo build graph explicit:

- Adds package-specific build graph entries for contracts, shared, client-runtime, web, server (`t3`), and generated protocol packages.
- Gives no-emitted-artifact package build nodes explicit empty outputs instead of inheriting app artifact outputs.
- Sets `@t3tools/web#build` to wait on contracts, shared, and client-runtime.
- Sets `t3#build` to wait on contracts, shared, `effect-acp`, and `effect-codex-app-server`.
- Updates the existing desktop package Turbo config so `@t3tools/desktop#build` waits on the web and server bundles.
- Includes safe `_meta.json` metadata without copying private platform/system/developer instructions.

## Demo

Short demo video:

https://raw.githubusercontent.com/laoliLee222/Bounty-Hunters/codex-demo-artifacts-821-828-20260604184631/demo/turbo-graph-828-demo.webm

Turbo dry-run dependency checks:

```console
$ bun turbo run build --dry=json --filter=@t3tools/web
@t3tools/web#build -> @t3tools/client-runtime#build,@t3tools/contracts#build,@t3tools/shared#build

$ bun turbo run build --dry=json --filter=t3
t3#build -> @t3tools/contracts#build,@t3tools/shared#build,effect-acp#build,effect-codex-app-server#build

$ bun turbo run build --dry=json --filter=@t3tools/desktop --filter=@t3tools/web --filter=t3
@t3tools/desktop#build -> @t3tools/web#build,t3#build
```

## Verification

- `bun fmt`
- `git diff --check`
- `bun turbo run build --dry=json --filter=@t3tools/web`
- `bun turbo run build --dry=json --filter=t3`
- `bun turbo run build --dry=json --filter=@t3tools/desktop --filter=@t3tools/web --filter=t3`
- `bun turbo run build --dry=json`
- `bun lint` (0 errors; existing warnings only)
- `bun typecheck`
