### PR TITLE
[OpenAI Codex] [ FastAPI ] Add SSE manager filtering and replay

### DIFF
--- a/fastapi/fastapi/.contributor.json
+++ b/fastapi/fastapi/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.",
+  "timestamp": "2026-06-06T23:20:00+08:00"
+}

--- a/fastapi/fastapi/sse.py
+++ b/fastapi/fastapi/sse.py
@@ -1,7 +1,11 @@
+import asyncio
+from collections import deque
+from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
 from annotated_doc import Doc
 from pydantic import AfterValidator, BaseModel, Field, model_validator
+from starlette.requests import Request
 from starlette.responses import StreamingResponse
 
 # Canonical SSE event schema matching the OpenAPI 3.2 spec
@@ -141,6 +145,115 @@ class ServerSentEvent(BaseModel):
                 "or 'raw_data' for pre-formatted strings."
             )
         return self
+
+
+class SSEManager:
+    """Manage Server-Sent Event subscribers, filtering, and replay history."""
+
+    def __init__(
+        self,
+        *,
+        history_size: int = 100,
+        retry: int | None = None,
+        disconnect_check_interval: float = 0.25,
+    ) -> None:
+        self.history_size = max(history_size, 0)
+        self.retry = retry
+        self.disconnect_check_interval = max(disconnect_check_interval, 0.001)
+        self._history: deque[ServerSentEvent] = deque(maxlen=self.history_size or None)
+        self._connections: set[asyncio.Queue[ServerSentEvent]] = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._connections)
+
+    async def broadcast(
+        self,
+        data: Any = None,
+        *,
+        event: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        raw_data: str | None = None,
+        comment: str | None = None,
+    ) -> ServerSentEvent:
+        sse_event = ServerSentEvent(
+            data=data,
+            raw_data=raw_data,
+            event=event,
+            id=id,
+            retry=self.retry if retry is None else retry,
+            comment=comment,
+        )
+        async with self._lock:
+            if self.history_size:
+                self._history.append(sse_event)
+            connections = tuple(self._connections)
+        for queue in connections:
+            queue.put_nowait(sse_event)
+        return sse_event
+
+    async def stream(
+        self,
+        *,
+        request: Request | None = None,
+        event_type: str | None = None,
+        last_event_id: str | None = None,
+    ) -> AsyncIterator[ServerSentEvent]:
+        queue: asyncio.Queue[ServerSentEvent] = asyncio.Queue()
+        async with self._lock:
+            replay_events = self._events_after(last_event_id)
+            self._connections.add(queue)
+        try:
+            for sse_event in replay_events:
+                if self._matches_event_type(sse_event, event_type):
+                    yield sse_event
+            while True:
+                if await self._is_disconnected(request):
+                    break
+                try:
+                    sse_event = await asyncio.wait_for(
+                        queue.get(), timeout=self.disconnect_check_interval
+                    )
+                except TimeoutError:
+                    continue
+                if self._matches_event_type(sse_event, event_type):
+                    yield sse_event
+        finally:
+            async with self._lock:
+                self._connections.discard(queue)
+
+    async def stream_for_request(
+        self,
+        request: Request,
+        *,
+        event_type_param: str = "event_type",
+        last_event_id_header: str = "last-event-id",
+    ) -> AsyncIterator[ServerSentEvent]:
+        async for sse_event in self.stream(
+            request=request,
+            event_type=request.query_params.get(event_type_param),
+            last_event_id=request.headers.get(last_event_id_header),
+        ):
+            yield sse_event
+
+    def _events_after(self, last_event_id: str | None) -> list[ServerSentEvent]:
+        if last_event_id is None:
+            return []
+        events = list(self._history)
+        for index, sse_event in enumerate(events):
+            if sse_event.id == last_event_id:
+                return events[index + 1 :]
+        return events
+
+    def _matches_event_type(
+        self, sse_event: ServerSentEvent, event_type: str | None
+    ) -> bool:
+        return event_type is None or sse_event.event == event_type
+
+    async def _is_disconnected(self, request: Request | None) -> bool:
+        return request is not None and await request.is_disconnected()
 
 
 def format_sse_event(

--- a/fastapi/tests/test_sse.py
+++ b/fastapi/tests/test_sse.py
@@ -6,7 +6,7 @@ import fastapi.routing
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
-from fastapi.sse import ServerSentEvent
+from fastapi.sse import ServerSentEvent, SSEManager
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
@@ -316,3 +316,88 @@ def test_no_keepalive_when_fast(client: TestClient):
     assert response.status_code == 200
     # KEEPALIVE_COMMENT is ": ping\n\n".
     assert ": ping\n" not in response.text
+
+
+def test_sse_manager_filters_broadcasts_and_sets_retry():
+    async def scenario():
+        manager = SSEManager(retry=5000)
+        stream = manager.stream(event_type="inventory")
+        next_event = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+
+        await manager.broadcast({"ignored": True}, event="orders", id="1")
+        await manager.broadcast({"stock": 3}, event="inventory", id="2")
+
+        sse_event = await asyncio.wait_for(next_event, timeout=1)
+        await stream.aclose()
+
+        assert sse_event.event == "inventory"
+        assert sse_event.data == {"stock": 3}
+        assert sse_event.id == "2"
+        assert sse_event.retry == 5000
+        assert manager.connection_count == 0
+
+    asyncio.run(scenario())
+
+
+def test_sse_manager_replays_after_last_event_id():
+    async def scenario():
+        manager = SSEManager()
+        await manager.broadcast("first", event="message", id="1")
+        await manager.broadcast("second", event="message", id="2")
+        await manager.broadcast("third", event="message", id="3")
+
+        stream = manager.stream(last_event_id="1")
+        replayed = await asyncio.wait_for(anext(stream), timeout=1)
+        await stream.aclose()
+
+        assert replayed.data == "second"
+        assert replayed.id == "2"
+        assert manager.connection_count == 0
+
+    asyncio.run(scenario())
+
+
+def test_sse_manager_stream_for_request_reads_filter_and_last_event_id():
+    class FakeRequest:
+        query_params = {"event_type": "inventory"}
+        headers = {"last-event-id": "2"}
+
+        async def is_disconnected(self):
+            return False
+
+    async def scenario():
+        manager = SSEManager()
+        await manager.broadcast("order", event="orders", id="1")
+        await manager.broadcast("old-stock", event="inventory", id="2")
+        await manager.broadcast("new-stock", event="inventory", id="3")
+
+        stream = manager.stream_for_request(FakeRequest())  # type: ignore[arg-type]
+        replayed = await asyncio.wait_for(anext(stream), timeout=1)
+        await stream.aclose()
+
+        assert replayed.data == "new-stock"
+        assert replayed.event == "inventory"
+        assert replayed.id == "3"
+
+    asyncio.run(scenario())
+
+
+def test_sse_manager_stops_and_cleans_up_on_disconnect():
+    class DisconnectedRequest:
+        query_params = {}
+        headers = {}
+
+        async def is_disconnected(self):
+            return True
+
+    async def scenario():
+        manager = SSEManager(disconnect_check_interval=0.01)
+        stream = manager.stream(request=DisconnectedRequest())  # type: ignore[arg-type]
+
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(anext(stream), timeout=1)
+
+        assert manager.connection_count == 0
+
+    asyncio.run(scenario())


### PR DESCRIPTION
/claim #798

## Summary
- Added `SSEManager` for broadcast-based Server-Sent Event streams.
- Added event-type filtering, bounded Last-Event-ID replay, and configurable retry defaults.
- Added request disconnect detection and subscriber cleanup for managed streams.
- Added focused tests for filtering, replay, request header/query handling, and disconnect cleanup.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-798-demo-20260606/sse-798-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_sse.py -q` -> 22 passed
- `uv run --python 3.14 ruff check fastapi/sse.py tests/test_sse.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/sse.py tests/test_sse.py` -> passed
- `git diff --check` -> passed

## Provenance
- `.contributor.json` contains safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.