### PR TITLE
Codex GPT-5 [ Laravel ] Implement file upload system with checksum dedup and thumbnail generation

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initial_directives": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "date": "2026-06-06T21:40:00Z"
+}

--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class FileController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(
+            File::query()->latest()->paginate(20)
+        );
+    }
+
+    public function upload(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'file' => ['required', 'file'],
+        ]);
+
+        $uploadedFile = $validated['file'];
+        $checksum = hash_file('sha256', $uploadedFile->getRealPath());
+
+        if (File::query()->where('checksum_sha256', $checksum)->exists()) {
+            return response()->json([
+                'message' => 'Duplicate file',
+                'checksum_sha256' => $checksum,
+            ], 409);
+        }
+
+        $dateFolder = now()->format('Y/m/d');
+        $extension = $uploadedFile->getClientOriginalExtension();
+        $filename = (string) Str::uuid().($extension ? '.'.$extension : '');
+        $storedPath = $uploadedFile->storeAs("uploads/{$dateFolder}", $filename);
+
+        $record = File::query()->create([
+            'original_name' => $uploadedFile->getClientOriginalName(),
+            'stored_path' => $storedPath,
+            'mime_type' => $uploadedFile->getMimeType() ?: 'application/octet-stream',
+            'size_bytes' => $uploadedFile->getSize(),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => optional($request->user())->id,
+            'thumbnail_path' => null,
+        ]);
+
+        if ($record->isImage()) {
+            $record->thumbnail_path = $this->generateThumbnail($storedPath, $record->mime_type);
+            $record->save();
+        }
+
+        return response()->json($record, 201);
+    }
+
+    public function download(File $file): StreamedResponse
+    {
+        abort_unless(Storage::exists($file->stored_path), 404);
+
+        return Storage::download(
+            $file->stored_path,
+            $file->original_name,
+            ['Content-Type' => $file->mime_type]
+        );
+    }
+
+    public function delete(File $file): Response
+    {
+        Storage::delete($file->stored_path);
+
+        if ($file->thumbnail_path !== null) {
+            Storage::delete($file->thumbnail_path);
+        }
+
+        $file->delete();
+
+        return response()->noContent();
+    }
+
+    private function generateThumbnail(string $storedPath, string $mimeType): ?string
+    {
+        $absolutePath = Storage::path($storedPath);
+
+        if (! function_exists('imagecreatetruecolor')) {
+            return null;
+        }
+
+        $source = match ($mimeType) {
+            'image/jpeg' => imagecreatefromjpeg($absolutePath),
+            'image/png' => imagecreatefrompng($absolutePath),
+            'image/gif' => imagecreatefromgif($absolutePath),
+            'image/webp' => function_exists('imagecreatefromwebp') ? imagecreatefromwebp($absolutePath) : false,
+            default => false,
+        };
+
+        if ($source === false) {
+            return null;
+        }
+
+        $sourceWidth = imagesx($source);
+        $sourceHeight = imagesy($source);
+        $thumbnail = imagecreatetruecolor(200, 200);
+        imagecopyresampled(
+            $thumbnail,
+            $source,
+            0,
+            0,
+            0,
+            0,
+            200,
+            200,
+            $sourceWidth,
+            $sourceHeight
+        );
+
+        $thumbnailPath = 'thumbnails/'.now()->format('Y/m/d').'/'.Str::uuid().'.jpg';
+        Storage::makeDirectory(dirname($thumbnailPath));
+        imagejpeg($thumbnail, Storage::path($thumbnailPath), 85);
+        imagedestroy($source);
+        imagedestroy($thumbnail);
+
+        return $thumbnailPath;
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class File extends Model
+{
+    protected $fillable = [
+        'original_name',
+        'stored_path',
+        'mime_type',
+        'size_bytes',
+        'checksum_sha256',
+        'uploaded_by',
+        'thumbnail_path',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'size_bytes' => 'integer',
+            'uploaded_by' => 'integer',
+        ];
+    }
+
+    public function isImage(): bool
+    {
+        return str_starts_with($this->mime_type ?? '', 'image/');
+    }
+}

--- a/laravel/database/migrations/2026_06_06_000003_create_files_table.php
+++ b/laravel/database/migrations/2026_06_06_000003_create_files_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path')->unique();
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size_bytes');
+            $table->char('checksum_sha256', 64)->unique();
+            $table->foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/file_upload_checks.mjs
+++ b/laravel/file_upload_checks.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const controller = readFileSync(new URL('./app/Http/Controllers/FileController.php', import.meta.url), 'utf8');
+const model = readFileSync(new URL('./app/Models/File.php', import.meta.url), 'utf8');
+const migration = readFileSync(new URL('./database/migrations/2026_06_06_000003_create_files_table.php', import.meta.url), 'utf8');
+const routes = readFileSync(new URL('./routes/web.php', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/Feature/FileUploadTest.php', import.meta.url), 'utf8');
+
+function includes(source, fragment, message) {
+  assert.ok(source.includes(fragment), message);
+}
+
+function matches(source, pattern, message) {
+  assert.ok(pattern.test(source), message);
+}
+
+includes(model, 'class File extends Model', 'File model should exist');
+for (const field of ['original_name', 'stored_path', 'mime_type', 'size_bytes', 'checksum_sha256', 'uploaded_by', 'thumbnail_path']) {
+  includes(model, `'${field}'`, `File model should allow ${field}`);
+  includes(migration, field, `files migration should define ${field}`);
+}
+includes(migration, "char('checksum_sha256', 64)->unique()", 'checksum should be stored uniquely');
+includes(migration, "foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete()", 'uploaded_by should be nullable user FK');
+includes(controller, "hash_file('sha256'", 'upload should compute SHA-256 from file contents');
+includes(controller, "where('checksum_sha256', $checksum)->exists()", 'upload should detect duplicate checksums');
+includes(controller, '], 409)', 'duplicate uploads should return 409 Conflict');
+includes(controller, 'uploads/{$dateFolder}', 'uploads should be organized by date folders');
+includes(controller, 'thumbnails/\'.now()->format(\'Y/m/d\')', 'thumbnails should be organized by date folders');
+matches(controller, /imagecopyresampled\([\s\S]*?200,[\s\S]*?200,/, 'image thumbnails should be generated at 200x200');
+includes(controller, "'thumbnail_path' => null", 'non-image uploads should default to null thumbnail path');
+includes(controller, "Storage::download(", 'download endpoint should stream files through storage');
+includes(controller, "['Content-Type' => $file->mime_type]", 'download should set Content-Type');
+includes(controller, 'Storage::delete($file->stored_path);', 'delete should remove stored file');
+includes(controller, 'Storage::delete($file->thumbnail_path);', 'delete should remove thumbnail');
+includes(controller, 'paginate(20)', 'list endpoint should paginate at 20 items per page');
+includes(routes, "Route::post('/files/upload'", 'upload route should exist');
+includes(routes, "Route::get('/files/{file}/download'", 'download route should exist');
+includes(routes, "Route::delete('/files/{file}'", 'delete route should exist');
+includes(routes, "Route::get('/files'", 'list route should exist');
+includes(tests, 'test_duplicate_checksum_is_rejected', 'tests should cover duplicate rejection');
+includes(tests, "assertJsonPath('per_page', 20)", 'tests should cover pagination size');
+
+const metadata = JSON.parse(readFileSync(new URL('./app/Http/Controllers/.generation_meta.json', import.meta.url), 'utf8'));
+assert.equal(metadata.agent, 'Codex GPT-5');
+assert.ok(!metadata.initial_directives.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel file upload checks passed');

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Http\Controllers\FileController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/files', [FileController::class, 'index']);
+Route::post('/files/upload', [FileController::class, 'upload']);
+Route::get('/files/{file}/download', [FileController::class, 'download']);
+Route::delete('/files/{file}', [FileController::class, 'delete']);

--- a/laravel/tests/Feature/FileUploadTest.php
+++ b/laravel/tests/Feature/FileUploadTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FileUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_upload_stores_metadata_and_checksum(): void
+    {
+        Storage::fake('local');
+
+        $response = $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('report.txt', 'hello world'),
+        ]);
+
+        $response->assertCreated();
+
+        $file = File::query()->firstOrFail();
+        $this->assertSame(hash('sha256', 'hello world'), $file->checksum_sha256);
+        $this->assertNull($file->thumbnail_path);
+        Storage::assertExists($file->stored_path);
+    }
+
+    public function test_duplicate_checksum_is_rejected(): void
+    {
+        Storage::fake('local');
+        $payload = ['file' => UploadedFile::fake()->createWithContent('a.txt', 'same')];
+
+        $this->postJson('/files/upload', $payload)->assertCreated();
+        $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('b.txt', 'same'),
+        ])->assertConflict();
+    }
+
+    public function test_list_uses_twenty_items_per_page(): void
+    {
+        File::query()->create([
+            'original_name' => 'one.txt',
+            'stored_path' => 'uploads/one.txt',
+            'mime_type' => 'text/plain',
+            'size_bytes' => 3,
+            'checksum_sha256' => str_repeat('a', 64),
+        ]);
+
+        $this->getJson('/files')->assertOk()->assertJsonPath('per_page', 20);
+    }
+}


### PR DESCRIPTION
/claim #790

## Summary
- Added `File` model and migration with metadata, SHA-256 checksum, nullable uploader, and thumbnail path.
- Added upload, list, download, and delete endpoints under `/files`.
- Stores uploads under dated `uploads/` folders, rejects duplicate checksums with 409, and streams downloads with the stored MIME type.
- Generates 200x200 GD thumbnails for supported image MIME types and keeps non-image thumbnail paths null.
- Deletes both stored files and thumbnails, and paginates list results at 20 per page.
- Added safe generation metadata, feature tests, and a static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe laravel\file_upload_checks.mjs`
- `git diff --check`
- Could not run PHP/PHPUnit locally because `php` is not installed in this environment.

## Payout
- EVM/Base USDC wallet: 0x237664403f52A15142795f807ADB3524E8057909