### PR TITLE
[OWL] fix(config): correct docker image tag from lastest to latest (#310)

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
Fix docker-compose.yml image tag typo: `lastest` → `latest`

## Changes
- `config/docker-compose.yml`: Corrected the api service image tag from `lastest` to `latest`

## Testing
- Verified the fix is a single-character correction

## Wallet for payout
`0xd9c96DF15CF857E31ee3A4ABD6315233288a8A2F`

Fixes #310