### PR TITLE
Codex GPT-5 [ T3 Code ] Add IPC message queuing

### DIFF
--- a/t3code/apps/desktop/src/ipc/DesktopIpc.test.ts
+++ b/t3code/apps/desktop/src/ipc/DesktopIpc.test.ts
@@ -1,0 +1,152 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+
+import * as DesktopIpc from "./DesktopIpc.ts";
+
+class TestIpcMain implements DesktopIpc.DesktopIpcMain {
+  readonly handlers = new Map<string, DesktopIpc.DesktopIpcHandleListener>();
+  readonly syncHandlers = new Map<string, DesktopIpc.DesktopIpcSyncListener>();
+
+  removeHandler(channel: string): void {
+    this.handlers.delete(channel);
+  }
+
+  handle(channel: string, listener: DesktopIpc.DesktopIpcHandleListener): void {
+    this.handlers.set(channel, listener);
+  }
+
+  removeAllListeners(channel: string): void {
+    this.syncHandlers.delete(channel);
+  }
+
+  on(channel: string, listener: DesktopIpc.DesktopIpcSyncListener): void {
+    this.syncHandlers.set(channel, listener);
+  }
+
+  invoke(channel: string, raw: unknown) {
+    const listener = this.handlers.get(channel);
+    if (listener === undefined) {
+      throw new Error(`No handler registered for ${channel}`);
+    }
+    return listener({}, raw);
+  }
+}
+
+describe("DesktopIpc queue", () => {
+  it.effect("runs calls directly while the backend is connected", () =>
+    Effect.gen(function* () {
+      const backendReady = yield* Ref.make(true);
+      const ipcMain = new TestIpcMain();
+      const ipc = DesktopIpc.make(ipcMain, { backendReady });
+
+      yield* Effect.scoped(Effect.gen(function* () {
+        yield* ipc.handle({
+          channel: "test:direct",
+          handler: (raw) => Effect.succeed({ raw }),
+        });
+
+        const result = yield* Effect.promise(() =>
+          Promise.resolve(ipcMain.invoke("test:direct", "alpha")),
+        );
+        assert.deepStrictEqual(result, { raw: "alpha" });
+        assert.equal(yield* SubscriptionRef.get(ipc.connectionState), "connected");
+      }));
+    }),
+  );
+
+  it.effect("queues disconnected calls and flushes them in FIFO order on reconnect", () =>
+    Effect.gen(function* () {
+      const backendReady = yield* Ref.make(false);
+      const ipcMain = new TestIpcMain();
+      const seen: unknown[] = [];
+      const ipc = DesktopIpc.make(ipcMain, {
+        backendReady,
+        pollInterval: "5 millis",
+      });
+
+      yield* Effect.scoped(Effect.gen(function* () {
+        yield* ipc.handle({
+          channel: "test:fifo",
+          handler: (raw) =>
+            Effect.sync(() => {
+              seen.push(raw);
+              return raw;
+            }),
+        });
+
+        const first = ipcMain.invoke("test:fifo", 1);
+        const second = ipcMain.invoke("test:fifo", 2);
+
+        yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 10)));
+        assert.equal(yield* SubscriptionRef.get(ipc.connectionState), "reconnecting");
+        yield* Ref.set(backendReady, true);
+        yield* ipc.flushQueue;
+        const third = ipcMain.invoke("test:fifo", 3);
+
+        const results = yield* Effect.promise(() =>
+          Promise.all([Promise.resolve(first), Promise.resolve(second), Promise.resolve(third)]),
+        );
+        assert.deepStrictEqual(results, [1, 2, 3]);
+        assert.deepStrictEqual(seen, [1, 2, 3]);
+        assert.equal(yield* SubscriptionRef.get(ipc.connectionState), "connected");
+      }));
+    }),
+  );
+
+  it.effect("drops the oldest queued message when the queue is full", () =>
+    Effect.gen(function* () {
+      const backendReady = yield* Ref.make(false);
+      const ipcMain = new TestIpcMain();
+      const ipc = DesktopIpc.make(ipcMain, {
+        backendReady,
+        maxSize: 1,
+        pollInterval: "5 millis",
+      });
+
+      yield* Effect.scoped(Effect.gen(function* () {
+        yield* ipc.handle({
+          channel: "test:overflow",
+          handler: (raw) => Effect.succeed(raw),
+        });
+
+        const first = ipcMain.invoke("test:overflow", "oldest");
+        const second = ipcMain.invoke("test:overflow", "newest");
+
+        const firstError = yield* Effect.promise<unknown>(() =>
+          Promise.resolve(first).catch((error) => error),
+        );
+        assert.equal((firstError as { readonly _tag?: string })._tag, "DesktopIpcQueueOverflowError");
+
+        yield* Ref.set(backendReady, true);
+        const secondResult = yield* Effect.promise(() => Promise.resolve(second));
+        assert.equal(secondResult, "newest");
+      }));
+    }),
+  );
+
+  it.effect("expires queued messages with a typed timeout error", () =>
+    Effect.gen(function* () {
+      const backendReady = yield* Ref.make(false);
+      const ipcMain = new TestIpcMain();
+      const ipc = DesktopIpc.make(ipcMain, {
+        backendReady,
+        messageTtl: "10 millis",
+      });
+
+      yield* Effect.scoped(Effect.gen(function* () {
+        yield* ipc.handle({
+          channel: "test:timeout",
+          handler: (raw) => Effect.succeed(raw),
+        });
+
+        const result = yield* Effect.promise<unknown>(() =>
+          Promise.resolve(ipcMain.invoke("test:timeout", "late")).catch((error) => error),
+        );
+
+        assert.equal((result as { readonly _tag?: string })._tag, "DesktopIpcQueueTimeoutError");
+      }));
+    }),
+  );
+});

--- a/t3code/apps/desktop/src/ipc/DesktopIpc.ts
+++ b/t3code/apps/desktop/src/ipc/DesktopIpc.ts
@@ -1,7 +1,11 @@
 import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as SubscriptionRef from "effect/SubscriptionRef";
 
 export interface DesktopIpcInvokeEvent {}
 
@@ -40,12 +44,160 @@ export interface DesktopIpcShape {
   readonly handleSync: <E, R>(
     input: DesktopSyncIpcMethod<E, R>,
   ) => Effect.Effect<void, never, R | Scope.Scope>;
+  readonly connectionState: SubscriptionRef.SubscriptionRef<DesktopIpcConnectionState>;
+  readonly flushQueue: Effect.Effect<void>;
 }
 
 export class DesktopIpc extends Context.Service<DesktopIpc, DesktopIpcShape>()("t3/desktop/Ipc") {}
 
-export const make = (ipcMain: DesktopIpcMain): DesktopIpcShape =>
-  DesktopIpc.of({
+export type DesktopIpcConnectionState = "connected" | "disconnected" | "reconnecting";
+
+export class DesktopIpcQueueTimeoutError extends Data.TaggedError("DesktopIpcQueueTimeoutError")<{
+  readonly channel: string;
+  readonly ageMillis: number;
+}> {
+  override get message() {
+    return `Queued IPC call on ${this.channel} expired after ${this.ageMillis}ms.`;
+  }
+}
+
+export class DesktopIpcQueueOverflowError extends Data.TaggedError("DesktopIpcQueueOverflowError")<{
+  readonly channel: string;
+  readonly maxSize: number;
+}> {
+  override get message() {
+    return `Queued IPC call on ${this.channel} was dropped because the queue exceeded ${this.maxSize} messages.`;
+  }
+}
+
+export interface DesktopIpcQueueOptions {
+  readonly backendReady?: Ref.Ref<boolean> | undefined;
+  readonly maxSize?: number | undefined;
+  readonly messageTtl?: Duration.Input | undefined;
+  readonly pollInterval?: Duration.Input | undefined;
+}
+
+interface QueuedIpcCall {
+  readonly channel: string;
+  readonly enqueuedAt: number;
+  readonly run: () => Promise<unknown>;
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: unknown) => void;
+  readonly timeout: ReturnType<typeof setTimeout>;
+}
+
+const now = () => Date.now();
+
+export const make = (ipcMain: DesktopIpcMain, options: DesktopIpcQueueOptions = {}): DesktopIpcShape => {
+  const maxSize = options.maxSize ?? 100;
+  const messageTtlMs = Duration.toMillis(Duration.fromInputUnsafe(options.messageTtl ?? "30 seconds"));
+  const pollIntervalMs = Duration.toMillis(
+    Duration.fromInputUnsafe(options.pollInterval ?? "100 millis"),
+  );
+  const connectionState = Effect.runSync(SubscriptionRef.make<DesktopIpcConnectionState>("connected"));
+  const queue: QueuedIpcCall[] = [];
+  let flushing: Promise<void> | undefined;
+
+  const setConnectionState = (state: DesktopIpcConnectionState) => {
+    if (SubscriptionRef.getUnsafe(connectionState) !== state) {
+      Effect.runSync(SubscriptionRef.set(connectionState, state));
+    }
+  };
+
+  const isBackendReady = async () =>
+    options.backendReady === undefined ? true : await Effect.runPromise(Ref.get(options.backendReady));
+
+  const failExpired = () => {
+    const timestamp = now();
+    for (let index = queue.length - 1; index >= 0; index--) {
+      const item = queue[index]!;
+      const ageMillis = timestamp - item.enqueuedAt;
+      if (ageMillis >= messageTtlMs) {
+        queue.splice(index, 1);
+        clearTimeout(item.timeout);
+        item.reject(new DesktopIpcQueueTimeoutError({ channel: item.channel, ageMillis }));
+      }
+    }
+  };
+
+  const flushQueue = async () => {
+    if (flushing !== undefined) {
+      return flushing;
+    }
+
+    flushing = (async () => {
+      try {
+        if (!(await isBackendReady())) {
+          setConnectionState(queue.length === 0 ? "disconnected" : "reconnecting");
+          return;
+        }
+
+        setConnectionState("connected");
+        while (queue.length > 0) {
+          failExpired();
+          const item = queue.shift();
+          if (item === undefined) {
+            continue;
+          }
+
+          clearTimeout(item.timeout);
+          try {
+            item.resolve(await item.run());
+          } catch (error) {
+            item.reject(error);
+          }
+        }
+      } finally {
+        flushing = undefined;
+      }
+    })();
+
+    return flushing;
+  };
+
+  const enqueue = (channel: string, run: () => Promise<unknown>) => {
+    setConnectionState("reconnecting");
+    return new Promise<unknown>((resolve, reject) => {
+      const enqueuedAt = now();
+      const timeout = setTimeout(() => {
+        const index = queue.findIndex((item) => item.timeout === timeout);
+        if (index >= 0) {
+          queue.splice(index, 1);
+        }
+        reject(new DesktopIpcQueueTimeoutError({ channel, ageMillis: now() - enqueuedAt }));
+      }, messageTtlMs);
+
+      queue.push({ channel, enqueuedAt, run, resolve, reject, timeout });
+
+      while (queue.length > maxSize) {
+        const dropped = queue.shift()!;
+        clearTimeout(dropped.timeout);
+        dropped.reject(new DesktopIpcQueueOverflowError({ channel: dropped.channel, maxSize }));
+      }
+    });
+  };
+
+  const dispatch = async (channel: string, run: () => Promise<unknown>) => {
+    failExpired();
+    if ((await isBackendReady()) && queue.length === 0) {
+      setConnectionState("connected");
+      return run();
+    }
+
+    const queued = enqueue(channel, run);
+    if (await isBackendReady()) {
+      await flushQueue();
+    }
+    return queued;
+  };
+
+  if (options.backendReady !== undefined) {
+    setInterval(() => {
+      void flushQueue();
+    }, pollIntervalMs).unref?.();
+  }
+
+  return DesktopIpc.of({
     handle: Effect.fn("desktop.ipc.registerInvoke")(function* <E, R>({
       channel,
       handler,
@@ -58,11 +210,13 @@ export const make = (ipcMain: DesktopIpcMain): DesktopIpcShape =>
         Effect.sync(() => {
           ipcMain.removeHandler(channel);
           ipcMain.handle(channel, (_event, raw) =>
-            runPromise(
-              Effect.gen(function* () {
-                yield* Effect.annotateCurrentSpan({ channel });
-                return yield* handler(raw);
-              }).pipe(Effect.annotateLogs({ channel }), Effect.withSpan("desktop.ipc.invoke")),
+            dispatch(channel, () =>
+              runPromise(
+                Effect.gen(function* () {
+                  yield* Effect.annotateCurrentSpan({ channel });
+                  return yield* handler(raw);
+                }).pipe(Effect.annotateLogs({ channel }), Effect.withSpan("desktop.ipc.invoke")),
+              ),
             ),
           );
         }),
@@ -93,7 +247,10 @@ export const make = (ipcMain: DesktopIpcMain): DesktopIpcShape =>
         () => Effect.sync(() => ipcMain.removeAllListeners(channel)),
       );
     }),
+    connectionState,
+    flushQueue: Effect.promise(() => flushQueue()),
   });
+};
 
 /**
  * Convenience helpers for creating IPC methods

--- a/t3code/apps/desktop/src/ipc/_contributor.json
+++ b/t3code/apps/desktop/src/ipc/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex GPT-5",
+  "runtime_instructions": "Public summary only: autonomous coding agent working on GitHub bounty issue #826. Private runtime, system, developer, user, credential, and hidden session instructions are intentionally not reproduced.",
+  "timestamp": "2026-06-06T19:14:00Z"
+}

--- a/t3code/apps/desktop/src/main.ts
+++ b/t3code/apps/desktop/src/main.ts
@@ -5,6 +5,7 @@ import * as NodeOS from "node:os";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 
 import * as Electron from "electron";
 
@@ -93,6 +94,13 @@ const desktopSshEnvironmentLayer = Layer.unwrap(
   }),
 );
 
+const desktopState = Effect.runSync(
+  Effect.all({
+    backendReady: Ref.make(false),
+    quitting: Ref.make(false),
+  }),
+);
+
 const electronLayer = Layer.mergeAll(
   ElectronApp.layer,
   ElectronDialog.layer,
@@ -103,11 +111,14 @@ const electronLayer = Layer.mergeAll(
   ElectronTheme.layer,
   ElectronUpdater.layer,
   ElectronWindow.layer,
-  Layer.succeed(DesktopIpc.DesktopIpc, DesktopIpc.make(Electron.ipcMain)),
+  Layer.succeed(
+    DesktopIpc.DesktopIpc,
+    DesktopIpc.make(Electron.ipcMain, { backendReady: desktopState.backendReady }),
+  ),
 );
 
 const desktopFoundationLayer = Layer.mergeAll(
-  DesktopState.layer,
+  Layer.succeed(DesktopState.DesktopState, desktopState),
   DesktopLifecycle.layerShutdown,
   DesktopAppSettings.layer,
   DesktopClientSettings.layer,


### PR DESCRIPTION
﻿/claim #826

## Summary
- Adds a bounded FIFO queue for desktop IPC invoke calls while the backend is disconnected or reconnecting.
- Defaults to 100 queued messages, 30-second queued-call expiry, typed timeout/overflow errors, and FIFO flush when the backend is ready again.
- Exposes a `connectionState` `SubscriptionRef` plus explicit `flushQueue`, and wires DesktopIpc to the shared desktop backend readiness ref in `main.ts`.
- Keeps healthy connected calls on the direct path when the queue is empty.

## Validation
- `node node_modules/vitest/vitest.mjs run apps/desktop/src/ipc/DesktopIpc.test.ts --reporter=verbose` -> 4 passed
- `node node_modules/typescript/bin/tsc --noEmit -p apps/desktop/tsconfig.json`
- `_contributor.json` JSON parse check passed
- `git diff --check`

## Attribution / security
The requested `_contributor.json` is included next to the primary IPC changes with safe public metadata only. Private runtime, system, developer, user, credential, and hidden session instructions are intentionally not copied into the repository or PR text.

Preferred payout when applicable: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`.
