### PR TITLE
Codex GPT-5 [ T3 Code ] Add HTTP compression

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "Public summary only: autonomous coding agent working on GitHub bounty issue #863. Private runtime, system, developer, user, credential, and hidden session instructions are intentionally not reproduced.",
+  "timestamp": "2026-06-06T19:35:00Z"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -78,6 +78,7 @@ const makeCliTestServerConfig = (baseDir: string) =>
       logWebSocketEvents: false,
       tailscaleServeEnabled: false,
       tailscaleServePort: 443,
+      compressionLevel: 6,
     } satisfies ServerConfigShape;
   });
 

--- a/t3code/apps/server/src/cli/config.ts
+++ b/t3code/apps/server/src/cli/config.ts
@@ -136,6 +136,7 @@ const EnvServerConfig = Config.all({
     Config.option,
     Config.map(Option.getOrUndefined),
   ),
+  compressionLevel: Config.int("T3CODE_COMPRESSION_LEVEL").pipe(Config.withDefault(6)),
 });
 
 export interface CliServerFlags {
@@ -374,6 +375,7 @@ export const resolveServerConfig = (
       logWebSocketEvents,
       tailscaleServeEnabled,
       tailscaleServePort,
+      compressionLevel: Math.min(Math.max(env.compressionLevel, 1), 11),
     };
 
     return config;

--- a/t3code/apps/server/src/config.ts
+++ b/t3code/apps/server/src/config.ts
@@ -73,6 +73,7 @@ export interface ServerConfigShape extends ServerDerivedPaths {
   readonly logWebSocketEvents: boolean;
   readonly tailscaleServeEnabled: boolean;
   readonly tailscaleServePort: number;
+  readonly compressionLevel: number;
 }
 
 export const deriveServerPaths = Effect.fn(function* (
@@ -168,6 +169,7 @@ export class ServerConfig extends Context.Service<ServerConfig, ServerConfigShap
           logWebSocketEvents: false,
           tailscaleServeEnabled: false,
           tailscaleServePort: 443,
+          compressionLevel: 6,
           port: 0,
           host: undefined,
           desktopBootstrapToken: undefined,

--- a/t3code/apps/server/src/environment/Layers/ServerEnvironment.test.ts
+++ b/t3code/apps/server/src/environment/Layers/ServerEnvironment.test.ts
@@ -37,6 +37,7 @@ const makeServerConfig = Effect.fn(function* (baseDir: string) {
     logWebSocketEvents: false,
     tailscaleServeEnabled: false,
     tailscaleServePort: 443,
+    compressionLevel: 6,
     port: 0,
     host: undefined,
     desktopBootstrapToken: undefined,

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,15 +1,20 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
+import { brotliCompress, brotliDecompress, constants as zlibConstants, gzip, gunzip } from "node:zlib";
+import { promisify } from "node:util";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import { cast } from "effect/Function";
 import {
+  Headers,
   HttpBody,
   HttpClient,
   HttpClientResponse,
+  HttpMiddleware,
   HttpRouter,
   HttpServerResponse,
   HttpServerRequest,
@@ -22,7 +27,7 @@ import {
   resolveAttachmentRelativePath,
 } from "./attachmentPaths.ts";
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
-import { resolveStaticDir, ServerConfig } from "./config.ts";
+import { resolveStaticDir, ServerConfig, type ServerConfigShape } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
@@ -38,6 +43,142 @@ const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
+const COMPRESSION_MIN_BYTES = 1024;
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+const brotliCompressAsync = promisify(brotliCompress);
+const brotliDecompressAsync = promisify(brotliDecompress);
+
+type CompressionEncoding = "br" | "gzip";
+
+const COMPRESSED_CONTENT_TYPE_PATTERNS = [
+  /^image\//i,
+  /^audio\//i,
+  /^video\//i,
+  /^font\//i,
+  /application\/(zip|gzip|x-gzip|x-7z-compressed|x-rar-compressed|x-tar|pdf)/i,
+  /application\/octet-stream/i,
+];
+
+const getHeader = (headers: Headers.Headers, name: string): string | undefined =>
+  headers[name.toLowerCase()];
+
+export const selectCompressionEncoding = (
+  acceptEncoding: string | undefined,
+): CompressionEncoding | undefined => {
+  if (!acceptEncoding) return undefined;
+  const encodings = acceptEncoding
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  const supports = (encoding: CompressionEncoding) =>
+    encodings.some((entry) => {
+      const [name, ...parameters] = entry.split(";").map((part) => part.trim());
+      if (name !== encoding) return false;
+      const q = parameters.find((parameter) => parameter.startsWith("q="));
+      return q === undefined || Number.parseFloat(q.slice(2)) > 0;
+    });
+  if (supports("br")) return "br";
+  if (supports("gzip")) return "gzip";
+  return undefined;
+};
+
+export const isCompressibleContentType = (contentType: string | undefined): boolean => {
+  if (!contentType) return false;
+  return !COMPRESSED_CONTENT_TYPE_PATTERNS.some((pattern) => pattern.test(contentType));
+};
+
+const compressionOptions = (config: ServerConfigShape) => ({
+  gzip: { level: Math.min(config.compressionLevel, 9) },
+  brotli: {
+    params: {
+      [zlibConstants.BROTLI_PARAM_QUALITY]: Math.min(config.compressionLevel, 11),
+    },
+  },
+});
+
+const compressBytes = (
+  encoding: CompressionEncoding,
+  body: Uint8Array,
+  config: ServerConfigShape,
+) =>
+  Effect.promise(() => {
+    const options = compressionOptions(config);
+    return encoding === "br"
+      ? brotliCompressAsync(body, options.brotli)
+      : gzipAsync(body, options.gzip);
+  }).pipe(Effect.map((buffer) => new Uint8Array(buffer)));
+
+export const decompressBytes = (encoding: string | undefined, body: Uint8Array) => {
+  const normalized = encoding?.trim().toLowerCase();
+  if (normalized === undefined || normalized === "" || normalized === "identity") {
+    return Effect.succeed(body);
+  }
+  if (normalized === "br") {
+    return Effect.promise(() => brotliDecompressAsync(body)).pipe(
+      Effect.map((buffer) => new Uint8Array(buffer)),
+    );
+  }
+  if (normalized === "gzip") {
+    return Effect.promise(() => gunzipAsync(body)).pipe(Effect.map((buffer) => new Uint8Array(buffer)));
+  }
+  return Effect.fail(new UnsupportedContentEncodingError({ encoding: normalized }));
+};
+
+class UnsupportedContentEncodingError extends Data.TaggedError("UnsupportedContentEncodingError")<{
+  readonly encoding: string;
+}> {}
+
+const compressResponse = (response: HttpServerResponse.HttpServerResponse) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const config = yield* ServerConfig;
+    if (response.status < 200 || response.status === 204 || response.status === 304) {
+      return response;
+    }
+    if (getHeader(response.headers, "content-encoding")) {
+      return response;
+    }
+    if (response.body._tag !== "Uint8Array") {
+      return response;
+    }
+    if (response.body.contentLength < COMPRESSION_MIN_BYTES) {
+      return response;
+    }
+    if (!isCompressibleContentType(response.body.contentType)) {
+      return response;
+    }
+
+    const encoding = selectCompressionEncoding(getHeader(request.headers, "accept-encoding"));
+    if (encoding === undefined) {
+      return response;
+    }
+
+    const compressed = yield* compressBytes(encoding, response.body.body, config);
+    return HttpServerResponse.uint8Array(compressed, {
+      status: response.status,
+      statusText: response.statusText,
+      contentType: response.body.contentType,
+      headers: Headers.setAll(response.headers, {
+        "content-encoding": encoding,
+        "content-length": String(compressed.length),
+        vary: getHeader(response.headers, "vary")
+          ? `${getHeader(response.headers, "vary")}, Accept-Encoding`
+          : "Accept-Encoding",
+      }),
+      cookies: response.cookies,
+    });
+  });
+
+export const httpCompressionMiddleware = HttpMiddleware.make((httpApp) =>
+  Effect.flatMap(httpApp, compressResponse),
+);
+
+export const httpCompressionLayer = Layer.effectDiscard(
+  Effect.flatMap(Effect.service(HttpRouter.HttpRouter), (router) =>
+    router.addGlobalMiddleware(httpCompressionMiddleware),
+  ),
+);
 
 export const browserApiCorsLayer = HttpRouter.cors({
   allowedMethods: [...browserApiCorsAllowedMethods],
@@ -96,7 +237,27 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
     const otlpTracesUrl = config.otlpTracesUrl;
     const browserTraceCollector = yield* BrowserTraceCollector;
     const httpClient = yield* HttpClient.HttpClient;
-    const bodyJson = cast<unknown, OtlpTracer.TraceData>(yield* request.json);
+    const bodyBytes = new Uint8Array(yield* request.arrayBuffer);
+    const decompressedBodyResult = yield* Effect.result(
+      decompressBytes(getHeader(request.headers, "content-encoding"), bodyBytes),
+    );
+    if (decompressedBodyResult._tag === "Failure") {
+      return HttpServerResponse.text("Unsupported Content-Encoding", { status: 415 });
+    }
+    const parsedBodyResult = yield* Effect.result(
+      Effect.try({
+        try: () => JSON.parse(new TextDecoder().decode(decompressedBodyResult.success)),
+        catch: (cause) =>
+          new DecodeOtlpTraceRecordsError({
+            cause,
+            bodyJson: cast<unknown, OtlpTracer.TraceData>({}),
+          }),
+      }),
+    );
+    if (parsedBodyResult._tag === "Failure") {
+      return HttpServerResponse.text("Invalid trace payload", { status: 400 });
+    }
+    const bodyJson = cast<unknown, OtlpTracer.TraceData>(parsedBodyResult.success);
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),

--- a/t3code/apps/server/src/httpCompression.test.ts
+++ b/t3code/apps/server/src/httpCompression.test.ts
@@ -1,0 +1,40 @@
+import { brotliCompressSync, gzipSync } from "node:zlib";
+
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import {
+  decompressBytes,
+  isCompressibleContentType,
+  selectCompressionEncoding,
+} from "./http.ts";
+
+it("prefers brotli over gzip when both encodings are accepted", () => {
+  assert.equal(selectCompressionEncoding("gzip, br"), "br");
+  assert.equal(selectCompressionEncoding("gzip"), "gzip");
+  assert.equal(selectCompressionEncoding("br;q=0, gzip;q=1"), "gzip");
+  assert.equal(selectCompressionEncoding("identity"), undefined);
+});
+
+it("skips already-compressed response content types", () => {
+  assert.equal(isCompressibleContentType("application/json"), true);
+  assert.equal(isCompressibleContentType("text/html; charset=utf-8"), true);
+  assert.equal(isCompressibleContentType("image/png"), false);
+  assert.equal(isCompressibleContentType("application/zip"), false);
+  assert.equal(isCompressibleContentType("application/octet-stream"), false);
+});
+
+it.effect("decompresses gzip and brotli request bodies", () =>
+  Effect.gen(function* () {
+    const payload = new TextEncoder().encode(JSON.stringify({ ok: true, value: "payload" }));
+
+    const gzipPayload = gzipSync(payload);
+    const brotliPayload = brotliCompressSync(payload);
+
+    const gunzipped = yield* decompressBytes("gzip", gzipPayload);
+    const unbrotlied = yield* decompressBytes("br", brotliPayload);
+
+    assert.equal(new TextDecoder().decode(gunzipped), new TextDecoder().decode(payload));
+    assert.equal(new TextDecoder().decode(unbrotlied), new TextDecoder().decode(payload));
+  }),
+);

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -371,6 +371,7 @@ const buildAppUnderTest = (options?: {
       logWebSocketEvents: false,
       tailscaleServeEnabled: false,
       tailscaleServePort: 443,
+      compressionLevel: 6,
       ...options?.config,
     };
     const layerConfig = Layer.succeed(ServerConfig, config);

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -10,6 +10,7 @@ import {
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  httpCompressionLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -312,7 +313,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
-).pipe(Layer.provide(browserApiCorsLayer));
+).pipe(Layer.provide(browserApiCorsLayer), Layer.provide(httpCompressionLayer));
 
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {


### PR DESCRIPTION
﻿/claim #863

## Summary
- Adds global HTTP response compression middleware for eligible `Uint8Array` responses over 1KB.
- Negotiates `Accept-Encoding` with brotli preferred over gzip and sets `Content-Encoding`, `Content-Length`, and `Vary: Accept-Encoding` on compressed responses.
- Skips already-compressed content types such as images, audio/video, fonts, archives, PDFs, and octet-stream payloads.
- Adds gzip/brotli request-body decompression for the OTLP trace JSON endpoint before payload decoding.
- Adds `T3CODE_COMPRESSION_LEVEL` config with a safe default and clamp.

## Validation
- `node node_modules/vitest/vitest.mjs run apps/server/src/httpCompression.test.ts --reporter=verbose` -> 3 passed
- `node node_modules/typescript/bin/tsc --noEmit -p apps/server/tsconfig.json`
- `_provenance.json` JSON parse check passed
- `git diff --check`

## Attribution / security
The requested `_provenance.json` is included under `apps/server/src` with safe public metadata only. Private runtime, system, developer, user, credential, and hidden session instructions are intentionally not copied into the repository or PR text.

Preferred payout when applicable: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`.
