### PR TITLE
OpenAI Codex [ FastAPI ] Fix encoders.py bytes encoding

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Safe public summary: implemented FastAPI issue #759 by updating jsonable_encoder bytes and memoryview handling with base64 and hex options. Private system, developer, platform, and session instructions are intentionally not reproduced.",
+  "timestamp": "2026-06-04T11:11:16Z"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -81,8 +82,16 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
         return float(dec_value)
 
 
+def bytes_encoder(value: bytes | memoryview, bytes_encoding: str) -> str:
+    bytes_value = value.tobytes() if isinstance(value, memoryview) else value
+    if bytes_encoding == "base64":
+        return base64.b64encode(bytes_value).decode("ascii")
+    if bytes_encoding == "hex":
+        return bytes_value.hex()
+    raise ValueError("bytes_encoding must be 'base64' or 'hex'")
+
+
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -215,6 +224,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding to use for bytes and memoryview objects. Supported values
+            are "base64" and "hex".
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -242,7 +260,7 @@ def jsonable_encoder(
         exclude = set(exclude)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     if isinstance(obj, BaseModel):
         obj_dict = obj.model_dump(
-            mode="json",
+            mode="python",
             include=include,
             exclude=exclude,
             by_alias=by_alias,
@@ -255,6 +273,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +288,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -276,6 +296,8 @@ def jsonable_encoder(
         return str(obj)
     if isinstance(obj, (str, int, float, type(None))):
         return obj
+    if isinstance(obj, (bytes, memoryview)):
+        return bytes_encoder(obj, bytes_encoding)
     if isinstance(obj, PydanticUndefinedType):
         return None
     if isinstance(obj, dict):
@@ -302,6 +324,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +333,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +351,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +386,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -72,6 +72,10 @@ class ModelWithDefault(BaseModel):
     bla: str = "bla"
 
 
+class ModelWithBytes(BaseModel):
+    payload: bytes
+
+
 def test_encode_dict():
     pet = {"name": "Firulais", "owner": {"name": "Foo"}}
     assert jsonable_encoder(pet) == {"name": "Firulais", "owner": {"name": "Foo"}}
@@ -135,6 +139,44 @@ def test_encode_unsupported():
     unserializable = Unserializable()
     with pytest.raises(ValueError):
         jsonable_encoder(unserializable)
+
+
+def test_encode_bytes_as_base64_by_default():
+    assert jsonable_encoder(b"\xff\x00hello") == "/wBoZWxsbw=="
+
+
+def test_encode_memoryview_as_base64_by_default():
+    assert jsonable_encoder(memoryview(b"\x00\xff")) == "AP8="
+
+
+def test_encode_bytes_as_hex():
+    assert jsonable_encoder(b"\xff\x00hello", bytes_encoding="hex") == "ff0068656c6c6f"
+
+
+def test_encode_memoryview_as_hex():
+    assert jsonable_encoder(memoryview(b"\x00\xff"), bytes_encoding="hex") == "00ff"
+
+
+def test_encode_nested_bytes_with_encoding_option():
+    payload = {"items": [b"hello", {"view": memoryview(b"\xff")}]}
+
+    assert jsonable_encoder(payload, bytes_encoding="hex") == {
+        "items": ["68656c6c6f", {"view": "ff"}]
+    }
+
+
+def test_encode_model_with_bytes_field():
+    model = ModelWithBytes(payload=b"\xff\x00hello")
+
+    assert jsonable_encoder(model) == {"payload": "/wBoZWxsbw=="}
+    assert jsonable_encoder(model, bytes_encoding="hex") == {
+        "payload": "ff0068656c6c6f"
+    }
+
+
+def test_invalid_bytes_encoding_raises():
+    with pytest.raises(ValueError, match="bytes_encoding"):
+        jsonable_encoder(b"hello", bytes_encoding="utf-8")
 
 
 def test_encode_custom_json_encoders_model_pydanticv2():


### PR DESCRIPTION
/claim #759

Summary:
- Encode raw `bytes` and `memoryview` values as base64 strings by default in `jsonable_encoder`.
- Add `bytes_encoding="hex"` and propagate it through nested lists, dicts, dataclasses, and Pydantic model fields.
- Keep Pydantic model bytes in Python mode before recursive encoding so non-UTF-8 bytes do not fail before FastAPI can encode them.
- Add focused tests for bytes, memoryview, nested data, Pydantic model fields, both encoding modes, and invalid encoding names.

Demo:
https://raw.githubusercontent.com/laoliLee222/Bounty-Hunters/codex-demo-artifacts-759-20260604191459/demo/fastapi-jsonable-bytes-759-demo.webm

Verification:
- `/Users/user/Documents/New Lee/outputs/earn_24h_20260604/fastapi-test-venv-311/bin/python -m pytest tests/test_jsonable_encoder.py`
- `/Users/user/Documents/New Lee/outputs/earn_24h_20260604/fastapi-test-venv-311/bin/python -m pytest tests/test_jsonable_encoder.py tests/test_response_model_data_filter.py tests/test_serialize_response_model.py`
- `/Users/user/Documents/New Lee/outputs/earn_24h_20260604/fastapi-test-venv-311/bin/python -m ruff check fastapi/encoders.py tests/test_jsonable_encoder.py`
- `/Users/user/Documents/New Lee/outputs/earn_24h_20260604/fastapi-test-venv-311/bin/python -m compileall fastapi/encoders.py tests/test_jsonable_encoder.py`
- `git diff --check`

Metadata:
- Includes safe public provenance at `fastapi/fastapi/_provenance.json`; private runtime/system instructions are not copied into repository files or PR text.
