### PR TITLE
Codex GPT-5 [ Crypto ] Fix StakingVault reentrancy

### DIFF
--- a/solidity/contracts/.provenance.json
+++ b/solidity/contracts/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex GPT-5",
+  "config_snapshot": "Safe public metadata only. Private system, developer, runtime, credential, and pre-task configuration text is intentionally not included.",
+  "created": "2026-06-06T20:53:00Z"
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -17,13 +18,14 @@ contract StakingVault {
     event RewardClaimed(address indexed user, uint256 amount);
 
     constructor(address _stakingToken, uint256 _rewardRate) {
+        require(_stakingToken != address(0), "Invalid staking token");
         stakingToken = IERC20(_stakingToken);
         rewardRate = _rewardRate;
     }
 
     function stake(uint256 amount) external {
         require(amount > 0, "Cannot stake 0");
-        stakingToken.transferFrom(msg.sender, address(this), amount);
+        require(stakingToken.transferFrom(msg.sender, address(this), amount), "Stake transfer failed");
         _updateReward(msg.sender);
         balances[msg.sender] += amount;
         totalStaked += amount;
@@ -39,31 +41,30 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    function withdraw(uint256 amount) external nonReentrant {
+        require(amount > 0, "Cannot withdraw 0");
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 

--- a/solidity/tests/staking_vault_reentrancy_checks.mjs
+++ b/solidity/tests/staking_vault_reentrancy_checks.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourcePath = path.join(root, "contracts", "StakingVault.sol");
+const source = fs.readFileSync(sourcePath, "utf8");
+const withdrawBody = source.slice(source.indexOf("function withdraw"), source.indexOf("function claimRewards"));
+const claimBody = source.slice(source.indexOf("function claimRewards"), source.indexOf("function getStakedBalance"));
+
+function assertIncludes(text, message) {
+  assert.ok(source.includes(text), message);
+}
+
+function assertMatches(pattern, message, text = source) {
+  assert.match(text, pattern, message);
+}
+
+function assertBefore(first, second, message, text = source) {
+  const firstIndex = text.indexOf(first);
+  const secondIndex = text.indexOf(second);
+  assert.notEqual(firstIndex, -1, `${first} not found`);
+  assert.notEqual(secondIndex, -1, `${second} not found`);
+  assert.ok(firstIndex < secondIndex, message);
+}
+
+assertIncludes('import "@openzeppelin/contracts/security/ReentrancyGuard.sol";', "ReentrancyGuard must be imported");
+assertIncludes("contract StakingVault is ReentrancyGuard", "vault must inherit ReentrancyGuard");
+assertMatches(/function withdraw\(uint256 amount\) external nonReentrant/, "withdraw must be nonReentrant");
+assertMatches(/function claimRewards\(\) external nonReentrant/, "claimRewards must be nonReentrant");
+assertBefore("balances[msg.sender] -= amount;", "payable(msg.sender).call{value: amount}", "withdraw balance update must precede ETH transfer", withdrawBody);
+assertBefore("totalStaked -= amount;", "payable(msg.sender).call{value: amount}", "withdraw totalStaked update must precede ETH transfer", withdrawBody);
+assertBefore("rewards[msg.sender] = 0;", "payable(msg.sender).call{value: reward}", "claimRewards reward reset must precede ETH transfer", claimBody);
+assertIncludes('require(stakingToken.transferFrom(msg.sender, address(this), amount), "Stake transfer failed");', "stake must check ERC20 transfer result");
+assertIncludes('require(_stakingToken != address(0), "Invalid staking token");', "constructor must reject zero token");
+
+console.log("StakingVault reentrancy checks passed.");


### PR DESCRIPTION
Closes #911

/claim #911

## Summary
- Imports OpenZeppelin `ReentrancyGuard` and applies `nonReentrant` to both `withdraw()` and `claimRewards()`.
- Moves `balances`, `totalStaked`, and `rewards` state updates before external ETH transfers.
- Checks the staking token transfer result and rejects a zero staking token address.
- Adds safe public `.provenance.json`; private system/developer/runtime/pre-task configuration text is intentionally not published.

## Verification
- `node solidity/tests/staking_vault_reentrancy_checks.mjs`
- `git diff --cached --check`
- `solidity/contracts/.provenance.json` JSON parse check

Local result: `StakingVault reentrancy checks passed.`

Payment: USDC on Base to `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`