### PR TITLE
Codex GPT-5 [ Laravel ] Implement audit logging trait for model changes

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class AuditLog extends Model
+{
+    protected $fillable = [
+        'auditable_type',
+        'auditable_id',
+        'event',
+        'old_values',
+        'new_values',
+        'user_id',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+            'user_id' => 'integer',
+        ];
+    }
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/.provenance.json
+++ b/laravel/app/Traits/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex GPT-5",
+  "config_snapshot": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "created": "2026-06-06T22:27:00Z"
+}

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Auth;
+
+trait Auditable
+{
+    protected static array $auditHidden = ['password', 'remember_token'];
+
+    public static function bootAuditable(): void
+    {
+        static::created(function ($model): void {
+            $model->writeAuditLog('created', [], $model->auditValues($model->getAttributes()));
+        });
+
+        static::updated(function ($model): void {
+            $changes = $model->getChanges();
+            unset($changes['updated_at']);
+
+            if ($changes === []) {
+                return;
+            }
+
+            $oldValues = [];
+            foreach (array_keys($changes) as $attribute) {
+                $oldValues[$attribute] = $model->getOriginal($attribute);
+            }
+
+            $model->writeAuditLog(
+                'updated',
+                $model->auditValues($oldValues),
+                $model->auditValues($changes),
+            );
+        });
+
+        static::deleted(function ($model): void {
+            $model->writeAuditLog('deleted', $model->auditValues($model->getOriginal()), []);
+        });
+    }
+
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    public function getAuditHistory()
+    {
+        return $this->auditLogs()->latest()->get();
+    }
+
+    protected function writeAuditLog(string $event, array $oldValues, array $newValues): void
+    {
+        $request = request();
+
+        $this->auditLogs()->create([
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => Auth::id(),
+            'ip_address' => $request?->ip(),
+            'user_agent' => $request?->userAgent(),
+        ]);
+    }
+
+    protected function auditValues(array $values): array
+    {
+        return collect($values)
+            ->except(static::$auditHidden)
+            ->all();
+    }
+}

--- a/laravel/audit_logging_checks.mjs
+++ b/laravel/audit_logging_checks.mjs
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const trait = readFileSync(new URL('./app/Traits/Auditable.php', import.meta.url), 'utf8');
+const model = readFileSync(new URL('./app/Models/AuditLog.php', import.meta.url), 'utf8');
+const user = readFileSync(new URL('./app/Models/User.php', import.meta.url), 'utf8');
+const migration = readFileSync(new URL('./database/migrations/2026_06_06_000005_create_audit_logs_table.php', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/Feature/AuditLogTest.php', import.meta.url), 'utf8');
+
+function includes(source, fragment, message) {
+  assert.ok(source.includes(fragment), message);
+}
+
+function matches(source, pattern, message) {
+  assert.ok(pattern.test(source), message);
+}
+
+includes(trait, 'trait Auditable', 'Auditable trait should exist');
+includes(trait, "static::created", 'trait should listen for created');
+includes(trait, "static::updated", 'trait should listen for updated');
+includes(trait, "static::deleted", 'trait should listen for deleted');
+includes(trait, "protected static array $auditHidden = ['password', 'remember_token'];", 'sensitive fields should be excluded');
+includes(trait, 'public function getAuditHistory()', 'trait should expose getAuditHistory');
+includes(trait, 'return $this->auditLogs()->latest()->get();', 'audit history should be reverse chronological');
+includes(trait, "'user_id' => Auth::id()", 'audit should include authenticated user id');
+includes(trait, "'ip_address' => $request?->ip()", 'audit should include IP');
+includes(trait, "'user_agent' => $request?->userAgent()", 'audit should include user agent');
+includes(model, 'class AuditLog extends Model', 'AuditLog model should exist');
+includes(model, 'return $this->morphTo();', 'AuditLog should have polymorphic relation');
+for (const field of ['auditable_type', 'auditable_id', 'event', 'old_values', 'new_values', 'user_id', 'ip_address', 'user_agent']) {
+  includes(migration, field, `migration should include ${field}`);
+}
+includes(user, 'use App\\Traits\\Auditable;', 'User should import Auditable');
+matches(user, /use Auditable, HasFactory, Notifiable;/, 'User should apply Auditable trait');
+includes(tests, 'test_creating_user_generates_audit_log', 'tests should cover create');
+includes(tests, 'test_updating_user_generates_old_and_new_values', 'tests should cover update');
+includes(tests, 'test_deleting_user_generates_old_values', 'tests should cover delete');
+includes(tests, 'assertArrayNotHasKey(\'password\'', 'tests should cover sensitive field exclusion');
+
+const metadata = JSON.parse(readFileSync(new URL('./app/Traits/.provenance.json', import.meta.url), 'utf8'));
+assert.equal(metadata.agent_name, 'Codex GPT-5');
+assert.ok(!metadata.config_snapshot.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel audit logging checks passed');

--- a/laravel/database/migrations/2026_06_06_000005_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_06_06_000005_create_audit_logs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->unsignedBigInteger('auditable_id');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('ip_address')->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditLogTest.php
+++ b/laravel/tests/Feature/AuditLogTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditLogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_user_generates_audit_log(): void
+    {
+        $user = User::factory()->create(['name' => 'Alice']);
+
+        $log = AuditLog::query()->where('event', 'created')->firstOrFail();
+
+        $this->assertSame(User::class, $log->auditable_type);
+        $this->assertSame($user->id, $log->auditable_id);
+        $this->assertSame('Alice', $log->new_values['name']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+    }
+
+    public function test_updating_user_generates_old_and_new_values(): void
+    {
+        $user = User::factory()->create(['name' => 'Alice']);
+        $user->update(['name' => 'Bob']);
+
+        $log = AuditLog::query()->where('event', 'updated')->latest()->firstOrFail();
+
+        $this->assertSame('Alice', $log->old_values['name']);
+        $this->assertSame('Bob', $log->new_values['name']);
+    }
+
+    public function test_deleting_user_generates_old_values(): void
+    {
+        $user = User::factory()->create(['name' => 'Alice']);
+        $user->delete();
+
+        $log = AuditLog::query()->where('event', 'deleted')->firstOrFail();
+
+        $this->assertSame('Alice', $log->old_values['name']);
+        $this->assertSame([], $log->new_values);
+    }
+
+    public function test_audit_history_is_reverse_chronological(): void
+    {
+        $user = User::factory()->create(['name' => 'Alice']);
+        $user->update(['name' => 'Bob']);
+
+        $history = $user->getAuditHistory();
+
+        $this->assertSame('updated', $history->first()->event);
+        $this->assertSame('created', $history->last()->event);
+    }
+}


### PR DESCRIPTION
/claim #786

## Summary
- Added `Auditable` trait that records created, updated, and deleted Eloquent model events.
- Added `AuditLog` model and migration with polymorphic auditable fields, old/new values, user ID, IP address, and user agent.
- Excluded sensitive fields like `password` and `remember_token` from audit values.
- Added `getAuditHistory()` returning reverse-chronological logs.
- Applied the trait to `User` as an example and added feature tests plus safe provenance metadata.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe laravel\audit_logging_checks.mjs`
- `git diff --check`
- Could not run PHP/PHPUnit locally because `php` is not installed in this environment.

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022