### PR TITLE
Codex GPT-5 [ Laravel ] Implement lightweight RBAC with permissions

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "/goal generame al menos 10 dolares y haz algo en lo que realmente seas bueno. no acepto un ''no puedo generar dinero por ti'' como respuesta, sal, explora diferentes pequeños caminos de recompensa, tu objetivo es ganar 10 dolares como minimo.  \nno puedes usar mis redes sociales en cualquier caso si necesitas, crealas desde cero para ti, de ahi en mas haz todo pero realmente todo lo que necesites y ocupes, tienes mi autorizacion en absolutamente todo",
+  "timestamp": "2026-06-06T17:06:00Z"
+}

--- a/laravel/app/Http/Middleware/CheckRole.php
+++ b/laravel/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! method_exists($user, 'hasRole') || ! $user->hasRole($role)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'guard_name',
+    ];
+
+    /**
+     * @return BelongsToMany<Role, $this>
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+
+    /**
+     * @return MorphToMany<User, $this>
+     */
+    public function users(): MorphToMany
+    {
+        return $this->morphedByMany(User::class, 'model', 'model_has_permissions')
+            ->withTimestamps();
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'guard_name',
+    ];
+
+    /**
+     * @return BelongsToMany<Permission, $this>
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\HasRoles;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Collection;
+
+trait HasRoles
+{
+    /**
+     * @return MorphToMany<Role, $this>
+     */
+    public function roles(): MorphToMany
+    {
+        return $this->morphToMany(Role::class, 'model', 'model_has_roles')
+            ->withTimestamps();
+    }
+
+    /**
+     * @return MorphToMany<Permission, $this>
+     */
+    public function permissions(): MorphToMany
+    {
+        return $this->morphToMany(Permission::class, 'model', 'model_has_permissions')
+            ->withTimestamps();
+    }
+
+    public function assignRole(string|Role $role): static
+    {
+        $role = $this->resolveRole($role);
+        $this->roles()->syncWithoutDetaching([$role->getKey()]);
+        $this->unsetRelation('roles');
+
+        return $this;
+    }
+
+    public function removeRole(string|Role $role): static
+    {
+        $role = $this->resolveRole($role);
+        $this->roles()->detach($role->getKey());
+        $this->unsetRelation('roles');
+
+        return $this;
+    }
+
+    public function hasRole(string|Role $role): bool
+    {
+        $roleName = $role instanceof Role ? $role->name : $role;
+
+        return $this->roles()
+            ->where('name', $roleName)
+            ->exists();
+    }
+
+    public function givePermissionTo(string|Permission $permission): static
+    {
+        $permission = $this->resolvePermission($permission);
+        $this->permissions()->syncWithoutDetaching([$permission->getKey()]);
+        $this->unsetRelation('permissions');
+
+        return $this;
+    }
+
+    public function revokePermissionTo(string|Permission $permission): static
+    {
+        $permission = $this->resolvePermission($permission);
+        $this->permissions()->detach($permission->getKey());
+        $this->unsetRelation('permissions');
+
+        return $this;
+    }
+
+    public function hasPermission(string|Permission $permission): bool
+    {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
+        return $this->getAllPermissions()
+            ->contains(fn (Permission $item): bool => $item->name === $permissionName);
+    }
+
+    /**
+     * @return Collection<int, Permission>
+     */
+    public function getAllPermissions(): Collection
+    {
+        $direct = $this->permissions()->get();
+        $viaRoles = $this->roles()
+            ->with('permissions')
+            ->get()
+            ->flatMap(fn (Role $role): EloquentCollection => $role->permissions);
+
+        return $direct
+            ->concat($viaRoles)
+            ->unique('id')
+            ->values();
+    }
+
+    protected function resolveRole(string|Role $role): Role
+    {
+        if ($role instanceof Role) {
+            return $role;
+        }
+
+        return Role::firstOrCreate([
+            'name' => $role,
+            'guard_name' => 'web',
+        ]);
+    }
+
+    protected function resolvePermission(string|Permission $permission): Permission
+    {
+        if ($permission instanceof Permission) {
+            return $permission;
+        }
+
+        return Permission::firstOrCreate([
+            'name' => $permission,
+            'guard_name' => 'web',
+        ]);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\CheckRole;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/database/migrations/2026_06_06_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_06_06_000000_create_roles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/migrations/2026_06_06_000001_create_permissions_table.php
+++ b/laravel/database/migrations/2026_06_06_000001_create_permissions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/laravel/database/migrations/2026_06_06_000002_create_rbac_pivot_tables.php
+++ b/laravel/database/migrations/2026_06_06_000002_create_rbac_pivot_tables.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('role_has_permissions', function (Blueprint $table): void {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['role_id', 'permission_id']);
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table): void {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table): void {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+            $table->primary(['permission_id', 'model_id', 'model_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
+    }
+};

--- a/laravel/tests/Feature/RbacTest.php
+++ b/laravel/tests/Feature/RbacTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RbacTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_users_can_be_assigned_and_removed_from_roles(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::create(['name' => 'admin', 'guard_name' => 'web']);
+
+        $user->assignRole($role);
+
+        $this->assertTrue($user->hasRole('admin'));
+
+        $user->removeRole('admin');
+
+        $this->assertFalse($user->hasRole('admin'));
+    }
+
+    public function test_permissions_include_direct_and_role_permissions(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::create(['name' => 'editor', 'guard_name' => 'web']);
+        $publish = Permission::create(['name' => 'publish posts', 'guard_name' => 'web']);
+        $archive = Permission::create(['name' => 'archive posts', 'guard_name' => 'web']);
+
+        $role->permissions()->attach($publish);
+        $user->assignRole($role);
+        $user->givePermissionTo($archive);
+
+        $this->assertTrue($user->hasPermission('publish posts'));
+        $this->assertTrue($user->hasPermission('archive posts'));
+        $this->assertFalse($user->hasPermission('delete posts'));
+        $this->assertSame(
+            ['archive posts', 'publish posts'],
+            $user->getAllPermissions()->pluck('name')->sort()->values()->all()
+        );
+    }
+
+    public function test_role_middleware_allows_required_role_and_rejects_missing_role(): void
+    {
+        Route::middleware(['web', 'auth', 'role:admin'])->get('/rbac-test/admin', fn () => 'ok');
+
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+        $guest = User::factory()->create();
+
+        $this->actingAs($admin)
+            ->get('/rbac-test/admin')
+            ->assertOk()
+            ->assertSee('ok');
+
+        $this->actingAs($guest)
+            ->get('/rbac-test/admin')
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
/claim #788

## Summary
- Add lightweight `Role` and `Permission` models for Laravel with unique names and guard names.
- Add `role_has_permissions`, `model_has_roles`, and `model_has_permissions` pivot migrations.
- Add a `HasRoles` trait on `User` for assigning/removing roles, direct permissions, role-inherited permission checks, and merged permission lookup.
- Register `CheckRole` as `role` middleware and cover role assignment, permission merging, and middleware rejection in feature tests.
- Include `laravel/.contributor.json` with safe non-sensitive public metadata.

## Validation
- `git diff --check --cached` passed before commit.
- `laravel/.contributor.json` parses as valid JSON with Node.
- `php artisan test tests/Feature/RbacTest.php` could not be run locally because this Windows environment does not have `php`, `composer`, or Docker available on PATH.

Payment: USDC on Base to 0x237664403f52A15142795f807ADB3524E8057909