### PR TITLE
Codex GPT-5 [ T3 Code ] Add provider response cache

### DIFF
--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -58,6 +58,10 @@ export const providerRuntimeEventsTotal = Metric.counter("t3_provider_runtime_ev
   description: "Total canonical provider runtime events processed.",
 });
 
+export const providerCacheRequestsTotal = Metric.counter("t3_provider_cache_requests_total", {
+  description: "Total provider response cache lookups by cache type and hit/miss outcome.",
+});
+
 export const gitCommandsTotal = Metric.counter("t3_git_commands_total", {
   description: "Total git commands executed by the server runtime.",
 });

--- a/t3code/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -41,6 +41,7 @@ import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
 
 import { ServerConfig } from "../../config.ts";
+import { makeProviderCache } from "../Services/ProviderCache.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
 import {
@@ -198,6 +199,7 @@ export const ProviderRegistryLive = Layer.effect(
       PubSub.unbounded<ReadonlyArray<ServerProvider>>(),
       PubSub.shutdown,
     );
+    const providerCache = yield* makeProviderCache();
 
     // Boot-only: hydrate `providersRef` from the on-disk per-instance
     // cache so the UI has something to render during the first refresh.
@@ -429,14 +431,16 @@ export const ProviderRegistryLive = Layer.effect(
 
     const refreshOneSource = Effect.fn("refreshOneSource")(function* (
       providerSource: ProviderSnapshotSource,
+      options: { readonly useCache?: boolean } = {},
     ) {
-      return yield* providerSource.refresh.pipe(
-        Effect.flatMap((nextProvider) =>
-          correlateSnapshotWithSource(providerSource, nextProvider).pipe(
-            Effect.flatMap(syncProvider),
-          ),
-        ),
+      const refreshSnapshot = providerSource.refresh.pipe(
+        Effect.flatMap((nextProvider) => correlateSnapshotWithSource(providerSource, nextProvider)),
       );
+      const nextProvider =
+        options.useCache === false
+          ? yield* refreshSnapshot
+          : yield* providerCache.getModelList(providerSource.instanceId, refreshSnapshot);
+      return yield* syncProvider(nextProvider);
     });
 
     const refreshAll = Effect.fn("refreshAll")(function* () {
@@ -539,6 +543,7 @@ export const ProviderRegistryLive = Layer.effect(
           if (carriedOver.has(instanceId)) {
             continue;
           }
+          yield* providerCache.invalidateProvider(instanceId);
           newlyAdded.push([instanceId, instance] as const);
         }
 
@@ -563,7 +568,9 @@ export const ProviderRegistryLive = Layer.effect(
         yield* Effect.forEach(
           newlyAdded,
           ([, instance]) =>
-            refreshOneSource(buildSnapshotSource(instance)).pipe(Effect.ignoreCause({ log: true })),
+            refreshOneSource(buildSnapshotSource(instance), { useCache: false }).pipe(
+              Effect.ignoreCause({ log: true }),
+            ),
           { concurrency: "unbounded", discard: true },
         );
         yield* upsertProviders(unavailableProviders, {
@@ -579,6 +586,13 @@ export const ProviderRegistryLive = Layer.effect(
 
         // Drop aggregator state for instances that have disappeared —
         // otherwise the UI would keep rendering ghosts.
+        const removedInstanceIds = Array.from(previousSubs.keys()).filter(
+          (instanceId) => !knownInstanceIds.has(instanceId),
+        );
+        yield* Effect.forEach(removedInstanceIds, providerCache.invalidateProvider, {
+          discard: true,
+        });
+
         const [previousProviders, providers] = yield* Ref.modify(
           providersRef,
           (previousProviders) => {

--- a/t3code/apps/server/src/provider/Layers/ProviderService.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderService.ts
@@ -48,6 +48,7 @@ import {
 import { type ProviderAdapterError, ProviderValidationError } from "../Errors.ts";
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
+import { makeProviderCache } from "../Services/ProviderCache.ts";
 import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
 import {
   ProviderSessionDirectory,
@@ -210,6 +211,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
 
   const registry = yield* ProviderAdapterRegistry;
   const directory = yield* ProviderSessionDirectory;
+  const providerCache = yield* makeProviderCache();
   const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 
@@ -929,8 +931,15 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     },
   );
 
+  yield* Stream.runForEach(registry.streamChanges, () => providerCache.invalidateAll).pipe(
+    Effect.forkScoped,
+  );
+
   const getCapabilities: ProviderServiceShape["getCapabilities"] = (instanceId) =>
-    registry.getByInstance(instanceId).pipe(Effect.map((adapter) => adapter.capabilities));
+    providerCache.getCapabilities(
+      instanceId,
+      registry.getByInstance(instanceId).pipe(Effect.map((adapter) => adapter.capabilities)),
+    );
 
   const getInstanceInfo: ProviderServiceShape["getInstanceInfo"] = (instanceId) =>
     registry.getInstanceInfo(instanceId);

--- a/t3code/apps/server/src/provider/Services/ProviderCache.test.ts
+++ b/t3code/apps/server/src/provider/Services/ProviderCache.test.ts
@@ -1,0 +1,93 @@
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+import { it, assert } from "@effect/vitest";
+
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Ref from "effect/Ref";
+import * as TestClock from "effect/testing/TestClock";
+
+import { makeProviderCache } from "./ProviderCache.ts";
+
+const instanceId = ProviderInstanceId.make("codex");
+const driverKind = ProviderDriverKind.make("codex");
+
+const makeProvider = (version: number): ServerProvider =>
+  ({
+    instanceId,
+    driver: driverKind,
+    enabled: true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-06-06T00:00:00.000Z",
+    models: [
+      { slug: `model-${version}`, name: `Model ${version}`, isCustom: false, capabilities: null },
+    ],
+    slashCommands: [],
+    skills: [],
+  });
+
+it.effect("serves model lists from cache until TTL expires", () =>
+  Effect.gen(function* () {
+    const cache = yield* makeProviderCache({ modelListTtl: "1 minute" });
+    const calls = yield* Ref.make(0);
+    const lookup = Ref.updateAndGet(calls, (value) => value + 1).pipe(Effect.map(makeProvider));
+
+    assert.strictEqual((yield* cache.getModelList(instanceId, lookup)).models[0]?.slug, "model-1");
+    assert.strictEqual((yield* cache.getModelList(instanceId, lookup)).models[0]?.slug, "model-1");
+    assert.strictEqual(yield* Ref.get(calls), 1);
+
+    yield* TestClock.adjust("61 seconds");
+
+    assert.strictEqual((yield* cache.getModelList(instanceId, lookup)).models[0]?.slug, "model-2");
+    assert.strictEqual(yield* Ref.get(calls), 2);
+  }),
+);
+
+it.effect("invalidates provider entries on config changes", () =>
+  Effect.gen(function* () {
+    const cache = yield* makeProviderCache({ modelListTtl: "5 minutes" });
+    const calls = yield* Ref.make(0);
+    const lookup = Ref.updateAndGet(calls, (value) => value + 1).pipe(Effect.map(makeProvider));
+
+    yield* cache.getModelList(instanceId, lookup);
+    yield* cache.invalidateProvider(instanceId);
+    assert.strictEqual((yield* cache.getModelList(instanceId, lookup)).models[0]?.slug, "model-2");
+  }),
+);
+
+it.effect("deduplicates concurrent same-key model list misses", () =>
+  Effect.gen(function* () {
+    const cache = yield* makeProviderCache({ modelListTtl: "5 minutes" });
+    const calls = yield* Ref.make(0);
+    const lookup = Effect.gen(function* () {
+      yield* Ref.update(calls, (value) => value + 1);
+      yield* Effect.sleep("1 second");
+      return makeProvider(1);
+    });
+
+    const left = yield* cache.getModelList(instanceId, lookup).pipe(Effect.forkScoped);
+    const right = yield* cache.getModelList(instanceId, lookup).pipe(Effect.forkScoped);
+    yield* TestClock.adjust("1 second");
+    yield* Fiber.join(left);
+    yield* Fiber.join(right);
+
+    assert.strictEqual(yield* Ref.get(calls), 1);
+  }),
+);
+
+it.effect("tracks hit and miss stats for model lists and capabilities", () =>
+  Effect.gen(function* () {
+    const cache = yield* makeProviderCache({ modelListTtl: "5 minutes", capabilityTtl: "15 minutes" });
+    yield* cache.getModelList(instanceId, Effect.succeed(makeProvider(1)));
+    yield* cache.getModelList(instanceId, Effect.succeed(makeProvider(2)));
+    yield* cache.getCapabilities(instanceId, Effect.succeed({ sessionModelSwitch: "unsupported" }));
+    yield* cache.getCapabilities(instanceId, Effect.succeed({ sessionModelSwitch: "in-session" }));
+
+    assert.deepStrictEqual(yield* cache.getStats, {
+      modelList: { hits: 1, misses: 1 },
+      capabilities: { hits: 1, misses: 1 },
+    });
+  }),
+);

--- a/t3code/apps/server/src/provider/Services/ProviderCache.ts
+++ b/t3code/apps/server/src/provider/Services/ProviderCache.ts
@@ -1,0 +1,168 @@
+/**
+ * ProviderCache - bounded TTL cache for provider API responses.
+ *
+ * Keeps expensive provider model-list refreshes and adapter capability reads
+ * deduplicated while preserving explicit invalidation on provider config
+ * changes.
+ *
+ * @module ProviderCache
+ */
+import type { ProviderInstanceId, ServerProvider } from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+
+import { increment, providerCacheRequestsTotal } from "../../observability/Metrics.ts";
+import type { ProviderAdapterCapabilities } from "./ProviderAdapter.ts";
+
+export interface ProviderCacheConfig {
+  readonly modelListTtl?: Duration.Input;
+  readonly capabilityTtl?: Duration.Input;
+  readonly maxEntries?: number;
+}
+
+export interface ProviderCacheStats {
+  readonly modelList: {
+    readonly hits: number;
+    readonly misses: number;
+  };
+  readonly capabilities: {
+    readonly hits: number;
+    readonly misses: number;
+  };
+}
+
+type CacheType = keyof ProviderCacheStats;
+type Loader<A> = Effect.Effect<A, unknown>;
+
+export interface ProviderCacheShape {
+  readonly getModelList: <E>(
+    instanceId: ProviderInstanceId,
+    lookup: Effect.Effect<ServerProvider, E>,
+  ) => Effect.Effect<ServerProvider, E>;
+  readonly getCapabilities: <E>(
+    instanceId: ProviderInstanceId,
+    lookup: Effect.Effect<ProviderAdapterCapabilities, E>,
+  ) => Effect.Effect<ProviderAdapterCapabilities, E>;
+  readonly invalidateProvider: (instanceId: ProviderInstanceId) => Effect.Effect<void>;
+  readonly invalidateAll: Effect.Effect<void>;
+  readonly getStats: Effect.Effect<ProviderCacheStats>;
+}
+
+const DEFAULT_MODEL_LIST_TTL = Duration.minutes(5);
+const DEFAULT_CAPABILITY_TTL = Duration.minutes(15);
+const DEFAULT_MAX_ENTRIES = 256;
+
+const emptyStats = (): ProviderCacheStats => ({
+  modelList: { hits: 0, misses: 0 },
+  capabilities: { hits: 0, misses: 0 },
+});
+
+const updateStats = (
+  statsRef: Ref.Ref<ProviderCacheStats>,
+  cacheType: CacheType,
+  outcome: "hit" | "miss",
+) =>
+  Ref.update(statsRef, (stats) => ({
+    ...stats,
+    [cacheType]: {
+      ...stats[cacheType],
+      [outcome === "hit" ? "hits" : "misses"]:
+        stats[cacheType][outcome === "hit" ? "hits" : "misses"] + 1,
+    },
+  }));
+
+export const makeProviderCache = (config: ProviderCacheConfig = {}) =>
+  Effect.gen(function* () {
+    const maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    const statsRef = yield* Ref.make(emptyStats());
+    const modelListLoaders = yield* Ref.make(new Map<ProviderInstanceId, Loader<ServerProvider>>());
+    const capabilityLoaders = yield* Ref.make(
+      new Map<ProviderInstanceId, Loader<ProviderAdapterCapabilities>>(),
+    );
+
+    const modelListCache = yield* Cache.make<ProviderInstanceId, ServerProvider, unknown>({
+      capacity: maxEntries,
+      timeToLive: config.modelListTtl ?? DEFAULT_MODEL_LIST_TTL,
+      lookup: (instanceId) =>
+        Ref.get(modelListLoaders).pipe(
+          Effect.flatMap((loaders) => loaders.get(instanceId) ?? Effect.die("missing model loader")),
+        ),
+    });
+
+    const capabilityCache = yield* Cache.make<
+      ProviderInstanceId,
+      ProviderAdapterCapabilities,
+      unknown
+    >({
+      capacity: maxEntries,
+      timeToLive: config.capabilityTtl ?? DEFAULT_CAPABILITY_TTL,
+      lookup: (instanceId) =>
+        Ref.get(capabilityLoaders).pipe(
+          Effect.flatMap(
+            (loaders) => loaders.get(instanceId) ?? Effect.die("missing capability loader"),
+          ),
+        ),
+    });
+
+    const cached = <A, E>(input: {
+      readonly cacheType: CacheType;
+      readonly cache: Cache.Cache<ProviderInstanceId, A, unknown>;
+      readonly loadersRef: Ref.Ref<Map<ProviderInstanceId, Loader<A>>>;
+      readonly instanceId: ProviderInstanceId;
+      readonly lookup: Effect.Effect<A, E>;
+    }): Effect.Effect<A, E> =>
+      Effect.gen(function* () {
+        yield* Ref.update(input.loadersRef, (loaders) => {
+          const next = new Map(loaders);
+          next.set(input.instanceId, input.lookup as Loader<A>);
+          return next;
+        });
+        const hasEntry = yield* Cache.has(input.cache, input.instanceId);
+        const outcome = hasEntry ? "hit" : "miss";
+        yield* updateStats(statsRef, input.cacheType, outcome);
+        yield* increment(providerCacheRequestsTotal, {
+          cache: input.cacheType,
+          outcome,
+          providerInstanceId: input.instanceId,
+        });
+        return (yield* Cache.get(input.cache, input.instanceId)) as A;
+      }) as Effect.Effect<A, E>;
+
+    const invalidateProvider = (instanceId: ProviderInstanceId) =>
+      Effect.all(
+        [Cache.invalidate(modelListCache, instanceId), Cache.invalidate(capabilityCache, instanceId)],
+        { discard: true },
+      );
+
+    return {
+      getModelList: (instanceId, lookup) =>
+        cached({
+          cacheType: "modelList",
+          cache: modelListCache,
+          loadersRef: modelListLoaders,
+          instanceId,
+          lookup,
+        }),
+      getCapabilities: (instanceId, lookup) =>
+        cached({
+          cacheType: "capabilities",
+          cache: capabilityCache,
+          loadersRef: capabilityLoaders,
+          instanceId,
+          lookup,
+        }),
+      invalidateProvider,
+      invalidateAll: Effect.all(
+        [Cache.invalidateAll(modelListCache), Cache.invalidateAll(capabilityCache)],
+        { discard: true },
+      ),
+      getStats: Ref.get(statsRef),
+    } satisfies ProviderCacheShape;
+  });
+
+export class ProviderCache extends Context.Service<ProviderCache, ProviderCacheShape>()(
+  "t3/provider/Services/ProviderCache",
+) {}

--- a/t3code/contributor_meta.json
+++ b/t3code/contributor_meta.json
@@ -1,0 +1,11 @@
+{
+  "agent": "Codex GPT-5",
+  "issue": 865,
+  "summary": "Implemented provider API response caching with bounded TTL caches, invalidation on provider instance changes, hit/miss metrics, and focused tests for TTL expiry, invalidation, concurrent deduplication, and stats.",
+  "session_init": "Public summary only: user authorized technical bounty work for payable USD/crypto tasks, excluding personal social accounts and new low-value/non-USD tasks.",
+  "payout": {
+    "network": "Base",
+    "asset": "USDC",
+    "address": "0x237664403f52A15142795f807ADB3524E8057909"
+  }
+}


### PR DESCRIPTION
/claim #865

## Summary
- Added a bounded provider response cache built on `Effect.Cache` with separate TTLs for model-list snapshots and adapter capabilities.
- Wired provider snapshot refreshes through the cache for repeated/manual refreshes while bypassing and invalidating on new or rebuilt provider instances.
- Cached `ProviderService.getCapabilities` lookups and invalidated them when adapter registry changes are published.
- Added provider cache hit/miss metrics via `t3_provider_cache_requests_total` and focused tests for TTL expiry, invalidation, concurrent same-key miss deduplication, and stats.
- Added `contributor_meta.json` with a public-only session summary and payout preference.

## Validation
- `node node_modules/vitest/vitest.mjs run apps/server/src/provider/Services/ProviderCache.test.ts --reporter=verbose` -> 4 passed
- `node node_modules/typescript/bin/tsc --noEmit -p apps/server/tsconfig.json` -> passed
- `node -e JSON.parse(require('fs').readFileSync('contributor_meta.json','utf8'))` -> passed
- `git diff --check` -> passed

Local note: two existing ProviderRegistry missing-binary assertions fail on this Windows/NodeServices environment because the snapshot reaches `status: error` but reports `installed: true`; the new cache test suite and server typecheck pass.

Preferred payout if selected: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`.