### PR TITLE
[OpenAI Codex] [ FastAPI ] Add UploadFile validation constraints

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Safe public provenance only. Private system, developer, runtime, and user instructions are intentionally not disclosed.",
+  "ts": "2026-06-06T14:24:30Z"
+}

--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -7,6 +7,7 @@ from starlette import status as status
 from .applications import FastAPI as FastAPI
 from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
+from .datastructures import UploadFileValidationResult as UploadFileValidationResult
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
 from .param_functions import Body as Body

--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import (
     Annotated,
     Any,
@@ -8,7 +8,7 @@ from typing import (
 )
 
 from annotated_doc import Doc
-from pydantic import GetJsonSchemaHandler
+from pydantic import BaseModel, GetJsonSchemaHandler
 from starlette.datastructures import URL as URL  # noqa: F401
 from starlette.datastructures import Address as Address  # noqa: F401
 from starlette.datastructures import FormData as FormData  # noqa: F401
@@ -16,6 +16,13 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+from starlette.exceptions import HTTPException
+
+
+class UploadFileValidationResult(BaseModel):
+    is_valid: bool
+    file_size: int | None
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +69,29 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+    max_size: Annotated[
+        int | None, Doc("Optional maximum accepted file size in bytes.")
+    ]
+    allowed_content_types: Annotated[
+        Sequence[str] | None,
+        Doc("Optional allowlist of accepted MIME content types."),
+    ]
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(file=file, size=size, filename=filename, headers=headers)
+        self.max_size = max_size
+        self.allowed_content_types = (
+            tuple(allowed_content_types) if allowed_content_types is not None else None
+        )
 
     async def write(
         self,
@@ -128,6 +158,48 @@ class UploadFile(StarletteUploadFile):
         To be awaitable, compatible with async, this is run in threadpool.
         """
         return await super().close()
+
+    async def validate(self) -> UploadFileValidationResult:
+        """
+        Validate optional size and content-type constraints for this upload.
+        """
+        file_size = self._current_file_size()
+        content_type = self.content_type
+
+        if (
+            self.max_size is not None
+            and file_size is not None
+            and file_size > self.max_size
+        ):
+            raise HTTPException(status_code=413, detail="Uploaded file is too large")
+
+        if (
+            self.allowed_content_types is not None
+            and content_type not in self.allowed_content_types
+        ):
+            raise HTTPException(
+                status_code=415,
+                detail="Uploaded file content type is not supported",
+            )
+
+        return UploadFileValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=content_type,
+        )
+
+    def _current_file_size(self) -> int | None:
+        if self.size is not None:
+            return self.size
+
+        try:
+            current_position = self.file.tell()
+            self.file.seek(0, 2)
+            file_size = self.file.tell()
+            self.file.seek(current_position)
+        except (AttributeError, OSError):
+            return None
+        return file_size
 
     @classmethod
     def _validate(cls, __input_value: Any, _: Any) -> "UploadFile":

--- a/fastapi/tests/test_upload_file_validation.py
+++ b/fastapi/tests/test_upload_file_validation.py
@@ -1,0 +1,90 @@
+import io
+
+import pytest
+from fastapi import UploadFile, UploadFileValidationResult
+from starlette.datastructures import Headers
+from starlette.exceptions import HTTPException
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_returns_metadata_and_preserves_position():
+    stream = io.BytesIO(b"abcdef")
+    stream.seek(3)
+    upload = UploadFile(
+        file=stream,
+        filename="data.txt",
+        headers=Headers({"content-type": "text/plain"}),
+        max_size=10,
+        allowed_content_types=["text/plain"],
+    )
+
+    result = await upload.validate()
+
+    assert isinstance(result, UploadFileValidationResult)
+    assert result.is_valid is True
+    assert result.file_size == 6
+    assert result.content_type == "text/plain"
+    assert stream.tell() == 3
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_uses_known_size_without_reading_file():
+    stream = io.BytesIO(b"abc")
+    upload = UploadFile(
+        file=stream,
+        size=123,
+        headers=Headers({"content-type": "application/octet-stream"}),
+    )
+
+    result = await upload.validate()
+
+    assert result.file_size == 123
+    assert stream.tell() == 0
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_oversized_file():
+    upload = UploadFile(file=io.BytesIO(b"abcdef"), max_size=5)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_skips_size_check_when_max_size_is_none():
+    upload = UploadFile(file=io.BytesIO(b"abcdef"), max_size=None)
+
+    result = await upload.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 6
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_disallowed_content_type():
+    upload = UploadFile(
+        file=io.BytesIO(b"image"),
+        headers=Headers({"content-type": "image/png"}),
+        allowed_content_types=["text/plain"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload.validate()
+
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_skips_content_type_check_without_allowlist():
+    upload = UploadFile(
+        file=io.BytesIO(b"image"),
+        headers=Headers({"content-type": "image/png"}),
+        allowed_content_types=None,
+    )
+
+    result = await upload.validate()
+
+    assert result.is_valid is True
+    assert result.content_type == "image/png"


### PR DESCRIPTION
/claim #761

## Summary
- Added optional UploadFile max_size and allowed_content_types constraints while keeping defaults backward-compatible.
- Added async validate() returning UploadFileValidationResult metadata.
- Preserves file pointer position while measuring size and raises 413/415 when configured constraints fail.
- Exports UploadFileValidationResult from fastapi for callers that want to type-check the validation result.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-761-demo-20260606/uploadfile-validation-761-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout -p anyio.pytest_plugin tests/test_datastructures.py tests/test_upload_file_validation.py -q` -> 18 passed
- `uv run --python 3.14 ruff check fastapi/__init__.py fastapi/datastructures.py tests/test_datastructures.py tests/test_upload_file_validation.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/__init__.py fastapi/datastructures.py tests/test_upload_file_validation.py` -> passed
- `git diff --check` -> passed

## Provenance
- contributor_meta.json contains safe public provenance only. Private system, developer, runtime, and hidden session instructions are not published.