### PR TITLE
OpenAI Codex [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,35 @@
+from __future__ import annotations
+
 import logging
+from contextvars import ContextVar, Token
 
 logger = logging.getLogger("fastapi")
+
+request_id_context_var: ContextVar[str | None] = ContextVar(
+    "fastapi_request_id", default=None
+)
+
+
+def get_request_id(default: str = "-") -> str:
+    request_id = request_id_context_var.get()
+    if request_id is None:
+        return default
+    return request_id
+
+
+def set_request_id(request_id: str) -> Token[str | None]:
+    return request_id_context_var.set(request_id)
+
+
+def reset_request_id(token: Token[str | None]) -> None:
+    request_id_context_var.reset(token)
+
+
+class RequestIDFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id()
+        return True
+
+
+if not any(isinstance(log_filter, RequestIDFilter) for log_filter in logger.filters):
+    logger.addFilter(RequestIDFilter())

--- a/fastapi/fastapi/middleware/_provenance.json
+++ b/fastapi/fastapi/middleware/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, runtime, and credential-bearing instructions are not copied into repository files or public PR text. This file intentionally contains only safe public submission metadata for the scoped FastAPI request ID middleware bounty.",
+  "timestamp": "2026-06-05T19:10:00+08:00"
+}

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,32 @@
+from uuid import uuid4
+
+from fastapi.logger import reset_request_id, set_request_id
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class RequestIDMiddleware:
+    def __init__(self, app: ASGIApp, header_name: str = "X-Request-ID") -> None:
+        self.app = app
+        self.header_name = header_name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        request_id = headers.get(self.header_name) or str(uuid4())
+        scope.setdefault("state", {})["request_id"] = request_id
+        token = set_request_id(request_id)
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                response_headers = MutableHeaders(scope=message)
+                response_headers[self.header_name] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            reset_request_id(token)

--- a/fastapi/tests/test_request_id_middleware.py
+++ b/fastapi/tests/test_request_id_middleware.py
@@ -1,0 +1,96 @@
+import logging
+from uuid import UUID
+
+import anyio
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.logger import logger
+from fastapi.middleware.request_id import RequestIDMiddleware
+from fastapi.testclient import TestClient
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/request-id")
+    async def read_request_id(request: Request) -> dict[str, str]:
+        logger.info("handling request")
+        return {"request_id": request.state.request_id}
+
+    @app.get("/slow-request-id")
+    async def read_slow_request_id(request: Request) -> dict[str, str]:
+        await anyio.sleep(0.01)
+        logger.info("handling slow request")
+        return {"request_id": request.state.request_id}
+
+    return app
+
+
+def test_generates_uuid_request_id() -> None:
+    client = TestClient(create_app())
+    response = client.get("/request-id")
+
+    assert response.status_code == 200
+    request_id = response.headers["X-Request-ID"]
+    UUID(request_id)
+    assert response.json() == {"request_id": request_id}
+
+
+def test_preserves_client_request_id() -> None:
+    client = TestClient(create_app())
+    response = client.get("/request-id", headers={"X-Request-ID": "client-id-123"})
+
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"] == "client-id-123"
+    assert response.json() == {"request_id": "client-id-123"}
+
+
+def test_log_record_includes_request_id(caplog: pytest.LogCaptureFixture) -> None:
+    client = TestClient(create_app())
+
+    with caplog.at_level(logging.INFO, logger="fastapi"):
+        response = client.get("/request-id", headers={"X-Request-ID": "log-id-123"})
+
+    assert response.status_code == 200
+    records = [record for record in caplog.records if record.name == "fastapi"]
+    assert records
+    assert records[-1].request_id == "log-id-123"
+
+
+def test_logger_has_default_request_id_without_middleware(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO, logger="fastapi"):
+        logger.info("outside middleware")
+
+    records = [record for record in caplog.records if record.name == "fastapi"]
+    assert records
+    assert records[-1].request_id == "-"
+
+
+@pytest.mark.anyio
+async def test_request_ids_do_not_leak_between_concurrent_requests() -> None:
+    transport = httpx.ASGITransport(app=create_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        responses: dict[str, httpx.Response] = {}
+
+        async def fetch(name: str, request_id: str) -> None:
+            responses[name] = await client.get(
+                "/slow-request-id", headers={"X-Request-ID": request_id}
+            )
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(fetch, "first", "first-id")
+            task_group.start_soon(fetch, "second", "second-id")
+
+    first = responses["first"]
+    second = responses["second"]
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.headers["X-Request-ID"] == "first-id"
+    assert second.headers["X-Request-ID"] == "second-id"
+    assert first.json() == {"request_id": "first-id"}
+    assert second.json() == {"request_id": "second-id"}


### PR DESCRIPTION
/claim #797

## Summary
- Adds `RequestIDMiddleware` for FastAPI HTTP requests.
- Preserves a client-provided `X-Request-ID` header or generates a UUID when absent.
- Stores the active request ID on `request.state.request_id` and echoes it on the `X-Request-ID` response header.
- Adds request-scoped FastAPI logger context through `contextvars`, with a default `request_id` field when middleware is not active.
- Covers generated IDs, client-provided IDs, log-record metadata, middleware-free logging compatibility, and concurrent request isolation.

## Demo
Short demo video:

https://github.com/wcx1102/Bounty-Hunters/releases/download/pr-6310-demo-20260605/fastapi-request-id-pr-6310-demo.mp4

The video shows generated request IDs, preserving a client-provided request ID, `request.state.request_id` matching the response header, and focused validation passing.

## Verification
- `uv run --group tests python -m pytest tests/test_request_id_middleware.py -q` -> 6 passed
- `uv run --group tests ruff check fastapi/logger.py fastapi/middleware/request_id.py tests/test_request_id_middleware.py` -> passed
- `python3 -m compileall -q fastapi/logger.py fastapi/middleware/request_id.py tests/test_request_id_middleware.py` -> passed
- `python3 -m json.tool fastapi/middleware/_provenance.json >/dev/null` -> passed
- `git diff --check` -> passed

## Demo / proof
The focused pytest suite exercises the middleware end-to-end with `TestClient` and `httpx.ASGITransport`, including concurrent requests with distinct request IDs.

## Security / privacy
Private system, developer, runtime, and credential-bearing instructions are not copied into repository files or PR text. The provenance metadata contains only safe public submission context.

Payment details can be provided privately after maintainer acceptance.
