### PR TITLE
[OpenAI Codex] [ FastAPI ] Fix encoders.py bytes handling

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Safe public provenance only. Private system, developer, runtime, and hidden session instructions are intentionally not disclosed.",
+  "timestamp": "2026-06-06T14:40:39Z"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -15,7 +16,7 @@ from ipaddress import (
 from pathlib import Path, PurePath
 from re import Pattern
 from types import GeneratorType
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from annotated_doc import Doc
@@ -81,8 +82,18 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
         return float(dec_value)
 
 
+def _encode_bytes(value: bytes | memoryview, bytes_encoding: str) -> str:
+    data = bytes(value)
+    if bytes_encoding == "base64":
+        return base64.b64encode(data).decode("ascii")
+    if bytes_encoding == "hex":
+        return data.hex()
+    raise ValueError('bytes_encoding must be either "base64" or "hex"')
+
+
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
+    bytes: lambda o: _encode_bytes(o, "base64"),
+    memoryview: lambda o: _encode_bytes(o, "base64"),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -215,6 +226,16 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        Literal["base64", "hex"],
+        Doc(
+            """
+            The encoding to use for raw bytes and memoryview objects. By default,
+            binary values are encoded as base64 strings. Set this to "hex" to
+            encode bytes as hexadecimal strings instead.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -242,7 +263,7 @@ def jsonable_encoder(
         exclude = set(exclude)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     if isinstance(obj, BaseModel):
         obj_dict = obj.model_dump(
-            mode="json",
+            mode="python",
             include=include,
             exclude=exclude,
             by_alias=by_alias,
@@ -255,6 +276,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +291,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -276,6 +299,8 @@ def jsonable_encoder(
         return str(obj)
     if isinstance(obj, (str, int, float, type(None))):
         return obj
+    if isinstance(obj, (bytes, memoryview)):
+        return _encode_bytes(obj, bytes_encoding)
     if isinstance(obj, PydanticUndefinedType):
         return None
     if isinstance(obj, dict):
@@ -302,6 +327,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +336,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +354,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +389,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -329,3 +329,34 @@ def test_encode_color(module_path):
 
     data = {"color": Color("blue")}
     assert jsonable_encoder(data) == {"color": "blue"}
+
+
+def test_encode_bytes_as_base64_by_default():
+    assert jsonable_encoder(b"\xff\x00") == "/wA="
+
+
+def test_encode_memoryview_as_base64_by_default():
+    assert jsonable_encoder(memoryview(b"\xff\x00")) == "/wA="
+
+
+def test_encode_bytes_as_hex():
+    assert jsonable_encoder(b"\xff\x00", bytes_encoding="hex") == "ff00"
+
+
+def test_encode_nested_bytes_uses_selected_encoding():
+    data = {"raw": [b"\xff\x00", memoryview(b"abc")]}
+
+    assert jsonable_encoder(data) == {"raw": ["/wA=", "YWJj"]}
+    assert jsonable_encoder(data, bytes_encoding="hex") == {"raw": ["ff00", "616263"]}
+
+
+def test_encode_model_bytes_as_base64():
+    class ModelWithBytes(BaseModel):
+        data: bytes
+
+    assert jsonable_encoder(ModelWithBytes(data=b"\xff\x00")) == {"data": "/wA="}
+
+
+def test_encode_invalid_bytes_encoding_raises():
+    with pytest.raises(ValueError):
+        jsonable_encoder(b"abc", bytes_encoding="utf-8")  # type: ignore[arg-type]


### PR DESCRIPTION
/claim #759

## Summary
- Encodes raw bytes and memoryview objects as base64 strings by default in jsonable_encoder.
- Adds `bytes_encoding="hex"` for hexadecimal output.
- Propagates the option through recursive encoding, including nested values and Pydantic model fields.
- Keeps custom encoders first so caller-provided byte encoders still override the default behavior.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-759-demo-20260606/jsonable-encoder-759-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_jsonable_encoder.py -q` -> 31 passed, 1 skipped
- `uv run --python 3.14 ruff check fastapi/encoders.py tests/test_jsonable_encoder.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/encoders.py tests/test_jsonable_encoder.py` -> passed
- `git diff --check` -> passed

## Provenance
- `_provenance.json` contains safe public provenance only. Private system, developer, runtime, and hidden session instructions are not published.