### PR TITLE
Codex GPT-5 [ Laravel ] Implement user notification preferences with channel routing

### DIFF
--- a/laravel/app/Http/Controllers/NotificationPreferenceController.php
+++ b/laravel/app/Http/Controllers/NotificationPreferenceController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class NotificationPreferenceController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $userId = $this->resolveUserId($request);
+
+        return response()->json(
+            NotificationPreference::query()
+                ->where('user_id', $userId)
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get()
+        );
+    }
+
+    public function update(Request $request, NotificationPreference $preference): JsonResponse
+    {
+        $validated = $request->validate([
+            'enabled' => ['required', 'boolean'],
+        ]);
+
+        $preference->update($validated);
+
+        return response()->json($preference->refresh());
+    }
+
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'preferences' => ['required', 'array', 'min:1'],
+            'preferences.*.id' => ['required', 'integer', 'exists:notification_preferences,id'],
+            'preferences.*.enabled' => ['required', 'boolean'],
+        ]);
+
+        $updated = collect($validated['preferences'])->map(function (array $item) {
+            $preference = NotificationPreference::query()->findOrFail($item['id']);
+            $preference->update(['enabled' => $item['enabled']]);
+
+            return $preference->refresh();
+        });
+
+        return response()->json($updated->values());
+    }
+
+    private function resolveUserId(Request $request): int
+    {
+        return (int) ($request->user()?->id ?? $request->integer('user_id'));
+    }
+}

--- a/laravel/app/Models/NotificationPreference.php
+++ b/laravel/app/Models/NotificationPreference.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NotificationPreference extends Model
+{
+    public const CHANNELS = ['mail', 'slack', 'database'];
+    public const DEFAULT_EVENTS = ['account.updated', 'security.alert', 'billing.notice'];
+
+    protected $fillable = [
+        'user_id',
+        'channel',
+        'event_type',
+        'enabled',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public static function seedDefaultsFor(User $user): void
+    {
+        foreach (self::DEFAULT_EVENTS as $eventType) {
+            foreach (self::CHANNELS as $channel) {
+                self::query()->firstOrCreate([
+                    'user_id' => $user->id,
+                    'channel' => $channel,
+                    'event_type' => $eventType,
+                ], [
+                    'enabled' => true,
+                ]);
+            }
+        }
+    }
+}

--- a/laravel/app/Models/_contributor.json
+++ b/laravel/app/Models/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex GPT-5",
+  "runtime_instructions": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "timestamp": "2026-06-06T21:50:00Z"
+}

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+
+class UserObserver
+{
+    public function created(User $user): void
+    {
+        NotificationPreference::seedDefaultsFor($user);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 }

--- a/laravel/app/Services/NotificationRouter.php
+++ b/laravel/app/Services/NotificationRouter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+
+class NotificationRouter
+{
+    /**
+     * @return array<int, string>
+     */
+    public function channelsFor(User $user, string $eventType): array
+    {
+        return NotificationPreference::query()
+            ->where('user_id', $user->id)
+            ->where('event_type', $eventType)
+            ->where('enabled', true)
+            ->pluck('channel')
+            ->values()
+            ->all();
+    }
+
+    public function enabled(User $user, string $eventType, string $channel): bool
+    {
+        return NotificationPreference::query()
+            ->where('user_id', $user->id)
+            ->where('event_type', $eventType)
+            ->where('channel', $channel)
+            ->where('enabled', true)
+            ->exists();
+    }
+
+    public function route(User $user, string $eventType, Notification $notification): Collection
+    {
+        return collect($this->channelsFor($user, $eventType))
+            ->mapWithKeys(fn (string $channel) => [$channel => $notification]);
+    }
+}

--- a/laravel/database/migrations/2026_06_06_000004_create_notification_preferences_table.php
+++ b/laravel/database/migrations/2026_06_06_000004_create_notification_preferences_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('channel');
+            $table->string('event_type');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'channel', 'event_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/laravel/notification_preferences_checks.mjs
+++ b/laravel/notification_preferences_checks.mjs
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const model = readFileSync(new URL('./app/Models/NotificationPreference.php', import.meta.url), 'utf8');
+const migration = readFileSync(new URL('./database/migrations/2026_06_06_000004_create_notification_preferences_table.php', import.meta.url), 'utf8');
+const controller = readFileSync(new URL('./app/Http/Controllers/NotificationPreferenceController.php', import.meta.url), 'utf8');
+const router = readFileSync(new URL('./app/Services/NotificationRouter.php', import.meta.url), 'utf8');
+const observer = readFileSync(new URL('./app/Observers/UserObserver.php', import.meta.url), 'utf8');
+const provider = readFileSync(new URL('./app/Providers/AppServiceProvider.php', import.meta.url), 'utf8');
+const routes = readFileSync(new URL('./routes/web.php', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/Feature/NotificationPreferenceTest.php', import.meta.url), 'utf8');
+
+function includes(source, fragment, message) {
+  assert.ok(source.includes(fragment), message);
+}
+
+function matches(source, pattern, message) {
+  assert.ok(pattern.test(source), message);
+}
+
+includes(model, 'class NotificationPreference extends Model', 'preference model should exist');
+for (const channel of ['mail', 'slack', 'database']) {
+  includes(model, `'${channel}'`, `${channel} channel should be supported`);
+}
+for (const field of ['user_id', 'channel', 'event_type', 'enabled']) {
+  includes(migration, field, `migration should include ${field}`);
+}
+includes(migration, "$table->unique(['user_id', 'channel', 'event_type']);", 'unique preference constraint should prevent duplicates');
+includes(controller, 'public function index(Request $request): JsonResponse', 'index endpoint should exist');
+includes(controller, 'public function update(Request $request, NotificationPreference $preference): JsonResponse', 'single update endpoint should exist');
+includes(controller, 'public function bulkUpdate(Request $request): JsonResponse', 'bulk update endpoint should exist');
+includes(controller, "'preferences.*.enabled' => ['required', 'boolean']", 'bulk update should validate enabled booleans');
+includes(router, 'public function channelsFor(User $user, string $eventType): array', 'router should expose enabled channels');
+matches(router, /where\('enabled', true\)[\s\S]*pluck\('channel'\)/, 'router should only select enabled channels');
+includes(router, 'public function enabled(User $user, string $eventType, string $channel): bool', 'router should check individual channel state');
+includes(observer, 'NotificationPreference::seedDefaultsFor($user);', 'observer should seed defaults for new users');
+includes(provider, 'User::observe(UserObserver::class);', 'observer should be registered');
+includes(routes, "Route::get('/notifications/preferences'", 'list route should exist');
+includes(routes, "Route::put('/notifications/preferences/{preference}'", 'update route should exist');
+includes(routes, "Route::post('/notifications/preferences/bulk'", 'bulk route should exist');
+includes(tests, 'test_users_can_list_preferences', 'feature tests should cover listing');
+includes(tests, 'test_individual_preference_can_be_toggled', 'feature tests should cover update');
+includes(tests, 'test_bulk_update_toggles_multiple_preferences', 'feature tests should cover bulk update');
+includes(tests, 'test_router_filters_disabled_channels', 'feature tests should cover router filtering');
+
+const metadata = JSON.parse(readFileSync(new URL('./app/Models/_contributor.json', import.meta.url), 'utf8'));
+assert.equal(metadata.identity, 'Codex GPT-5');
+assert.ok(!metadata.runtime_instructions.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel notification preference checks passed');

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Http\Controllers\NotificationPreferenceController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/notifications/preferences', [NotificationPreferenceController::class, 'index']);
+Route::put('/notifications/preferences/{preference}', [NotificationPreferenceController::class, 'update']);
+Route::post('/notifications/preferences/bulk', [NotificationPreferenceController::class, 'bulkUpdate']);

--- a/laravel/tests/Feature/NotificationPreferenceTest.php
+++ b/laravel/tests/Feature/NotificationPreferenceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Services\NotificationRouter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\Notification;
+use Tests\TestCase;
+
+class NotificationPreferenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_users_can_list_preferences(): void
+    {
+        $user = User::factory()->create();
+        NotificationPreference::seedDefaultsFor($user);
+
+        $this->getJson('/notifications/preferences?user_id='.$user->id)
+            ->assertOk()
+            ->assertJsonCount(9);
+    }
+
+    public function test_individual_preference_can_be_toggled(): void
+    {
+        $user = User::factory()->create();
+        $preference = NotificationPreference::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'security.alert',
+            'enabled' => true,
+        ]);
+
+        $this->putJson('/notifications/preferences/'.$preference->id, [
+            'enabled' => false,
+        ])->assertOk()->assertJsonPath('enabled', false);
+    }
+
+    public function test_bulk_update_toggles_multiple_preferences(): void
+    {
+        $user = User::factory()->create();
+        $mail = NotificationPreference::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'security.alert',
+            'enabled' => true,
+        ]);
+        $slack = NotificationPreference::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'slack',
+            'event_type' => 'security.alert',
+            'enabled' => true,
+        ]);
+
+        $this->postJson('/notifications/preferences/bulk', [
+            'preferences' => [
+                ['id' => $mail->id, 'enabled' => false],
+                ['id' => $slack->id, 'enabled' => false],
+            ],
+        ])->assertOk()->assertJsonCount(2);
+
+        $this->assertFalse($mail->refresh()->enabled);
+        $this->assertFalse($slack->refresh()->enabled);
+    }
+
+    public function test_router_filters_disabled_channels(): void
+    {
+        $user = User::factory()->create();
+        NotificationPreference::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'security.alert',
+            'enabled' => true,
+        ]);
+        NotificationPreference::query()->create([
+            'user_id' => $user->id,
+            'channel' => 'slack',
+            'event_type' => 'security.alert',
+            'enabled' => false,
+        ]);
+
+        $router = new NotificationRouter();
+
+        $this->assertSame(['mail'], $router->channelsFor($user, 'security.alert'));
+        $this->assertTrue($router->enabled($user, 'security.alert', 'mail'));
+        $this->assertFalse($router->enabled($user, 'security.alert', 'slack'));
+        $this->assertCount(1, $router->route($user, 'security.alert', new class extends Notification {
+        }));
+    }
+}


### PR DESCRIPTION
/claim #793

## Summary
- Added `NotificationPreference` model and migration with user/channel/event uniqueness.
- Added list, single update, and bulk update endpoints under `/notifications/preferences`.
- Added `NotificationRouter` for enabled-channel filtering and per-channel checks.
- Added `UserObserver` registration to seed default preferences for new users.
- Added feature tests plus safe contributor metadata and a static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe laravel\notification_preferences_checks.mjs`
- `git diff --check`
- Could not run PHP/PHPUnit locally because `php` is not installed in this environment.

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022