### PR TITLE
[OpenAI Codex] [ FastAPI ] Add concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Safe public provenance only. Private system, developer, runtime, and hidden session instructions are intentionally not disclosed.",
+  "timestamp": "2026-06-06T14:33:40Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,9 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable
+from collections.abc import Sequence as SequenceABC
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +14,59 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        failures: SequenceABC[BaseException],
+        partial_results: SequenceABC[object | None],
+    ) -> None:
+        self.failures = list(failures)
+        self.partial_results = list(partial_results)
+        super().__init__(f"{len(self.failures)} concurrent task(s) failed")
+
+
+async def run_concurrently(
+    coroutines: SequenceABC[Awaitable[_T]],
+    *,
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be greater than or equal to 1")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[_T | None] = [None] * len(coroutines)
+    failures: list[BaseException] = []
+
+    async def run_one(index: int, coroutine: Awaitable[_T]) -> None:
+        async with semaphore:
+            try:
+                results[index] = await coroutine
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                failures.append(exc)
+
+    tasks = [
+        asyncio.create_task(run_one(index, coroutine))
+        for index, coroutine in enumerate(coroutines)
+    ]
+
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=timeout)
+    except TimeoutError as exc:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        failures.append(exc)
+
+    if failures:
+        raise ConcurrencyError(failures=failures, partial_results=results)
+
+    return cast(list[_T], results)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,140 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_preserves_input_order():
+    async def work(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    results = await run_concurrently(
+        [
+            work(1, 0.03),
+            work(2, 0.01),
+            work(3, 0.02),
+        ],
+        max_concurrency=3,
+    )
+
+    assert results == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_limits_active_tasks():
+    running = 0
+    peak_running = 0
+    lock = asyncio.Lock()
+
+    async def work() -> int:
+        nonlocal running, peak_running
+        async with lock:
+            running += 1
+            peak_running = max(peak_running, running)
+        await asyncio.sleep(0.02)
+        async with lock:
+            running -= 1
+        return peak_running
+
+    await run_concurrently([work() for _ in range(5)], max_concurrency=2)
+
+    assert peak_running == 2
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_max_concurrency_one_is_sequential():
+    events: list[str] = []
+
+    async def work(value: int) -> int:
+        events.append(f"start-{value}")
+        await asyncio.sleep(0)
+        events.append(f"end-{value}")
+        return value
+
+    results = await run_concurrently([work(1), work(2)], max_concurrency=1)
+
+    assert results == [1, 2]
+    assert events == ["start-1", "end-1", "start-2", "end-2"]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_allows_concurrency_greater_than_task_count():
+    running = 0
+    peak_running = 0
+    lock = asyncio.Lock()
+
+    async def work(value: int) -> int:
+        nonlocal running, peak_running
+        async with lock:
+            running += 1
+            peak_running = max(peak_running, running)
+        await asyncio.sleep(0.01)
+        async with lock:
+            running -= 1
+        return value
+
+    results = await run_concurrently([work(1), work(2)], max_concurrency=10)
+
+    assert results == [1, 2]
+    assert peak_running == 2
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_collects_all_failures():
+    async def succeed() -> str:
+        return "ok"
+
+    async def fail(exc: Exception) -> None:
+        raise exc
+
+    first = RuntimeError("first failure")
+    second = ValueError("second failure")
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [fail(first), succeed(), fail(second)],
+            max_concurrency=3,
+        )
+
+    assert exc_info.value.failures == [first, second]
+    assert exc_info.value.partial_results == [None, "ok", None]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_timeout_cancels_remaining_tasks():
+    cancelled = asyncio.Event()
+
+    async def quick() -> str:
+        return "done"
+
+    async def slow() -> str:
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "late"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [quick(), slow()],
+            max_concurrency=2,
+            timeout=0.05,
+        )
+
+    assert any(isinstance(failure, TimeoutError) for failure in exc_info.value.failures)
+    assert exc_info.value.partial_results == ["done", None]
+    assert cancelled.is_set()
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_rejects_invalid_max_concurrency():
+    with pytest.raises(ValueError):
+        await run_concurrently([], max_concurrency=0)


### PR DESCRIPTION
/claim #803

## Summary
- Added `run_concurrently()` to `fastapi.concurrency` with `asyncio.Semaphore` concurrency limiting.
- Preserves input-order results regardless of completion order.
- Adds `ConcurrencyError` with `failures` and `partial_results` for task failures and timeout cancellation.
- Supports total timeout cancellation for unfinished tasks.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-803-demo-20260606/run-concurrently-803-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout -p anyio.pytest_plugin tests/test_concurrency.py -q` -> 7 passed
- `uv run --python 3.14 ruff check fastapi/concurrency.py tests/test_concurrency.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/concurrency.py tests/test_concurrency.py` -> passed
- `git diff --check` -> passed

## Provenance
- `_contributor.json` contains safe public provenance only. Private system, developer, runtime, and hidden session instructions are not published.