### PR TITLE
[OpenAI Codex] [ FastAPI ] Add FastAPITestClient auth helpers

### DIFF
--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Safe public provenance only. Private system, developer, runtime, and hidden session instructions are intentionally not disclosed.",
+  "completed_at": "2026-06-06T15:00:15Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,53 @@
+from base64 import b64encode
+from typing import Any
+
 from starlette.testclient import TestClient as TestClient  # noqa
+from starlette.testclient import WebSocketTestSession
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> "FastAPITestClient":
+        self.headers["Authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(self, username: str, password: str) -> "FastAPITestClient":
+        credentials = f"{username}:{password}".encode()
+        token = b64encode(credentials).decode("ascii")
+        self.headers["Authorization"] = f"Basic {token}"
+        return self
+
+    def reset_auth(self) -> "FastAPITestClient":
+        self.headers.pop("Authorization", None)
+        return self
+
+    def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: list[str] | None = None,
+        **kwargs: Any,
+    ) -> WebSocketTestSession:
+        websocket_headers = dict(self.headers)
+        if headers is not None:
+            websocket_headers.update(headers)
+        return self.websocket_connect(
+            url,
+            subprotocols=subprotocols,
+            headers=websocket_headers,
+            **kwargs,
+        )
+
+    def assert_status(
+        self,
+        method: str,
+        url: str,
+        expected_status_code: int,
+        **kwargs: Any,
+    ):
+        response = self.request(method, url, **kwargs)
+        assert response.status_code == expected_status_code, (
+            f"Expected status code {expected_status_code}, "
+            f"got {response.status_code}: {response.text}"
+        )
+        return response

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,116 @@
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+
+app = FastAPI()
+
+
+@app.get("/headers")
+def read_headers():
+    return {}
+
+
+@app.get("/auth")
+def read_auth_header():
+    return {}
+
+
+@app.get("/ok")
+def read_ok():
+    return {"ok": True}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept(subprotocol="chat")
+    await websocket.send_json(
+        {
+            "authorization": websocket.headers.get("authorization"),
+            "x-client": websocket.headers.get("x-client"),
+            "subprotocols": websocket.scope["subprotocols"],
+        }
+    )
+    await websocket.close()
+
+
+def test_existing_testclient_import_still_works():
+    client = TestClient(app)
+
+    response = client.get("/ok")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_fastapi_testclient_authenticate_sets_bearer_header():
+    client = FastAPITestClient(app)
+
+    client.authenticate("first-token")
+    response = client.get("/auth")
+
+    assert response.request.headers["authorization"] == "Bearer first-token"
+
+
+def test_fastapi_testclient_authenticate_replaces_previous_token():
+    client = FastAPITestClient(app)
+
+    client.authenticate("first-token")
+    client.authenticate("second-token")
+    response = client.get("/auth")
+
+    assert response.request.headers["authorization"] == "Bearer second-token"
+
+
+def test_fastapi_testclient_authenticate_basic_sets_basic_header():
+    client = FastAPITestClient(app)
+
+    client.authenticate_basic("alice", "secret")
+    response = client.get("/auth")
+
+    assert response.request.headers["authorization"] == "Basic YWxpY2U6c2VjcmV0"
+
+
+def test_fastapi_testclient_reset_auth_clears_header():
+    client = FastAPITestClient(app)
+
+    client.authenticate("secret")
+    client.reset_auth()
+    response = client.get("/auth")
+
+    assert "authorization" not in response.request.headers
+
+
+def test_fastapi_testclient_ws_connect_merges_headers_and_subprotocols():
+    client = FastAPITestClient(app)
+
+    client.authenticate("socket-token")
+    with client.ws_connect(
+        "/ws",
+        headers={"x-client": "codex"},
+        subprotocols=["chat", "superchat"],
+    ) as websocket:
+        data = websocket.receive_json()
+
+    assert data == {
+        "authorization": "Bearer socket-token",
+        "x-client": "codex",
+        "subprotocols": ["chat", "superchat"],
+    }
+    assert websocket.accepted_subprotocol == "chat"
+
+
+def test_fastapi_testclient_assert_status_returns_response():
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("GET", "/ok", 200)
+
+    assert response.json() == {"ok": True}
+
+
+def test_fastapi_testclient_assert_status_has_helpful_message():
+    client = FastAPITestClient(app)
+
+    with pytest.raises(AssertionError) as exc_info:
+        client.assert_status("GET", "/missing", 200)
+
+    assert "Expected status code 200, got 404" in str(exc_info.value)


### PR DESCRIPTION
/claim #804

## Summary
- Added an opt-in `FastAPITestClient` subclass while preserving the existing `TestClient` re-export.
- Added bearer and HTTP Basic auth helpers plus `reset_auth()`.
- Added `ws_connect()` for WebSocket connections with merged auth/custom headers and subprotocols.
- Added `assert_status()` for request plus status assertion with a helpful failure message.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-804-demo-20260606/testclient-804-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_fastapi_testclient.py -q` -> 8 passed
- `uv run --python 3.14 ruff check fastapi/testclient.py tests/test_fastapi_testclient.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/testclient.py tests/test_fastapi_testclient.py` -> passed
- `git diff --check` -> passed

## Provenance
- `.audit.json` contains safe public provenance only. Private system, developer, runtime, and hidden session instructions are not published.