### PR TITLE
Codex GPT-5 [ FastAPI ] Implement dynamic CORS origin validation

### DIFF
--- a/fastapi/dynamic_cors_checks.mjs
+++ b/fastapi/dynamic_cors_checks.mjs
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const source = readFileSync(new URL('./fastapi/middleware/cors.py', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/test_dynamic_cors.py', import.meta.url), 'utf8');
+
+function includes(text, fragment, message) {
+  assert.ok(text.includes(fragment), message);
+}
+
+function matches(text, pattern, message) {
+  assert.ok(pattern.test(text), message);
+}
+
+includes(source, 'CORSMiddleware as CORSMiddleware', 'existing CORSMiddleware export should remain');
+includes(source, 'class DynamicCORSMiddleware:', 'DynamicCORSMiddleware should exist');
+includes(source, 'allow_origin_func: AllowOriginFunc | None = None', 'dynamic callback should be configurable');
+includes(source, 'cors_max_age: int = 600', 'cors_max_age parameter should exist');
+includes(source, 'inspect.isawaitable(result)', 'async callbacks should be awaited');
+includes(source, 'self.allow_all_origins or origin in self.allow_origins', 'static fallback should be supported');
+includes(source, '"Access-Control-Max-Age": self.cors_max_age', 'preflight should set max age');
+includes(source, '"Access-Control-Allow-Origin"', 'allow origin header should be set');
+matches(source, /scope\["method"\] == "OPTIONS"[\s\S]*access-control-request-method/, 'preflight requests should be handled');
+includes(tests, 'test_dynamic_allow_origin', 'tests should cover dynamic allow');
+includes(tests, 'test_dynamic_deny_origin', 'tests should cover dynamic deny');
+includes(tests, 'test_async_callback_is_awaited', 'tests should cover async callback');
+includes(tests, 'test_static_fallback_and_preflight_max_age', 'tests should cover static fallback/max age');
+
+const metadata = JSON.parse(readFileSync(new URL('./fastapi/middleware/_generation.json', import.meta.url), 'utf8'));
+assert.equal(metadata.agent, 'Codex GPT-5');
+assert.ok(!metadata.pre_task_context.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('fastapi dynamic CORS checks passed');

--- a/fastapi/fastapi/middleware/_generation.json
+++ b/fastapi/fastapi/middleware/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "pre_task_context": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "timestamp": "2026-06-06T22:39:00Z"
+}

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,89 @@
+import inspect
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
+
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+AllowOriginFunc = Callable[[str], bool | Awaitable[bool]]
+
+
+class DynamicCORSMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        allow_origin_func: AllowOriginFunc | None = None,
+        allow_origins: Iterable[str] = (),
+        allow_methods: Iterable[str] = ("GET",),
+        allow_headers: Iterable[str] = (),
+        allow_credentials: bool = False,
+        cors_max_age: int = 600,
+    ) -> None:
+        self.app = app
+        self.allow_origin_func = allow_origin_func
+        self.allow_origins = set(allow_origins)
+        self.allow_all_origins = "*" in self.allow_origins
+        self.allow_methods = ", ".join(allow_methods)
+        self.allow_headers = ", ".join(allow_headers)
+        self.allow_credentials = allow_credentials
+        self.cors_max_age = str(cors_max_age)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+        if origin is None:
+            await self.app(scope, receive, send)
+            return
+
+        if (
+            scope["method"] == "OPTIONS"
+            and headers.get("access-control-request-method") is not None
+        ):
+            response = await self.preflight_response(origin)
+            await response(scope, receive, send)
+            return
+
+        async def send_with_cors(message: Message) -> None:
+            if message["type"] == "http.response.start" and await self.is_allowed_origin(origin):
+                response_headers = MutableHeaders(scope=message)
+                self.add_cors_headers(response_headers, origin)
+            await send(message)
+
+        await self.app(scope, receive, send_with_cors)
+
+    async def preflight_response(self, origin: str) -> PlainTextResponse:
+        allowed = await self.is_allowed_origin(origin)
+        status_code = 200 if allowed else 400
+        headers: dict[str, str] = {
+            "Access-Control-Allow-Methods": self.allow_methods,
+            "Access-Control-Max-Age": self.cors_max_age,
+        }
+        if self.allow_headers:
+            headers["Access-Control-Allow-Headers"] = self.allow_headers
+        if allowed:
+            self.add_cors_headers(MutableHeaders(headers=headers), origin)
+        return PlainTextResponse(
+            "OK" if allowed else "Disallowed CORS origin",
+            status_code=status_code,
+            headers=headers,
+        )
+
+    async def is_allowed_origin(self, origin: str) -> bool:
+        if self.allow_origin_func is not None:
+            result = self.allow_origin_func(origin)
+            if inspect.isawaitable(result):
+                result = await result
+            return bool(result)
+        return self.allow_all_origins or origin in self.allow_origins
+
+    def add_cors_headers(self, headers: MutableHeaders, origin: str) -> None:
+        headers["Access-Control-Allow-Origin"] = "*" if self.allow_all_origins else origin
+        if self.allow_credentials:
+            headers["Access-Control-Allow-Credentials"] = "true"

--- a/fastapi/tests/test_dynamic_cors.py
+++ b/fastapi/tests/test_dynamic_cors.py
@@ -1,0 +1,81 @@
+import pytest
+
+from fastapi.middleware.cors import DynamicCORSMiddleware
+
+
+async def app(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def run_request(middleware, *, origin, method="GET", extra_headers=None):
+    messages = []
+    headers = [(b"origin", origin.encode())]
+    for name, value in extra_headers or []:
+        headers.append((name.encode(), value.encode()))
+    scope = {"type": "http", "method": method, "headers": headers}
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        messages.append(message)
+
+    await middleware(scope, receive, send)
+    return messages
+
+
+@pytest.mark.anyio
+async def test_dynamic_allow_origin():
+    middleware = DynamicCORSMiddleware(
+        app,
+        allow_origin_func=lambda origin: origin.endswith(".example.com"),
+    )
+
+    messages = await run_request(middleware, origin="https://api.example.com")
+
+    assert (b"Access-Control-Allow-Origin".lower(), b"https://api.example.com") in [
+        (name.lower(), value) for name, value in messages[0]["headers"]
+    ]
+
+
+@pytest.mark.anyio
+async def test_dynamic_deny_origin():
+    middleware = DynamicCORSMiddleware(app, allow_origin_func=lambda origin: False)
+
+    messages = await run_request(middleware, origin="https://evil.example")
+
+    assert messages[0]["headers"] == []
+
+
+@pytest.mark.anyio
+async def test_async_callback_is_awaited():
+    async def allow(origin):
+        return origin == "https://allowed.example"
+
+    middleware = DynamicCORSMiddleware(app, allow_origin_func=allow)
+
+    messages = await run_request(middleware, origin="https://allowed.example")
+
+    assert any(name.lower() == b"access-control-allow-origin" for name, _ in messages[0]["headers"])
+
+
+@pytest.mark.anyio
+async def test_static_fallback_and_preflight_max_age():
+    middleware = DynamicCORSMiddleware(
+        app,
+        allow_origins=["https://allowed.example"],
+        allow_methods=["GET", "POST"],
+        cors_max_age=123,
+    )
+
+    messages = await run_request(
+        middleware,
+        origin="https://allowed.example",
+        method="OPTIONS",
+        extra_headers=[("access-control-request-method", "POST")],
+    )
+    headers = {name.lower(): value for name, value in messages[0]["headers"]}
+
+    assert messages[0]["status"] == 200
+    assert headers[b"Access-Control-Max-Age".lower()] == b"123"


### PR DESCRIPTION
/claim #763

## Summary
- Added `DynamicCORSMiddleware` while preserving the existing `CORSMiddleware` re-export.
- Supports sync and async `allow_origin_func` callbacks for per-request origin validation.
- Falls back to static `allow_origins` when no callback is configured.
- Handles CORS preflight responses with configurable `cors_max_age`.
- Added tests for dynamic allow/deny, async callback, and static fallback preflight behavior.
- Added safe generation metadata and static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe fastapi\dynamic_cors_checks.mjs`
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m py_compile fastapi\fastapi\middleware\cors.py fastapi\tests\test_dynamic_cors.py`
- `git diff --check`
- Could not run full pytest locally because this runtime lacks pytest/starlette.

## Payout
- EVM/Base USDC wallet: 0x237664403f52A15142795f807ADB3524E8057909