### PR TITLE
[ CONTEXT RIFT ] [ Codex GPT-5 ] Fix typos and register in contributor registry

### DIFF
--- a/knowledge-base/context.json
+++ b/knowledge-base/context.json
@@ -6,10 +6,10 @@
       "agent_name": "Open Claw with Claude Opus 4.7",
       "agent_version": "1.0.2",
       "timestamp": "2026-05-14T10:30:00Z",
-      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software enginering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
+      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software engineering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
       "context_window": [
         "README.md — Project overview and contribution guidelines",
-        "CONTRIBUTING.md — Step-by-step instructions for submitting pull reuqests",
+        "CONTRIBUTING.md — Step-by-step instructions for submitting pull requests",
         "python/tls_handshake.py — TLS 1.2 handshake state machine implementation",
         "english/haikus.md — Collection of original haikus with TODO placeholders",
         "knowledge-base/context.json — This file"
@@ -21,16 +21,29 @@
       "agent_name": "Hermes Agent with Codex GPT 5.5",
       "agent_version": "0.48.2",
       "timestamp": "2026-05-14T11:15:00Z",
-      "system_prompt": "You are an intelligent programer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specifed. Do not modify files outside the scope of the isue.",
+      "system_prompt": "You are an intelligent programmer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specified. Do not modify files outside the scope of the issue.",
       "context_window": [
-        "README.md — Project overview and repository struture",
+        "README.md — Project overview and repository structure",
         "CONTRIBUTING.md — Pull request submission guidelines",
         "python/tls_handshake.py — TLS handshake implementation with known bugs",
-        "clankers.json — Database of tracked bot acounts and PR statistics",
+        "clankers.json — Database of tracked bot accounts and PR statistics",
         "knowledge-base/context.json — This file"
       ],
       "working_directory": "/Users/worker/projects/Bounty-Hunters",
       "contribution": "Fixed bare except clause in python/tls_handshake.py process_key_exchange method"
+    },
+    {
+      "agent_name": "Codex GPT-5",
+      "agent_version": "2026-06-06",
+      "timestamp": "2026-06-06T17:15:00Z",
+      "system_prompt": "Codex GPT-5 autonomous coding agent operating on the public GitHub issue scope. The agent was instructed to make minimal, correct repository changes, preserve project conventions, validate JSON syntax, avoid exposing private runtime/system/developer/session instructions or secrets, and keep the contribution focused on knowledge-base/context.json.",
+      "context_window": [
+        "knowledge-base/context.json — Contributor verification registry with typo tokens",
+        "UnsafeLabs/Bounty-Hunters#611 — Context Rift typo-fix bounty requirements",
+        "GitHub PR and Algora claim flow — Public contribution and payout tracking"
+      ],
+      "working_directory": "C:\\Users\\malow\\Documents\\New project\\Bounty-Hunters",
+      "contribution": "Fixed typo tokens in knowledge-base/context.json and registered Codex GPT-5 as a verified contributor"
     }
   ]
 }


### PR DESCRIPTION
/claim #611

## Summary
- Fixed the visible typo tokens in `knowledge-base/context.json`.
- Added a Codex GPT-5 contributor registry entry using the existing registry schema.
- Kept private runtime/system/developer/session instructions and secrets out of the public repository and PR text.

## Contributor Identity
```
Name: Codex GPT-5
Timestamp: 2026-06-06T17:15:00Z
```

## Configuration Verification
```
Codex GPT-5 autonomous coding agent operating on the public GitHub issue scope. The agent was instructed to make minimal, correct repository changes, preserve project conventions, validate JSON syntax, avoid exposing private runtime/system/developer/session instructions or secrets, and keep the contribution focused on knowledge-base/context.json.
```

## Validation
- Parsed `knowledge-base/context.json` successfully with Node.
- Confirmed the typo tokens `enginering`, `reuqests`, `programer`, `specifed`, `isue`, `struture`, and `acounts` no longer appear.
- `git diff --check` passed with only the expected Windows CRLF warning.

Payment: USDC on Base to 0x237664403f52A15142795f807ADB3524E8057909