### PR TITLE
[OpenAI Codex] [ FastAPI ] Add standardized pagination helpers

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.",
+  "date": "2026-06-06T23:12:00+08:00"
+}

--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -9,6 +9,9 @@ from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
+from .pagination import PaginatedResponse as PaginatedResponse
+from .pagination import Paginator as Paginator
+from .pagination import paginate as paginate
 from .param_functions import Body as Body
 from .param_functions import Cookie as Cookie
 from .param_functions import Depends as Depends

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import base64
+import json
+import math
+from collections.abc import Callable, Iterable, Sequence
+from typing import Annotated, Any, Generic, TypeVar
+
+from pydantic import BaseModel
+
+from .param_functions import Query
+
+T = TypeVar("T")
+QueryT = TypeVar("QueryT")
+CursorKey = str | Callable[[Any], Any] | None
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+class Paginator:
+    def __init__(
+        self,
+        page: int = 1,
+        page_size: int = 50,
+        *,
+        max_page_size: int = 100,
+    ) -> None:
+        self.max_page_size = max(max_page_size, 1)
+        self.page = max(page, 1)
+        self.page_size = min(max(page_size, 1), self.max_page_size)
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def skip(self) -> int:
+        return self.offset
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    def total_pages(self, total: int) -> int:
+        if total <= 0:
+            return 0
+        return math.ceil(total / self.page_size)
+
+    def create_response(
+        self,
+        items: Iterable[T],
+        *,
+        total: int,
+        page: int | None = None,
+        next_cursor: str | None = None,
+        previous_cursor: str | None = None,
+    ) -> PaginatedResponse[T]:
+        current_page = self.page if page is None else max(page, 1)
+        total_pages = self.total_pages(total)
+        return PaginatedResponse[T](
+            items=list(items),
+            total=max(total, 0),
+            page=current_page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=current_page < total_pages,
+            has_previous=current_page > 1 and total_pages > 0,
+            next_cursor=next_cursor,
+            previous_cursor=previous_cursor,
+        )
+
+    def paginate_sequence(self, items: Sequence[T]) -> PaginatedResponse[T]:
+        return self.create_response(
+            items[self.offset : self.offset + self.page_size],
+            total=len(items),
+        )
+
+    def apply(self, query: QueryT) -> QueryT:
+        offset = query.offset
+        limit = offset(self.offset).limit
+        return limit(self.limit)
+
+    def encode_cursor(self, value: Any) -> str:
+        raw = json.dumps({"value": value}, default=str, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    def decode_cursor(self, cursor: str) -> Any:
+        padding = "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(f"{cursor}{padding}".encode())
+        payload = json.loads(raw.decode())
+        return payload["value"]
+
+    def paginate_cursor(
+        self,
+        items: Sequence[T],
+        *,
+        after: str | None = None,
+        before: str | None = None,
+        cursor_key: CursorKey = None,
+    ) -> PaginatedResponse[T]:
+        total = len(items)
+        start = self._cursor_start(items, after, before, cursor_key)
+        page_items = list(items[start : start + self.page_size])
+        has_next = start + self.page_size < total
+        has_previous = start > 0
+        page = (start // self.page_size) + 1
+        return PaginatedResponse[T](
+            items=page_items,
+            total=total,
+            page=page,
+            page_size=self.page_size,
+            total_pages=self.total_pages(total),
+            has_next=has_next,
+            has_previous=has_previous,
+            next_cursor=self._page_cursor(
+                page_items[-1], start + len(page_items) - 1, cursor_key
+            )
+            if has_next and page_items
+            else None,
+            previous_cursor=self._page_cursor(page_items[0], start, cursor_key)
+            if has_previous and page_items
+            else None,
+        )
+
+    def _cursor_start(
+        self,
+        items: Sequence[T],
+        after: str | None,
+        before: str | None,
+        cursor_key: CursorKey,
+    ) -> int:
+        if before is not None:
+            before_index = self._find_cursor_index(items, before, cursor_key)
+            return max(before_index - self.page_size, 0)
+        if after is not None:
+            after_index = self._find_cursor_index(items, after, cursor_key)
+            return min(after_index + 1, len(items))
+        return 0
+
+    def _find_cursor_index(
+        self, items: Sequence[T], cursor: str, cursor_key: CursorKey
+    ) -> int:
+        cursor_value = self.decode_cursor(cursor)
+        for index, item in enumerate(items):
+            if self._cursor_value(item, index, cursor_key) == cursor_value:
+                return index
+        return -1
+
+    def _page_cursor(self, item: T, index: int, cursor_key: CursorKey) -> str:
+        return self.encode_cursor(self._cursor_value(item, index, cursor_key))
+
+    def _cursor_value(self, item: T, index: int, cursor_key: CursorKey) -> Any:
+        if cursor_key is None:
+            return index
+        if callable(cursor_key):
+            return cursor_key(item)
+        if isinstance(item, dict):
+            return item[cursor_key]
+        return getattr(item, cursor_key)
+
+
+def paginate(
+    page: Annotated[
+        int,
+        Query(description="1-based page number."),
+    ] = 1,
+    page_size: Annotated[
+        int,
+        Query(description="Number of items per page."),
+    ] = 50,
+) -> Paginator:
+    return Paginator(page=page, page_size=page_size)

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,153 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from fastapi.pagination import PaginatedResponse, Paginator, paginate
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+def test_offset_pagination_calculates_boundaries():
+    items = [Item(id=index, name=f"item-{index}") for index in range(1, 8)]
+    paginator = Paginator(page=2, page_size=3)
+
+    response = paginator.paginate_sequence(items)
+
+    assert paginator.offset == 3
+    assert paginator.skip == 3
+    assert paginator.limit == 3
+    assert response.model_dump() == {
+        "items": [
+            {"id": 4, "name": "item-4"},
+            {"id": 5, "name": "item-5"},
+            {"id": 6, "name": "item-6"},
+        ],
+        "total": 7,
+        "page": 2,
+        "page_size": 3,
+        "total_pages": 3,
+        "has_next": True,
+        "has_previous": True,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_invalid_page_inputs_are_clamped_and_empty_results_work():
+    paginator = Paginator(page=-5, page_size=0)
+    response = paginator.paginate_sequence([])
+
+    assert paginator.page == 1
+    assert paginator.page_size == 1
+    assert response.model_dump() == {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "page_size": 1,
+        "total_pages": 0,
+        "has_next": False,
+        "has_previous": False,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_paginator_applies_sqlalchemy_style_offset_and_limit():
+    class Query:
+        def __init__(self) -> None:
+            self.offset_value = None
+            self.limit_value = None
+
+        def offset(self, value: int):
+            self.offset_value = value
+            return self
+
+        def limit(self, value: int):
+            self.limit_value = value
+            return self
+
+    query = Query()
+    returned = Paginator(page=3, page_size=25).apply(query)
+
+    assert returned is query
+    assert query.offset_value == 50
+    assert query.limit_value == 25
+
+
+def test_cursor_pagination_uses_encoded_next_and_previous_cursors():
+    items = [Item(id=index, name=f"item-{index}") for index in range(1, 6)]
+    paginator = Paginator(page_size=2)
+
+    first_page = paginator.paginate_cursor(items, cursor_key="id")
+    second_page = paginator.paginate_cursor(
+        items, after=first_page.next_cursor, cursor_key="id"
+    )
+    previous_page = paginator.paginate_cursor(
+        items, before=second_page.previous_cursor, cursor_key="id"
+    )
+
+    assert [item.id for item in first_page.items] == [1, 2]
+    assert first_page.next_cursor is not None
+    assert first_page.next_cursor != "2"
+    assert first_page.previous_cursor is None
+    assert first_page.has_next is True
+    assert first_page.has_previous is False
+
+    assert [item.id for item in second_page.items] == [3, 4]
+    assert second_page.page == 2
+    assert second_page.next_cursor is not None
+    assert second_page.previous_cursor is not None
+    assert second_page.has_next is True
+    assert second_page.has_previous is True
+
+    assert [item.id for item in previous_page.items] == [1, 2]
+
+
+def test_paginated_response_wraps_pydantic_models():
+    page = PaginatedResponse[Item](
+        items=[Item(id=1, name="portal")],
+        total=1,
+        page=1,
+        page_size=10,
+        total_pages=1,
+        has_next=False,
+        has_previous=False,
+    )
+
+    assert page.model_dump()["items"] == [{"id": 1, "name": "portal"}]
+
+
+def test_paginate_dependency_reads_query_parameters():
+    app = FastAPI()
+    items = [Item(id=index, name=f"item-{index}") for index in range(1, 5)]
+
+    @app.get("/items", response_model=PaginatedResponse[Item])
+    def list_items(
+        paginator: Annotated[Paginator, Depends(paginate)],
+    ) -> PaginatedResponse[Item]:
+        return paginator.paginate_sequence(items)
+
+    client = TestClient(app)
+
+    response = client.get("/items?page=2&page_size=2")
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [{"id": 3, "name": "item-3"}, {"id": 4, "name": "item-4"}],
+        "total": 4,
+        "page": 2,
+        "page_size": 2,
+        "total_pages": 2,
+        "has_next": False,
+        "has_previous": True,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+    response = client.get("/items?page=0&page_size=0")
+    assert response.status_code == 200
+    assert response.json()["page"] == 1
+    assert response.json()["page_size"] == 1


### PR DESCRIPTION
/claim #802

## Summary
- Added `fastapi.pagination` with `Paginator`, generic `PaginatedResponse[T]`, and a `paginate()` dependency.
- Added offset/page metadata helpers plus SQLAlchemy-style `offset()`/`limit()` application.
- Added URL-safe cursor pagination with `next_cursor` and `previous_cursor` navigation.
- Added top-level FastAPI exports and safe public attribution metadata only.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-802-demo-20260606/pagination-802-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_pagination.py -q` -> 6 passed
- `uv run --python 3.14 ruff check fastapi/pagination.py fastapi/__init__.py tests/test_pagination.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/pagination.py fastapi/__init__.py tests/test_pagination.py` -> passed
- `git diff --check` -> passed

## Provenance
- `.attribution.json` contains safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.