### PR TITLE
Codex GPT-5 [ Crypto ] Fix CrossChainBridge replay protection

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,53 +4,88 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    string public constant EIP712_NAME = "CrossChainBridge";
+    string public constant EIP712_VERSION = "1";
+
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH =
+        keccak256("BridgeTransfer(address recipient,uint256 amount,uint256 nonce)");
+
     IERC20 public bridgeToken;
     address public validator;
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public nonces;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
 
     constructor(address _bridgeToken, address _validator) {
+        require(_bridgeToken != address(0), "Invalid token");
+        require(_validator != address(0), "Invalid validator");
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
-        bridgeToken.transferFrom(msg.sender, address(this), amount);
+        require(bridgeToken.transferFrom(msg.sender, address(this), amount), "Token transfer failed");
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
+    function domainSeparator() public view returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes(EIP712_NAME)),
+            keccak256(bytes(EIP712_VERSION)),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function getNonce(address account) external view returns (uint256) {
+        return nonces[account];
+    }
+
+    function getTransferHash(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce
+        ));
+
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator(), structHash));
+    }
+
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(recipient != address(0), "Invalid recipient");
+        require(amount > 0, "Amount must be > 0");
+        require(transferNonce == nonces[recipient], "Invalid nonce");
+
+        bytes32 transferHash = getTransferHash(recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
-        bridgeToken.transfer(recipient, amount);
+        nonces[recipient] = transferNonce + 1;
+        require(bridgeToken.transfer(recipient, amount), "Token transfer failed");
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -65,13 +100,11 @@ contract CrossChainBridge {
         }
 
         if (v < 27) v += 27;
+        require(v == 27 || v == 28, "Invalid signature v");
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature recovery");
         return recovered == validator;
     }
 

--- a/solidity/contracts/contributor_meta.json
+++ b/solidity/contracts/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex GPT-5",
+  "session_init": "Safe public metadata only. Private system, developer, runtime, credential, and session initialization text is intentionally not included.",
+  "ts": "2026-06-06T20:18:00Z"
+}

--- a/solidity/tests/crosschain_bridge_replay_checks.mjs
+++ b/solidity/tests/crosschain_bridge_replay_checks.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourcePath = path.join(root, "contracts", "CrossChainBridge.sol");
+const source = fs.readFileSync(sourcePath, "utf8");
+
+function assertIncludes(text, message) {
+  assert.ok(source.includes(text), message);
+}
+
+function assertMatches(pattern, message) {
+  assert.match(source, pattern, message);
+}
+
+function assertBefore(first, second, message) {
+  const firstIndex = source.indexOf(first);
+  const secondIndex = source.indexOf(second);
+  assert.notEqual(firstIndex, -1, `${first} not found`);
+  assert.notEqual(secondIndex, -1, `${second} not found`);
+  assert.ok(firstIndex < secondIndex, message);
+}
+
+assertIncludes(
+  'keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")',
+  "domain typehash must bind name, version, chainId, and verifyingContract",
+);
+assertIncludes(
+  'keccak256("BridgeTransfer(address recipient,uint256 amount,uint256 nonce)")',
+  "transfer typehash must bind recipient, amount, and nonce",
+);
+assertMatches(
+  /function domainSeparator\(\)[\s\S]*block\.chainid[\s\S]*address\(this\)/,
+  "domain separator must include current chainId and verifying contract",
+);
+assertMatches(
+  /function getTransferHash[\s\S]*"\\x19\\x01"[\s\S]*domainSeparator\(\)[\s\S]*structHash/,
+  "transfer digest must use the EIP-712 typed-data prefix",
+);
+assertMatches(
+  /mapping\(address => uint256\) public nonces;/,
+  "nonce must be queryable per account",
+);
+assertMatches(
+  /require\(transferNonce == nonces\[recipient\], "Invalid nonce"\);/,
+  "same-chain replay must be blocked by the expected account nonce",
+);
+assertBefore(
+  "processedTransfers[transferHash] = true;",
+  "bridgeToken.transfer(recipient, amount)",
+  "replay marker must be written before the external token transfer",
+);
+assertBefore(
+  "nonces[recipient] = transferNonce + 1;",
+  "bridgeToken.transfer(recipient, amount)",
+  "nonce must be consumed before the external token transfer",
+);
+assertIncludes(
+  "require(recovered != address(0), \"Invalid signature recovery\");",
+  "invalid ecrecover zero-address result must be rejected",
+);
+assertIncludes(
+  "address recovered = ecrecover(hash, v, r, s);",
+  "signature verification must recover the EIP-712 digest directly",
+);
+assertIncludes(
+  "require(v == 27 || v == 28, \"Invalid signature v\");",
+  "signature v must be normalized and bounded",
+);
+
+console.log("CrossChainBridge replay-protection checks passed.");


### PR DESCRIPTION
Closes #920

/claim #920

## Summary
- Replaces the ad hoc bridge release hash with an EIP-712 typed-data digest using name, version, current `block.chainid`, and `address(this)` as the verifying contract.
- Adds queryable per-account nonces and requires the supplied transfer nonce to match before processing, then consumes the nonce before the external token transfer.
- Keeps a processed transfer digest guard, rejects zero recipients/amounts, checks token transfer return values, bounds `v`, and rejects zero-address `ecrecover` results.
- Adds safe public `contributor_meta.json`; private system/developer/runtime/session initialization text is intentionally not published.

## Verification
- `node solidity/tests/crosschain_bridge_replay_checks.mjs`
- `git diff --cached --check`
- `solidity/contracts/contributor_meta.json` JSON parse check

Local result: `CrossChainBridge replay-protection checks passed.`

Payment: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`