### PR TITLE
[Danop404] [ Laravel ] Fix User model password cast not applying bcrypt rounds from config

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Danop404",
+  "generation_context": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#745 requested fixing Laravel User password hashing so config('hashing.bcrypt.rounds') is respected, updating UserFactory, adding a unit test, and including payout contact details in the PR draft. No separate public generation-context payload was available in the local Codex environment.",
+  "completed_at": "2026-06-05T09:40:00+02:00"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,25 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value === null || $value === '') {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        if (password_get_info($value)['algoName'] !== 'unknown') {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value, [
+            'rounds' => (int) config('hashing.bcrypt.rounds'),
+        ]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,11 +13,6 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
-     */
-    protected static ?string $password;
-
-    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
@@ -28,7 +23,9 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => Hash::make('password', [
+                'rounds' => (int) config('hashing.bcrypt.rounds'),
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/PasswordHashingTest.php
+++ b/laravel/tests/Unit/PasswordHashingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Database\Factories\UserFactory;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class PasswordHashingTest extends TestCase
+{
+    public function test_user_password_mutator_uses_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User();
+        $user->password = 'secret-password';
+
+        $hash = $user->getAttributes()['password'];
+
+        $this->assertTrue(Hash::check('secret-password', $hash));
+        $this->assertSame(6, $this->bcryptCost($hash));
+    }
+
+    public function test_user_factory_uses_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 7]);
+
+        $attributes = (new UserFactory())->definition();
+        $hash = $attributes['password'];
+
+        $this->assertTrue(Hash::check('password', $hash));
+        $this->assertSame(7, $this->bcryptCost($hash));
+    }
+
+    public function test_existing_default_rounds_hashes_still_verify(): void
+    {
+        $legacyHash = password_hash('legacy-password', PASSWORD_BCRYPT, ['cost' => 10]);
+
+        $this->assertTrue(Hash::check('legacy-password', $legacyHash));
+        $this->assertSame(10, $this->bcryptCost($legacyHash));
+    }
+
+    private function bcryptCost(string $hash): int
+    {
+        $info = password_get_info($hash);
+
+        return (int) ($info['options']['cost'] ?? 0);
+    }
+}


### PR DESCRIPTION
# [Danop404] [ Laravel ] Fix User model password cast not applying bcrypt rounds from config

Closes UnsafeLabs/Bounty-Hunters#745.

## Summary

- Replace the generic `password => hashed` cast with a `setPasswordAttribute` mutator that calls `Hash::make()` with `config('hashing.bcrypt.rounds')`.
- Preserve already-hashed password values so legacy hashes are not rehashed during assignment/import flows.
- Update `UserFactory` to generate bcrypt hashes with the configured rounds.
- Add `config/hashing.php` so `BCRYPT_ROUNDS` is available through Laravel config.
- Add unit coverage for configured model rounds, configured factory rounds, and legacy default-round hash verification.
- Add the requested `_meta.json` file.

## Verification

Not run locally: PHP and Composer are not installed in this Windows environment.

Suggested verification:

```bash
cd laravel
composer test -- --filter PasswordHashingTest
```

## Bounty payout details

Email: faresboubakeur14@gmail.com

PayPal: paypal.me/FaresBoubakeur
