### PR TITLE
Codex GPT-5 [ FastAPI ] Implement standardized pagination with offset and cursor support

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "date": "2026-06-06T20:55:00Z"
+}

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,138 @@
+import base64
+import json
+import math
+from collections.abc import Sequence
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel, Field
+
+from .param_functions import Query
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
+    total: int = Field(ge=0)
+    page: int = Field(ge=1)
+    page_size: int = Field(ge=1)
+    total_pages: int = Field(ge=0)
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+class Paginator:
+    default_page_size = 50
+    max_page_size = 100
+
+    def __init__(
+        self,
+        page: int = 1,
+        page_size: int = default_page_size,
+        cursor: str | None = None,
+    ) -> None:
+        self.page = max(1, page)
+        self.page_size = self._normalize_page_size(page_size)
+        self.cursor = cursor
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    def apply_offset(self, source: Any) -> Any:
+        if hasattr(source, "offset") and hasattr(source, "limit"):
+            return source.offset(self.offset).limit(self.limit)
+        return source[self.offset : self.offset + self.limit]
+
+    def paginate_offset(
+        self,
+        items: Sequence[T],
+        total: int | None = None,
+    ) -> PaginatedResponse[T]:
+        resolved_total = len(items) if total is None else max(0, total)
+        page_items = list(items[self.offset : self.offset + self.page_size])
+        return self._build_response(
+            items=page_items,
+            total=resolved_total,
+            page=self.page,
+            offset=self.offset,
+        )
+
+    def paginate_cursor(
+        self,
+        items: Sequence[T],
+        total: int | None = None,
+    ) -> PaginatedResponse[T]:
+        offset = self.decode_cursor(self.cursor) if self.cursor else 0
+        resolved_total = len(items) if total is None else max(0, total)
+        page = offset // self.page_size + 1
+        page_items = list(items[offset : offset + self.page_size])
+        return self._build_response(
+            items=page_items,
+            total=resolved_total,
+            page=page,
+            offset=offset,
+            include_cursors=True,
+        )
+
+    def _build_response(
+        self,
+        *,
+        items: list[T],
+        total: int,
+        page: int,
+        offset: int,
+        include_cursors: bool = False,
+    ) -> PaginatedResponse[T]:
+        total_pages = math.ceil(total / self.page_size) if total else 0
+        next_offset = offset + self.page_size
+        previous_offset = max(0, offset - self.page_size)
+        has_next = next_offset < total
+        has_previous = offset > 0 and total > 0
+        return PaginatedResponse[T](
+            items=items,
+            total=total,
+            page=page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=has_next,
+            has_previous=has_previous,
+            next_cursor=self.encode_cursor(next_offset) if include_cursors and has_next else None,
+            previous_cursor=self.encode_cursor(previous_offset)
+            if include_cursors and has_previous
+            else None,
+        )
+
+    @classmethod
+    def _normalize_page_size(cls, page_size: int) -> int:
+        if page_size <= 0:
+            return cls.default_page_size
+        return min(page_size, cls.max_page_size)
+
+    @staticmethod
+    def encode_cursor(offset: int) -> str:
+        payload = json.dumps({"offset": max(0, offset)}, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+    @staticmethod
+    def decode_cursor(cursor: str) -> int:
+        try:
+            padded = cursor + "=" * (-len(cursor) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(padded.encode()))
+            return max(0, int(payload.get("offset", 0)))
+        except (ValueError, TypeError, json.JSONDecodeError):
+            return 0
+
+
+def paginate(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    cursor: str | None = Query(None),
+) -> Paginator:
+    return Paginator(page=page, page_size=page_size, cursor=cursor)

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,94 @@
+from pydantic import BaseModel
+
+from fastapi.pagination import PaginatedResponse, Paginator, paginate
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+def test_offset_pagination_calculates_boundaries() -> None:
+    paginator = Paginator(page=2, page_size=3)
+
+    response = paginator.paginate_offset(list(range(10)))
+
+    assert response.items == [3, 4, 5]
+    assert response.total == 10
+    assert response.page == 2
+    assert response.page_size == 3
+    assert response.total_pages == 4
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_offset_boundaries_for_first_last_and_empty_pages() -> None:
+    assert Paginator(page=1, page_size=2).paginate_offset([1, 2]).has_previous is False
+    assert Paginator(page=1, page_size=2).paginate_offset([1, 2]).has_next is False
+
+    empty = Paginator(page=1, page_size=10).paginate_offset([])
+
+    assert empty.items == []
+    assert empty.total == 0
+    assert empty.total_pages == 0
+    assert empty.has_next is False
+    assert empty.has_previous is False
+
+
+def test_page_and_page_size_edge_cases_are_normalized() -> None:
+    paginator = Paginator(page=0, page_size=0)
+
+    assert paginator.page == 1
+    assert paginator.page_size == Paginator.default_page_size
+    assert paginator.offset == 0
+
+    negative = Paginator(page=-2, page_size=-5)
+
+    assert negative.page == 1
+    assert negative.page_size == Paginator.default_page_size
+
+
+def test_cursor_pagination_returns_navigation_cursors() -> None:
+    first = Paginator(page_size=3).paginate_cursor(list(range(8)))
+
+    assert first.items == [0, 1, 2]
+    assert first.next_cursor is not None
+    assert first.previous_cursor is None
+
+    second = Paginator(page_size=3, cursor=first.next_cursor).paginate_cursor(list(range(8)))
+
+    assert second.items == [3, 4, 5]
+    assert second.has_next is True
+    assert second.has_previous is True
+    assert second.next_cursor is not None
+    assert second.previous_cursor is not None
+
+    last = Paginator(page_size=3, cursor=second.next_cursor).paginate_cursor(list(range(8)))
+
+    assert last.items == [6, 7]
+    assert last.has_next is False
+    assert last.has_previous is True
+
+
+def test_cursor_decoding_handles_invalid_values() -> None:
+    response = Paginator(page_size=2, cursor="not-a-cursor").paginate_cursor([1, 2, 3])
+
+    assert response.items == [1, 2]
+    assert response.page == 1
+
+
+def test_paginated_response_supports_pydantic_models() -> None:
+    response: PaginatedResponse[Item] = Paginator(page=1, page_size=2).paginate_offset(
+        [Item(id=1, name="one"), Item(id=2, name="two")]
+    )
+
+    assert response.items[0].name == "one"
+    assert response.model_dump()["items"][1]["id"] == 2
+
+
+def test_paginate_dependency_uses_query_defaults() -> None:
+    paginator = paginate()
+
+    assert isinstance(paginator, Paginator)
+    assert paginator.page == 1
+    assert paginator.page_size == 50


### PR DESCRIPTION
/claim #802

## Summary
- Added `fastapi.pagination` with `Paginator`, `PaginatedResponse`, and injectable `paginate` dependency.
- Supports offset pagination, cursor pagination, SQLAlchemy-style offset/limit application, encoded cursors, and boundary flags.
- Handles page/page_size edge cases and empty result sets.
- Added Pydantic generic response tests and safe attribution metadata.

## Verification
- Local logic check with bundled Python and a minimal `Query` stub because local runtime lacks `starlette`/`pytest`.
- `git diff --check`

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022