### PR TITLE
OpenAI Codex [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Public summary only: the user asked Codex to legally earn 100 USD or 100 RMB within 24 hours without selling existing belongings. Private system, developer, platform, and runtime instructions are intentionally not reproduced.",
+  "timestamp": "2026-06-04T11:05:00Z"
+}

--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,22 @@
 import logging
+from contextvars import ContextVar
+
+request_id_context: ContextVar[str | None] = ContextVar(
+    "fastapi_request_id", default=None
+)
+
+
+def get_request_id() -> str | None:
+    return request_id_context.get()
+
+
+class RequestIDLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id() or ""
+        return True
+
 
 logger = logging.getLogger("fastapi")
+
+if not any(isinstance(filter_, RequestIDLogFilter) for filter_ in logger.filters):
+    logger.addFilter(RequestIDLogFilter())

--- a/fastapi/fastapi/middleware/__init__.py
+++ b/fastapi/fastapi/middleware/__init__.py
@@ -1,1 +1,2 @@
+from fastapi.middleware.request_id import RequestIDMiddleware as RequestIDMiddleware
 from starlette.middleware import Middleware as Middleware

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,48 @@
+import uuid
+from collections.abc import Callable
+
+from fastapi.logger import request_id_context
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+class RequestIDMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        header_name: str = REQUEST_ID_HEADER,
+        generator: Callable[[], str] | None = None,
+    ) -> None:
+        self.app = app
+        self.header_name = header_name
+        self._header_name_bytes = header_name.lower().encode("latin-1")
+        self.generator = generator or (lambda: str(uuid.uuid4()))
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = self._get_request_id(scope)
+        state = scope.setdefault("state", {})
+        state["request_id"] = request_id
+        token = request_id_context.set(request_id)
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers[self.header_name] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            request_id_context.reset(token)
+
+    def _get_request_id(self, scope: Scope) -> str:
+        for key, value in scope.get("headers", []):
+            if key.lower() == self._header_name_bytes:
+                return value.decode("latin-1")
+        return self.generator()

--- a/fastapi/tests/test_request_id_middleware.py
+++ b/fastapi/tests/test_request_id_middleware.py
@@ -1,0 +1,104 @@
+import logging
+import uuid
+
+import anyio
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.logger import get_request_id, logger
+from fastapi.middleware.request_id import RequestIDMiddleware
+from fastapi.testclient import TestClient
+
+
+def make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/request-id")
+    async def read_request_id(request: Request) -> dict[str, str | None]:
+        logger.info("request handler log")
+        return {
+            "state_request_id": request.state.request_id,
+            "context_request_id": get_request_id(),
+        }
+
+    return app
+
+
+def test_generates_unique_request_id_header_and_state() -> None:
+    client = TestClient(make_app())
+
+    first = client.get("/request-id")
+    second = client.get("/request-id")
+
+    first_id = first.headers["X-Request-ID"]
+    second_id = second.headers["X-Request-ID"]
+    uuid.UUID(first_id)
+    uuid.UUID(second_id)
+    assert first_id != second_id
+    assert first.json() == {
+        "state_request_id": first_id,
+        "context_request_id": first_id,
+    }
+    assert second.json() == {
+        "state_request_id": second_id,
+        "context_request_id": second_id,
+    }
+
+
+def test_preserves_client_supplied_request_id() -> None:
+    client = TestClient(make_app())
+
+    response = client.get("/request-id", headers={"X-Request-ID": "client-request-1"})
+
+    assert response.headers["X-Request-ID"] == "client-request-1"
+    assert response.json() == {
+        "state_request_id": "client-request-1",
+        "context_request_id": "client-request-1",
+    }
+
+
+def test_logger_records_include_request_id(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="fastapi")
+    client = TestClient(make_app())
+
+    client.get("/request-id", headers={"X-Request-ID": "log-request-1"})
+
+    records = [record for record in caplog.records if record.message == "request handler log"]
+    assert records
+    assert records[-1].request_id == "log-request-1"
+
+
+def test_logger_still_works_without_middleware(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="fastapi")
+
+    logger.info("outside request")
+
+    records = [record for record in caplog.records if record.message == "outside request"]
+    assert records
+    assert records[-1].request_id == ""
+
+
+@pytest.mark.anyio
+async def test_concurrent_request_ids_do_not_leak() -> None:
+    app = make_app()
+    results: dict[str, httpx.Response] = {}
+
+    async def fetch(client: httpx.AsyncClient, request_id: str) -> None:
+        response = await client.get(
+            "/request-id", headers={"X-Request-ID": request_id}
+        )
+        results[request_id] = response
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        async with anyio.create_task_group() as task_group:
+            for request_id in ("concurrent-a", "concurrent-b", "concurrent-c"):
+                task_group.start_soon(fetch, client, request_id)
+
+    for request_id, response in results.items():
+        assert response.headers["X-Request-ID"] == request_id
+        assert response.json() == {
+            "state_request_id": request_id,
+            "context_request_id": request_id,
+        }


### PR DESCRIPTION
## Summary

/claim #797

This PR adds request ID correlation support for FastAPI:

- Adds a pure ASGI `RequestIDMiddleware`.
- Preserves a client-provided `X-Request-ID` header or generates a UUID when missing.
- Stores the active request ID on `request.state.request_id`.
- Echoes the request ID on the `X-Request-ID` response header.
- Adds a ContextVar-backed FastAPI logger filter so FastAPI log records expose `record.request_id` during the request.
- Keeps logger behavior compatible outside the middleware by using an empty request ID.
- Includes safe provenance metadata without copying private platform/system/developer instructions.

## Demo

Short demo video:

https://raw.githubusercontent.com/laoliLee222/Bounty-Hunters/codex-demo-artifacts-797-20260604185928/demo/fastapi-request-id-797-demo.webm

## Verification

- `python -m pytest tests/test_request_id_middleware.py` (5 passed)
- `python -m ruff check fastapi/logger.py fastapi/middleware/__init__.py fastapi/middleware/request_id.py tests/test_request_id_middleware.py`
- `python -m compileall fastapi/logger.py fastapi/middleware/request_id.py tests/test_request_id_middleware.py`
- `git diff --check`
