### PR TITLE
[OpenAI Codex] [ FastAPI ] Fix duplicate generated operation IDs

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Safe public provenance only. Private system, developer, runtime, and hidden session instructions are intentionally not disclosed.",
+  "date": "2026-06-06T14:52:33Z"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -250,6 +250,12 @@ def get_openapi_operation_metadata(
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        suffix = 2
+        original_operation_id = operation_id
+        operation_id = f"{original_operation_id}_{suffix}"
+        while operation_id in operation_ids:
+            suffix += 1
+            operation_id = f"{original_operation_id}_{suffix}"
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -92,12 +92,18 @@ def generate_operation_id_for_path(
     return operation_id
 
 
+def _sanitize_operation_id_part(value: str) -> str:
+    operation_id = re.sub(r"\W", "_", value)
+    operation_id = re.sub(r"_+", "_", operation_id)
+    return operation_id.strip("_").lower()
+
+
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0].lower()
+    path = _sanitize_operation_id_part(route.path_format)
+    name = _sanitize_operation_id_part(route.name)
+    return "_".join(part for part in (method, path, name) if part)
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_operation_id_generation.py
+++ b/fastapi/tests/test_operation_id_generation.py
@@ -1,0 +1,78 @@
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_operation_ids_include_method_path_and_function_name():
+    app = FastAPI()
+    users_router = APIRouter(prefix="/users")
+    admins_router = APIRouter(prefix="/admin/users")
+
+    @users_router.get("/", name="list_users")
+    def list_regular_users():
+        return []
+
+    @admins_router.get("/", name="list_users")
+    def list_admin_users():
+        return []
+
+    app.include_router(users_router)
+    app.include_router(admins_router)
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert schema["paths"]["/users/"]["get"]["operationId"] == "get_users_list_users"
+    assert (
+        schema["paths"]["/admin/users/"]["get"]["operationId"]
+        == "get_admin_users_list_users"
+    )
+
+
+def test_operation_ids_are_lowercase_alphanumeric_and_underscores():
+    app = FastAPI()
+
+    @app.post("/API/v1/widgets/{Widget-ID}")
+    def Create_Widget():
+        return {}
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert (
+        schema["paths"]["/API/v1/widgets/{Widget-ID}"]["post"]["operationId"]
+        == "post_api_v1_widgets_widget_id_create_widget"
+    )
+
+
+def test_operation_id_collisions_receive_numeric_suffixes():
+    app = FastAPI()
+
+    @app.get("/items/a-b", name="read_item")
+    def read_dash_item():
+        return {}
+
+    @app.get("/items/a_b", name="read_item")
+    def read_underscore_item():
+        return {}
+
+    with pytest.warns(UserWarning, match="Duplicate Operation ID"):
+        schema = TestClient(app).get("/openapi.json").json()
+
+    assert (
+        schema["paths"]["/items/a-b"]["get"]["operationId"] == "get_items_a_b_read_item"
+    )
+    assert (
+        schema["paths"]["/items/a_b"]["get"]["operationId"]
+        == "get_items_a_b_read_item_2"
+    )
+
+
+def test_operation_id_without_prefix_uses_consistent_method_name_format():
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return {}
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert schema["paths"]["/"]["get"]["operationId"] == "get_read_root"


### PR DESCRIPTION
/claim #764

## Summary
- Updated default operation IDs to use `method_path_function` with lowercase alphanumeric/underscore sanitization.
- Includes router prefixes through `route.path_format`, preventing identical endpoint names across routers from colliding.
- Adds numeric suffixing for genuine OpenAPI `operationId` collisions while preserving duplicate warnings for compatibility.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-764-demo-20260606/operation-id-764-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_operation_id_generation.py tests/test_generate_unique_id_function.py::test_warn_duplicate_operation_id -q` -> 5 passed
- `uv run --python 3.14 ruff check fastapi/utils.py fastapi/openapi/utils.py tests/test_operation_id_generation.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/utils.py fastapi/openapi/utils.py tests/test_operation_id_generation.py` -> passed
- `git diff --check` -> passed

## Provenance
- `.attribution.json` contains safe public provenance only. Private system, developer, runtime, and hidden session instructions are not published.