### PR TITLE
Codex GPT-5 [ Laravel ] Implement webhook system with signature verification and retry queue

### DIFF
--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebhookController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(Webhook::query()->latest()->paginate());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $webhook = Webhook::query()->create($this->validatePayload($request));
+
+        return response()->json($webhook, 201);
+    }
+
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json($webhook->load('deliveries'));
+    }
+
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $webhook->update($this->validatePayload($request, partial: true));
+
+        return response()->json($webhook->refresh());
+    }
+
+    public function destroy(Webhook $webhook): JsonResponse
+    {
+        $webhook->delete();
+
+        return response()->json(status: 204);
+    }
+
+    private function validatePayload(Request $request, bool $partial = false): array
+    {
+        $required = $partial ? 'sometimes' : 'required';
+
+        return $request->validate([
+            'url' => [$required, 'url'],
+            'secret' => [$required, 'string', 'min:16'],
+            'events' => [$required, 'array', 'min:1'],
+            'events.*' => ['string'],
+            'active' => ['sometimes', 'boolean'],
+        ]);
+    }
+}

--- a/laravel/app/Jobs/DispatchWebhookJob.php
+++ b/laravel/app/Jobs/DispatchWebhookJob.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Bus\Dispatchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DispatchWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = WebhookDispatcher::MAX_ATTEMPTS;
+
+    public function __construct(public WebhookDelivery $delivery)
+    {
+    }
+
+    public function handle(WebhookDispatcher $dispatcher): void
+    {
+        $delivery = $this->delivery->fresh(['webhook']) ?? $this->delivery->load('webhook');
+
+        $dispatcher->send($delivery);
+    }
+
+    public function backoff(): array
+    {
+        return [60, 120, 240, 480, 960];
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Webhook extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'url',
+        'secret',
+        'events',
+        'active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'events' => 'array',
+            'active' => 'boolean',
+        ];
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    public function listensFor(string $event): bool
+    {
+        return $this->active && in_array($event, $this->events ?? [], true);
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebhookDelivery extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'webhook_id',
+        'event',
+        'payload',
+        'response_code',
+        'attempts',
+        'next_retry_at',
+        'delivered_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'attempts' => 'integer',
+            'next_retry_at' => 'datetime',
+            'delivered_at' => 'datetime',
+        ];
+    }
+
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+
+    public function markDelivered(int $responseCode): void
+    {
+        $this->forceFill([
+            'response_code' => $responseCode,
+            'delivered_at' => now(),
+            'next_retry_at' => null,
+        ])->save();
+    }
+}

--- a/laravel/app/Services/.attribution.json
+++ b/laravel/app/Services/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "date": "2026-06-06T21:02:00Z"
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+
+class WebhookDispatcher
+{
+    public const MAX_ATTEMPTS = 5;
+
+    public function dispatch(string $event, array $payload): void
+    {
+        Webhook::query()
+            ->where('active', true)
+            ->get()
+            ->filter(fn (Webhook $webhook) => $webhook->listensFor($event))
+            ->each(function (Webhook $webhook) use ($event, $payload): void {
+                $delivery = $webhook->deliveries()->create([
+                    'event' => $event,
+                    'payload' => $payload,
+                    'attempts' => 0,
+                ]);
+
+                DispatchWebhookJob::dispatch($delivery);
+            });
+    }
+
+    public function send(WebhookDelivery $delivery): void
+    {
+        $webhook = $delivery->webhook;
+        $payload = $delivery->payload ?? [];
+        $body = $this->canonicalPayload($delivery->event, $payload);
+        $attempts = $delivery->attempts + 1;
+
+        $response = Http::timeout(10)
+            ->withHeaders([
+                'X-Webhook-Event' => $delivery->event,
+                'X-Webhook-Signature' => $this->signature($body, $webhook->secret),
+            ])
+            ->withBody($body, 'application/json')
+            ->post($webhook->url);
+
+        $delivery->forceFill([
+            'attempts' => $attempts,
+            'response_code' => $response->status(),
+        ]);
+
+        if ($response->successful()) {
+            $delivery->delivered_at = now();
+            $delivery->next_retry_at = null;
+        } elseif ($attempts < self::MAX_ATTEMPTS) {
+            $delivery->next_retry_at = $this->nextRetryAt($attempts);
+        } else {
+            $delivery->next_retry_at = null;
+        }
+
+        $delivery->save();
+    }
+
+    public function canonicalPayload(string $event, array $payload): string
+    {
+        return json_encode([
+            'event' => $event,
+            'payload' => $payload,
+        ], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    public function signature(string $body, string $secret): string
+    {
+        return 'sha256='.hash_hmac('sha256', $body, $secret);
+    }
+
+    public function nextRetryAt(int $attempts): Carbon
+    {
+        return now()->addSeconds($this->retryDelaySeconds($attempts));
+    }
+
+    public function retryDelaySeconds(int $attempts): int
+    {
+        return 2 ** max(0, $attempts - 1) * 60;
+    }
+}

--- a/laravel/database/migrations/2026_06_06_000001_create_webhooks_table.php
+++ b/laravel/database/migrations/2026_06_06_000001_create_webhooks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true)->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/database/migrations/2026_06_06_000002_create_webhook_deliveries_table.php
+++ b/laravel/database/migrations/2026_06_06_000002_create_webhook_deliveries_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event');
+            $table->json('payload');
+            $table->unsignedSmallInteger('response_code')->nullable();
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable()->index();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\WebhookController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::apiResource('webhooks', WebhookController::class);

--- a/laravel/tests/Unit/WebhookDispatcherTest.php
+++ b/laravel/tests/Unit/WebhookDispatcherTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\WebhookDispatcher;
+use PHPUnit\Framework\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    public function test_signature_generation_uses_hmac_sha256(): void
+    {
+        $dispatcher = new WebhookDispatcher();
+        $body = '{"event":"user.created","payload":{"id":1}}';
+        $secret = 'super-secret-webhook-key';
+
+        $this->assertSame(
+            'sha256='.hash_hmac('sha256', $body, $secret),
+            $dispatcher->signature($body, $secret),
+        );
+    }
+
+    public function test_retry_timing_uses_exponential_backoff(): void
+    {
+        $dispatcher = new WebhookDispatcher();
+
+        $this->assertSame(60, $dispatcher->retryDelaySeconds(1));
+        $this->assertSame(120, $dispatcher->retryDelaySeconds(2));
+        $this->assertSame(240, $dispatcher->retryDelaySeconds(3));
+        $this->assertSame(480, $dispatcher->retryDelaySeconds(4));
+        $this->assertSame(960, $dispatcher->retryDelaySeconds(5));
+    }
+}


### PR DESCRIPTION
/claim #754

## Summary
- Added `Webhook` and `WebhookDelivery` models with migrations and relationships.
- Added `WebhookDispatcher` for JSON delivery, HMAC-SHA256 signatures, delivery tracking, and exponential retry timing.
- Added queued `DispatchWebhookJob` with five attempts and increasing backoff.
- Added `WebhookController` CRUD endpoints and `webhooks` resource routes.
- Added unit tests for signature generation and retry delay calculation plus safe attribution metadata.

## Verification
- `git diff --check`
- Static code inspection for required HMAC, retry, model, and route paths.
- Could not run PHP/PHPUnit locally because `php` is not installed in this environment.

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022