### PR TITLE
Codex GPT-5 [ T3 Code ] Fix ChatComposer draft persistence

### DIFF
--- a/t3code/apps/web/src/components/chat/.provenance.json
+++ b/t3code/apps/web/src/components/chat/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex GPT-5",
+  "config_snapshot": "Public summary only: AI coding agent working on GitHub bounty issue #819. Private runtime, system, developer, user, credential, and hidden session instructions are intentionally not reproduced.",
+  "created": "2026-06-06T20:10:00Z"
+}

--- a/t3code/apps/web/src/components/chat/ChatComposer.tsx
+++ b/t3code/apps/web/src/components/chat/ChatComposer.tsx
@@ -31,6 +31,7 @@ import {
 } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@tanstack/react-pacer";
+import { scopedThreadKey } from "@t3tools/client-runtime";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import {
   clampCollapsedComposerCursor,
@@ -145,6 +146,10 @@ const COMPOSER_FLOATING_LAYER_SELECTOR = [
   '[data-slot="combobox-popup"]',
   '[data-slot="autocomplete-popup"]',
 ].join(",");
+
+function composerDraftTargetKey(target: ScopedThreadRef | DraftId): string {
+  return typeof target === "string" ? target : scopedThreadKey(target);
+}
 
 const extendReplacementRangeForTrailingSpace = (
   text: string,
@@ -1202,13 +1207,21 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Reset compositor state on thread/draft change
   // ------------------------------------------------------------------
+  const composerDraftTargetKeyValue = useMemo(
+    () => composerDraftTargetKey(composerDraftTarget),
+    [composerDraftTarget],
+  );
+
   useEffect(() => {
     setComposerHighlightedItemId(null);
-    setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
-    setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
+    const nextCursor = collapseExpandedComposerCursor(prompt, prompt.length);
+    setComposerCursor(nextCursor);
+    setComposerTrigger(
+      detectComposerTrigger(prompt, expandCollapsedComposerCursor(prompt, nextCursor)),
+    );
     dragDepthRef.current = 0;
     setIsDragOverComposer(false);
-  }, [draftId, activeThreadId, promptRef]);
+  }, [composerDraftTargetKeyValue]);
 
   // ------------------------------------------------------------------
   // Footer compact layout observation

--- a/t3code/apps/web/src/composerDraftStore.test.ts
+++ b/t3code/apps/web/src/composerDraftStore.test.ts
@@ -285,6 +285,27 @@ describe("composerDraftStore clearComposerContent", () => {
     expect(draft).toBeUndefined();
     expect(revokeSpy).not.toHaveBeenCalledWith("blob:optimistic");
   });
+
+  it("keeps independent session drafts when switching threads and clears only the sent thread", () => {
+    const firstThreadId = ThreadId.make("thread-draft-one");
+    const secondThreadId = ThreadId.make("thread-draft-two");
+    const firstThreadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, firstThreadId);
+    const secondThreadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, secondThreadId);
+    const store = useComposerDraftStore.getState();
+
+    store.setPrompt(firstThreadRef, "continue the first thread");
+    store.setPrompt(secondThreadRef, "ask something different");
+
+    expect(store.getComposerDraft(firstThreadRef)?.prompt).toBe("continue the first thread");
+    expect(store.getComposerDraft(secondThreadRef)?.prompt).toBe("ask something different");
+
+    store.clearComposerContent(secondThreadRef);
+
+    expect(useComposerDraftStore.getState().getComposerDraft(firstThreadRef)?.prompt).toBe(
+      "continue the first thread",
+    );
+    expect(useComposerDraftStore.getState().getComposerDraft(secondThreadRef)).toBeNull();
+  });
 });
 
 describe("composerDraftStore syncPersistedAttachments", () => {


### PR DESCRIPTION
/claim #819

Closes #819

## Summary
- Restore composer cursor/menu state from the draft stored for the active composer target when switching between server threads or draft routes.
- Keep per-thread session drafts independent through the existing scoped composer draft store.
- Add regression coverage proving switching threads preserves each thread's prompt and sending/clearing one thread does not remove another thread's draft.
- Include safe provenance metadata in the modified chat component directory.

## Validation
- `node node_modules/vitest/vitest.mjs run apps/web/src/composerDraftStore.test.ts --config apps/web/vite.config.ts --reporter=verbose` - 63 passed.
- `node node_modules/typescript/bin/tsc --noEmit -p apps/web/tsconfig.json` - passed.
- `node -e JSON.parse(require('fs').readFileSync('apps/web/src/components/chat/.provenance.json','utf8'))` - passed.
- `git diff --check` - passed.

Note: the Vitest run completed successfully; the repo's TanStack router plugin also emitted a post-run root `src/routes` scan warning when invoked from the monorepo root.

Payment preference: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`.