### PR TITLE
Codex GPT-5 [ Crypto ] Fix MultiSigWallet confirmation race

### DIFF
--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -13,8 +13,17 @@ contract MultiSigWallet {
         bool executed;
     }
 
+    struct Confirmation {
+        bool active;
+        uint256 confirmedAtBlock;
+        uint256 confirmedAt;
+        uint256 revokedAtBlock;
+        uint256 revokedAt;
+    }
+
     mapping(uint256 => Transaction) public transactions;
-    mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => Confirmation)) public confirmations;
+    mapping(uint256 => bool) public executionInProgress;
     mapping(address => bool) public isOwner;
 
     event Submitted(uint256 indexed txId);
@@ -27,18 +36,33 @@ contract MultiSigWallet {
         _;
     }
 
+    modifier notExecuting(uint256 txId) {
+        require(!executionInProgress[txId], "Execution in progress");
+        _;
+    }
+
+    modifier txExists(uint256 txId) {
+        require(txId < transactionCount, "Unknown transaction");
+        _;
+    }
+
     constructor(address[] memory _owners, uint256 _required) {
         require(_owners.length > 0, "No owners");
         require(_required > 0 && _required <= _owners.length, "Invalid required");
         for (uint256 i = 0; i < _owners.length; i++) {
-            isOwner[_owners[i]] = true;
+            address owner = _owners[i];
+            require(owner != address(0), "Invalid owner");
+            require(!isOwner[owner], "Duplicate owner");
+            isOwner[owner] = true;
         }
         owners = _owners;
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid target");
+        require(data.length == 0 || to.code.length > 0, "Target is not contract");
+
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
@@ -50,36 +74,65 @@ contract MultiSigWallet {
         return txId;
     }
 
-    function confirmTransaction(uint256 txId) external onlyOwner {
+    function confirmTransaction(uint256 txId) external onlyOwner txExists(txId) notExecuting(txId) {
         require(!transactions[txId].executed, "Already executed");
-        require(!confirmations[txId][msg.sender], "Already confirmed");
-        confirmations[txId][msg.sender] = true;
+        Confirmation storage confirmation = confirmations[txId][msg.sender];
+        require(!confirmation.active, "Already confirmed");
+        confirmation.active = true;
+        confirmation.confirmedAtBlock = block.number;
+        confirmation.confirmedAt = block.timestamp;
+        confirmation.revokedAtBlock = 0;
+        confirmation.revokedAt = 0;
         emit Confirmed(txId, msg.sender);
     }
 
-    function revokeConfirmation(uint256 txId) external onlyOwner {
+    function revokeConfirmation(uint256 txId) external onlyOwner txExists(txId) notExecuting(txId) {
         require(!transactions[txId].executed, "Already executed");
-        require(confirmations[txId][msg.sender], "Not confirmed");
-        confirmations[txId][msg.sender] = false;
+        Confirmation storage confirmation = confirmations[txId][msg.sender];
+        require(confirmation.active, "Not confirmed");
+        confirmation.active = false;
+        confirmation.revokedAtBlock = block.number;
+        confirmation.revokedAt = block.timestamp;
         emit Revoked(txId, msg.sender);
+    }
+
+    function isConfirmedAtBlock(
+        uint256 txId,
+        address owner,
+        uint256 blockNumber
+    ) public view returns (bool) {
+        Confirmation storage confirmation = confirmations[txId][owner];
+        if (confirmation.confirmedAtBlock == 0 || confirmation.confirmedAtBlock > blockNumber) {
+            return false;
+        }
+        return confirmation.revokedAtBlock == 0 || confirmation.revokedAtBlock > blockNumber;
     }
 
     function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
         for (uint256 i = 0; i < owners.length; i++) {
-            if (confirmations[txId][owners[i]]) count++;
+            if (confirmations[txId][owners[i]].active) count++;
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
+        for (uint256 i = 0; i < owners.length; i++) {
+            if (isConfirmedAtBlock(txId, owners[i], blockNumber)) count++;
+        }
+    }
 
+    function executeTransaction(uint256 txId) external onlyOwner txExists(txId) notExecuting(txId) {
         Transaction storage txn = transactions[txId];
+        require(!txn.executed, "Already executed");
+
+        uint256 executionBlock = block.number;
+        require(getConfirmationCountAtBlock(txId, executionBlock) >= required, "Not enough confirmations");
+
+        executionInProgress[txId] = true;
         txn.executed = true;
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
+
+        executionInProgress[txId] = false;
         require(success, "Execution failed");
 
         emit Executed(txId);

--- a/solidity/contracts/_provenance.json
+++ b/solidity/contracts/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "Safe public metadata only. Private system, developer, runtime, credential, and session initialization text is intentionally not included.",
+  "timestamp": "2026-06-06T20:25:00Z"
+}

--- a/solidity/tests/multisig_wallet_race_checks.mjs
+++ b/solidity/tests/multisig_wallet_race_checks.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourcePath = path.join(root, "contracts", "MultiSigWallet.sol");
+const source = fs.readFileSync(sourcePath, "utf8");
+
+function assertIncludes(text, message) {
+  assert.ok(source.includes(text), message);
+}
+
+function assertMatches(pattern, message) {
+  assert.match(source, pattern, message);
+}
+
+function assertBefore(first, second, message) {
+  const firstIndex = source.indexOf(first);
+  const secondIndex = source.indexOf(second);
+  assert.notEqual(firstIndex, -1, `${first} not found`);
+  assert.notEqual(secondIndex, -1, `${second} not found`);
+  assert.ok(firstIndex < secondIndex, message);
+}
+
+assertIncludes("struct Confirmation", "confirmations must carry block/timestamp metadata");
+assertIncludes("uint256 confirmedAtBlock;", "confirmation block must be recorded");
+assertIncludes("uint256 revokedAtBlock;", "revocation block must be recorded");
+assertIncludes(
+  "mapping(uint256 => mapping(address => Confirmation)) public confirmations;",
+  "confirmation tracking must use metadata records instead of booleans",
+);
+assertIncludes(
+  "mapping(uint256 => bool) public executionInProgress;",
+  "executeTransaction must have a per-transaction execution guard",
+);
+assertMatches(
+  /function isConfirmedAtBlock\([\s\S]*confirmedAtBlock[\s\S]*revokedAtBlock/,
+  "block-level confirmation helper must account for confirmations and revocations",
+);
+assertMatches(
+  /function getConfirmationCountAtBlock\([\s\S]*isConfirmedAtBlock/,
+  "execution must be able to count confirmations at a snapshot block",
+);
+assertMatches(
+  /require\(to != address\(0\), "Invalid target"\);/,
+  "submitTransaction must reject zero-address targets",
+);
+assertMatches(
+  /require\(data\.length == 0 \|\| to\.code\.length > 0, "Target is not contract"\);/,
+  "contract calls must reject non-contract targets while allowing simple ETH transfers",
+);
+assertBefore(
+  "executionInProgress[txId] = true;",
+  "txn.to.call{value: txn.value}(txn.data)",
+  "execution guard must be set before the external callback",
+);
+assertBefore(
+  "txn.executed = true;",
+  "txn.to.call{value: txn.value}(txn.data)",
+  "transaction must be marked executed before the external callback",
+);
+assertBefore(
+  "require(getConfirmationCountAtBlock(txId, executionBlock) >= required",
+  "executionInProgress[txId] = true;",
+  "execution must use a block-level confirmation snapshot before starting",
+);
+assertMatches(
+  /function revokeConfirmation\(uint256 txId\) external onlyOwner txExists\(txId\) notExecuting\(txId\)/,
+  "revocation must be blocked during execution callbacks",
+);
+assertIncludes(
+  'require(txId < transactionCount, "Unknown transaction");',
+  "confirmation, revocation, and execution must reject unknown transaction ids",
+);
+
+console.log("MultiSigWallet race-protection checks passed.");


### PR DESCRIPTION
Closes #916

/claim #916

## Summary
- Replaces boolean confirmations with block/timestamp-aware confirmation records.
- Adds `isConfirmedAtBlock` and `getConfirmationCountAtBlock` so execution uses a block-level confirmation snapshot and front-running revocations are excluded.
- Adds a per-transaction execution guard and blocks confirm/revoke changes during execution callbacks.
- Marks transactions executed before the external call, rejects unknown transaction ids, rejects zero-address targets, and requires calldata targets to be contracts while preserving simple ETH transfers to EOAs.
- Adds safe public `_provenance.json`; private system/developer/runtime/session initialization text is intentionally not published.

## Verification
- `node solidity/tests/multisig_wallet_race_checks.mjs`
- `git diff --cached --check`
- `solidity/contracts/_provenance.json` JSON parse check

Local result: `MultiSigWallet race-protection checks passed.`

Payment: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`