### PR TITLE
fix: replace tx.origin with msg.sender in GovernanceToken to prevent phishing (#912)

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,30 +28,30 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // FIXED: Use msg.sender instead of tx.sender — prevents phishing attacks
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    // FIXED: Use msg.sender instead of tx.origin
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
+    // FIXED: Use msg.sender instead of tx.origin for admin check
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        require(msg.sender == admin, "Not admin");
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Fix: Replace tx.origin with msg.sender in GovernanceToken

Closes #912

### Bug
`delegateVote`, `revokeDelegate`, and `snapshot` use `tx.origin` instead of `msg.sender`.

### Impact
Phishing attack: a malicious contract can delegate votes on behalf of users who interact with it. The attacker calls the malicious contract, which calls `delegateVote` — `tx.origin` is the victim, so the delegation happens without their consent.

### Fix
Replace all `tx.origin` with `msg.sender` in:
- `delegateVote()`
- `revokeDelegate()`
- `snapshot()`

### ETH Wallet for payout
`0xd9c96DF15CF857E31ee3A4ABD6315233288a8A2F`