### PR TITLE
Codex GPT-5 [ T3 Code ] Add Codex request streaming

### DIFF
--- a/t3code/packages/effect-codex-app-server/src/_generation.json
+++ b/t3code/packages/effect-codex-app-server/src/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "pre_task_context": "Public summary only: implemented Effect.Stream-based streaming support for issue #845. Private system, developer, runtime, session, credential, and hidden context instructions are intentionally excluded.",
+  "timestamp": "2026-06-06T18:30:00Z"
+}

--- a/t3code/packages/effect-codex-app-server/src/client.test.ts
+++ b/t3code/packages/effect-codex-app-server/src/client.test.ts
@@ -1,15 +1,27 @@
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Effect from "effect/Effect";
+import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
+import * as TestClock from "effect/testing/TestClock";
 
+import * as CodexError from "./errors.ts";
 import * as CodexClient from "./client.ts";
+import { makeInMemoryStdio } from "./_internal/stdio.ts";
+
+const encodeUnknownJsonString = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
+const encoder = new TextEncoder();
+
+const encodeJsonl = (value: unknown) => encoder.encode(`${encodeUnknownJsonString(value)}\n`);
 
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/codex-app-server-mock-peer.ts"),
@@ -149,6 +161,193 @@ it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
       }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
 
       assert.equal(initialized.userAgent, "mock-codex-app-server");
+    }),
+  );
+
+  it.effect("streams request notifications in order before the final response", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+      const context = yield* Layer.buildWithScope(
+        Layer.effect(CodexClient.CodexAppServerClient, CodexClient.make(stdio)),
+        scope,
+      );
+
+      const eventsFiber = yield* Effect.gen(function* () {
+        const client = yield* CodexClient.CodexAppServerClient;
+        return yield* client
+          .requestStream("initialize", {
+            clientInfo: {
+              name: "effect-codex-app-server-test",
+              title: "Effect Codex App Server Test",
+              version: "0.0.0",
+            },
+            capabilities: {
+              experimentalApi: true,
+              optOutNotificationMethods: null,
+            },
+          })
+          .pipe(Stream.runCollect);
+      }).pipe(Effect.provide(context), Effect.forkScoped);
+
+      const requestLine = yield* Queue.take(output);
+      assert.include(requestLine, '"method":"initialize"');
+
+      yield* Queue.offer(
+        input,
+        encodeJsonl({
+          method: "item/agentMessage/delta",
+          params: {
+            delta: "one",
+            itemId: "item-1",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        }),
+      );
+      yield* Queue.offer(
+        input,
+        encodeJsonl({
+          method: "item/agentMessage/delta",
+          params: {
+            delta: "two",
+            itemId: "item-1",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        }),
+      );
+      yield* Queue.offer(
+        input,
+        encodeJsonl({
+          id: 1,
+          result: {
+            userAgent: "mock-codex-app-server",
+            codexHome: "/tmp/codex-home",
+            platformFamily: "unix",
+            platformOs: "macos",
+          },
+        }),
+      );
+
+      const events = yield* Fiber.join(eventsFiber);
+      assert.deepEqual(
+        events.map((event) =>
+          event.type === "chunk"
+            ? {
+                type: event.type,
+                method: event.notification.method,
+                delta: (event.notification.params as { readonly delta?: string }).delta,
+              }
+            : {
+                type: event.type,
+                userAgent: event.type === "response" ? event.response.userAgent : undefined,
+              },
+        ),
+        [
+          { type: "chunk", method: "item/agentMessage/delta", delta: "one" },
+          { type: "chunk", method: "item/agentMessage/delta", delta: "two" },
+          { type: "response", userAgent: "mock-codex-app-server" },
+        ],
+      );
+
+      yield* Scope.close(scope, Exit.void);
+    }),
+  );
+
+  it.effect("emits an idle warning before failing a stalled stream", () =>
+    Effect.gen(function* () {
+      const { stdio, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+      const context = yield* Layer.buildWithScope(
+        Layer.effect(CodexClient.CodexAppServerClient, CodexClient.make(stdio)),
+        scope,
+      );
+
+      const stream = Effect.gen(function* () {
+        const client = yield* CodexClient.CodexAppServerClient;
+        return client.requestStream(
+          "initialize",
+          {
+            clientInfo: {
+              name: "effect-codex-app-server-test",
+              title: "Effect Codex App Server Test",
+              version: "0.0.0",
+            },
+            capabilities: {
+              experimentalApi: true,
+              optOutNotificationMethods: null,
+            },
+          },
+          { warningAfterMillis: 30, failAfterMillis: 120 },
+        );
+      }).pipe(Effect.provide(context));
+
+      const firstEventFiber = yield* stream.pipe(
+        Effect.flatMap((requestStream) => requestStream.pipe(Stream.take(1), Stream.runCollect)),
+        Effect.forkScoped,
+      );
+      yield* Queue.take(output);
+      yield* TestClock.adjust("30 millis");
+      const firstEvent = (yield* Fiber.join(firstEventFiber))[0];
+      assert.deepEqual(firstEvent, {
+        type: "warning",
+        reason: "chunk_timeout",
+        idleMillis: 30,
+      });
+
+      const failureFiber = yield* stream.pipe(
+        Effect.flatMap((requestStream) => requestStream.pipe(Stream.runCollect)),
+        Effect.flip,
+        Effect.forkScoped,
+      );
+      yield* Queue.take(output);
+      yield* TestClock.adjust("120 millis");
+      const error = yield* Fiber.join(failureFiber);
+      assert.instanceOf(error, CodexError.CodexAppServerStreamTimeoutError);
+      assert.equal(error.idleMillis, 120);
+
+      yield* Scope.close(scope, Exit.void);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("aborts a streaming request cleanly", () =>
+    Effect.gen(function* () {
+      const { stdio, output } = yield* makeInMemoryStdio();
+      const scope = yield* Scope.make();
+      const context = yield* Layer.buildWithScope(
+        Layer.effect(CodexClient.CodexAppServerClient, CodexClient.make(stdio)),
+        scope,
+      );
+      const abortController = new AbortController();
+
+      const eventsFiber = yield* Effect.gen(function* () {
+        const client = yield* CodexClient.CodexAppServerClient;
+        return yield* client
+          .requestStream(
+            "initialize",
+            {
+              clientInfo: {
+                name: "effect-codex-app-server-test",
+                title: "Effect Codex App Server Test",
+                version: "0.0.0",
+              },
+              capabilities: {
+                experimentalApi: true,
+                optOutNotificationMethods: null,
+              },
+            },
+            { abortSignal: abortController.signal },
+          )
+          .pipe(Stream.runCollect);
+      }).pipe(Effect.provide(context), Effect.forkScoped);
+
+      yield* Queue.take(output);
+      abortController.abort();
+      const events = yield* Fiber.join(eventsFiber);
+      assert.deepEqual(events, []);
+
+      yield* Scope.close(scope, Exit.void);
     }),
   );
 });

--- a/t3code/packages/effect-codex-app-server/src/client.ts
+++ b/t3code/packages/effect-codex-app-server/src/client.ts
@@ -1,9 +1,15 @@
 import * as Context from "effect/Context";
+import * as Exit from "effect/Exit";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stdio from "effect/Stdio";
+import * as Stream from "effect/Stream";
+import * as Take from "effect/Take";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as CodexRpc from "./_generated/meta.gen.ts";
@@ -18,6 +24,9 @@ import {
 import { makeChildStdio, makeTerminationError } from "./_internal/stdio.ts";
 
 const DEFAULT_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
+const DEFAULT_STREAM_WARNING_AFTER_MILLIS = 30_000;
+const DEFAULT_STREAM_FAIL_AFTER_MILLIS = 120_000;
+const DEFAULT_STREAM_BUFFER_SIZE = 16;
 
 export interface CodexAppServerClientOptions {
   readonly logIncoming?: boolean;
@@ -36,12 +45,45 @@ interface CodexAppServerClientRaw {
   readonly respondError: CodexProtocol.CodexAppServerPatchedProtocol["respondError"];
 }
 
+export type CodexAppServerRequestStreamEvent<M extends CodexRpc.ClientRequestMethod> =
+  | {
+      readonly type: "chunk";
+      readonly notification: CodexProtocol.CodexAppServerIncomingNotification;
+    }
+  | {
+      readonly type: "warning";
+      readonly reason: "chunk_timeout";
+      readonly idleMillis: number;
+    }
+  | {
+      readonly type: "response";
+      readonly response: CodexRpc.ClientRequestResponsesByMethod[M];
+    };
+
+export interface CodexAppServerRequestStreamOptions {
+  readonly bufferSize?: number;
+  readonly warningAfterMillis?: number;
+  readonly failAfterMillis?: number;
+  readonly abortSignal?: AbortSignal;
+  readonly includeNotification?: (
+    notification: CodexProtocol.CodexAppServerIncomingNotification,
+  ) => boolean;
+}
+
 export interface CodexAppServerClientShape {
   readonly raw: CodexAppServerClientRaw;
   readonly request: <M extends CodexRpc.ClientRequestMethod>(
     method: M,
     payload: CodexRpc.ClientRequestParamsByMethod[M],
   ) => Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexError.CodexAppServerError>;
+  readonly requestStream: <M extends CodexRpc.ClientRequestMethod>(
+    method: M,
+    payload: CodexRpc.ClientRequestParamsByMethod[M],
+    options?: CodexAppServerRequestStreamOptions,
+  ) => Stream.Stream<
+    CodexAppServerRequestStreamEvent<M>,
+    CodexError.CodexAppServerError
+  >;
   readonly notify: <M extends CodexRpc.ClientNotificationMethod>(
     method: M,
     payload: CodexRpc.ClientNotificationParamsByMethod[M],
@@ -83,6 +125,14 @@ type ServerRequestHandler = (
 type ServerNotificationHandler = (
   payload: unknown,
 ) => Effect.Effect<void, CodexError.CodexAppServerError>;
+type StreamSubscriber = {
+  readonly includeNotification: (
+    notification: CodexProtocol.CodexAppServerIncomingNotification,
+  ) => boolean;
+  readonly offer: (
+    notification: CodexProtocol.CodexAppServerIncomingNotification,
+  ) => Effect.Effect<void, CodexError.CodexAppServerError>;
+};
 
 export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make")(function* (
   stdio: Stdio.Stdio,
@@ -91,6 +141,7 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
 ): Effect.fn.Return<CodexAppServerClientShape, never, Scope.Scope> {
   const requestHandlers = new Map<string, ServerRequestHandler>();
   const notificationHandlers = new Map<string, Array<ServerNotificationHandler>>();
+  const streamSubscribers = new Set<StreamSubscriber>();
   let unknownRequestHandler:
     | ((method: string, params: unknown) => Effect.Effect<unknown, CodexError.CodexAppServerError>)
     | undefined;
@@ -148,8 +199,18 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
         : undefined;
     const handlers = notificationHandlers.get(notification.method) ?? [];
 
+    const publishToStreams = Effect.forEach(
+      [...streamSubscribers],
+      (subscriber) =>
+        subscriber.includeNotification(notification)
+          ? subscriber.offer(notification)
+          : Effect.void,
+      { discard: true },
+    ).pipe(Effect.catch(() => Effect.void));
+
     if (schema) {
-      return decodeNotificationPayload(notification.method, schema, notification.params).pipe(
+      return publishToStreams.pipe(
+        Effect.andThen(decodeNotificationPayload(notification.method, schema, notification.params)),
         Effect.flatMap((decoded) =>
           Effect.forEach(handlers, (handler) => handler(decoded), { discard: true }),
         ),
@@ -157,11 +218,14 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
       );
     }
 
-    return unknownNotificationHandler
-      ? unknownNotificationHandler(notification.method, notification.params).pipe(
-          Effect.catch(() => Effect.void),
-        )
-      : Effect.void;
+    return publishToStreams.pipe(
+      Effect.andThen(
+        unknownNotificationHandler
+          ? unknownNotificationHandler(notification.method, notification.params)
+          : Effect.void,
+      ),
+      Effect.catch(() => Effect.void),
+    );
   };
 
   const dispatchRequest = (
@@ -210,6 +274,107 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
       ),
     );
 
+  const requestStream = <M extends CodexRpc.ClientRequestMethod>(
+    method: M,
+    payload: CodexRpc.ClientRequestParamsByMethod[M],
+    options: CodexAppServerRequestStreamOptions = {},
+  ): Stream.Stream<
+    CodexAppServerRequestStreamEvent<M>,
+    CodexError.CodexAppServerError
+  > =>
+    Stream.scoped(Stream.unwrap(
+      Effect.gen(function* () {
+        const bufferSize = Math.max(1, Math.floor(options.bufferSize ?? DEFAULT_STREAM_BUFFER_SIZE));
+        const warningAfterMillis = Math.max(
+          1,
+          Math.floor(options.warningAfterMillis ?? DEFAULT_STREAM_WARNING_AFTER_MILLIS),
+        );
+        const failAfterMillis = Math.max(
+          warningAfterMillis + 1,
+          Math.floor(options.failAfterMillis ?? DEFAULT_STREAM_FAIL_AFTER_MILLIS),
+        );
+        const output =
+          yield* Queue.bounded<Take.Take<CodexAppServerRequestStreamEvent<M>, CodexError.CodexAppServerError>>(
+            bufferSize,
+          );
+        const activityVersion = yield* Ref.make(0);
+
+        const emit = (event: CodexAppServerRequestStreamEvent<M>) =>
+          Ref.update(activityVersion, (current) => current + 1).pipe(
+            Effect.andThen(Queue.offer(output, [event])),
+          );
+        const fail = (error: CodexError.CodexAppServerError) =>
+          Queue.offer(output, Exit.fail(error));
+        const end = Queue.offer(output, Exit.void);
+        const subscriber: StreamSubscriber = {
+          includeNotification: options.includeNotification ?? (() => true),
+          offer: (notification) => emit({ type: "chunk", notification }),
+        };
+
+        yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            streamSubscribers.add(subscriber);
+          }),
+          () =>
+            Effect.sync(() => {
+              streamSubscribers.delete(subscriber);
+            }).pipe(Effect.andThen(Queue.shutdown(output))),
+        );
+
+        const monitor = Effect.gen(function* () {
+          while (true) {
+            const observedVersion = yield* Ref.get(activityVersion);
+            yield* Effect.sleep(`${warningAfterMillis} millis`);
+            if ((yield* Ref.get(activityVersion)) !== observedVersion) {
+              continue;
+            }
+            yield* emit({
+              type: "warning",
+              reason: "chunk_timeout",
+              idleMillis: warningAfterMillis,
+            });
+            yield* Effect.sleep(`${failAfterMillis - warningAfterMillis} millis`);
+            if ((yield* Ref.get(activityVersion)) === observedVersion + 1) {
+              yield* fail(
+                new CodexError.CodexAppServerStreamTimeoutError({
+                  idleMillis: failAfterMillis,
+                }),
+              );
+              break;
+            }
+          }
+        });
+
+        yield* Effect.forkScoped(monitor);
+        const requestFiber = yield* request(method, payload).pipe(
+          Effect.flatMap((response) => emit({ type: "response", response })),
+          Effect.andThen(end),
+          Effect.catch(fail),
+          Effect.forkScoped,
+        );
+
+        if (options.abortSignal) {
+          const abort = () => {
+            Effect.runFork(Fiber.interrupt(requestFiber).pipe(Effect.andThen(end)));
+          };
+          yield* Effect.acquireRelease(
+            Effect.sync(() => {
+              options.abortSignal?.addEventListener("abort", abort, { once: true });
+              if (options.abortSignal?.aborted) {
+                abort();
+              }
+            }),
+            () =>
+              Effect.sync(() => {
+                options.abortSignal?.removeEventListener("abort", abort);
+              }),
+          );
+        }
+
+        return Stream.fromQueue(output).pipe(Stream.flattenTake);
+      }),
+    ));
+
   const notify = <M extends CodexRpc.ClientNotificationMethod>(
     method: M,
     payload: CodexRpc.ClientNotificationParamsByMethod[M],
@@ -228,6 +393,7 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
       respondError: transport.respondError,
     },
     request,
+    requestStream,
     notify,
     handleServerRequest: (method, handler) =>
       Effect.sync(() => {

--- a/t3code/packages/effect-codex-app-server/src/errors.ts
+++ b/t3code/packages/effect-codex-app-server/src/errors.ts
@@ -58,6 +58,17 @@ export class CodexAppServerTransportError extends Schema.TaggedErrorClass<CodexA
   }
 }
 
+export class CodexAppServerStreamTimeoutError extends Schema.TaggedErrorClass<CodexAppServerStreamTimeoutError>()(
+  "CodexAppServerStreamTimeoutError",
+  {
+    idleMillis: Schema.Number,
+  },
+) {
+  override get message() {
+    return `Codex App Server stream timed out after ${this.idleMillis}ms without a chunk`;
+  }
+}
+
 export class CodexAppServerRequestError extends Schema.TaggedErrorClass<CodexAppServerRequestError>()(
   "CodexAppServerRequestError",
   {
@@ -140,6 +151,7 @@ export const CodexAppServerError = Schema.Union([
   CodexAppServerProcessExitedError,
   CodexAppServerProtocolParseError,
   CodexAppServerTransportError,
+  CodexAppServerStreamTimeoutError,
 ]);
 
 export type CodexAppServerError = typeof CodexAppServerError.Type;


### PR DESCRIPTION
﻿/claim #845

## Summary
- Add `client.requestStream(...)` to the Effect Codex App Server wrapper while preserving the existing `client.request(...)` API.
- Stream request-scoped protocol notifications as `Effect.Stream` `chunk` events and emit a final typed `response` event in order.
- Use bounded queues for streamed events; publishing awaits slow consumers, providing backpressure instead of unbounded memory growth.
- Emit `chunk_timeout` warnings after idle periods and fail stalled streams with `CodexAppServerStreamTimeoutError` after the configured fail deadline; production defaults are 30s warning and 120s failure.
- Support `AbortSignal` cancellation so consumers can terminate a pending stream cleanly.
- Add safe public `_generation.json` metadata only; private system/developer/runtime/session instructions and secrets are intentionally not reproduced.

## Validation
- `node node_modules/typescript/bin/tsc --noEmit -p packages/effect-codex-app-server/tsconfig.json`
- `node node_modules/vitest/vitest.mjs run packages/effect-codex-app-server/src/client.test.ts --testNamePattern "streams request|idle warning|aborts" --reporter=verbose` (3 passed, 2 skipped)
- `_generation.json` parsed successfully with Node
- `git diff --check`

## Local note
The full `client.test.ts` suite still contains two pre-existing tests that spawn `bun`; those fail in this Windows workspace because `bun` is not available on PATH. The new in-memory streaming tests above do not require `bun` and passed.

## Payout
USDC on Base: `0x237664403f52A15142795f807ADB3524E8057909`
