### PR TITLE
Codex GPT-5 [ Crypto ] Fix zero-fee flash loans and add pool drainage protection

### DIFF
--- a/solidity/contracts/.contributor.json
+++ b/solidity/contracts/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "timestamp": "2026-06-06T20:38:00Z"
+}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -8,58 +8,115 @@ interface IFlashLoanReceiver {
 }
 
 contract FlashLoan {
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
+    uint256 public accountedPoolBalance;
     address public owner;
     bool public paused;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event PoolDeposit(address indexed depositor, uint256 amount);
+    event FeesWithdrawn(address indexed owner, uint256 amount);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
 
     constructor(address _loanToken, uint256 _feeBPS) {
+        require(_loanToken != address(0), "Invalid token");
+        require(_feeBPS <= BPS_DENOMINATOR, "Invalid fee");
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
-    function flashLoan(uint256 amount, bytes calldata data) external {
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier whenNotPaused() {
         require(!paused, "Paused");
+        _;
+    }
+
+    function flashLoan(uint256 amount, bytes calldata data) external {
+        flashLoan(amount, data, msg.sender);
+    }
+
+    function flashLoan(uint256 amount, bytes calldata data, address receiver) public whenNotPaused {
         require(amount > 0, "Amount must be > 0");
+        require(receiver != address(0), "Invalid receiver");
+
+        uint256 poolBalance = accountedPoolBalance;
+        require(poolBalance >= amount, "Insufficient pool balance");
+        require(amount <= maxLoanAmount(), "Exceeds max loan");
 
         uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        require(balanceBefore == poolBalance, "Unsupported rebasing token");
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
+        uint256 fee = calculateFee(amount);
 
-        loanToken.transfer(msg.sender, amount);
+        require(loanToken.transfer(receiver, amount), "Transfer failed");
 
-        IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
+        IFlashLoanReceiver(receiver).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
+        uint256 expectedBalance = poolBalance + fee;
         uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(balanceAfter == expectedBalance, "Loan not repaid");
 
+        accountedPoolBalance = expectedBalance;
         totalFees += fee;
-        emit FlashLoanExecuted(msg.sender, amount, fee);
+        emit FlashLoanExecuted(receiver, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(amount > 0, "Amount must be > 0");
+        uint256 balanceBefore = loanToken.balanceOf(address(this));
+        require(balanceBefore == accountedPoolBalance, "Unsupported rebasing token");
+
+        require(loanToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+
+        uint256 balanceAfter = loanToken.balanceOf(address(this));
+        require(balanceAfter == balanceBefore + amount, "Unsupported rebasing token");
+
+        accountedPoolBalance += amount;
+        emit PoolDeposit(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
+        require(fees > 0, "No fees");
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        accountedPoolBalance -= fees;
+        require(loanToken.transfer(owner, fees), "Transfer failed");
+        emit FeesWithdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    function calculateFee(uint256 amount) public view returns (uint256) {
+        uint256 fee = amount * feeBPS / BPS_DENOMINATOR;
+        if (fee == 0) {
+            return 1;
+        }
+        return fee;
+    }
+
+    function maxLoanAmount() public view returns (uint256) {
+        return accountedPoolBalance / 2;
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return accountedPoolBalance;
     }
 }

--- a/solidity/tests/flashloan_pool_protection_checks.mjs
+++ b/solidity/tests/flashloan_pool_protection_checks.mjs
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const source = readFileSync(new URL('../contracts/FlashLoan.sol', import.meta.url), 'utf8');
+
+function includes(fragment, message) {
+  assert.ok(source.includes(fragment), message);
+}
+
+function matches(pattern, message) {
+  assert.ok(pattern.test(source), message);
+}
+
+includes('uint256 public constant BPS_DENOMINATOR = 10_000;', 'basis point denominator should be explicit');
+includes('uint256 public accountedPoolBalance;', 'pool balance should be tracked with internal accounting');
+includes('function calculateFee(uint256 amount) public view returns (uint256)', 'fee helper should be public for verification');
+matches(/if\s*\(\s*fee\s*==\s*0\s*\)\s*\{\s*return\s+1;/s, 'small loans must pay at least one token unit');
+includes('function maxLoanAmount() public view returns (uint256)', 'max loan helper should be exposed');
+matches(/return\s+accountedPoolBalance\s*\/\s*2\s*;/, 'max loan amount should be 50% of the accounted pool');
+matches(/require\s*\(\s*amount\s*<=\s*maxLoanAmount\(\)\s*,\s*"Exceeds max loan"\s*\)/, 'flash loans over the cap should be rejected');
+matches(/require\s*\(\s*balanceBefore\s*==\s*poolBalance\s*,\s*"Unsupported rebasing token"\s*\)/, 'loan start should reject balance drift from rebasing/unaccounted tokens');
+matches(/require\s*\(\s*balanceAfter\s*==\s*expectedBalance\s*,\s*"Loan not repaid"\s*\)/, 'loan completion should require exact accounted repayment plus fee');
+matches(/accountedPoolBalance\s*=\s*expectedBalance\s*;\s*totalFees\s*\+=\s*fee\s*;/s, 'fees should accrue into both pool accounting and totalFees');
+includes('function pause() external onlyOwner', 'owner should be able to pause flash loans');
+includes('function unpause() external onlyOwner', 'owner should be able to unpause flash loans');
+matches(/function\s+flashLoan\(uint256 amount, bytes calldata data, address receiver\)\s+public\s+whenNotPaused/, 'flash loan entrypoint should be pause-gated');
+matches(/require\s*\(\s*loanToken\.transfer\(receiver,\s*amount\)\s*,\s*"Transfer failed"\s*\)/, 'loan transfer result should be checked');
+matches(/require\s*\(\s*loanToken\.transferFrom\(msg\.sender,\s*address\(this\),\s*amount\)\s*,\s*"Transfer failed"\s*\)/, 'deposit transfer result should be checked');
+matches(/require\s*\(\s*balanceAfter\s*==\s*balanceBefore\s*\+\s*amount\s*,\s*"Unsupported rebasing token"\s*\)/, 'deposits should reject fee-on-transfer/rebasing balance drift');
+matches(/accountedPoolBalance\s*-=\s*fees\s*;/, 'fee withdrawal should reduce accounted pool balance');
+
+const metadata = JSON.parse(readFileSync(new URL('../contracts/.contributor.json', import.meta.url), 'utf8'));
+assert.equal(metadata.agent, 'Codex GPT-5');
+assert.ok(!metadata.initialized_with.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('flashloan pool-protection checks passed');


### PR DESCRIPTION
/claim #919

## Summary
- Added a minimum one-unit flash loan fee and a 50% accounted-pool max loan cap.
- Added internal pool accounting, exact repayment checks, and rebasing/unaccounted-balance rejection.
- Added owner pause/unpause controls and checked ERC20 transfer results.
- Added safe contributor metadata and a local static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe solidity\tests\flashloan_pool_protection_checks.mjs`
- `git diff --check`

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022