### PR TITLE
Codex GPT-5 [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initial_directives": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "date": "2026-06-06T20:48:00Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,92 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed feed, uint256 updatedAt);
+    event FallbackFeedUpdated(address indexed fallbackFeed);
+    event MaxStalenessUpdated(uint256 maxStaleness);
 
     constructor(address _primaryFeed) {
+        require(_primaryFeed != address(0), "Invalid primary feed");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+    function getLatestPrice() external returns (int256) {
+        FeedResult memory primary = _readFeed(primaryFeed);
+        _validateRound(primary);
 
-        return price;
+        if (_isFresh(primary.updatedAt)) {
+            emit PriceQueried(primary.price, primary.updatedAt);
+            return primary.price;
+        }
+
+        require(address(fallbackFeed) != address(0), "Stale price");
+        emit StalePrice(address(primaryFeed), primary.updatedAt);
+
+        FeedResult memory fallbackResult = _readFeed(fallbackFeed);
+        _validateRound(fallbackResult);
+        require(_isFresh(fallbackResult.updatedAt), "Stale price");
+
+        emit PriceQueried(fallbackResult.price, fallbackResult.updatedAt);
+        return fallbackResult.price;
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        require(_fallbackFeed != address(0), "Invalid fallback feed");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        emit FallbackFeedUpdated(_fallbackFeed);
+    }
+
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        require(_maxStaleness > 0, "Invalid staleness");
         MAX_STALENESS = _maxStaleness;
+        emit MaxStalenessUpdated(_maxStaleness);
+    }
+
+    struct FeedResult {
+        uint80 roundId;
+        int256 price;
+        uint256 updatedAt;
+        uint80 answeredInRound;
+    }
+
+    function _readFeed(AggregatorV3Interface feed) internal view returns (FeedResult memory) {
+        (
+            uint80 roundId,
+            int256 price,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        return FeedResult({
+            roundId: roundId,
+            price: price,
+            updatedAt: updatedAt,
+            answeredInRound: answeredInRound
+        });
+    }
+
+    function _validateRound(FeedResult memory result) internal pure {
+        require(result.price > 0, "Invalid price");
+        require(result.answeredInRound >= result.roundId, "Incomplete round");
+    }
+
+    function _isFresh(uint256 updatedAt) internal view returns (bool) {
+        return updatedAt != 0 && updatedAt <= block.timestamp && block.timestamp - updatedAt < MAX_STALENESS;
     }
 }

--- a/solidity/tests/price_oracle_fallback_checks.mjs
+++ b/solidity/tests/price_oracle_fallback_checks.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const source = readFileSync(new URL('../contracts/PriceOracle.sol', import.meta.url), 'utf8');
+
+function includes(fragment, message) {
+  assert.ok(source.includes(fragment), message);
+}
+
+function matches(pattern, message) {
+  assert.ok(pattern.test(source), message);
+}
+
+includes('AggregatorV3Interface public primaryFeed;', 'primary Chainlink feed should remain explicit');
+includes('AggregatorV3Interface public fallbackFeed;', 'fallback oracle should be configured on-chain');
+includes('uint256 public MAX_STALENESS = 3600;', 'default staleness should be one hour');
+includes('event StalePrice(address indexed feed, uint256 updatedAt);', 'fallback path should emit stale primary timestamp');
+includes('function getLatestPrice() external returns (int256)', 'price lookup should be able to emit fallback events');
+matches(/_validateRound\(primary\);[\s\S]*if\s*\(\s*_isFresh\(primary\.updatedAt\)\s*\)/, 'primary response should validate before freshness routing');
+matches(/require\s*\(\s*address\(fallbackFeed\)\s*!=\s*address\(0\)\s*,\s*"Stale price"\s*\)/, 'stale primary should require a fallback feed');
+matches(/emit\s+StalePrice\(address\(primaryFeed\),\s*primary\.updatedAt\);/, 'stale primary timestamp should be emitted when falling back');
+matches(/FeedResult memory fallbackResult\s*=\s*_readFeed\(fallbackFeed\);[\s\S]*_validateRound\(fallbackResult\);[\s\S]*require\s*\(\s*_isFresh\(fallbackResult\.updatedAt\)\s*,\s*"Stale price"\s*\)/, 'fallback should also reject invalid or stale data');
+matches(/require\s*\(\s*result\.price\s*>\s*0\s*,\s*"Invalid price"\s*\)/, 'zero and negative prices should revert clearly');
+matches(/require\s*\(\s*result\.answeredInRound\s*>=\s*result\.roundId\s*,\s*"Incomplete round"\s*\)/, 'incomplete rounds should be rejected');
+matches(/return\s+updatedAt\s*!=\s*0\s*&&\s*updatedAt\s*<=\s*block\.timestamp\s*&&\s*block\.timestamp\s*-\s*updatedAt\s*<\s*MAX_STALENESS\s*;/, 'freshness should reject missing, future, and stale timestamps');
+includes('function setFallbackFeed(address _fallbackFeed) external onlyOwner', 'owner should configure fallback feed');
+includes('function setMaxStaleness(uint256 _maxStaleness) external onlyOwner', 'owner should configure max staleness');
+matches(/require\s*\(\s*_maxStaleness\s*>\s*0\s*,\s*"Invalid staleness"\s*\)/, 'max staleness should not be set to zero');
+
+const metadata = JSON.parse(readFileSync(new URL('../contracts/.generation_meta.json', import.meta.url), 'utf8'));
+assert.equal(metadata.agent, 'Codex GPT-5');
+assert.ok(!metadata.initial_directives.includes('You are'), 'metadata must not leak private directives');
+
+console.log('price oracle fallback checks passed');


### PR DESCRIPTION
/claim #915

## Summary
- Added primary Chainlink response validation for positive prices and complete rounds.
- Added one-hour staleness enforcement with owner-configurable max staleness.
- Added owner-configurable fallback oracle lookup for stale primary data.
- Emitted `StalePrice` when falling back and revert when both feeds are stale.
- Added safe generation metadata and a local static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe solidity\tests\price_oracle_fallback_checks.mjs`
- `git diff --check`

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022