### PR TITLE
Codex GPT-5 [ Crypto ] Fix GovernanceToken tx.origin delegation

### DIFF
--- a/solidity/contracts/.attribution.json
+++ b/solidity/contracts/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Safe public metadata only. Private system, developer, runtime, credential, and pre-conversation instructions are intentionally not included.",
+  "date": "2026-06-06T20:31:00Z"
+}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -23,40 +24,45 @@ contract GovernanceToken is ERC20 {
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        require(to != address(0), "Invalid delegate");
+        require(msg.sender != to, "Cannot delegate to self");
+
+        uint256 votingBalance = balanceOf(msg.sender);
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= votingBalance;
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+
+        delegates[msg.sender] = to;
+        delegatedPower[to] += votingBalance;
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 
     function getVotingPower(address account) public view returns (uint256) {
-        return balanceOf(account) + delegatedPower[account];
+        uint256 directPower = delegates[account] == address(0) ? balanceOf(account) : 0;
+        return directPower + delegatedPower[account];
     }
 
     function createProposal(string calldata description, uint256 duration) external returns (uint256) {

--- a/solidity/tests/governance_token_tx_origin_checks.mjs
+++ b/solidity/tests/governance_token_tx_origin_checks.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourcePath = path.join(root, "contracts", "GovernanceToken.sol");
+const source = fs.readFileSync(sourcePath, "utf8");
+
+function assertIncludes(text, message) {
+  assert.ok(source.includes(text), message);
+}
+
+function assertNotIncludes(text, message) {
+  assert.ok(!source.includes(text), message);
+}
+
+function assertMatches(pattern, message) {
+  assert.match(source, pattern, message);
+}
+
+assertNotIncludes("tx.origin", "contract must not use tx.origin for authorization or delegation");
+assertIncludes('import "@openzeppelin/contracts/access/Ownable.sol";', "OpenZeppelin Ownable must be used");
+assertIncludes("contract GovernanceToken is ERC20, Ownable", "contract must inherit Ownable");
+assertIncludes("Ownable(msg.sender)", "deployer must become the Ownable owner");
+assertMatches(/function snapshot\(\) external onlyOwner/, "snapshot must be protected by onlyOwner");
+assertMatches(/function delegateVote\(address to\) external[\s\S]*require\(msg\.sender != address\(0\)/, "delegateVote must use msg.sender");
+assertMatches(/delegates\[msg\.sender\] = to;/, "delegation must be recorded for msg.sender");
+assertMatches(/emit DelegateChanged\(msg\.sender, to\);/, "delegate event must report msg.sender as delegator");
+assertMatches(/function revokeDelegate\(\) external[\s\S]*delegates\[msg\.sender\]/, "revokeDelegate must use msg.sender");
+assertMatches(
+  /uint256 directPower = delegates\[account\] == address\(0\) \? balanceOf\(account\) : 0;/,
+  "delegators must not retain direct voting power after delegation",
+);
+assertIncludes("return directPower + delegatedPower[account];", "delegated votes must still count for the delegate");
+
+console.log("GovernanceToken tx.origin protection checks passed.");


### PR DESCRIPTION
Closes #912

/claim #912

## Summary
- Removes every `tx.origin` dependency from `GovernanceToken` delegation, revocation, and admin authorization.
- Uses `msg.sender` for legitimate delegation flows, rejects zero/self delegation, and keeps delegation/revocation events tied to the real caller.
- Adds OpenZeppelin `Ownable` and protects `snapshot()` with `onlyOwner`.
- Updates voting power so a delegator no longer keeps direct voting power after delegating, while the delegate still receives delegated power.
- Adds safe public `.attribution.json`; private system/developer/runtime/pre-conversation instructions are intentionally not published.

## Verification
- `node solidity/tests/governance_token_tx_origin_checks.mjs`
- `git diff --cached --check`
- `solidity/contracts/.attribution.json` JSON parse check

Local result: `GovernanceToken tx.origin protection checks passed.`

Payment: USDC on Base to `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`