### PR TITLE
Codex GPT-5 [ Cobol ] Fix race condition in concurrent CERT-STORE-FILE access causing FILE STATUS 92

### DIFF
--- a/cobol/.attribution.json
+++ b/cobol/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "date": "2026-06-06T21:18:00Z"
+}

--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -46,6 +46,10 @@
        01  WS-FILE-STATUS              PIC XX.
            88  WS-FILE-OK              VALUE '00'.
            88  WS-FILE-NOT-FOUND       VALUE '23'.
+           88  WS-FILE-LOGIC-ERROR     VALUE '92'.
+           88  WS-FILE-UNAVAILABLE     VALUE '93'.
+           88  WS-FILE-LOCKED          VALUE '95'.
+           88  WS-FILE-RETRYABLE       VALUE '92' '93' '95'.
        01  WS-CRL-FILE-STATUS          PIC XX.
            88  WS-CRL-OK               VALUE '00'.
            88  WS-CRL-EOF              VALUE '10'.
@@ -123,6 +127,15 @@
            88  WS-CERT-INVALID         VALUE 'I'.
        01  WS-VALIDATION-MSG           PIC X(128).
        01  WS-AUDIT-TIMESTAMP          PIC X(26).
+       01  WS-CERT-STORE-RESOURCE      PIC X(8)  VALUE 'CERTSTOR'.
+       01  WS-CERT-STORE-LOCKED        PIC X(1)  VALUE 'N'.
+           88  WS-CERT-STORE-ENQUEUED  VALUE 'Y'.
+           88  WS-CERT-STORE-FREE      VALUE 'N'.
+       01  WS-CERT-STORE-RETRY         PIC 9(1)  VALUE 0.
+       01  WS-MAX-CERT-STORE-RETRIES   PIC 9(1)  VALUE 3.
+       01  WS-CERT-STORE-READ-DONE     PIC X(1)  VALUE 'N'.
+           88  WS-CERT-STORE-READ-OK   VALUE 'Y'.
+           88  WS-CERT-STORE-READ-FAIL VALUE 'N'.
        01  WS-RETURN-CODE              PIC S9(4) COMP VALUE 0.
        PROCEDURE DIVISION.
        0000-MAIN-CONTROL.
@@ -140,9 +153,12 @@
            SET WS-CERT-NOT-EXPIRED TO TRUE
            SET WS-CERT-NOT-REVOKED TO TRUE
            SET WS-HOSTNAME-NO-MATCH TO TRUE
-           SET WS-CHAIN-IS-VALID TO TRUE
+           SET WS-CHAIN-IS-INVALID TO TRUE
            MOVE FUNCTION CURRENT-DATE TO WS-CURRENT-DATE-TIME
-           OPEN INPUT CERT-STORE-FILE
+           EXEC CICS HANDLE CONDITION
+               DSIDERR(1000-CERT-STORE-DSIDERR)
+           END-EXEC
+           OPEN I-O CERT-STORE-FILE
            IF NOT WS-FILE-OK
                DISPLAY 'TLSVAL-E001: CERT STORE FAILED '
                    WS-FILE-STATUS
@@ -165,16 +181,14 @@
                GO TO 2000-EXIT
            END-IF
            PERFORM VARYING WS-CHAIN-INDEX FROM 1 BY 1
-               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH + 1
+               UNTIL WS-CHAIN-INDEX > WS-CHAIN-LENGTH
                MOVE WS-CHN-SERIAL(WS-CHAIN-INDEX)
                    TO CS-CERT-SERIAL
-               READ CERT-STORE-FILE
-                   INVALID KEY
-                       DISPLAY 'TLSVAL-E011: UNKNOWN CERT '
-                           WS-CHN-SERIAL(WS-CHAIN-INDEX)
-                       SET WS-CHAIN-IS-INVALID TO TRUE
-                       GO TO 2000-EXIT
-               END-READ
+               PERFORM 2100-READ-CERT-STORE-WITH-RETRY
+               IF WS-CERT-STORE-READ-FAIL
+                   SET WS-CHAIN-IS-INVALID TO TRUE
+                   GO TO 2000-EXIT
+               END-IF
                IF WS-CHAIN-INDEX = WS-CHAIN-LENGTH
                    IF NOT CS-IS-TRUST-ANCHOR
                        SET WS-CHAIN-IS-INVALID TO TRUE
@@ -190,9 +204,100 @@
                END-IF
                SET WS-CHN-IS-VERIFIED(WS-CHAIN-INDEX) TO TRUE
            END-PERFORM
+           SET WS-CHAIN-IS-VALID TO TRUE
            .
        2000-EXIT.
+           IF WS-CERT-STORE-ENQUEUED
+               PERFORM 2200-DEQ-CERT-STORE
+           END-IF
            EXIT.
+       2100-READ-CERT-STORE-WITH-RETRY.
+           MOVE 0 TO WS-CERT-STORE-RETRY
+           SET WS-CERT-STORE-READ-FAIL TO TRUE
+           PERFORM UNTIL WS-CERT-STORE-READ-OK
+               OR WS-CERT-STORE-RETRY >= WS-MAX-CERT-STORE-RETRIES
+               ADD 1 TO WS-CERT-STORE-RETRY
+               PERFORM 2150-ENQ-CERT-STORE
+               READ CERT-STORE-FILE
+                   INVALID KEY
+                       DISPLAY 'TLSVAL-E011: UNKNOWN CERT '
+                           WS-CHN-SERIAL(WS-CHAIN-INDEX)
+                       SET WS-CERT-STORE-READ-FAIL TO TRUE
+                       PERFORM 2200-DEQ-CERT-STORE
+                       GO TO 2100-EXIT
+               END-READ
+               IF WS-FILE-OK
+                   REWRITE CERT-STORE-RECORD
+                   END-REWRITE
+                   PERFORM 2200-DEQ-CERT-STORE
+                   IF WS-FILE-OK
+                       SET WS-CERT-STORE-READ-OK TO TRUE
+                   ELSE
+                       IF WS-FILE-RETRYABLE
+                           DISPLAY 'TLSVAL-W013: CERT STORE REWRITE '
+                               WS-FILE-STATUS ' RETRY '
+                               WS-CERT-STORE-RETRY
+                           EXEC CICS DELAY FOR MILLISECONDS(100)
+                           END-EXEC
+                       ELSE
+                           DISPLAY 'TLSVAL-E014: CERT STORE REWRITE '
+                               WS-FILE-STATUS
+                           SET WS-CERT-STORE-READ-FAIL TO TRUE
+                           GO TO 2100-EXIT
+                       END-IF
+                   END-IF
+               ELSE
+                   PERFORM 2200-DEQ-CERT-STORE
+                   IF WS-FILE-RETRYABLE
+                       DISPLAY 'TLSVAL-W012: CERT STORE STATUS '
+                           WS-FILE-STATUS ' RETRY '
+                           WS-CERT-STORE-RETRY
+                       EXEC CICS DELAY FOR MILLISECONDS(100)
+                       END-EXEC
+                   ELSE
+                       DISPLAY 'TLSVAL-E012: CERT STORE STATUS '
+                           WS-FILE-STATUS
+                       SET WS-CERT-STORE-READ-FAIL TO TRUE
+                       GO TO 2100-EXIT
+                   END-IF
+               END-IF
+           END-PERFORM
+           IF WS-CERT-STORE-READ-FAIL
+               DISPLAY 'TLSVAL-E013: CERT STORE RETRIES EXHAUSTED '
+                   WS-FILE-STATUS
+               MOVE 'CERT STORE FILE STATUS '
+                   TO WS-VALIDATION-MSG
+               STRING WS-VALIDATION-MSG DELIMITED SPACES
+                   ' ' DELIMITED SIZE
+                   WS-FILE-STATUS DELIMITED SIZE
+                   INTO WS-VALIDATION-MSG
+               END-STRING
+           END-IF
+           .
+       2100-EXIT.
+           EXIT.
+       2150-ENQ-CERT-STORE.
+           EXEC CICS ENQ
+               RESOURCE('CERTSTOR')
+               LENGTH(8)
+           END-EXEC
+           SET WS-CERT-STORE-ENQUEUED TO TRUE
+           .
+       2200-DEQ-CERT-STORE.
+           EXEC CICS DEQ
+               RESOURCE('CERTSTOR')
+               LENGTH(8)
+           END-EXEC
+           SET WS-CERT-STORE-FREE TO TRUE
+           .
+       1000-CERT-STORE-DSIDERR.
+           DISPLAY 'TLSVAL-E002: CERT STORE DATASET MISSING'
+           SET WS-CHAIN-IS-INVALID TO TRUE
+           MOVE 'CERT STORE DATASET MISSING'
+               TO WS-VALIDATION-MSG
+           MOVE 12 TO WS-RETURN-CODE
+           PERFORM 9000-CLEANUP
+           STOP RUN.
        3000-CHECK-EXPIRY-DATE.
            MOVE WS-CERT-NOT-AFTER(1:2)  TO WS-EXP-YEAR-2D
            MOVE WS-CERT-NOT-AFTER(3:2)  TO WS-EXP-MONTH

--- a/cobol/certstore_race_checks.mjs
+++ b/cobol/certstore_race_checks.mjs
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const source = readFileSync(new URL('./TLS-CERT-VALIDATOR.cbl', import.meta.url), 'utf8');
+
+function includes(fragment, message) {
+  assert.ok(source.includes(fragment), message);
+}
+
+function matches(pattern, message) {
+  assert.ok(pattern.test(source), message);
+}
+
+includes("88  WS-FILE-LOGIC-ERROR     VALUE '92'.", 'FILE STATUS 92 should be named');
+includes("88  WS-FILE-UNAVAILABLE     VALUE '93'.", 'FILE STATUS 93 should be named');
+includes("88  WS-FILE-LOCKED          VALUE '95'.", 'FILE STATUS 95 should be named');
+includes("88  WS-FILE-RETRYABLE       VALUE '92' '93' '95'.", 'retryable file statuses should be explicit');
+includes('WS-MAX-CERT-STORE-RETRIES   PIC 9(1)  VALUE 3.', 'retry cap should be three attempts');
+includes('EXEC CICS HANDLE CONDITION', 'CICS condition handler should be installed');
+includes('DSIDERR(1000-CERT-STORE-DSIDERR)', 'DSIDERR should be handled at startup');
+includes("OPEN I-O CERT-STORE-FILE", 'certificate store should be opened for read/rewrite');
+includes("EXEC CICS ENQ", 'ENQ should protect read/rewrite sequence');
+includes("RESOURCE('CERTSTOR')", 'ENQ/DEQ should use CERTSTOR resource');
+includes('READ CERT-STORE-FILE', 'protected read should remain present');
+includes('REWRITE CERT-STORE-RECORD', 'protected rewrite should remain present');
+matches(/REWRITE CERT-STORE-RECORD[\s\S]*?PERFORM 2200-DEQ-CERT-STORE/, 'DEQ should happen after rewrite');
+matches(/REWRITE CERT-STORE-RECORD[\s\S]*?IF WS-FILE-OK[\s\S]*?SET WS-CERT-STORE-READ-OK TO TRUE[\s\S]*?ELSE[\s\S]*?IF WS-FILE-RETRYABLE/, 'rewrite failures should be checked and retried when retryable');
+includes('EXEC CICS DELAY FOR MILLISECONDS(100)', 'retry delay should be 100 milliseconds');
+matches(/IF WS-CERT-STORE-READ-FAIL[\s\S]*SET WS-CHAIN-IS-INVALID TO TRUE/, 'failed store access should invalidate the chain');
+includes("DISPLAY 'TLSVAL-E013: CERT STORE RETRIES EXHAUSTED '", 'exhausted retries should be logged');
+matches(/SET WS-CHAIN-IS-INVALID TO TRUE[\s\S]*MOVE FUNCTION CURRENT-DATE/, 'chain should start invalid by default');
+matches(/END-PERFORM\s+SET WS-CHAIN-IS-VALID TO TRUE/, 'chain should be marked valid only after successful loop completion');
+assert.ok(!/SET WS-CHAIN-IS-VALID TO TRUE[\s\S]{0,120}OPEN I-O CERT-STORE-FILE/.test(source), 'startup should not default to valid before file operations');
+
+const metadata = JSON.parse(readFileSync(new URL('./.attribution.json', import.meta.url), 'utf8'));
+assert.equal(metadata.tool, 'Codex GPT-5');
+assert.ok(!metadata.platform_config.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('cobol cert-store race checks passed');


### PR DESCRIPTION
```
Private system/developer/runtime prompts are intentionally not disclosed. This PR includes safe public contributor metadata only.
```

/claim #520

## Summary
- Added explicit FILE STATUS handling for 92, 93, and 95 as retryable certificate-store contention states.
- Added CICS DSIDERR handling at certificate-store startup and changed the store to `OPEN I-O` for the protected read/rewrite flow.
- Added ENQ/DEQ around the CERTSTOR read/rewrite sequence with three retry attempts and 100ms CICS delay between retryable failures.
- Ensured the chain starts invalid by default and is only marked valid after the full chain loop succeeds.
- Logged exhausted retry status into validation/audit context and fixed the chain loop boundary.
- Added safe attribution metadata and a local static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe cobol\certstore_race_checks.mjs`
- `git diff --check`
- No COBOL/CICS compiler is available locally, so verification is static/invariant-based.

## Payout
- EVM/Base USDC wallet: 0x237664403f52A15142795f807ADB3524E8057909