### PR TITLE
[OpenAI Codex] [ FastAPI ] Add OAuth2 refresh token helpers

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
+from .security import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/.provenance.json
+++ b/fastapi/fastapi/security/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.",
+  "created": "2026-06-06T23:34:00+08:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,67 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    Dependency class to collect OAuth2 refresh-token form data.
+    """
+
+    def __init__(
+        self,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 refresh token grant type. It must be the fixed string
+                "refresh_token".
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                The refresh token issued by the authorization server.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                Optional scopes requested for the refreshed access token.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 client ID.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                Optional OAuth2 client secret.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +603,74 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password bearer flow with an explicit refresh-token endpoint.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        refresh_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new one.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                OAuth2 scopes required by path operations using this dependency.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                Whether to automatically error when the Authorization header is
+                missing or not a Bearer token.
+                """
+            ),
+        ] = True,
+    ):
+        self.refresh_url = refresh_url
+        super().__init__(
+            tokenUrl=tokenUrl,
+            refreshUrl=refresh_url,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -1,0 +1,88 @@
+import pytest
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import OAuth2PasswordBearerWithRefresh, OAuth2RefreshRequestForm
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="/token",
+    refresh_url="/refresh",
+    scopes={"items": "Read items"},
+)
+
+
+@app.get("/items/")
+def read_items(token: str = Security(oauth2_scheme)):
+    return {"token": token}
+
+
+@app.post("/refresh")
+def refresh_token(form_data: OAuth2RefreshRequestForm = Depends()):
+    return {
+        "grant_type": form_data.grant_type,
+        "refresh_token": form_data.refresh_token,
+        "scopes": form_data.scopes,
+        "client_id": form_data.client_id,
+        "client_secret": form_data.client_secret,
+    }
+
+
+client = TestClient(app)
+
+
+def test_oauth2_password_bearer_with_refresh_reads_bearer_token():
+    response = client.get("/items/", headers={"Authorization": "Bearer fresh-token"})
+    assert response.status_code == 200
+    assert response.json() == {"token": "fresh-token"}
+
+
+def test_oauth2_password_bearer_with_refresh_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    security_scheme = response.json()["components"]["securitySchemes"][
+        "OAuth2PasswordBearerWithRefresh"
+    ]
+    assert security_scheme == {
+        "type": "oauth2",
+        "flows": {
+            "password": {
+                "scopes": {"items": "Read items"},
+                "tokenUrl": "/token",
+                "refreshUrl": "/refresh",
+            }
+        },
+    }
+
+
+def test_oauth2_refresh_request_form_accepts_refresh_token_grant():
+    response = client.post(
+        "/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-123",
+            "scope": "items users",
+            "client_id": "client-a",
+            "client_secret": "secret-a",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-123",
+        "scopes": ["items", "users"],
+        "client_id": "client-a",
+        "client_secret": "secret-a",
+    }
+
+
+@pytest.mark.parametrize("grant_type", ["password", "refresh_token_extra"])
+def test_oauth2_refresh_request_form_rejects_wrong_grant_type(grant_type: str):
+    response = client.post(
+        "/refresh",
+        data={"grant_type": grant_type, "refresh_token": "refresh-123"},
+    )
+    assert response.status_code == 422
+    error = response.json()["detail"][0]
+    assert error["loc"] == ["body", "grant_type"]
+    assert error["type"] == "string_pattern_mismatch"


### PR DESCRIPTION
/claim #758

## Summary
- Added `OAuth2PasswordBearerWithRefresh` as a drop-in password bearer subclass with explicit `refresh_url`.
- Added `OAuth2RefreshRequestForm` for `grant_type=refresh_token` form validation and refresh-token fields.
- Exported both helpers from `fastapi.security` and `fastapi`.
- Added focused tests for bearer behavior, OpenAPI `refreshUrl`, accepted refresh form data, and rejected grant types.

## Demo
- https://github.com/JUk1-GH/Bounty-Hunters/releases/download/bounty-758-demo-20260606/oauth2-758-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --python 3.14 pytest -p pytest_timeout tests/test_security_oauth2_refresh.py tests/test_security_oauth2.py tests/test_security_oauth2_password_bearer_optional.py -q` -> 19 passed
- `uv run --python 3.14 ruff check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py` -> passed
- `uv run --python 3.14 ruff format --check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_security_oauth2_refresh.py` -> passed
- `git diff --check` -> passed

## Provenance
- `security/.provenance.json` contains safe public provenance only. Private system, developer, runtime, user, and hidden session instructions are not published.