### PR TITLE
[OpenAI Codex] [ FastAPI ] Add StreamingCSVResponse for large dataset exports

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Safe public provenance only. Private system, developer, runtime, and user instructions are intentionally not disclosed.",
+  "ts": "2026-06-06T14:16:34Z"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,5 +1,9 @@
+import csv
 import importlib
+import io
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from typing import Any, Protocol, cast
+from urllib.parse import quote
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
@@ -11,6 +15,83 @@ from starlette.responses import RedirectResponse as RedirectResponse  # noqa
 from starlette.responses import Response as Response  # noqa
 from starlette.responses import StreamingResponse as StreamingResponse  # noqa
 from typing_extensions import deprecated
+
+
+def _csv_content_disposition(filename: str) -> str:
+    safe_filename = filename.replace("\r", "_").replace("\n", "_")
+    quoted_filename = quote(safe_filename, safe="")
+    if quoted_filename == safe_filename:
+        return f'attachment; filename="{safe_filename}"'
+    return f"attachment; filename*=utf-8''{quoted_filename}"
+
+
+def _csv_row_values(
+    row: Any,
+    headers: Sequence[str] | None,
+) -> Iterable[Any]:
+    if isinstance(row, Mapping):
+        if headers is None:
+            return row.values()
+        return (row.get(header, "") for header in headers)
+    if isinstance(row, str | bytes):
+        return (row,)
+    return row
+
+
+def _render_csv_row(
+    row: Iterable[Any],
+    delimiter: str,
+) -> bytes:
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, delimiter=delimiter, lineterminator="\r\n")
+    writer.writerow("" if value is None else value for value in row)
+    return output.getvalue().encode("utf-8")
+
+
+class StreamingCSVResponse(StreamingResponse):
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        rows: AsyncIterable[Any] | Iterable[Any],
+        *,
+        headers: Sequence[str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        response_headers: Mapping[str, str] | None = None,
+        background: Any = None,
+    ) -> None:
+        http_headers = dict(response_headers or {})
+        http_headers.setdefault(
+            "Content-Disposition",
+            _csv_content_disposition(filename),
+        )
+        super().__init__(
+            self._stream_rows(rows, csv_headers=headers, delimiter=delimiter),
+            status_code=status_code,
+            headers=http_headers,
+            media_type=self.media_type,
+            background=background,
+        )
+
+    @staticmethod
+    async def _stream_rows(
+        rows: AsyncIterable[Any] | Iterable[Any],
+        *,
+        csv_headers: Sequence[str] | None,
+        delimiter: str,
+    ) -> AsyncIterable[bytes]:
+        if csv_headers is not None:
+            yield _render_csv_row(csv_headers, delimiter)
+
+        if isinstance(rows, AsyncIterable):
+            async for row in rows:
+                yield _render_csv_row(_csv_row_values(row, csv_headers), delimiter)
+            return
+
+        for row in rows:
+            yield _render_csv_row(_csv_row_values(row, csv_headers), delimiter)
 
 
 class _UjsonModule(Protocol):

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,97 @@
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+
+def test_streaming_csv_response_writes_headers_and_escapes_values():
+    app = FastAPI()
+
+    async def rows():
+        yield {"name": "Alice", "note": "hello, world"}
+        yield {"name": "Bob", "note": 'He said "hi"'}
+        yield {"name": "Carol", "note": "line\nbreak"}
+
+    @app.get("/report")
+    async def report():
+        return StreamingCSVResponse(
+            rows(),
+            headers=["name", "note"],
+            filename="report.csv",
+        )
+
+    response = TestClient(app).get("/report")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert (
+        response.headers["content-disposition"] == 'attachment; filename="report.csv"'
+    )
+    assert response.content == (
+        b"name,note\r\n"
+        b'Alice,"hello, world"\r\n'
+        b'Bob,"He said ""hi"""\r\n'
+        b'Carol,"line\nbreak"\r\n'
+    )
+
+
+def test_streaming_csv_response_supports_custom_delimiter():
+    app = FastAPI()
+
+    @app.get("/semicolon")
+    async def semicolon():
+        return StreamingCSVResponse(
+            [["alice", "uses;delimiter"], ["bob", "plain"]],
+            headers=["name", "note"],
+            delimiter=";",
+        )
+
+    response = TestClient(app).get("/semicolon")
+
+    assert response.content == (b'name;note\r\nalice;"uses;delimiter"\r\nbob;plain\r\n')
+
+
+def test_streaming_csv_response_encodes_attachment_filename():
+    response = StreamingCSVResponse(
+        [],
+        filename="sales report.csv",
+    )
+
+    assert (
+        response.headers["content-disposition"]
+        == "attachment; filename*=utf-8''sales%20report.csv"
+    )
+
+
+def test_streaming_csv_response_is_lazy():
+    app = FastAPI()
+    consumed: list[str] = []
+
+    async def rows():
+        consumed.append("row")
+        yield ["Alice"]
+
+    @app.get("/lazy")
+    async def lazy():
+        response = StreamingCSVResponse(rows(), headers=["name"])
+        assert consumed == []
+        return response
+
+    response = TestClient(app).get("/lazy")
+
+    assert response.content == b"name\r\nAlice\r\n"
+    assert consumed == ["row"]
+
+
+def test_streaming_csv_response_maps_missing_dict_values_to_empty_cells():
+    app = FastAPI()
+
+    @app.get("/missing")
+    async def missing():
+        return StreamingCSVResponse(
+            [{"name": "Alice"}],
+            headers=["name", "email"],
+        )
+
+    response = TestClient(app).get("/missing")
+
+    assert response.content == b"name,email\r\nAlice,\r\n"


### PR DESCRIPTION
/claim #799

## Summary
- Added `StreamingCSVResponse` in `fastapi.responses` for incremental CSV row streaming.
- Supports optional column headers, configurable attachment filenames, custom delimiters, and RFC 4180 escaping through Python `csv.writer`.
- Added focused tests for headers, escaping, custom delimiters, attachment filenames, lazy row consumption, and missing dict values.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-799-demo-20260606/streaming-csv-response-799-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_streaming_csv_response.py -q` -> 5 passed
- `uv run --python 3.14 ruff format --check fastapi/responses.py tests/test_streaming_csv_response.py`
- `uv run --python 3.14 ruff check fastapi/responses.py tests/test_streaming_csv_response.py`
- `git diff --check`

## Provenance
- `contributor_meta.json` contains safe public provenance only. Private system, developer, runtime, and hidden session instructions are not published.