### PR TITLE
OpenAI Codex [ T3 Code ] Add server environment validation

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, runtime, and credential-bearing instructions are not included in repository files or public PR text. Public submission context: implement UnsafeLabs/Bounty-Hunters issue #853 for T3 Code by adding server environment validation, a --validate-config CLI path, focused tests, and safe review materials.",
+  "timestamp": "2026-06-05T11:23:28Z"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -158,6 +158,16 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),
   );
 
+  it.effect("prints environment validation output without starting the server", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["--validate-config"]));
+
+      assert.isTrue(output.includes("T3 Code environment validation: OK"));
+      assert.isTrue(output.includes("T3CODE_PORT"));
+      assert.isTrue(output.includes("Required variables: none currently"));
+    }),
+  );
+
   it.effect("rejects invalid log-level casing before launching the server", () =>
     Effect.gen(function* () {
       const error = yield* runCliWithRuntime(["--log-level", "Debug"]).pipe(Effect.flip);

--- a/t3code/apps/server/src/cli/config.ts
+++ b/t3code/apps/server/src/cli/config.ts
@@ -80,6 +80,10 @@ export const tailscaleServePortFlag = Flag.integer("tailscale-serve-port").pipe(
   Flag.withDescription("HTTPS port for Tailscale Serve when --tailscale-serve is enabled."),
   Flag.optional,
 );
+export const validateConfigFlag = Flag.boolean("validate-config").pipe(
+  Flag.withDescription("Validate environment configuration and exit without starting the server."),
+  Flag.optional,
+);
 
 const EnvServerConfig = Config.all({
   logLevel: Config.logLevel("T3CODE_LOG_LEVEL").pipe(Config.withDefault("Info")),
@@ -151,6 +155,7 @@ export interface CliServerFlags {
   readonly logWebSocketEvents: Option.Option<boolean>;
   readonly tailscaleServeEnabled: Option.Option<boolean>;
   readonly tailscaleServePort: Option.Option<number>;
+  readonly validateConfig?: Option.Option<boolean>;
 }
 
 export interface CliAuthLocationFlags {
@@ -185,6 +190,7 @@ export const sharedServerCommandFlags = {
   logWebSocketEvents: logWebSocketEventsFlag,
   tailscaleServeEnabled: tailscaleServeFlag,
   tailscaleServePort: tailscaleServePortFlag,
+  validateConfig: validateConfigFlag,
 } as const;
 
 export const authLocationFlags = sharedServerLocationFlags;

--- a/t3code/apps/server/src/cli/server.ts
+++ b/t3code/apps/server/src/cli/server.ts
@@ -1,7 +1,10 @@
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import { Command, GlobalFlag } from "effect/unstable/cli";
 
 import { ServerConfig, type StartupPresentation } from "../config.ts";
+import { formatServerEnvValidation, validateServerEnv } from "../envValidation.ts";
 import { runServer } from "../server.ts";
 import { type CliServerFlags, resolveServerConfig, sharedServerCommandFlags } from "./config.ts";
 
@@ -13,6 +16,19 @@ export const runServerCommand = (
   },
 ) =>
   Effect.gen(function* () {
+    const validateConfigOnly = Option.getOrElse(flags.validateConfig ?? Option.none(), () => false);
+    const envValidation = validateServerEnv();
+    if (validateConfigOnly || !envValidation.ok) {
+      const output = formatServerEnvValidation(envValidation);
+      yield* envValidation.ok ? Console.log(output) : Console.error(output);
+      if (!envValidation.ok) {
+        yield* Effect.sync(() => {
+          process.exitCode = 1;
+        });
+      }
+      return;
+    }
+
     const logLevel = yield* GlobalFlag.LogLevel;
     const config = yield* resolveServerConfig(flags, logLevel, options);
     return yield* runServer.pipe(Effect.provideService(ServerConfig, config));

--- a/t3code/apps/server/src/envValidation.test.ts
+++ b/t3code/apps/server/src/envValidation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { formatServerEnvValidation, validateServerEnv } from "./envValidation.ts";
+
+describe("server environment validation", () => {
+  it("accepts an empty environment and documents optional defaults", () => {
+    const result = validateServerEnv({});
+    const output = formatServerEnvValidation(result);
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(output).toContain("T3 Code environment validation: OK");
+    expect(output).toContain("Required variables: none currently");
+    expect(output).toContain("T3CODE_PORT");
+    expect(output).toContain("3773 or available port");
+    expect(output).toContain("T3CODE_TAILSCALE_SERVE_PORT");
+    expect(output).toContain("443");
+  });
+
+  it("accepts valid configured environment values", () => {
+    const result = validateServerEnv({
+      T3CODE_LOG_LEVEL: "Debug",
+      T3CODE_TRACE_MIN_LEVEL: "Warn",
+      T3CODE_TRACE_TIMING_ENABLED: "false",
+      T3CODE_TRACE_MAX_BYTES: "4096",
+      T3CODE_TRACE_MAX_FILES: "5",
+      T3CODE_TRACE_BATCH_WINDOW_MS: "50",
+      T3CODE_OTLP_TRACES_URL: "http://localhost:4318/v1/traces",
+      T3CODE_OTLP_METRICS_URL: "http://localhost:4318/v1/metrics",
+      T3CODE_OTLP_EXPORT_INTERVAL_MS: "2500",
+      T3CODE_OTLP_SERVICE_NAME: "local-t3",
+      T3CODE_MODE: "desktop",
+      T3CODE_PORT: "4888",
+      T3CODE_HOST: "127.0.0.1",
+      T3CODE_HOME: "/tmp/t3-home",
+      VITE_DEV_SERVER_URL: "http://127.0.0.1:5173",
+      T3CODE_NO_BROWSER: "true",
+      T3CODE_BOOTSTRAP_FD: "3",
+      T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "false",
+      T3CODE_LOG_WS_EVENTS: "true",
+      T3CODE_TAILSCALE_SERVE: "false",
+      T3CODE_TAILSCALE_SERVE_PORT: "443",
+      T3CODE_TELEMETRY_ENABLED: "false",
+      T3CODE_POSTHOG_KEY: "phc_custom",
+      T3CODE_POSTHOG_HOST: "https://posthog.test.local",
+      T3CODE_TELEMETRY_FLUSH_BATCH_SIZE: "10",
+      T3CODE_TELEMETRY_MAX_BUFFERED_EVENTS: "500",
+      T3CODE_BITBUCKET_API_BASE_URL: "https://bitbucket.test.local/2.0",
+      T3CODE_BITBUCKET_ACCESS_TOKEN: "access-token",
+      T3CODE_BITBUCKET_EMAIL: "user@example.com",
+      T3CODE_BITBUCKET_API_TOKEN: "api-token",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.rows.find((row) => row.name === "T3CODE_PORT")?.status).toBe("valid");
+  });
+
+  it("redacts sensitive configured values in the formatted output", () => {
+    const result = validateServerEnv({
+      T3CODE_POSTHOG_KEY: "phc_secret",
+      T3CODE_BITBUCKET_ACCESS_TOKEN: "access-secret",
+      T3CODE_BITBUCKET_EMAIL: "person@example.com",
+      T3CODE_BITBUCKET_API_TOKEN: "api-secret",
+    });
+    const output = formatServerEnvValidation(result);
+
+    expect(result.ok).toBe(true);
+    expect(output).toContain("T3CODE_POSTHOG_KEY");
+    expect(output).toContain("[set]");
+    expect(output).not.toContain("phc_secret");
+    expect(output).not.toContain("access-secret");
+    expect(output).not.toContain("person@example.com");
+    expect(output).not.toContain("api-secret");
+  });
+
+  it("reports invalid values with expected formats and received values", () => {
+    const result = validateServerEnv({
+      T3CODE_TRACE_TIMING_ENABLED: "sometimes",
+      T3CODE_TRACE_MAX_BYTES: "-1",
+      T3CODE_MODE: "mobile",
+      T3CODE_PORT: "abc",
+      VITE_DEV_SERVER_URL: "not a url",
+      T3CODE_BOOTSTRAP_FD: "-1",
+      T3CODE_POSTHOG_HOST: "not a url either",
+      T3CODE_TELEMETRY_FLUSH_BATCH_SIZE: "NaN",
+      T3CODE_BITBUCKET_API_BASE_URL: "bitbucket",
+    });
+    const output = formatServerEnvValidation(result);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((row) => row.name)).toEqual([
+      "T3CODE_TRACE_TIMING_ENABLED",
+      "T3CODE_TRACE_MAX_BYTES",
+      "T3CODE_MODE",
+      "T3CODE_PORT",
+      "VITE_DEV_SERVER_URL",
+      "T3CODE_BOOTSTRAP_FD",
+      "T3CODE_POSTHOG_HOST",
+      "T3CODE_TELEMETRY_FLUSH_BATCH_SIZE",
+      "T3CODE_BITBUCKET_API_BASE_URL",
+    ]);
+    expect(output).toContain("T3 Code environment validation: FAILED");
+    expect(output).toContain("true or false");
+    expect(output).toContain("sometimes");
+    expect(output).toContain("web or desktop");
+    expect(output).toContain("mobile");
+    expect(output).toContain("port 1-65535");
+    expect(output).toContain("abc");
+    expect(output).toContain("absolute URL");
+    expect(output).toContain("not a url");
+    expect(output).toContain("not a url either");
+    expect(output).toContain("NaN");
+    expect(output).toContain("bitbucket");
+  });
+
+  it("includes all rows in failure output so defaulted variables remain documented", () => {
+    const result = validateServerEnv({ T3CODE_PORT: "99999" });
+    const output = formatServerEnvValidation(result);
+
+    expect(result.ok).toBe(false);
+    expect(output).toContain("T3CODE_LOG_LEVEL");
+    expect(output).toContain("Info");
+    expect(output).toContain("T3CODE_PORT");
+    expect(output).toContain("99999");
+  });
+});

--- a/t3code/apps/server/src/envValidation.ts
+++ b/t3code/apps/server/src/envValidation.ts
@@ -1,0 +1,439 @@
+import * as Schema from "effect/Schema";
+
+type EnvVarKind =
+  | "boolean"
+  | "integer"
+  | "log-level"
+  | "mode"
+  | "number"
+  | "port"
+  | "string"
+  | "url";
+
+interface ServerEnvSpec {
+  readonly name: string;
+  readonly kind: EnvVarKind;
+  readonly required?: boolean;
+  readonly sensitive?: boolean;
+  readonly defaultValue?: string;
+  readonly expected: string;
+  readonly description: string;
+}
+
+export type EnvValidationStatus = "default" | "invalid" | "missing" | "valid";
+
+export interface EnvValidationRow {
+  readonly name: string;
+  readonly status: EnvValidationStatus;
+  readonly expected: string;
+  readonly received: string | undefined;
+  readonly defaultValue: string | undefined;
+  readonly required: boolean;
+  readonly description: string;
+}
+
+export interface EnvValidationResult {
+  readonly ok: boolean;
+  readonly rows: ReadonlyArray<EnvValidationRow>;
+  readonly issues: ReadonlyArray<EnvValidationRow>;
+}
+
+export const ServerEnvSchema = Schema.Struct({
+  T3CODE_LOG_LEVEL: Schema.optional(Schema.String),
+  T3CODE_TRACE_MIN_LEVEL: Schema.optional(Schema.String),
+  T3CODE_TRACE_TIMING_ENABLED: Schema.optional(Schema.String),
+  T3CODE_TRACE_FILE: Schema.optional(Schema.String),
+  T3CODE_TRACE_MAX_BYTES: Schema.optional(Schema.String),
+  T3CODE_TRACE_MAX_FILES: Schema.optional(Schema.String),
+  T3CODE_TRACE_BATCH_WINDOW_MS: Schema.optional(Schema.String),
+  T3CODE_OTLP_TRACES_URL: Schema.optional(Schema.String),
+  T3CODE_OTLP_METRICS_URL: Schema.optional(Schema.String),
+  T3CODE_OTLP_EXPORT_INTERVAL_MS: Schema.optional(Schema.String),
+  T3CODE_OTLP_SERVICE_NAME: Schema.optional(Schema.String),
+  T3CODE_MODE: Schema.optional(Schema.String),
+  T3CODE_PORT: Schema.optional(Schema.String),
+  T3CODE_HOST: Schema.optional(Schema.String),
+  T3CODE_HOME: Schema.optional(Schema.String),
+  VITE_DEV_SERVER_URL: Schema.optional(Schema.String),
+  T3CODE_NO_BROWSER: Schema.optional(Schema.String),
+  T3CODE_BOOTSTRAP_FD: Schema.optional(Schema.String),
+  T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: Schema.optional(Schema.String),
+  T3CODE_LOG_WS_EVENTS: Schema.optional(Schema.String),
+  T3CODE_TAILSCALE_SERVE: Schema.optional(Schema.String),
+  T3CODE_TAILSCALE_SERVE_PORT: Schema.optional(Schema.String),
+  T3CODE_TELEMETRY_ENABLED: Schema.optional(Schema.String),
+  T3CODE_POSTHOG_KEY: Schema.optional(Schema.String),
+  T3CODE_POSTHOG_HOST: Schema.optional(Schema.String),
+  T3CODE_TELEMETRY_FLUSH_BATCH_SIZE: Schema.optional(Schema.String),
+  T3CODE_TELEMETRY_MAX_BUFFERED_EVENTS: Schema.optional(Schema.String),
+  T3CODE_BITBUCKET_API_BASE_URL: Schema.optional(Schema.String),
+  T3CODE_BITBUCKET_ACCESS_TOKEN: Schema.optional(Schema.String),
+  T3CODE_BITBUCKET_EMAIL: Schema.optional(Schema.String),
+  T3CODE_BITBUCKET_API_TOKEN: Schema.optional(Schema.String),
+});
+
+export type ServerEnvShape = typeof ServerEnvSchema.Type;
+
+const decodeServerEnv = Schema.decodeUnknownSync(ServerEnvSchema);
+
+const LogLevels = new Set([
+  "all",
+  "fatal",
+  "error",
+  "warning",
+  "warn",
+  "info",
+  "debug",
+  "trace",
+  "none",
+]);
+
+export const ServerEnvSpecs: ReadonlyArray<ServerEnvSpec> = [
+  {
+    name: "T3CODE_LOG_LEVEL",
+    kind: "log-level",
+    defaultValue: "Info",
+    expected: "log level",
+    description: "Minimum level emitted to the server console.",
+  },
+  {
+    name: "T3CODE_TRACE_MIN_LEVEL",
+    kind: "log-level",
+    defaultValue: "Info",
+    expected: "log level",
+    description: "Minimum level written to the structured trace file.",
+  },
+  {
+    name: "T3CODE_TRACE_TIMING_ENABLED",
+    kind: "boolean",
+    defaultValue: "true",
+    expected: "true or false",
+    description: "Enables timing fields in server trace output.",
+  },
+  {
+    name: "T3CODE_TRACE_FILE",
+    kind: "string",
+    expected: "file path",
+    description: "Optional override for the server trace file path.",
+  },
+  {
+    name: "T3CODE_TRACE_MAX_BYTES",
+    kind: "integer",
+    defaultValue: String(10 * 1024 * 1024),
+    expected: "positive integer",
+    description: "Maximum size of each trace file before rotation.",
+  },
+  {
+    name: "T3CODE_TRACE_MAX_FILES",
+    kind: "integer",
+    defaultValue: "10",
+    expected: "positive integer",
+    description: "Maximum number of rotated trace files to keep.",
+  },
+  {
+    name: "T3CODE_TRACE_BATCH_WINDOW_MS",
+    kind: "integer",
+    defaultValue: "200",
+    expected: "positive integer milliseconds",
+    description: "Batch window for trace writes.",
+  },
+  {
+    name: "T3CODE_OTLP_TRACES_URL",
+    kind: "url",
+    expected: "absolute URL",
+    description: "Optional OTLP traces endpoint.",
+  },
+  {
+    name: "T3CODE_OTLP_METRICS_URL",
+    kind: "url",
+    expected: "absolute URL",
+    description: "Optional OTLP metrics endpoint.",
+  },
+  {
+    name: "T3CODE_OTLP_EXPORT_INTERVAL_MS",
+    kind: "integer",
+    defaultValue: "10000",
+    expected: "positive integer milliseconds",
+    description: "OTLP export interval.",
+  },
+  {
+    name: "T3CODE_OTLP_SERVICE_NAME",
+    kind: "string",
+    defaultValue: "t3-server",
+    expected: "non-empty string",
+    description: "Service name attached to telemetry exports.",
+  },
+  {
+    name: "T3CODE_MODE",
+    kind: "mode",
+    defaultValue: "web",
+    expected: "web or desktop",
+    description: "Runtime mode for server startup defaults.",
+  },
+  {
+    name: "T3CODE_PORT",
+    kind: "port",
+    defaultValue: "3773 or available port",
+    expected: "port 1-65535",
+    description: "HTTP and WebSocket listener port.",
+  },
+  {
+    name: "T3CODE_HOST",
+    kind: "string",
+    expected: "host or IP address",
+    description: "Optional host/interface to bind.",
+  },
+  {
+    name: "T3CODE_HOME",
+    kind: "string",
+    expected: "directory path",
+    description: "Optional base directory for server state.",
+  },
+  {
+    name: "VITE_DEV_SERVER_URL",
+    kind: "url",
+    expected: "absolute URL",
+    description: "Optional web dev server URL.",
+  },
+  {
+    name: "T3CODE_NO_BROWSER",
+    kind: "boolean",
+    defaultValue: "desktop mode true, web mode false",
+    expected: "true or false",
+    description: "Disables automatic browser opening.",
+  },
+  {
+    name: "T3CODE_BOOTSTRAP_FD",
+    kind: "integer",
+    expected: "non-negative integer",
+    description: "Optional file descriptor for desktop bootstrap secrets.",
+  },
+  {
+    name: "T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD",
+    kind: "boolean",
+    defaultValue: "true in web mode",
+    expected: "true or false",
+    description: "Creates a startup project for the current directory when missing.",
+  },
+  {
+    name: "T3CODE_LOG_WS_EVENTS",
+    kind: "boolean",
+    defaultValue: "true when dev URL is set",
+    expected: "true or false",
+    description: "Logs outbound WebSocket push events.",
+  },
+  {
+    name: "T3CODE_TAILSCALE_SERVE",
+    kind: "boolean",
+    defaultValue: "false",
+    expected: "true or false",
+    description: "Enables Tailscale Serve setup.",
+  },
+  {
+    name: "T3CODE_TAILSCALE_SERVE_PORT",
+    kind: "port",
+    defaultValue: "443",
+    expected: "port 1-65535",
+    description: "HTTPS port used for Tailscale Serve.",
+  },
+  {
+    name: "T3CODE_TELEMETRY_ENABLED",
+    kind: "boolean",
+    defaultValue: "true",
+    expected: "true or false",
+    description: "Enables anonymous PostHog telemetry.",
+  },
+  {
+    name: "T3CODE_POSTHOG_KEY",
+    kind: "string",
+    sensitive: true,
+    defaultValue: "bundled PostHog project key",
+    expected: "non-empty string",
+    description: "Project key used for telemetry events.",
+  },
+  {
+    name: "T3CODE_POSTHOG_HOST",
+    kind: "url",
+    defaultValue: "https://us.i.posthog.com",
+    expected: "absolute URL",
+    description: "PostHog ingestion host.",
+  },
+  {
+    name: "T3CODE_TELEMETRY_FLUSH_BATCH_SIZE",
+    kind: "integer",
+    defaultValue: "20",
+    expected: "positive integer",
+    description: "Maximum telemetry events sent per flush.",
+  },
+  {
+    name: "T3CODE_TELEMETRY_MAX_BUFFERED_EVENTS",
+    kind: "integer",
+    defaultValue: "1000",
+    expected: "positive integer",
+    description: "Maximum telemetry events buffered in memory.",
+  },
+  {
+    name: "T3CODE_BITBUCKET_API_BASE_URL",
+    kind: "url",
+    defaultValue: "https://api.bitbucket.org/2.0",
+    expected: "absolute URL",
+    description: "Bitbucket Cloud API base URL.",
+  },
+  {
+    name: "T3CODE_BITBUCKET_ACCESS_TOKEN",
+    kind: "string",
+    sensitive: true,
+    expected: "non-empty string",
+    description: "Optional Bitbucket bearer access token.",
+  },
+  {
+    name: "T3CODE_BITBUCKET_EMAIL",
+    kind: "string",
+    sensitive: true,
+    expected: "non-empty string",
+    description: "Optional Bitbucket account email for API-token auth.",
+  },
+  {
+    name: "T3CODE_BITBUCKET_API_TOKEN",
+    kind: "string",
+    sensitive: true,
+    expected: "non-empty string",
+    description: "Optional Bitbucket API token used with T3CODE_BITBUCKET_EMAIL.",
+  },
+];
+
+const hasValue = (value: string | undefined): value is string =>
+  value !== undefined && value.trim() !== "";
+
+const isInteger = (value: string): boolean => {
+  if (!/^-?\d+$/.test(value)) return false;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed);
+};
+
+const isPositiveInteger = (value: string): boolean => isInteger(value) && Number(value) > 0;
+
+const isNonNegativeInteger = (value: string): boolean => isInteger(value) && Number(value) >= 0;
+
+const isNumber = (value: string): boolean => {
+  const parsed = Number(value);
+  return value.trim() !== "" && Number.isFinite(parsed);
+};
+
+const isPort = (value: string): boolean => {
+  if (!isInteger(value)) return false;
+  const parsed = Number(value);
+  return parsed >= 1 && parsed <= 65535;
+};
+
+const isUrl = (value: string): boolean => {
+  try {
+    return new URL(value).href.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+const isValidValue = (spec: ServerEnvSpec, value: string): boolean => {
+  switch (spec.kind) {
+    case "boolean":
+      return value === "true" || value === "false";
+    case "integer":
+      return spec.name === "T3CODE_BOOTSTRAP_FD"
+        ? isNonNegativeInteger(value)
+        : isPositiveInteger(value);
+    case "log-level":
+      return LogLevels.has(value.toLowerCase());
+    case "mode":
+      return value === "web" || value === "desktop";
+    case "number":
+      return isNumber(value);
+    case "port":
+      return isPort(value);
+    case "string":
+      return value.trim().length > 0;
+    case "url":
+      return isUrl(value);
+  }
+};
+
+export const validateServerEnv = (
+  env: Record<string, string | undefined> = process.env,
+): EnvValidationResult => {
+  const decoded = decodeServerEnv(env) as Record<string, string | undefined>;
+  const rows = ServerEnvSpecs.map((spec): EnvValidationRow => {
+    const received = decoded[spec.name];
+    if (!hasValue(received)) {
+      return {
+        name: spec.name,
+        status: spec.required ? "missing" : "default",
+        expected: spec.expected,
+        received,
+        defaultValue: spec.defaultValue,
+        required: spec.required === true,
+        description: spec.description,
+      };
+    }
+
+    return {
+      name: spec.name,
+      status: isValidValue(spec, received) ? "valid" : "invalid",
+      expected: spec.expected,
+      received,
+      defaultValue: spec.defaultValue,
+      required: spec.required === true,
+      description: spec.description,
+    };
+  });
+  const issues = rows.filter((row) => row.status === "missing" || row.status === "invalid");
+  return { ok: issues.length === 0, rows, issues };
+};
+
+const normalizeCell = (value: string | undefined): string => {
+  if (value === undefined || value.trim() === "") return "-";
+  return value.replaceAll("\n", " ");
+};
+
+const formatReceivedCell = (row: EnvValidationRow): string => {
+  const spec = ServerEnvSpecs.find((candidate) => candidate.name === row.name);
+  if (spec?.sensitive && hasValue(row.received)) return "[set]";
+  return normalizeCell(row.received);
+};
+
+const padCell = (value: string, width: number): string => value.padEnd(width, " ");
+
+export const formatServerEnvValidation = (result: EnvValidationResult): string => {
+  const headers = ["Variable", "Status", "Required", "Expected", "Received", "Default"];
+  const bodyRows = result.rows.map((row) => [
+    row.name,
+    row.status,
+    row.required ? "yes" : "no",
+    row.expected,
+    formatReceivedCell(row),
+    normalizeCell(row.defaultValue),
+  ]);
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...bodyRows.map((row) => row[index]?.length ?? 0)),
+  );
+  const formatRow = (row: ReadonlyArray<string>) =>
+    row.map((cell, index) => padCell(cell, widths[index] ?? cell.length)).join("  ");
+
+  const lines = [
+    `T3 Code environment validation: ${result.ok ? "OK" : "FAILED"}`,
+    `Issues: ${result.issues.length}`,
+    "Required variables: none currently; optional variables and defaults are listed below.",
+    "",
+    formatRow(headers),
+    formatRow(widths.map((width) => "-".repeat(width))),
+    ...bodyRows.map(formatRow),
+  ];
+
+  if (!result.ok) {
+    lines.push(
+      "",
+      "Invalid configuration prevents server startup. Fix the rows marked invalid or missing.",
+    );
+  }
+
+  return lines.join("\n");
+};


### PR DESCRIPTION
/claim #853

## Summary
- Added a focused server environment validation layer for T3 Code server startup using Effect Schema-shaped env coverage.
- Validates CLI, telemetry, and Bitbucket-related T3CODE/VITE env vars before server config resolution or listener startup.
- Added `--validate-config` to print the validation table and exit without starting the server.
- Redacts sensitive configured values such as project keys, tokens, and emails in formatted output.
- Included `_provenance.json` with safe non-sensitive submission metadata.

## Demo / Proof
- Demo video: https://github.com/wcx1102/Bounty-Hunters/releases/download/pr-6313-demo-20260605/t3code-env-validation-pr-6313-demo.mp4
- The demo shows a successful validation run, an invalid `T3CODE_PORT` run that exits with code 1, and sensitive env value redaction.

## Verification
- `bun fmt`
- `bun run test src/envValidation.test.ts src/bin.test.ts` (2 files passed, 15 tests passed)
- `NODE_OPTIONS=--experimental-strip-types bun lint` (0 errors, existing web warnings only)
- `bun typecheck` (13 packages passed)
- `git diff --check`
- `python3 -m json.tool t3code/apps/server/src/_provenance.json`
- `bun --cwd t3code/apps/server src/bin.ts --validate-config`
- `env T3CODE_PORT=abc T3CODE_POSTHOG_KEY=secret-token bun --cwd t3code/apps/server src/bin.ts --validate-config` exits with 1 and redacts the sensitive value

## Security / Privacy
Private system, developer, runtime, and credential-bearing instructions are not included in the PR or repository files. Payment details can be provided privately after maintainer acceptance.
