### PR TITLE
Codex GPT-5 [ T3 Code ] Add request body size guard

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,6 @@
+{
+  "agent": "Codex GPT-5",
+  "issue": 841,
+  "summary": "Added request body size limiting with default and per-route limits, structured 413 responses, and safe public provenance only.",
+  "privacy": "No private system, developer, runtime, credential, or session instructions are included."
+}

--- a/t3code/apps/server/src/auth/http.ts
+++ b/t3code/apps/server/src/auth/http.ts
@@ -14,6 +14,10 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import { AuthError, ServerAuth } from "./Services/ServerAuth.ts";
 import { SessionCredentialService } from "./Services/SessionCredentialService.ts";
 import { deriveAuthClientMetadata } from "./utils.ts";
+import {
+  enforceRequestBodyLimit,
+  respondToRequestBodyTooLarge,
+} from "../httpBodyLimit.ts";
 import { browserApiCorsHeaders } from "../httpCors.ts";
 
 export const respondToAuthError = (error: AuthError) =>
@@ -70,6 +74,7 @@ export const authBootstrapRouteLayer = HttpRouter.add(
     const request = yield* HttpServerRequest.HttpServerRequest;
     const serverAuth = yield* ServerAuth;
     const sessions = yield* SessionCredentialService;
+    yield* enforceRequestBodyLimit();
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthBootstrapInput).pipe(
       Effect.mapError(
         (cause) =>
@@ -96,7 +101,10 @@ export const authBootstrapRouteLayer = HttpRouter.add(
         sameSite: "lax",
       }),
     );
-  }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),
+  }).pipe(
+    Effect.catchTag("RequestBodyTooLargeError", respondToRequestBodyTooLarge),
+    Effect.catchTag("AuthError", (error) => respondToAuthError(error)),
+  ),
 );
 
 export const authBearerBootstrapRouteLayer = HttpRouter.add(
@@ -105,6 +113,7 @@ export const authBearerBootstrapRouteLayer = HttpRouter.add(
   Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest;
     const serverAuth = yield* ServerAuth;
+    yield* enforceRequestBodyLimit();
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthBootstrapInput).pipe(
       Effect.mapError(
         (cause) =>
@@ -123,7 +132,10 @@ export const authBearerBootstrapRouteLayer = HttpRouter.add(
       status: 200,
       headers: browserApiCorsHeaders,
     });
-  }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),
+  }).pipe(
+    Effect.catchTag("RequestBodyTooLargeError", respondToRequestBodyTooLarge),
+    Effect.catchTag("AuthError", (error) => respondToAuthError(error)),
+  ),
 );
 
 export const authWebSocketTokenRouteLayer = HttpRouter.add(
@@ -148,6 +160,7 @@ export const authPairingCredentialRouteLayer = HttpRouter.add(
     const serverAuth = yield* ServerAuth;
     const request = yield* HttpServerRequest.HttpServerRequest;
     const session = yield* serverAuth.authenticateHttpRequest(request);
+    yield* enforceRequestBodyLimit();
     if (session.role !== "owner") {
       return yield* new AuthError({
         message: "Only owner sessions can create pairing credentials.",
@@ -178,7 +191,10 @@ export const authPairingCredentialRouteLayer = HttpRouter.add(
       : {};
     const result = yield* serverAuth.issuePairingCredential(payload);
     return HttpServerResponse.jsonUnsafe(result, { status: 200 });
-  }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),
+  }).pipe(
+    Effect.catchTag("RequestBodyTooLargeError", respondToRequestBodyTooLarge),
+    Effect.catchTag("AuthError", (error) => respondToAuthError(error)),
+  ),
 );
 
 const authenticateOwnerSession = Effect.gen(function* () {
@@ -209,6 +225,7 @@ export const authPairingLinksRevokeRouteLayer = HttpRouter.add(
   "/api/auth/pairing-links/revoke",
   Effect.gen(function* () {
     const { serverAuth } = yield* authenticateOwnerSession;
+    yield* enforceRequestBodyLimit();
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthRevokePairingLinkInput).pipe(
       Effect.mapError(
         (cause) =>
@@ -221,7 +238,10 @@ export const authPairingLinksRevokeRouteLayer = HttpRouter.add(
     );
     const revoked = yield* serverAuth.revokePairingLink(payload.id);
     return HttpServerResponse.jsonUnsafe({ revoked }, { status: 200 });
-  }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),
+  }).pipe(
+    Effect.catchTag("RequestBodyTooLargeError", respondToRequestBodyTooLarge),
+    Effect.catchTag("AuthError", (error) => respondToAuthError(error)),
+  ),
 );
 
 export const authClientsRouteLayer = HttpRouter.add(
@@ -239,6 +259,7 @@ export const authClientsRevokeRouteLayer = HttpRouter.add(
   "/api/auth/clients/revoke",
   Effect.gen(function* () {
     const { serverAuth, session } = yield* authenticateOwnerSession;
+    yield* enforceRequestBodyLimit();
     const payload = yield* HttpServerRequest.schemaBodyJson(AuthRevokeClientSessionInput).pipe(
       Effect.mapError(
         (cause) =>
@@ -251,7 +272,10 @@ export const authClientsRevokeRouteLayer = HttpRouter.add(
     );
     const revoked = yield* serverAuth.revokeClientSession(session.sessionId, payload.sessionId);
     return HttpServerResponse.jsonUnsafe({ revoked }, { status: 200 });
-  }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),
+  }).pipe(
+    Effect.catchTag("RequestBodyTooLargeError", respondToRequestBodyTooLarge),
+    Effect.catchTag("AuthError", (error) => respondToAuthError(error)),
+  ),
 );
 
 export const authClientsRevokeOthersRouteLayer = HttpRouter.add(

--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http";
 
 import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import {
+  BODY_LIMIT_HEADER,
+  DEFAULT_REQUEST_BODY_LIMIT_BYTES,
+  FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES,
+  enforceRequestBodyLimit,
+  parseContentLengthBytes,
+  requestBodyLimitExceeded,
+  resolveRequestBodyLimit,
+} from "./httpBodyLimit.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +34,61 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("request body limit", () => {
+  it("uses a 10MB default and supports a 50MB route override", () => {
+    expect(resolveRequestBodyLimit()).toBe(DEFAULT_REQUEST_BODY_LIMIT_BYTES);
+    expect(resolveRequestBodyLimit(FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES)).toBe(
+      FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES,
+    );
+  });
+
+  it("parses safe Content-Length values only", () => {
+    expect(parseContentLengthBytes({ "content-length": "42" })).toBe(42);
+    expect(parseContentLengthBytes({ "content-length": "" })).toBeUndefined();
+    expect(parseContentLengthBytes({ "content-length": "-1" })).toBeUndefined();
+    expect(parseContentLengthBytes({ "content-length": "10.5" })).toBeUndefined();
+    expect(parseContentLengthBytes({ "content-length": "not-a-number" })).toBeUndefined();
+  });
+
+  it("reports oversized bodies before route body parsing", () => {
+    const error = requestBodyLimitExceeded({
+      "content-length": String(DEFAULT_REQUEST_BODY_LIMIT_BYTES + 1),
+    });
+
+    expect(error?._tag).toBe("RequestBodyTooLargeError");
+    expect(error?.limitBytes).toBe(DEFAULT_REQUEST_BODY_LIMIT_BYTES);
+    expect(error?.receivedBytes).toBe(DEFAULT_REQUEST_BODY_LIMIT_BYTES + 1);
+  });
+
+  it("fails the request guard when Content-Length is over the limit", async () => {
+    const result = await Effect.runPromise(
+      Effect.flip(enforceRequestBodyLimit()).pipe(
+        Effect.provideService(HttpServerRequest.HttpServerRequest, {
+          headers: {
+            "content-length": String(DEFAULT_REQUEST_BODY_LIMIT_BYTES + 1),
+          },
+        } as unknown as HttpServerRequest.HttpServerRequest),
+      ),
+    );
+
+    expect(result._tag).toBe("RequestBodyTooLargeError");
+    expect(result.limitBytes).toBe(DEFAULT_REQUEST_BODY_LIMIT_BYTES);
+    expect(result.receivedBytes).toBe(DEFAULT_REQUEST_BODY_LIMIT_BYTES + 1);
+  });
+
+  it("allows requests under custom per-route limits", () => {
+    expect(
+      requestBodyLimitExceeded(
+        { "content-length": String(DEFAULT_REQUEST_BODY_LIMIT_BYTES + 1) },
+        FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("exports the response header required by clients", () => {
+    expect(BODY_LIMIT_HEADER).toBe("X-Max-Body-Size");
   });
 });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -33,6 +33,11 @@ import {
   browserApiCorsAllowedMethods,
   browserApiCorsHeaders,
 } from "./httpCors.ts";
+import {
+  FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES,
+  enforceRequestBodyLimit,
+  respondToRequestBodyTooLarge,
+} from "./httpBodyLimit.ts";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
@@ -91,6 +96,7 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
   OTLP_TRACES_PROXY_PATH,
   Effect.gen(function* () {
     yield* requireAuthenticatedRequest;
+    yield* enforceRequestBodyLimit(FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES);
     const request = yield* HttpServerRequest.HttpServerRequest;
     const config = yield* ServerConfig;
     const otlpTracesUrl = config.otlpTracesUrl;
@@ -132,7 +138,10 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
           Effect.succeed(HttpServerResponse.text("Trace export failed.", { status: 502 })),
         ),
       );
-  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+  }).pipe(
+    Effect.catchTag("RequestBodyTooLargeError", respondToRequestBodyTooLarge),
+    Effect.catchTag("AuthError", respondToAuthError),
+  ),
 );
 
 export const attachmentsRouteLayer = HttpRouter.add(

--- a/t3code/apps/server/src/httpBodyLimit.ts
+++ b/t3code/apps/server/src/httpBodyLimit.ts
@@ -1,0 +1,77 @@
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+import { browserApiCorsHeaders } from "./httpCors.ts";
+
+export const DEFAULT_REQUEST_BODY_LIMIT_BYTES = 10 * 1024 * 1024;
+export const FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES = 50 * 1024 * 1024;
+export const BODY_LIMIT_HEADER = "X-Max-Body-Size";
+
+export class RequestBodyTooLargeError extends Data.TaggedError("RequestBodyTooLargeError")<{
+  readonly limitBytes: number;
+  readonly receivedBytes: number;
+}> {}
+
+export function resolveRequestBodyLimit(limitBytes?: number): number {
+  if (typeof limitBytes === "number" && Number.isFinite(limitBytes) && limitBytes > 0) {
+    return Math.floor(limitBytes);
+  }
+  return DEFAULT_REQUEST_BODY_LIMIT_BYTES;
+}
+
+export function parseContentLengthBytes(headers: Record<string, string | undefined>) {
+  const value = headers["content-length"];
+  if (typeof value !== "string" || value.trim() === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+export function requestBodyLimitExceeded(
+  headers: Record<string, string | undefined>,
+  limitBytes = DEFAULT_REQUEST_BODY_LIMIT_BYTES,
+) {
+  const receivedBytes = parseContentLengthBytes(headers);
+  const resolvedLimitBytes = resolveRequestBodyLimit(limitBytes);
+  if (receivedBytes === undefined || receivedBytes <= resolvedLimitBytes) {
+    return undefined;
+  }
+  return new RequestBodyTooLargeError({
+    limitBytes: resolvedLimitBytes,
+    receivedBytes,
+  });
+}
+
+export const enforceRequestBodyLimit = (limitBytes = DEFAULT_REQUEST_BODY_LIMIT_BYTES) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const error = requestBodyLimitExceeded(request.headers, limitBytes);
+    if (error) {
+      return yield* error;
+    }
+  });
+
+export const respondToRequestBodyTooLarge = (error: RequestBodyTooLargeError) =>
+  Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      {
+        error: "Payload Too Large",
+        limit: error.limitBytes,
+        received: error.receivedBytes,
+      },
+      {
+        status: 413,
+        headers: {
+          ...browserApiCorsHeaders,
+          [BODY_LIMIT_HEADER]: String(error.limitBytes),
+        },
+      },
+    ),
+  );

--- a/t3code/apps/server/src/orchestration/http.ts
+++ b/t3code/apps/server/src/orchestration/http.ts
@@ -8,6 +8,10 @@ import * as Effect from "effect/Effect";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
 import { ServerAuth } from "../auth/Services/ServerAuth.ts";
+import {
+  enforceRequestBodyLimit,
+  respondToRequestBodyTooLarge,
+} from "../httpBodyLimit.ts";
 import { normalizeDispatchCommand } from "./Normalizer.ts";
 import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
@@ -68,6 +72,7 @@ export const orchestrationDispatchRouteLayer = HttpRouter.add(
   "/api/orchestration/dispatch",
   Effect.gen(function* () {
     yield* authenticateOwnerSession;
+    yield* enforceRequestBodyLimit();
     const orchestrationEngine = yield* OrchestrationEngineService;
     const command = yield* HttpServerRequest.schemaBodyJson(ClientOrchestrationCommand).pipe(
       Effect.mapError(
@@ -89,5 +94,8 @@ export const orchestrationDispatchRouteLayer = HttpRouter.add(
       ),
     );
     return HttpServerResponse.jsonUnsafe(result, { status: 200 });
-  }).pipe(Effect.catchTag("OrchestrationDispatchCommandError", respondToOrchestrationHttpError)),
+  }).pipe(
+    Effect.catchTag("RequestBodyTooLargeError", respondToRequestBodyTooLarge),
+    Effect.catchTag("OrchestrationDispatchCommandError", respondToOrchestrationHttpError),
+  ),
 );


### PR DESCRIPTION
﻿/claim #841

## Summary
- Add a reusable request body size guard with a 10MB default limit and explicit per-route overrides.
- Apply the guard before JSON body parsing on auth/orchestration POST routes and use a 50MB override for browser trace ingest.
- Return structured `413 Payload Too Large` JSON with `limit`, `received`, and the required `X-Max-Body-Size` header.
- Add safe public provenance metadata only; private runtime/system/developer/session instructions are intentionally not reproduced.

## Validation
- `node node_modules/vitest/vitest.mjs run apps/server/src/http.test.ts --reporter=verbose` (9 passed)
- `node node_modules/vitest/vitest.mjs run apps/server/src/server.test.ts --config apps/server/vitest.config.ts --testNamePattern "bootstraps a browser session|bootstraps a bearer session|reports unauthenticated session" --reporter=verbose` (3 passed, 62 skipped)
- `node node_modules/typescript/bin/tsc --noEmit -p apps/server/tsconfig.json`
- `git diff --check`

## Payout
USDC on Base: `0x237664403f52A15142795f807ADB3524E8057909`
