### PR TITLE
Add ChatView timeline keyboard accessibility

### DIFF
--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3550,8 +3550,26 @@ export default function ChatView(props: ChatViewProps) {
       <div className="flex min-h-0 min-w-0 flex-1">
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <nav aria-label="Chat skip links" className="sr-only focus-within:not-sr-only">
+            <a
+              href="#chat-messages"
+              className="absolute left-3 top-3 z-50 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Skip to messages
+            </a>
+            <a
+              href="#chat-composer"
+              className="absolute left-3 top-14 z-50 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Skip to composer
+            </a>
+          </nav>
           {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
+          <div
+            id="chat-messages"
+            tabIndex={-1}
+            className="relative flex min-h-0 flex-1 flex-col outline-none"
+          >
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}
@@ -3596,6 +3614,8 @@ export default function ChatView(props: ChatViewProps) {
 
           {/* Input bar */}
           <div
+            id="chat-composer"
+            tabIndex={-1}
             className={cn(
               "pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] pt-1.5 sm:pl-[calc(env(safe-area-inset-left)+1.25rem)] sm:pr-[calc(env(safe-area-inset-right)+1.25rem)] sm:pt-2",
               isGitRepo

--- a/t3code/apps/web/src/components/chat/.provenance.json
+++ b/t3code/apps/web/src/components/chat/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Private system, developer, user, workspace, and session instructions are intentionally not published. This change was produced for GitHub issue #852 with a public scope limited to ChatView timeline accessibility: polite live-region semantics, keyboard-focusable message rows, bounded timeline keyboard navigation, assistive labels, and targeted tests.",
+  "created": "2026-06-04T15:18:00Z"
+}

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -3,8 +3,10 @@ import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
+  getTimelineRowAriaLabel,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  resolveTimelineKeyboardNavigation,
 } from "./MessagesTimeline.logic";
 
 describe("computeMessageDurationStart", () => {
@@ -201,6 +203,121 @@ describe("resolveAssistantMessageCopyState", () => {
       text: "Interim thought",
       visible: false,
     });
+  });
+});
+
+describe("resolveTimelineKeyboardNavigation", () => {
+  it("moves to adjacent rows with arrow keys without leaving bounds", () => {
+    expect(
+      resolveTimelineKeyboardNavigation({ key: "ArrowUp", currentIndex: 1, rowCount: 3 }),
+    ).toBe(0);
+    expect(
+      resolveTimelineKeyboardNavigation({ key: "ArrowUp", currentIndex: 0, rowCount: 3 }),
+    ).toBe(0);
+    expect(
+      resolveTimelineKeyboardNavigation({ key: "ArrowDown", currentIndex: 1, rowCount: 3 }),
+    ).toBe(2);
+    expect(
+      resolveTimelineKeyboardNavigation({ key: "ArrowDown", currentIndex: 2, rowCount: 3 }),
+    ).toBe(2);
+  });
+
+  it("jumps to the first and last rows with Home and End", () => {
+    expect(resolveTimelineKeyboardNavigation({ key: "Home", currentIndex: 2, rowCount: 4 })).toBe(
+      0,
+    );
+    expect(resolveTimelineKeyboardNavigation({ key: "End", currentIndex: 0, rowCount: 4 })).toBe(
+      3,
+    );
+  });
+
+  it("ignores unsupported keys and invalid row positions", () => {
+    expect(resolveTimelineKeyboardNavigation({ key: "Enter", currentIndex: 1, rowCount: 3 })).toBe(
+      null,
+    );
+    expect(
+      resolveTimelineKeyboardNavigation({ key: "ArrowDown", currentIndex: -1, rowCount: 3 }),
+    ).toBe(null);
+    expect(
+      resolveTimelineKeyboardNavigation({ key: "ArrowDown", currentIndex: 0, rowCount: 0 }),
+    ).toBe(null);
+  });
+});
+
+describe("getTimelineRowAriaLabel", () => {
+  it("labels user, assistant, and streaming assistant message rows", () => {
+    const baseMessage = {
+      id: "message-1" as never,
+      role: "user" as const,
+      text: "Hello",
+      createdAt: "2026-01-01T00:00:00Z",
+      streaming: false,
+    };
+
+    expect(
+      getTimelineRowAriaLabel({
+        kind: "message",
+        id: "row-user",
+        createdAt: baseMessage.createdAt,
+        message: baseMessage,
+        durationStart: baseMessage.createdAt,
+        showCompletionDivider: false,
+        completionSummary: null,
+        showAssistantCopyButton: false,
+        assistantCopyStreaming: false,
+      }),
+    ).toBe("User message");
+
+    expect(
+      getTimelineRowAriaLabel({
+        kind: "message",
+        id: "row-assistant",
+        createdAt: baseMessage.createdAt,
+        message: {
+          ...baseMessage,
+          id: "message-2" as never,
+          role: "assistant" as const,
+          streaming: true,
+        },
+        durationStart: baseMessage.createdAt,
+        showCompletionDivider: false,
+        completionSummary: null,
+        showAssistantCopyButton: false,
+        assistantCopyStreaming: true,
+      }),
+    ).toBe("Assistant message, streaming");
+  });
+
+  it("labels non-message rows by timeline purpose", () => {
+    expect(
+      getTimelineRowAriaLabel({
+        kind: "work",
+        id: "work-row",
+        createdAt: "2026-01-01T00:00:00Z",
+        groupedEntries: [
+          {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:00Z",
+            label: "Read file",
+            tone: "tool",
+          },
+          {
+            id: "work-2",
+            createdAt: "2026-01-01T00:00:01Z",
+            label: "Edit file",
+            tone: "tool",
+          },
+        ],
+      }),
+    ).toBe("Work log, 2 entries");
+
+    expect(
+      getTimelineRowAriaLabel({
+        kind: "working",
+        id: "working-indicator-row",
+        createdAt: null,
+      }),
+    ).toBe("Assistant is working");
   });
 });
 

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -45,6 +45,50 @@ export interface StableMessagesTimelineRowsState {
   result: MessagesTimelineRow[];
 }
 
+export function resolveTimelineKeyboardNavigation({
+  key,
+  currentIndex,
+  rowCount,
+}: {
+  key: string;
+  currentIndex: number;
+  rowCount: number;
+}): number | null {
+  if (rowCount <= 0 || currentIndex < 0 || currentIndex >= rowCount) {
+    return null;
+  }
+
+  switch (key) {
+    case "ArrowUp":
+      return Math.max(0, currentIndex - 1);
+    case "ArrowDown":
+      return Math.min(rowCount - 1, currentIndex + 1);
+    case "Home":
+      return 0;
+    case "End":
+      return rowCount - 1;
+    default:
+      return null;
+  }
+}
+
+export function getTimelineRowAriaLabel(row: MessagesTimelineRow) {
+  switch (row.kind) {
+    case "message": {
+      const speaker = row.message.role === "user" ? "User" : "Assistant";
+      return row.message.streaming ? `${speaker} message, streaming` : `${speaker} message`;
+    }
+    case "work":
+      return row.groupedEntries.length === 1
+        ? "Work log, 1 entry"
+        : `Work log, ${row.groupedEntries.length} entries`;
+    case "proposed-plan":
+      return "Proposed plan";
+    case "working":
+      return "Assistant is working";
+  }
+}
+
 export function computeMessageDurationStart(
   messages: ReadonlyArray<TimelineDurationMessage>,
 ): Map<string, string> {

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
@@ -44,8 +45,10 @@ import {
   computeStableMessagesTimelineRows,
   MAX_VISIBLE_WORK_LOG_ENTRIES,
   deriveMessagesTimelineRows,
+  getTimelineRowAriaLabel,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  resolveTimelineKeyboardNavigation,
   type StableMessagesTimelineRowsState,
   type MessagesTimelineRow,
 } from "./MessagesTimeline.logic";
@@ -182,6 +185,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     ],
   );
   const rows = useStableRows(rawRows);
+  const [focusedRowId, setFocusedRowId] = useState<string | null>(null);
+  const rowRefs = useRef(new Map<string, HTMLDivElement>());
 
   const handleScroll = useCallback(() => {
     const state = listRef.current?.getState?.();
@@ -242,15 +247,79 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [isRevertingCheckpoint, isWorking],
   );
 
-  // Stable renderItem — no closure deps. Row components read shared state
-  // from TimelineRowCtx, which propagates through LegendList's memo.
+  useEffect(() => {
+    if (focusedRowId === null || rows.some((row) => row.id === focusedRowId)) {
+      return;
+    }
+    setFocusedRowId(null);
+  }, [focusedRowId, rows]);
+
+  const registerRowRef = useCallback(
+    (rowId: string) => (node: HTMLDivElement | null) => {
+      if (node) {
+        rowRefs.current.set(rowId, node);
+        return;
+      }
+      rowRefs.current.delete(rowId);
+    },
+    [],
+  );
+
+  const focusTimelineRow = useCallback((rowId: string) => {
+    const rowElement = rowRefs.current.get(rowId);
+    if (!rowElement) {
+      return;
+    }
+    setFocusedRowId(rowId);
+    rowElement.focus();
+  }, []);
+
+  const handleRowKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>, rowId: string) => {
+      if (event.key === "Escape") {
+        event.currentTarget.blur();
+        setFocusedRowId(null);
+        return;
+      }
+
+      const currentIndex = rows.findIndex((row) => row.id === rowId);
+      const nextIndex = resolveTimelineKeyboardNavigation({
+        key: event.key,
+        currentIndex,
+        rowCount: rows.length,
+      });
+
+      if (nextIndex === null) {
+        return;
+      }
+
+      event.preventDefault();
+      const nextRow = rows[nextIndex];
+      if (nextRow) {
+        focusTimelineRow(nextRow.id);
+      }
+    },
+    [focusTimelineRow, rows],
+  );
+
   const renderItem = useCallback(
     ({ item }: { item: MessagesTimelineRow }) => (
-      <div className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip" data-timeline-root="true">
+      <div
+        ref={registerRowRef(item.id)}
+        className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        role="article"
+        aria-label={getTimelineRowAriaLabel(item)}
+        tabIndex={
+          focusedRowId === item.id || (focusedRowId === null && rows[0]?.id === item.id) ? 0 : -1
+        }
+        data-timeline-root="true"
+        onFocus={() => setFocusedRowId(item.id)}
+        onKeyDown={(event) => handleRowKeyDown(event, item.id)}
+      >
         <TimelineRowContent row={item} />
       </div>
     ),
-    [],
+    [focusedRowId, handleRowKeyDown, registerRowRef, rows],
   );
 
   if (rows.length === 0 && !isWorking) {
@@ -278,6 +347,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           maintainVisibleContentPosition
           onScroll={handleScroll}
           className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
+          role="log"
+          aria-label="Conversation messages"
+          aria-live="polite"
+          aria-relevant="additions text"
           ListHeaderComponent={TIMELINE_LIST_HEADER}
           ListFooterComponent={TIMELINE_LIST_FOOTER}
         />


### PR DESCRIPTION
## Summary

/claim #852

This PR adds focused accessibility support to the T3 Code ChatView message timeline:

- Exposes the message timeline as a labelled polite live region with `role="log"`, `aria-live="polite"`, and `aria-relevant="additions text"`.
- Makes timeline rows keyboard-focusable `role="article"` entries with clear accessible labels for user, assistant, work-log, proposed-plan, and working rows.
- Adds roving tabindex keyboard navigation for ArrowUp, ArrowDown, Home, and End.
- Adds Escape behavior to blur the focused timeline row.
- Keeps the change UI-only: no auth, API, persistence, or data-fetching paths touched.
- Adds targeted logic tests for keyboard navigation and row ARIA labels.

## Demo

Short demo video:

https://raw.githubusercontent.com/BowenMilner/Bounty-Hunters/codex-demo-artifacts-852-20260604/demo/chat-a11y-demo.webm

## Verification

- `vitest run src/components/chat/MessagesTimeline.logic.test.ts` passed in the first local clone: 24 tests.
- `oxlint src/components/chat/MessagesTimeline.tsx src/components/chat/MessagesTimeline.logic.ts src/components/chat/MessagesTimeline.logic.test.ts` passed in the first local clone: 0 warnings, 0 errors.
- `git diff --check -- t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts t3code/apps/web/src/components/chat/MessagesTimeline.tsx t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts` passed in the clean clone.

Note: full app typecheck and clean-clone test reruns wedged silently in this local sandbox, so I am listing only completed verification above.