### PR TITLE
Codex GPT-5 [ Laravel ] Add cache health check and status command

### DIFF
--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status {store? : Cache store to check}';
+
+    protected $description = 'Check cache store availability and latency';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $status = $healthCheck->check($this->argument('store'));
+
+        $this->line('Driver: '.$status['driver']);
+        $this->line('Available: '.($status['available'] ? 'yes' : 'no'));
+        $this->line('Latency: '.$status['latency_ms'].'ms');
+
+        if (isset($status['message'])) {
+            $this->line('Message: '.$status['message']);
+        }
+
+        return $status['available'] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Throwable;
+
+class CacheHealthCheck
+{
+    public function check(?string $store = null): array
+    {
+        $storeName = $store ?: config('cache.default');
+        $storeConfig = config("cache.stores.{$storeName}", []);
+        $driver = $storeConfig['driver'] ?? $storeName;
+        $started = hrtime(true);
+        $key = 'cache-health-check:'.bin2hex(random_bytes(8));
+
+        try {
+            if (! config('cache.health_check_enabled', true)) {
+                return $this->result(true, $driver, $started, 'disabled');
+            }
+
+            $cache = Cache::store($storeName);
+            $cache->put($key, 'ok', config('cache.health_check_interval', 300));
+            $available = $cache->get($key) === 'ok';
+            $cache->forget($key);
+
+            return $this->result($available, $driver, $started);
+        } catch (Throwable $exception) {
+            return $this->result(false, $driver, $started, $exception->getMessage());
+        }
+    }
+
+    private function result(
+        bool $available,
+        string $driver,
+        int $started,
+        ?string $message = null,
+    ): array {
+        $result = [
+            'available' => $available,
+            'driver' => $driver,
+            'latency_ms' => round((hrtime(true) - $started) / 1_000_000, 2),
+        ];
+
+        if ($message !== null) {
+            $result['message'] = $message;
+        }
+
+        return $result;
+    }
+}

--- a/laravel/app/Services/_provenance.json
+++ b/laravel/app/Services/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "timestamp": "2026-06-06T22:18:00Z"
+}

--- a/laravel/cache_health_checks.mjs
+++ b/laravel/cache_health_checks.mjs
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const service = readFileSync(new URL('./app/Services/CacheHealthCheck.php', import.meta.url), 'utf8');
+const command = readFileSync(new URL('./app/Console/Commands/CacheStatusCommand.php', import.meta.url), 'utf8');
+const config = readFileSync(new URL('./config/cache.php', import.meta.url), 'utf8');
+const routes = readFileSync(new URL('./routes/web.php', import.meta.url), 'utf8');
+const serviceTest = readFileSync(new URL('./tests/Unit/CacheHealthCheckTest.php', import.meta.url), 'utf8');
+const commandTest = readFileSync(new URL('./tests/Feature/CacheStatusCommandTest.php', import.meta.url), 'utf8');
+
+function includes(source, fragment, message) {
+  assert.ok(source.includes(fragment), message);
+}
+
+function matches(source, pattern, message) {
+  assert.ok(pattern.test(source), message);
+}
+
+includes(service, 'class CacheHealthCheck', 'CacheHealthCheck service should exist');
+includes(service, "config('cache.default')", 'service should use active cache store');
+includes(service, 'Cache::store($storeName)', 'service should test selected store connection');
+includes(service, "'available' => $available", 'service should report availability');
+includes(service, "'driver' => $driver", 'service should report driver');
+includes(service, "'latency_ms' => round(", 'service should report latency in ms');
+includes(service, "config('cache.health_check_enabled', true)", 'service should respect enabled config');
+includes(service, "config('cache.health_check_interval', 300)", 'service should respect interval config');
+includes(command, "protected $signature = 'cache:status", 'artisan command should be cache:status');
+includes(command, "Driver: '.$status['driver']", 'command should output driver');
+includes(command, "Available: '.($status['available'] ? 'yes' : 'no')", 'command should output availability');
+includes(command, "Latency: '.$status['latency_ms'].'ms'", 'command should output latency');
+includes(config, "'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true)", 'config should include health_check_enabled default true');
+includes(config, "'health_check_interval' => env('CACHE_HEALTH_CHECK_INTERVAL', 300)", 'config should include interval default 300');
+includes(routes, "Route::get('/health/cache'", 'health endpoint should exist');
+includes(routes, "$status['available'] ? 200 : 503", 'endpoint should return 200 or 503 based on availability');
+includes(serviceTest, 'test_reports_available_cache_store', 'service tests should cover available cache');
+includes(serviceTest, 'test_respects_disabled_health_check_config', 'service tests should cover config');
+includes(commandTest, 'test_cache_status_command_outputs_driver_availability_and_latency', 'command tests should exist');
+matches(command, /return \$status\['available'\] \? self::SUCCESS : self::FAILURE;/, 'command should fail when unavailable');
+
+const metadata = JSON.parse(readFileSync(new URL('./app/Services/_provenance.json', import.meta.url), 'utf8'));
+assert.equal(metadata.tool_name, 'Codex GPT-5');
+assert.ok(!metadata.boot_context.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel cache health checks passed');

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -17,6 +17,10 @@ return [
 
     'default' => env('CACHE_STORE', 'database'),
 
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
     /*
     |--------------------------------------------------------------------------
     | Cache Stores

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    $status = $healthCheck->check();
+
+    return response()->json($status, $status['available'] ? 200 : 503);
 });

--- a/laravel/tests/Feature/CacheStatusCommandTest.php
+++ b/laravel/tests/Feature/CacheStatusCommandTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class CacheStatusCommandTest extends TestCase
+{
+    public function test_cache_status_command_outputs_driver_availability_and_latency(): void
+    {
+        config()->set('cache.default', 'array');
+
+        $this->artisan('cache:status')
+            ->expectsOutput('Driver: array')
+            ->expectsOutput('Available: yes')
+            ->assertSuccessful();
+    }
+}

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    public function test_reports_available_cache_store(): void
+    {
+        config()->set('cache.default', 'array');
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('array', $status['driver']);
+        $this->assertArrayHasKey('latency_ms', $status);
+    }
+
+    public function test_respects_disabled_health_check_config(): void
+    {
+        config()->set('cache.default', 'array');
+        config()->set('cache.health_check_enabled', false);
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('disabled', $status['message']);
+    }
+}


### PR DESCRIPTION
/claim #747

## Summary
- Added `CacheHealthCheck` service that probes the active cache store and reports `available`, `driver`, and `latency_ms`.
- Added cache health config flags: `health_check_enabled` and `health_check_interval`.
- Added `/health/cache` endpoint returning 200 when available and 503 when unavailable.
- Added `cache:status` artisan command with driver, availability, latency, and message output.
- Added service/command tests plus safe provenance metadata and static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe laravel\cache_health_checks.mjs`
- `git diff --check`
- Could not run PHP/PHPUnit locally because `php` is not installed in this environment.

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022