### PR TITLE
[OpenAI Codex] [ Laravel ] Fix DatabaseSeeder idempotency and roles

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+    "agent_name": "OpenAI Codex",
+    "config_snapshot": "Private system, developer, runtime, session, and credential-bearing instructions are not included. This file intentionally contains safe public submission metadata only.",
+    "created": "2026-06-05T12:31:49Z"
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word(),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_06_05_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_06_05_000000_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -17,9 +17,13 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
+        User::firstOrCreate([
             'email' => 'test@example.com',
+        ], [
+            'name' => 'Test User',
+            'password' => 'password',
         ]);
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * @var array<int, array{name: string, description: string}>
+     */
+    private const ROLES = [
+        [
+            'name' => 'admin',
+            'description' => 'Full access to manage the application.',
+        ],
+        [
+            'name' => 'editor',
+            'description' => 'Can create and update application content.',
+        ],
+        [
+            'name' => 'viewer',
+            'description' => 'Read-only access to application content.',
+        ],
+    ];
+
+    /**
+     * Seed the default application roles.
+     */
+    public function run(): void
+    {
+        foreach (self::ROLES as $role) {
+            Role::firstOrCreate([
+                'name' => $role['name'],
+            ], [
+                'description' => $role['description'],
+            ]);
+        }
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_can_run_more_than_once(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+            'name' => 'Test User',
+        ]);
+
+        $this->assertSame(3, Role::count());
+        $this->assertDefaultRolesExist();
+    }
+
+    public function test_role_seeder_can_run_more_than_once(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertSame(3, Role::count());
+        $this->assertDefaultRolesExist();
+    }
+
+    public function test_role_factory_creates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertNotEmpty($role->name);
+        $this->assertNotEmpty($role->description);
+        $this->assertDatabaseHas('roles', [
+            'id' => $role->id,
+            'name' => $role->name,
+            'description' => $role->description,
+        ]);
+    }
+
+    private function assertDefaultRolesExist(): void
+    {
+        foreach (['admin', 'editor', 'viewer'] as $roleName) {
+            $this->assertDatabaseHas('roles', [
+                'name' => $roleName,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- Made the default test user seed idempotent with `User::firstOrCreate()`.
- Added a `Role` model, `roles` migration, `RoleFactory`, and idempotent `RoleSeeder` for `admin`, `editor`, and `viewer`.
- Added feature coverage for repeated `DatabaseSeeder` and `RoleSeeder` runs plus Role factory validity.
- Included safe public provenance metadata without private runtime/system/developer instructions.

## Verification
- Parsed touched PHP files with `php-parser`: `Role.php`, `RoleFactory.php`, roles migration, `DatabaseSeeder.php`, `RoleSeeder.php`, and `DatabaseSeederTest.php`.
- Static checks passed for `User::firstOrCreate`, `RoleSeeder` call, role idempotency, default role names, unique role name migration, test coverage, and provenance safety text.
- `laravel/.provenance.json` parses successfully.
- `git diff --check` and staged whitespace checks passed.

Full `php artisan test` was not run because this local environment does not have PHP, Composer, or Docker installed.

Payment details can be provided privately after maintainer acceptance.

## Demo
- [Demo video](https://github.com/wcx1102/Bounty-Hunters/releases/download/pr-6319-demo-20260605/laravel-idempotent-roles-pr-6319-demo.mp4)