### PR TITLE
Codex GPT-5 [ FastAPI ] Add FastAPITestClient auth and WebSocket helpers

### DIFF
--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "environment_config": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "completed_at": "2026-06-06T22:48:00Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,50 @@
+import base64
+from typing import Any
+
 from starlette.testclient import TestClient as TestClient  # noqa
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> "FastAPITestClient":
+        self.headers["Authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(
+        self,
+        username: str,
+        password: str,
+    ) -> "FastAPITestClient":
+        credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+        self.headers["Authorization"] = f"Basic {credentials}"
+        return self
+
+    def reset_auth(self) -> "FastAPITestClient":
+        self.headers.pop("Authorization", None)
+        return self
+
+    def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        merged_headers = dict(headers or {})
+        if "Authorization" in self.headers and "Authorization" not in merged_headers:
+            merged_headers["Authorization"] = self.headers["Authorization"]
+        return self.websocket_connect(
+            url,
+            headers=merged_headers,
+            subprotocols=subprotocols,
+            **kwargs,
+        )
+
+    def assert_status(self, method: str, url: str, expected_status: int, **kwargs: Any):
+        response = self.request(method, url, **kwargs)
+        if response.status_code != expected_status:
+            raise AssertionError(
+                f"Expected status {expected_status} for {method.upper()} {url}, "
+                f"got {response.status_code}: {response.text}"
+            )
+        return response

--- a/fastapi/testclient_helpers_checks.mjs
+++ b/fastapi/testclient_helpers_checks.mjs
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const source = readFileSync(new URL('./fastapi/testclient.py', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/test_fastapi_testclient.py', import.meta.url), 'utf8');
+
+function includes(text, fragment, message) {
+  assert.ok(text.includes(fragment), message);
+}
+
+includes(source, 'TestClient as TestClient', 'existing TestClient import should remain');
+includes(source, 'class FastAPITestClient(TestClient):', 'FastAPITestClient should extend TestClient');
+includes(source, 'def authenticate(self, token: str)', 'Bearer auth helper should exist');
+includes(source, 'self.headers["Authorization"] = f"Bearer {token}"', 'Bearer helper should set header');
+includes(source, 'def authenticate_basic(', 'Basic auth helper should exist');
+includes(source, 'base64.b64encode', 'Basic auth should base64 encode credentials');
+includes(source, 'def reset_auth(self)', 'reset_auth should exist');
+includes(source, 'self.headers.pop("Authorization", None)', 'reset_auth should clear auth state');
+includes(source, 'def ws_connect(', 'ws_connect helper should exist');
+includes(source, 'self.websocket_connect(', 'ws_connect should call websocket_connect');
+includes(source, 'subprotocols=subprotocols', 'ws_connect should pass subprotocols');
+includes(source, 'def assert_status(', 'assert_status helper should exist');
+includes(source, 'Expected status', 'assert_status should raise helpful message');
+includes(tests, 'test_existing_testclient_import_still_works', 'tests should cover existing TestClient behavior');
+includes(tests, 'test_authenticate_sets_and_replaces_bearer_header', 'tests should cover Bearer auth replacement');
+includes(tests, 'test_authenticate_basic_sets_encoded_header', 'tests should cover Basic auth');
+includes(tests, 'test_reset_auth_clears_authentication_state', 'tests should cover reset_auth');
+includes(tests, 'test_ws_connect_supports_headers_and_subprotocols', 'tests should cover WebSocket helper');
+includes(tests, 'test_assert_status_returns_response_and_raises_helpfully', 'tests should cover assert_status');
+
+const metadata = JSON.parse(readFileSync(new URL('./fastapi/.audit.json', import.meta.url), 'utf8'));
+assert.equal(metadata.contributor, 'Codex GPT-5');
+assert.ok(!metadata.environment_config.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('fastapi testclient helper checks passed');

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,78 @@
+import base64
+
+import pytest
+
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+
+
+app = FastAPI()
+
+
+@app.get("/headers")
+def headers(authorization: str | None = None):
+    return {"authorization": authorization}
+
+
+@app.get("/ok")
+def ok():
+    return {"ok": True}
+
+
+@app.websocket("/ws")
+async def websocket(websocket: WebSocket):
+    await websocket.accept(subprotocol="chat")
+    await websocket.send_text(websocket.headers.get("x-test", "missing"))
+    await websocket.close()
+
+
+def test_existing_testclient_import_still_works():
+    assert TestClient(app).get("/ok").status_code == 200
+
+
+def test_authenticate_sets_and_replaces_bearer_header():
+    client = FastAPITestClient(app)
+
+    client.authenticate("one")
+    assert client.headers["Authorization"] == "Bearer one"
+
+    client.authenticate("two")
+    assert client.headers["Authorization"] == "Bearer two"
+
+
+def test_authenticate_basic_sets_encoded_header():
+    client = FastAPITestClient(app)
+    client.authenticate_basic("user", "secret")
+
+    encoded = base64.b64encode(b"user:secret").decode()
+    assert client.headers["Authorization"] == f"Basic {encoded}"
+
+
+def test_reset_auth_clears_authentication_state():
+    client = FastAPITestClient(app)
+
+    client.authenticate("secret").reset_auth()
+
+    assert "Authorization" not in client.headers
+
+
+def test_assert_status_returns_response_and_raises_helpfully():
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("GET", "/ok", 200)
+
+    assert response.json() == {"ok": True}
+
+    with pytest.raises(AssertionError, match="Expected status 404"):
+        client.assert_status("GET", "/ok", 404)
+
+
+def test_ws_connect_supports_headers_and_subprotocols():
+    client = FastAPITestClient(app)
+
+    with client.ws_connect(
+        "/ws",
+        headers={"x-test": "hello"},
+        subprotocols=["chat"],
+    ) as websocket:
+        assert websocket.receive_text() == "hello"


### PR DESCRIPTION
/claim #804

## Summary
- Added `FastAPITestClient` extending the existing Starlette `TestClient` re-export.
- Added Bearer and Basic authentication helpers, plus `reset_auth`.
- Added `ws_connect` for WebSocket connections with custom headers and subprotocols.
- Added `assert_status` helper with expected-vs-actual assertion messages.
- Added tests demonstrating each helper plus safe audit metadata and a static invariant harness.

## Verification
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe fastapi\testclient_helpers_checks.mjs`
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m py_compile fastapi\fastapi\testclient.py fastapi\tests\test_fastapi_testclient.py`
- `git diff --check`
- Could not run full pytest locally because this runtime lacks pytest/starlette.

## Payout
- EVM/Base USDC wallet: 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022