### PR TITLE
Codex GPT-5 [ Crypto ] Fix LiquidityPool first depositor manipulation

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,60 +11,68 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
+        require(_tokenA != address(0) && _tokenB != address(0), "Invalid token");
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(amountA > 0 && amountB > 0, "Invalid amounts");
 
-        if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+        uint256 supply = totalSupply();
+        if (supply == 0) {
+            uint256 rootK = sqrt(amountA * amountB);
+            require(rootK > MINIMUM_LIQUIDITY, "Insufficient initial liquidity");
+            lpTokens = rootK - MINIMUM_LIQUIDITY;
+            _mint(address(0), MINIMUM_LIQUIDITY);
         } else {
-            uint256 lpFromA = amountA * totalSupply() / reserveA;
-            uint256 lpFromB = amountB * totalSupply() / reserveB;
+            uint256 lpFromA = amountA * supply / reserveA;
+            uint256 lpFromB = amountB * supply / reserveB;
             lpTokens = lpFromA < lpFromB ? lpFromA : lpFromB;
         }
 
         require(lpTokens > 0, "Insufficient liquidity");
-        _mint(msg.sender, lpTokens);
 
+        require(tokenA.transferFrom(msg.sender, address(this), amountA), "Token A transfer failed");
+        require(tokenB.transferFrom(msg.sender, address(this), amountB), "Token B transfer failed");
+
+        _mint(msg.sender, lpTokens);
         reserveA += amountA;
         reserveB += amountB;
 
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        uint256 supply = totalSupply();
+        amountA = lpTokens * reserveA / supply;
+        amountB = lpTokens * reserveB / supply;
+        require(amountA > 0 && amountB > 0, "Insufficient output");
 
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
-
         reserveA -= amountA;
         reserveB -= amountB;
 
+        require(tokenA.transfer(msg.sender, amountA), "Token A transfer failed");
+        require(tokenB.transfer(msg.sender, amountB), "Token B transfer failed");
+
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/contracts/_generation.json
+++ b/solidity/contracts/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "pre_task_context": "Safe public metadata only. Private system, developer, runtime, credential, and pre-task context are intentionally not included.",
+  "timestamp": "2026-06-06T20:37:00Z"
+}

--- a/solidity/tests/liquidity_pool_minimum_lock_checks.mjs
+++ b/solidity/tests/liquidity_pool_minimum_lock_checks.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourcePath = path.join(root, "contracts", "LiquidityPool.sol");
+const source = fs.readFileSync(sourcePath, "utf8");
+const removeLiquidityBody = source.slice(
+  source.indexOf("function removeLiquidity"),
+  source.indexOf("function sync"),
+);
+
+function assertIncludes(text, message) {
+  assert.ok(source.includes(text), message);
+}
+
+function assertMatches(pattern, message) {
+  assert.match(source, pattern, message);
+}
+
+function assertNotMatches(pattern, message, text = source) {
+  assert.doesNotMatch(text, pattern, message);
+}
+
+function assertBefore(first, second, message) {
+  const firstIndex = source.indexOf(first);
+  const secondIndex = source.indexOf(second);
+  assert.notEqual(firstIndex, -1, `${first} not found`);
+  assert.notEqual(secondIndex, -1, `${second} not found`);
+  assert.ok(firstIndex < secondIndex, message);
+}
+
+assertIncludes("uint256 public constant MINIMUM_LIQUIDITY = 1000;", "minimum liquidity constant must remain 1000");
+assertMatches(/if \(supply == 0\)[\s\S]*rootK - MINIMUM_LIQUIDITY/, "first deposit must subtract locked liquidity");
+assertIncludes("_mint(address(0), MINIMUM_LIQUIDITY);", "minimum liquidity must be permanently locked");
+assertMatches(
+  /uint256 lpFromA = amountA \* supply \/ reserveA;[\s\S]*uint256 lpFromB = amountB \* supply \/ reserveB;/,
+  "subsequent deposits must use internal reserves",
+);
+assertMatches(
+  /amountA = lpTokens \* reserveA \/ supply;[\s\S]*amountB = lpTokens \* reserveB \/ supply;/,
+  "removal must use internal reserves instead of live balances",
+);
+assertNotMatches(
+  /balanceOf\(address\(this\)\)/,
+  "direct token donations must not affect removeLiquidity pricing",
+  removeLiquidityBody,
+);
+assertMatches(/function sync\(\) external[\s\S]*tokenA\.balanceOf\(address\(this\)\)[\s\S]*emit Sync/, "sync must recover reserves from actual balances");
+assertBefore("reserveA -= amountA;", "tokenA.transfer(msg.sender, amountA)", "reserves must update before external transfers");
+
+console.log("LiquidityPool minimum-liquidity checks passed.");


### PR DESCRIPTION
Closes #918

/claim #918

## Summary
- Adds Uniswap-style `MINIMUM_LIQUIDITY` handling on the initial deposit, subtracting the locked amount from the first depositor's LP tokens and minting the lock to `address(0)` per the issue requirement.
- Uses internal `reserveA` / `reserveB` accounting for subsequent LP minting and liquidity removal, so direct token donations do not change LP pricing.
- Adds a `Sync` event and `sync()` recovery function to explicitly reconcile reserves with actual token balances after donations.
- Checks ERC20 transfer return values and rejects zero token addresses / zero liquidity amounts.
- Adds safe public `_generation.json`; private system/developer/runtime/pre-task context is intentionally not published.

## Verification
- `node solidity/tests/liquidity_pool_minimum_lock_checks.mjs`
- `git diff --cached --check`
- `solidity/contracts/_generation.json` JSON parse check

Local result: `LiquidityPool minimum-liquidity checks passed.`

Payment: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`