### PR TITLE
[OpenAI Codex] [ FastAPI ] Add rate limiting to API key auth

### DIFF
--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.",
+  "completed_at": "2026-06-06T23:25:00+08:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -1,6 +1,7 @@
 from .api_key import APIKeyCookie as APIKeyCookie
 from .api_key import APIKeyHeader as APIKeyHeader
 from .api_key import APIKeyQuery as APIKeyQuery
+from .api_key import APIKeyWithRateLimit as APIKeyWithRateLimit
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials

--- a/fastapi/fastapi/security/api_key.py
+++ b/fastapi/fastapi/security/api_key.py
@@ -1,3 +1,7 @@
+import math
+import threading
+import time
+from collections.abc import Sequence
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -5,7 +9,8 @@ from fastapi.openapi.models import APIKey, APIKeyIn
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.responses import Response
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class APIKeyBase(SecurityBase):
@@ -230,6 +235,137 @@ class APIKeyHeader(APIKeyBase):
     async def __call__(self, request: Request) -> str | None:
         api_key = request.headers.get(self.model.name)
         return self.check_api_key(api_key)
+
+
+class APIKeyWithRateLimit(APIKeyHeader):
+    """
+    API key header authentication with per-key in-memory rate limiting.
+
+    This extends `APIKeyHeader` without changing its behavior. It adds a sliding
+    window counter per API key and can mark deprecated keys with a `Warning`
+    response header while still accepting them.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: Annotated[str, Doc("Header name.")],
+        rate_limit: Annotated[
+            str,
+            Doc(
+                """
+                Limit string in the form `100/minute`, `1000/hour`,
+                `10/second`, or `500/day`.
+                """
+            ),
+        ],
+        deprecated_keys: Annotated[
+            Sequence[str] | None,
+            Doc(
+                """
+                API keys that should still authenticate but receive a
+                `Warning` response header.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                Whether to automatically error when the header is missing.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            name=name,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.max_requests, self.window_seconds = self._parse_rate_limit(rate_limit)
+        self.deprecated_keys = set(deprecated_keys or ())
+        self._requests_by_key: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    async def __call__(self, request: Request, response: Response) -> str | None:
+        api_key = request.headers.get(self.model.name)
+        checked_api_key = self.check_api_key(api_key)
+        if checked_api_key is None:
+            return None
+
+        retry_after = self._record_request(checked_api_key)
+        if retry_after is not None:
+            raise HTTPException(
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+                detail="Rate limit exceeded",
+                headers={"Retry-After": str(retry_after)},
+            )
+
+        if checked_api_key in self.deprecated_keys:
+            response.headers["Warning"] = (
+                '299 - "API key is deprecated and will be deactivated"'
+            )
+        return checked_api_key
+
+    def _record_request(self, api_key: str) -> int | None:
+        now = time.monotonic()
+        window_start = now - self.window_seconds
+        with self._lock:
+            timestamps = [
+                timestamp
+                for timestamp in self._requests_by_key.get(api_key, [])
+                if timestamp > window_start
+            ]
+            if len(timestamps) >= self.max_requests:
+                self._requests_by_key[api_key] = timestamps
+                retry_after = timestamps[0] + self.window_seconds - now
+                return max(math.ceil(retry_after), 1)
+            timestamps.append(now)
+            self._requests_by_key[api_key] = timestamps
+        return None
+
+    def _parse_rate_limit(self, rate_limit: str) -> tuple[int, int]:
+        count_text, separator, period_text = rate_limit.partition("/")
+        if not separator:
+            raise ValueError("rate_limit must use '<count>/<period>' format")
+        try:
+            count = int(count_text)
+        except ValueError as exc:
+            raise ValueError("rate_limit count must be an integer") from exc
+        if count <= 0:
+            raise ValueError("rate_limit count must be greater than 0")
+
+        periods = {
+            "second": 1,
+            "minute": 60,
+            "hour": 3600,
+            "day": 86400,
+        }
+        normalized_period = period_text.strip().lower().removesuffix("s")
+        try:
+            seconds = periods[normalized_period]
+        except KeyError as exc:
+            raise ValueError(
+                "rate_limit period must be one of: second, minute, hour, day"
+            ) from exc
+        return count, seconds
 
 
 class APIKeyCookie(APIKeyBase):

--- a/fastapi/tests/test_security_api_key_rate_limit.py
+++ b/fastapi/tests/test_security_api_key_rate_limit.py
@@ -1,0 +1,89 @@
+import pytest
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import APIKeyWithRateLimit
+from fastapi.security import api_key as api_key_module
+from fastapi.testclient import TestClient
+
+
+def make_client(security: APIKeyWithRateLimit) -> TestClient:
+    app = FastAPI()
+
+    def get_current_key(api_key: str = Security(security)):
+        return api_key
+
+    @app.get("/limited")
+    def limited(api_key: str = Depends(get_current_key)):
+        return {"api_key": api_key}
+
+    return TestClient(app)
+
+
+def test_api_key_rate_limit_tracks_each_key_independently():
+    client = make_client(APIKeyWithRateLimit(name="key", rate_limit="2/minute"))
+
+    assert client.get("/limited", headers={"key": "alpha"}).status_code == 200
+    assert client.get("/limited", headers={"key": "alpha"}).status_code == 200
+
+    response = client.get("/limited", headers={"key": "alpha"})
+    assert response.status_code == 429
+    assert response.json() == {"detail": "Rate limit exceeded"}
+    assert response.headers["Retry-After"] == "60"
+
+    response = client.get("/limited", headers={"key": "beta"})
+    assert response.status_code == 200
+    assert response.json() == {"api_key": "beta"}
+
+
+def test_api_key_rate_limit_resets_after_window(monkeypatch: pytest.MonkeyPatch):
+    current_time = 0.0
+
+    def monotonic() -> float:
+        return current_time
+
+    monkeypatch.setattr(api_key_module.time, "monotonic", monotonic)
+    client = make_client(APIKeyWithRateLimit(name="key", rate_limit="1/second"))
+
+    assert client.get("/limited", headers={"key": "alpha"}).status_code == 200
+    response = client.get("/limited", headers={"key": "alpha"})
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "1"
+
+    current_time = 1.1
+    response = client.get("/limited", headers={"key": "alpha"})
+    assert response.status_code == 200
+
+
+def test_deprecated_keys_authenticate_with_warning_header():
+    client = make_client(
+        APIKeyWithRateLimit(
+            name="key",
+            rate_limit="10/minute",
+            deprecated_keys=["old-key"],
+        )
+    )
+
+    response = client.get("/limited", headers={"key": "old-key"})
+    assert response.status_code == 200
+    assert response.json() == {"api_key": "old-key"}
+    assert response.headers["Warning"] == (
+        '299 - "API key is deprecated and will be deactivated"'
+    )
+
+    response = client.get("/limited", headers={"key": "new-key"})
+    assert response.status_code == 200
+    assert "Warning" not in response.headers
+
+
+def test_api_key_with_rate_limit_preserves_missing_key_error():
+    client = make_client(APIKeyWithRateLimit(name="key", rate_limit="10/minute"))
+
+    response = client.get("/limited")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated"}
+    assert response.headers["WWW-Authenticate"] == "APIKey"
+
+
+@pytest.mark.parametrize("rate_limit", ["0/minute", "ten/minute", "10/month", "10"])
+def test_invalid_rate_limit_raises_value_error(rate_limit: str):
+    with pytest.raises(ValueError):
+        APIKeyWithRateLimit(name="key", rate_limit=rate_limit)


### PR DESCRIPTION
/claim #768

## Summary
- Added `APIKeyWithRateLimit` as an opt-in extension of `APIKeyHeader`.
- Added per-key sliding-window rate limiting with a lock-protected in-memory store.
- Added 429 `Retry-After` responses when a key exceeds its configured limit.
- Added `deprecated_keys` support that authenticates old keys while adding a `Warning` response header.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-768-demo-20260606/api-key-768-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_security_api_key_rate_limit.py tests/test_security_api_key_header.py -q` -> 11 passed
- `uv run --python 3.14 ruff check fastapi/security/api_key.py fastapi/security/__init__.py tests/test_security_api_key_rate_limit.py tests/test_security_api_key_header.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/security/api_key.py fastapi/security/__init__.py tests/test_security_api_key_rate_limit.py tests/test_security_api_key_header.py` -> passed
- `git diff --check` -> passed

## Provenance
- `.audit.json` contains safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.