### PR TITLE
[OpenAI Codex] [ FastAPI ] Add dynamic CORS origin validation

### DIFF
--- a/fastapi/fastapi/middleware/_generation.json
+++ b/fastapi/fastapi/middleware/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.",
+  "timestamp": "2026-06-06T23:30:00+08:00"
+}

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,144 @@
+import functools
+from collections.abc import Awaitable, Callable
+from inspect import isawaitable
+from typing import Any
+
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.responses import PlainTextResponse
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    def __init__(
+        self,
+        app: Any,
+        *,
+        allow_origin_func: Callable[[str], bool | Awaitable[bool]] | None = None,
+        cors_max_age: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.allow_origin_func = allow_origin_func
+        if cors_max_age is not None:
+            kwargs["max_age"] = cors_max_age
+        super().__init__(app, **kwargs)
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if self.allow_origin_func is None:
+            await super().__call__(scope, receive, send)
+            return
+
+        if scope["type"] != "http":  # pragma: no cover
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+
+        if origin is None:
+            await self.app(scope, receive, send)
+            return
+
+        origin_allowed = await self._call_allow_origin_func(origin)
+        if method == "OPTIONS" and "access-control-request-method" in headers:
+            response = self._dynamic_preflight_response(
+                request_headers=headers, origin_allowed=origin_allowed
+            )
+            await response(scope, receive, send)
+            return
+
+        await self._dynamic_simple_response(
+            scope,
+            receive,
+            send,
+            request_headers=headers,
+            origin_allowed=origin_allowed,
+        )
+
+    async def _call_allow_origin_func(self, origin: str) -> bool:
+        assert self.allow_origin_func is not None
+        result = self.allow_origin_func(origin)
+        if isawaitable(result):
+            result = await result
+        return bool(result)
+
+    def _dynamic_preflight_response(
+        self, *, request_headers: Headers, origin_allowed: bool
+    ) -> PlainTextResponse:
+        requested_origin = request_headers["origin"]
+        requested_method = request_headers["access-control-request-method"]
+        requested_headers = request_headers.get("access-control-request-headers")
+        requested_private_network = request_headers.get(
+            "access-control-request-private-network"
+        )
+
+        headers = dict(self.preflight_headers)
+        headers.pop("Access-Control-Allow-Origin", None)
+        headers["Vary"] = "Origin"
+        failures: list[str] = []
+
+        if origin_allowed:
+            headers["Access-Control-Allow-Origin"] = requested_origin
+        else:
+            failures.append("origin")
+
+        if requested_method not in self.allow_methods:
+            failures.append("method")
+
+        if self.allow_all_headers and requested_headers is not None:
+            headers["Access-Control-Allow-Headers"] = requested_headers
+        elif requested_headers is not None:
+            for header in [h.lower() for h in requested_headers.split(",")]:
+                if header.strip() not in self.allow_headers:
+                    failures.append("headers")
+                    break
+
+        if requested_private_network is not None:
+            if self.allow_private_network:
+                headers["Access-Control-Allow-Private-Network"] = "true"
+            else:
+                failures.append("private-network")
+
+        if failures:
+            failure_text = "Disallowed CORS " + ", ".join(failures)
+            return PlainTextResponse(failure_text, status_code=400, headers=headers)
+
+        return PlainTextResponse("OK", status_code=200, headers=headers)
+
+    async def _dynamic_simple_response(
+        self,
+        scope: Any,
+        receive: Any,
+        send: Any,
+        *,
+        request_headers: Headers,
+        origin_allowed: bool,
+    ) -> None:
+        dynamic_send = functools.partial(
+            self._dynamic_send,
+            send=send,
+            request_headers=request_headers,
+            origin_allowed=origin_allowed,
+        )
+        await self.app(scope, receive, dynamic_send)
+
+    async def _dynamic_send(
+        self,
+        message: Any,
+        send: Any,
+        request_headers: Headers,
+        origin_allowed: bool,
+    ) -> None:
+        if message["type"] != "http.response.start":
+            await send(message)
+            return
+
+        message.setdefault("headers", [])
+        headers = MutableHeaders(scope=message)
+        simple_headers = dict(self.simple_headers)
+        simple_headers.pop("Access-Control-Allow-Origin", None)
+        headers.update(simple_headers)
+        if origin_allowed:
+            self.allow_explicit_origin(headers, request_headers["Origin"])
+
+        await send(message)

--- a/fastapi/tests/test_dynamic_cors.py
+++ b/fastapi/tests/test_dynamic_cors.py
@@ -1,0 +1,102 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware, DynamicCORSMiddleware
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware as StarletteCORSMiddleware
+
+
+def build_client(**middleware_kwargs):
+    app = FastAPI()
+    app.add_middleware(DynamicCORSMiddleware, **middleware_kwargs)
+
+    @app.get("/")
+    def read_root():
+        return {"message": "ok"}
+
+    return TestClient(app)
+
+
+def test_existing_cors_middleware_export_unchanged():
+    assert CORSMiddleware is StarletteCORSMiddleware
+
+
+def test_dynamic_cors_allows_origin_and_sets_cors_max_age():
+    client = build_client(
+        allow_origin_func=lambda origin: origin.endswith(".example.com"),
+        allow_methods=["GET"],
+        allow_headers=["X-Token"],
+        cors_max_age=123,
+    )
+
+    response = client.get("/", headers={"Origin": "https://api.example.com"})
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == (
+        "https://api.example.com"
+    )
+    assert response.headers["vary"] == "Origin"
+
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://api.example.com",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "X-Token",
+        },
+    )
+    assert response.status_code == 200
+    assert response.text == "OK"
+    assert response.headers["access-control-allow-origin"] == (
+        "https://api.example.com"
+    )
+    assert response.headers["access-control-max-age"] == "123"
+
+
+def test_dynamic_cors_denies_origin():
+    client = build_client(
+        allow_origin_func=lambda origin: origin == "https://allowed.example.com",
+        allow_methods=["GET"],
+    )
+
+    response = client.get("/", headers={"Origin": "https://evil.example.com"})
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 400
+    assert response.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_dynamic_cors_awaits_async_callback():
+    async def allow_origin(origin: str) -> bool:
+        return origin == "https://async.example.com"
+
+    client = build_client(allow_origin_func=allow_origin, allow_methods=["GET"])
+
+    response = client.get("/", headers={"Origin": "https://async.example.com"})
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == (
+        "https://async.example.com"
+    )
+
+
+def test_dynamic_cors_falls_back_to_static_origins_without_callback():
+    client = build_client(
+        allow_origins=["https://static.example.com"],
+        allow_methods=["GET"],
+    )
+
+    response = client.get("/", headers={"Origin": "https://static.example.com"})
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == (
+        "https://static.example.com"
+    )
+
+    response = client.get("/", headers={"Origin": "https://blocked.example.com"})
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
/claim #763

## Summary
- Added `DynamicCORSMiddleware` while preserving the existing Starlette `CORSMiddleware` re-export.
- Added sync and async `allow_origin_func` support for dynamic origin allow/deny decisions.
- Added dynamic handling for simple and preflight CORS responses plus `cors_max_age`.
- Added fallback to static `allow_origins` behavior when no callback is supplied.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-763-demo-20260606/cors-763-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_dynamic_cors.py -q` -> 5 passed
- `uv run --python 3.14 ruff check fastapi/middleware/cors.py tests/test_dynamic_cors.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/middleware/cors.py tests/test_dynamic_cors.py` -> passed
- `git diff --check` -> passed

## Provenance
- `middleware/_generation.json` contains safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.