### PR TITLE
[OpenAI Codex] [ Laravel ] Fix logging channels and JSON formatter

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+    "tool_name": "OpenAI Codex",
+    "boot_context": "Private system, developer, runtime, session, and credential-bearing instructions are not included. This file intentionally contains safe public submission metadata only.",
+    "timestamp": "2026-06-05T12:40:24Z"
+}

--- a/laravel/app/Logging/JsonLogFormatter.php
+++ b/laravel/app/Logging/JsonLogFormatter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\LogRecord;
+
+class JsonLogFormatter extends NormalizerFormatter
+{
+    /**
+     * Format a log record as one JSON object per line.
+     */
+    public function format(LogRecord $record): string
+    {
+        return $this->toJson([
+            'timestamp' => $record->datetime->format('c'),
+            'level' => $record->level->getName(),
+            'message' => $record->message,
+            'context' => $record->context,
+        ], true).PHP_EOL;
+    }
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\JsonLogFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,24 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/laravel-json.log'),
+            ],
+            'formatter' => JsonLogFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [

--- a/laravel/tests/Unit/LoggingConfigTest.php
+++ b/laravel/tests/Unit/LoggingConfigTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Logging\JsonLogFormatter;
+use DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Tests\TestCase;
+
+class LoggingConfigTest extends TestCase
+{
+    public function test_stack_writes_to_daily_and_error_logs_by_default(): void
+    {
+        $stack = config('logging.channels.stack');
+
+        $this->assertSame('stack', $stack['driver']);
+        $this->assertSame(['daily', 'error'], $stack['channels']);
+        $this->assertFalse($stack['ignore_exceptions']);
+    }
+
+    public function test_error_channel_writes_only_error_and_above_to_error_log(): void
+    {
+        $error = config('logging.channels.error');
+
+        $this->assertSame('single', $error['driver']);
+        $this->assertStringEndsWith('storage/logs/error.log', $error['path']);
+        $this->assertSame('error', $error['level']);
+        $this->assertTrue($error['replace_placeholders']);
+    }
+
+    public function test_daily_channel_keeps_fourteen_days(): void
+    {
+        $this->assertEquals(14, config('logging.channels.daily.days'));
+    }
+
+    public function test_json_channel_uses_structured_formatter(): void
+    {
+        $json = config('logging.channels.json');
+
+        $this->assertSame('monolog', $json['driver']);
+        $this->assertSame(JsonLogFormatter::class, $json['formatter']);
+        $this->assertStringEndsWith('storage/logs/laravel-json.log', $json['handler_with']['stream']);
+    }
+
+    public function test_json_formatter_outputs_required_fields(): void
+    {
+        $formatter = new JsonLogFormatter();
+        $record = new LogRecord(
+            new DateTimeImmutable('2026-06-05T00:00:00+00:00'),
+            'testing',
+            Level::Error,
+            'Failed to process webhook',
+            ['request_id' => 'abc123'],
+            [],
+        );
+
+        $payload = json_decode($formatter->format($record), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('2026-06-05T00:00:00+00:00', $payload['timestamp']);
+        $this->assertSame('ERROR', $payload['level']);
+        $this->assertSame('Failed to process webhook', $payload['message']);
+        $this->assertSame(['request_id' => 'abc123'], $payload['context']);
+    }
+}


### PR DESCRIPTION
/claim #787

## Summary
- Updated the default Laravel log stack to write to both `daily` and a new error-only `error` channel.
- Added an `error` channel that writes ERROR and above to `storage/logs/error.log`.
- Added a `json` Monolog channel with a formatter that emits `timestamp`, `level`, `message`, and `context` fields.
- Added focused unit coverage for stack membership, error channel config, daily retention, JSON channel config, and formatter output.
- Included safe public provenance metadata without private runtime/system/developer instructions.

## Verification
- Parsed touched PHP files with `php-parser`: `JsonLogFormatter.php`, `logging.php`, and `LoggingConfigTest.php`.
- Static checks passed for stack default, error channel path/level, JSON channel, formatter fields, tests, and provenance safety text.
- `laravel/_provenance.json` parses successfully.
- `git diff --check` and staged whitespace checks passed.

Full `php artisan test` was not run because this local environment does not have PHP, Composer, or Docker installed.

Payment details can be provided privately after maintainer acceptance.

## Demo
- [Demo video](https://github.com/wcx1102/Bounty-Hunters/releases/download/pr-6320-demo-20260605/laravel-logging-pr-6320-demo.mp4)