### PR TITLE
OpenAI Codex [ FastAPI ] Add run_concurrently helper

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Private system, developer, runtime, and credential-bearing instructions are not included in repository files or public PR text. Public submission context: implement UnsafeLabs/Bounty-Hunters issue #803 by adding a FastAPI run_concurrently helper, focused tests, and safe review materials.",
+  "timestamp": "2026-06-05T11:45:36Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,9 @@
-from collections.abc import AsyncGenerator
+import asyncio
+import inspect
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +14,72 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+_Unset = object()
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        failures: Sequence[Exception],
+        partial_results: Sequence[Any],
+        failed_indices: Sequence[int | None],
+    ) -> None:
+        self.failures = list(failures)
+        self.partial_results = list(partial_results)
+        self.failed_indices = list(failed_indices)
+        super().__init__(
+            f"{len(self.failures)} concurrent task"
+            f"{'s' if len(self.failures) != 1 else ''} failed"
+        )
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be greater than or equal to 1")
+    if not coroutines:
+        return []
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [_Unset] * len(coroutines)
+    failures: list[Exception] = []
+    failed_indices: list[int | None] = []
+
+    async def run_one(index: int, coroutine: Awaitable[_T]) -> None:
+        started = False
+        try:
+            async with semaphore:
+                started = True
+                results[index] = await coroutine
+        except asyncio.CancelledError:
+            if not started and inspect.iscoroutine(coroutine):
+                coroutine.close()
+            raise
+        except Exception as exc:
+            failures.append(exc)
+            failed_indices.append(index)
+
+    tasks = [
+        asyncio.create_task(run_one(index, coroutine))
+        for index, coroutine in enumerate(coroutines)
+    ]
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=timeout)
+    except TimeoutError as exc:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        failures.append(exc)
+        failed_indices.append(None)
+
+    if failures:
+        partial_results = [None if result is _Unset else result for result in results]
+        raise ConcurrencyError(failures, partial_results, failed_indices)
+
+    return cast(list[_T], results)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,136 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_limits_active_tasks() -> None:
+    active = 0
+    max_seen = 0
+
+    async def tracked(value: int) -> int:
+        nonlocal active, max_seen
+        active += 1
+        max_seen = max(max_seen, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return value
+
+    result = await run_concurrently([tracked(index) for index in range(6)], 2)
+
+    assert result == [0, 1, 2, 3, 4, 5]
+    assert max_seen == 2
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_preserves_input_order() -> None:
+    async def delayed(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    result = await run_concurrently(
+        [delayed(1, 0.03), delayed(2, 0.01), delayed(3, 0.02)],
+        3,
+    )
+
+    assert result == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_collects_all_failures() -> None:
+    async def fail_with(exc: Exception) -> None:
+        await asyncio.sleep(0)
+        raise exc
+
+    async def succeed() -> str:
+        await asyncio.sleep(0)
+        return "ok"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [
+                fail_with(ValueError("first")),
+                succeed(),
+                fail_with(RuntimeError("second")),
+            ],
+            3,
+        )
+
+    error = exc_info.value
+    assert [type(exc) for exc in error.failures] == [ValueError, RuntimeError]
+    assert error.failed_indices == [0, 2]
+    assert error.partial_results == [None, "ok", None]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_timeout_cancels_remaining_tasks() -> None:
+    cancelled = False
+
+    async def quick() -> str:
+        await asyncio.sleep(0.01)
+        return "done"
+
+    async def slow() -> str:
+        nonlocal cancelled
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+        return "late"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([quick(), slow()], 2, timeout=0.05)
+
+    error = exc_info.value
+    assert any(isinstance(exc, TimeoutError) for exc in error.failures)
+    assert error.partial_results == ["done", None]
+    assert error.failed_indices == [None]
+    assert cancelled is True
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_max_concurrency_one_runs_sequentially() -> None:
+    events: list[str] = []
+
+    async def tracked(value: int) -> int:
+        events.append(f"start-{value}")
+        await asyncio.sleep(0)
+        events.append(f"end-{value}")
+        return value
+
+    result = await run_concurrently([tracked(1), tracked(2), tracked(3)], 1)
+
+    assert result == [1, 2, 3]
+    assert events == ["start-1", "end-1", "start-2", "end-2", "start-3", "end-3"]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_allows_concurrency_above_task_count() -> None:
+    active = 0
+    max_seen = 0
+
+    async def tracked(value: int) -> int:
+        nonlocal active, max_seen
+        active += 1
+        max_seen = max(max_seen, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return value
+
+    result = await run_concurrently([tracked(1), tracked(2), tracked(3)], 10)
+
+    assert result == [1, 2, 3]
+    assert max_seen == 3
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_rejects_invalid_max_concurrency() -> None:
+    with pytest.raises(ValueError):
+        await run_concurrently([], 0)


### PR DESCRIPTION
/claim #803

## Summary
- Added `ConcurrencyError` and `run_concurrently()` to `fastapi.concurrency`.
- Uses `asyncio.Semaphore` to enforce `max_concurrency` while preserving input-order results.
- Collects task failures into `ConcurrencyError.failures`, exposes `failed_indices`, and includes `partial_results`.
- Supports a total `timeout` that cancels unfinished tasks and reports a timeout failure with partial results.
- Included `_contributor.json` with safe non-sensitive submission metadata.

## Demo / Proof
- Demo video: https://github.com/wcx1102/Bounty-Hunters/releases/download/pr-6314-demo-20260605/fastapi-run-concurrently-pr-6314-demo.mp4

## Verification
- `uv run pytest tests/test_concurrency.py -q` (7 passed)
- `uv run ruff check fastapi/concurrency.py tests/test_concurrency.py`
- `uv run ruff format --check fastapi/concurrency.py tests/test_concurrency.py`
- `uv run mypy fastapi/concurrency.py`
- `python3 -m json.tool fastapi/_contributor.json`
- `git diff --check`

## Security / Privacy
Private system, developer, runtime, and credential-bearing instructions are not included in the PR or repository files. Payment details can be provided privately after maintainer acceptance.
