### PR TITLE
Codex GPT-5 [ T3 Code ] Track debounced auth session activity

### DIFF
--- a/t3code/apps/server/src/auth/.attribution.json
+++ b/t3code/apps/server/src/auth/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Public-safe summary: Codex GPT-5 autonomous coding agent working on UnsafeLabs/Bounty-Hunters issue #835. Private system, developer, runtime, credential, clipboard, and hidden session instructions are intentionally excluded.",
+  "date": "2026-06-06T18:24:00Z"
+}

--- a/t3code/apps/server/src/auth/Layers/ServerAuth.test.ts
+++ b/t3code/apps/server/src/auth/Layers/ServerAuth.test.ts
@@ -1,7 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Duration from "effect/Duration";
 import * as Layer from "effect/Layer";
+import * as TestClock from "effect/testing/TestClock";
 
 import type { ServerConfigShape } from "../../config.ts";
 import { ServerConfig } from "../../config.ts";
@@ -177,6 +179,53 @@ it.layer(NodeServices.layer)("ServerAuthLive", (it) => {
         makeServerAuthLayer({
           desktopBootstrapToken: "desktop-bootstrap-token",
         }),
+      ),
+    ),
+  );
+
+  it.effect("marks authenticated requests active without rewriting within debounce window", () =>
+    Effect.gen(function* () {
+      const serverAuth = yield* ServerAuth;
+
+      const exchanged = yield* serverAuth.exchangeBootstrapCredential(
+        "desktop-bootstrap-token",
+        requestMetadata,
+      );
+      const verified = yield* serverAuth.authenticateHttpRequest(
+        makeCookieRequest(exchanged.sessionToken),
+      );
+      const firstClients = yield* serverAuth.listClientSessions(verified.sessionId);
+      const firstActiveAt = firstClients.find(
+        (entry) => entry.sessionId === verified.sessionId,
+      )?.lastConnectedAt;
+
+      yield* TestClock.adjust(Duration.minutes(4));
+      yield* serverAuth.authenticateHttpRequest(makeCookieRequest(exchanged.sessionToken));
+      const debouncedClients = yield* serverAuth.listClientSessions(verified.sessionId);
+
+      yield* TestClock.adjust(Duration.minutes(1));
+      yield* serverAuth.authenticateHttpRequest(makeCookieRequest(exchanged.sessionToken));
+      const refreshedClients = yield* serverAuth.listClientSessions(verified.sessionId);
+
+      expect(firstActiveAt).not.toBeNull();
+      expect(
+        debouncedClients
+          .find((entry) => entry.sessionId === verified.sessionId)
+          ?.lastConnectedAt?.toString(),
+      ).toBe(firstActiveAt?.toString());
+      expect(
+        refreshedClients
+          .find((entry) => entry.sessionId === verified.sessionId)
+          ?.lastConnectedAt?.toString(),
+      ).not.toBe(firstActiveAt?.toString());
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          makeServerAuthLayer({
+            desktopBootstrapToken: "desktop-bootstrap-token",
+          }),
+          TestClock.layer(),
+        ),
       ),
     ),
   );

--- a/t3code/apps/server/src/auth/Layers/ServerAuth.ts
+++ b/t3code/apps/server/src/auth/Layers/ServerAuth.ts
@@ -85,6 +85,7 @@ export const makeServerAuth = Effect.gen(function* () {
         role: session.role,
         ...(session.expiresAt ? { expiresAt: session.expiresAt } : {}),
       })),
+      Effect.tap((session) => sessions.markActive(session.sessionId)),
       Effect.mapError(
         (cause) =>
           new AuthError({

--- a/t3code/apps/server/src/auth/Layers/SessionCredentialService.test.ts
+++ b/t3code/apps/server/src/auth/Layers/SessionCredentialService.test.ts
@@ -190,4 +190,33 @@ it.layer(NodeServices.layer)("SessionCredentialServiceLive", (it) => {
       expect(afterReconnect[0]?.lastConnectedAt?.toString()).not.toBe(firstConnectedAt?.toString());
     }).pipe(Effect.provide(Layer.merge(makeSessionCredentialLayer(), TestClock.layer()))),
   );
+
+  it.effect("debounces authenticated session activity updates", () =>
+    Effect.gen(function* () {
+      const sessions = yield* SessionCredentialService;
+      const issued = yield* sessions.issue({
+        subject: "activity-test",
+        method: "bearer-session-token",
+      });
+
+      yield* sessions.markActive(issued.sessionId);
+      const firstActivity = yield* sessions.listActive();
+      const firstActiveAt = firstActivity[0]?.lastConnectedAt;
+      expect(firstActiveAt).not.toBeNull();
+
+      yield* TestClock.adjust(Duration.minutes(4));
+      yield* sessions.markActive(issued.sessionId);
+      const debouncedActivity = yield* sessions.listActive();
+      expect(debouncedActivity[0]?.lastConnectedAt?.toString()).toBe(
+        firstActiveAt?.toString(),
+      );
+
+      yield* TestClock.adjust(Duration.minutes(1));
+      yield* sessions.markActive(issued.sessionId);
+      const refreshedActivity = yield* sessions.listActive();
+      expect(refreshedActivity[0]?.lastConnectedAt?.toString()).not.toBe(
+        firstActiveAt?.toString(),
+      );
+    }).pipe(Effect.provide(Layer.merge(makeSessionCredentialLayer(), TestClock.layer()))),
+  );
 });

--- a/t3code/apps/server/src/auth/Layers/SessionCredentialService.ts
+++ b/t3code/apps/server/src/auth/Layers/SessionCredentialService.ts
@@ -33,6 +33,7 @@ import {
 const SIGNING_SECRET_NAME = "server-signing-key";
 const DEFAULT_SESSION_TTL = Duration.days(30);
 const DEFAULT_WEBSOCKET_TOKEN_TTL = Duration.minutes(5);
+const LAST_ACTIVE_UPDATE_DEBOUNCE = Duration.minutes(5);
 
 const SessionClaims = Schema.Struct({
   v: Schema.Literal(1),
@@ -95,6 +96,7 @@ export const makeSessionCredentialService = Effect.gen(function* () {
   const authSessions = yield* AuthSessionRepository;
   const signingSecret = yield* secretStore.getOrCreateRandom(SIGNING_SECRET_NAME, 32);
   const connectedSessionsRef = yield* Ref.make(new Map<string, number>());
+  const lastActiveWriteRef = yield* Ref.make(new Map<string, number>());
   const changesPubSub = yield* PubSub.unbounded<SessionCredentialChange>();
   const cookieName = resolveSessionCookieName({
     mode: serverConfig.mode,
@@ -192,6 +194,45 @@ export const makeSessionCredentialService = Effect.gen(function* () {
       ),
       Effect.catchCause((cause) =>
         Effect.logError("Failed to publish disconnected-session auth update.").pipe(
+          Effect.annotateLogs({
+            sessionId,
+            cause,
+          }),
+        ),
+      ),
+    );
+
+  const markActive: SessionCredentialServiceShape["markActive"] = (sessionId) =>
+    DateTime.now.pipe(
+      Effect.flatMap((lastActiveAt) =>
+        Ref.modify(lastActiveWriteRef, (current) => {
+          const previousWrite = current.get(sessionId);
+          const shouldWrite =
+            previousWrite === undefined ||
+            lastActiveAt.epochMilliseconds - previousWrite >=
+              Duration.toMillis(LAST_ACTIVE_UPDATE_DEBOUNCE);
+          if (!shouldWrite) {
+            return [null, current] as const;
+          }
+          const next = new Map(current);
+          next.set(sessionId, lastActiveAt.epochMilliseconds);
+          return [lastActiveAt, next] as const;
+        }),
+      ),
+      Effect.flatMap((lastActiveAt) =>
+        lastActiveAt === null
+          ? Effect.void
+          : authSessions.setLastConnectedAt({
+              sessionId,
+              lastConnectedAt: lastActiveAt,
+            }),
+      ),
+      Effect.flatMap(() => loadActiveSession(sessionId)),
+      Effect.flatMap((session) =>
+        Option.isSome(session) ? emitUpsert(session.value) : Effect.void,
+      ),
+      Effect.catchCause((cause) =>
+        Effect.logError("Failed to persist debounced session activity.").pipe(
           Effect.annotateLogs({
             sessionId,
             cause,
@@ -519,6 +560,7 @@ export const makeSessionCredentialService = Effect.gen(function* () {
     revokeAllExcept,
     markConnected,
     markDisconnected,
+    markActive,
   } satisfies SessionCredentialServiceShape;
 });
 

--- a/t3code/apps/server/src/auth/Services/SessionCredentialService.ts
+++ b/t3code/apps/server/src/auth/Services/SessionCredentialService.ts
@@ -83,6 +83,7 @@ export interface SessionCredentialServiceShape {
   ) => Effect.Effect<number, SessionCredentialError>;
   readonly markConnected: (sessionId: AuthSessionId) => Effect.Effect<void, never>;
   readonly markDisconnected: (sessionId: AuthSessionId) => Effect.Effect<void, never>;
+  readonly markActive: (sessionId: AuthSessionId) => Effect.Effect<void, never>;
 }
 
 export class SessionCredentialService extends Context.Service<

--- a/t3code/apps/server/src/persistence/Layers/AuthSessions.ts
+++ b/t3code/apps/server/src/persistence/Layers/AuthSessions.ts
@@ -156,7 +156,7 @@ const makeAuthSessionRepository = Effect.gen(function* () {
         FROM auth_sessions
         WHERE revoked_at IS NULL
           AND expires_at > ${now}
-        ORDER BY issued_at DESC, session_id DESC
+        ORDER BY COALESCE(last_connected_at, issued_at) DESC, issued_at DESC, session_id DESC
       `,
   });
 


### PR DESCRIPTION
/claim #835

## Summary
- Adds debounced authenticated-session activity tracking on every verified HTTP request.
- Persists activity at most once every 5 minutes per session to avoid excessive SQLite writes.
- Keeps existing multi-session create/list/revoke/revoke-others behavior intact while sorting active sessions by most recent activity.
- Adds focused tests for direct session activity debounce and authenticated request activity debounce.
- Includes required `.attribution.json` with safe public metadata only.

## Validation
- `node node_modules/vitest/vitest.mjs run apps/server/src/auth/Layers/SessionCredentialService.test.ts apps/server/src/auth/Layers/ServerAuth.test.ts --reporter=verbose` -> 13 tests passed
- `node node_modules/typescript/bin/tsc --noEmit -p apps/server/tsconfig.json` -> passed
- `git diff --check` -> passed, with Windows CRLF warnings only

## Notes
`origin/main` already contains the auth session table, device metadata persistence, session listing, revocation, and revoke-other flow. This PR closes the remaining request-activity/debounce behavior for #835 without replacing those existing boundaries.

Payment: USDC on Base to 0x237664403f52A15142795f807ADB3524E8057909