### PR TITLE
Codex GPT-5 [ FastAPI ] Add WebSocket heartbeat wrapper

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex GPT-5",
+  "runtime_instructions": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "timestamp": "2026-06-06T22:58:00Z"
+}

--- a/fastapi/fastapi/websockets.py
+++ b/fastapi/fastapi/websockets.py
@@ -1,3 +1,139 @@
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
 from starlette.websockets import WebSocket as WebSocket  # noqa
 from starlette.websockets import WebSocketDisconnect as WebSocketDisconnect  # noqa
 from starlette.websockets import WebSocketState as WebSocketState  # noqa
+
+DisconnectCallback = Callable[[int, float], None | Awaitable[None]]
+PONG_MESSAGE = "__pong__"
+PING_MESSAGE = "__ping__"
+
+
+class WebSocketWithHeartbeat:
+    def __init__(
+        self,
+        websocket: WebSocket,
+        *,
+        ping_interval: float = 30.0,
+        pong_timeout: float = 10.0,
+        on_disconnect: DisconnectCallback | None = None,
+        close_code: int = 1001,
+        ping_message: str = PING_MESSAGE,
+        pong_message: str = PONG_MESSAGE,
+    ) -> None:
+        self.websocket = websocket
+        self.ping_interval = ping_interval
+        self.pong_timeout = pong_timeout
+        self.on_disconnect = on_disconnect
+        self.close_code = close_code
+        self.ping_message = ping_message
+        self.pong_message = pong_message
+        self.message_count = 0
+        self._started_at = time.monotonic()
+        self._last_pong_at = self._started_at
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._disconnect_notified = False
+
+    @property
+    def connection_duration(self) -> float:
+        return time.monotonic() - self._started_at
+
+    async def accept(self, *args: Any, **kwargs: Any) -> None:
+        await self.websocket.accept(*args, **kwargs)
+        self.start_heartbeat()
+
+    def start_heartbeat(self) -> None:
+        if self._heartbeat_task is None or self._heartbeat_task.done():
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self._closed = True
+        if (
+            self._heartbeat_task is not None
+            and self._heartbeat_task is not asyncio.current_task()
+        ):
+            self._heartbeat_task.cancel()
+        kwargs: dict[str, Any] = {"code": code}
+        if reason is not None:
+            kwargs["reason"] = reason
+        await self.websocket.close(**kwargs)
+        await self._fire_disconnect(code)
+
+    async def receive(self) -> dict[str, Any]:
+        try:
+            message = await self.websocket.receive()
+        except WebSocketDisconnect as exc:
+            await self._fire_disconnect(exc.code)
+            raise
+        return self._track_message(message)
+
+    async def receive_text(self) -> str:
+        try:
+            text = await self.websocket.receive_text()
+        except WebSocketDisconnect as exc:
+            await self._fire_disconnect(exc.code)
+            raise
+        self.message_count += 1
+        self._track_pong(text)
+        return text
+
+    async def receive_bytes(self) -> bytes:
+        try:
+            data = await self.websocket.receive_bytes()
+        except WebSocketDisconnect as exc:
+            await self._fire_disconnect(exc.code)
+            raise
+        self.message_count += 1
+        return data
+
+    async def receive_json(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            data = await self.websocket.receive_json(*args, **kwargs)
+        except WebSocketDisconnect as exc:
+            await self._fire_disconnect(exc.code)
+            raise
+        self.message_count += 1
+        return data
+
+    def record_pong(self) -> None:
+        self._last_pong_at = time.monotonic()
+
+    async def send_ping(self) -> None:
+        await self.websocket.send_text(self.ping_message)
+
+    async def _heartbeat_loop(self) -> None:
+        try:
+            while not self._closed:
+                await asyncio.sleep(self.ping_interval)
+                await self.send_ping()
+                await asyncio.sleep(self.pong_timeout)
+                if time.monotonic() - self._last_pong_at > self.ping_interval + self.pong_timeout:
+                    await self.close(code=self.close_code)
+                    return
+        except asyncio.CancelledError:
+            return
+
+    def _track_message(self, message: dict[str, Any]) -> dict[str, Any]:
+        self.message_count += 1
+        if message.get("type") == "websocket.receive":
+            self._track_pong(message.get("text"))
+        return message
+
+    def _track_pong(self, text: str | None) -> None:
+        if text == self.pong_message:
+            self.record_pong()
+
+    async def _fire_disconnect(self, code: int) -> None:
+        if self.on_disconnect is None or self._disconnect_notified:
+            return
+        self._disconnect_notified = True
+        result = self.on_disconnect(code, self.connection_duration)
+        if result is not None:
+            await result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.websocket, name)

--- a/fastapi/tests/test_websocket_heartbeat.py
+++ b/fastapi/tests/test_websocket_heartbeat.py
@@ -1,0 +1,77 @@
+import asyncio
+
+import pytest
+
+from fastapi.websockets import WebSocketWithHeartbeat
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.accepted = False
+        self.sent = []
+        self.closed = None
+        self.incoming = asyncio.Queue()
+
+    async def accept(self, *args, **kwargs):
+        self.accepted = True
+
+    async def send_text(self, text):
+        self.sent.append(text)
+
+    async def close(self, **kwargs):
+        self.closed = kwargs
+
+    async def receive_text(self):
+        return await self.incoming.get()
+
+
+@pytest.mark.anyio
+async def test_heartbeat_sends_ping_and_closes_on_timeout():
+    websocket = FakeWebSocket()
+    wrapper = WebSocketWithHeartbeat(websocket, ping_interval=0.01, pong_timeout=0.01)
+
+    await wrapper.accept()
+    await asyncio.sleep(0.04)
+
+    assert "__ping__" in websocket.sent
+    assert websocket.closed["code"] == 1001
+
+
+@pytest.mark.anyio
+async def test_on_disconnect_receives_close_code_and_duration():
+    seen = []
+    websocket = FakeWebSocket()
+    wrapper = WebSocketWithHeartbeat(
+        websocket,
+        on_disconnect=lambda code, duration: seen.append((code, duration)),
+    )
+
+    await wrapper.close(code=1000)
+
+    assert seen[0][0] == 1000
+    assert seen[0][1] >= 0
+
+
+@pytest.mark.anyio
+async def test_receive_text_tracks_message_count_and_pong():
+    websocket = FakeWebSocket()
+    wrapper = WebSocketWithHeartbeat(websocket)
+
+    await websocket.incoming.put("__pong__")
+    assert await wrapper.receive_text() == "__pong__"
+
+    assert wrapper.message_count == 1
+    assert wrapper.connection_duration >= 0
+
+
+def test_defaults_can_be_overridden_per_connection():
+    wrapper = WebSocketWithHeartbeat(
+        FakeWebSocket(),
+        ping_interval=5,
+        pong_timeout=2,
+        close_code=1001,
+    )
+
+    assert wrapper.ping_interval == 5
+    assert wrapper.pong_timeout == 2
+    assert wrapper.close_code == 1001

--- a/fastapi/websocket_heartbeat_checks.mjs
+++ b/fastapi/websocket_heartbeat_checks.mjs
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+
+const source = readFileSync(new URL('./fastapi/websockets.py', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/test_websocket_heartbeat.py', import.meta.url), 'utf8');
+
+function includes(text, fragment, message) {
+  assert.ok(text.includes(fragment), message);
+}
+
+includes(source, 'WebSocket as WebSocket', 'existing WebSocket export should remain');
+includes(source, 'WebSocketDisconnect as WebSocketDisconnect', 'existing disconnect export should remain');
+includes(source, 'class WebSocketWithHeartbeat:', 'heartbeat wrapper should exist');
+includes(source, 'ping_interval: float = 30.0', 'default ping interval should be 30 seconds');
+includes(source, 'pong_timeout: float = 10.0', 'default pong timeout should be 10 seconds');
+includes(source, 'self.message_count = 0', 'message count should be tracked');
+includes(source, 'def connection_duration(self) -> float:', 'connection duration property should exist');
+includes(source, 'asyncio.create_task(self._heartbeat_loop())', 'heartbeat task should be started');
+includes(source, 'await self.send_ping()', 'heartbeat should send ping');
+includes(source, 'await self.close(code=self.close_code)', 'timeout should close with configured code');
+includes(source, 'self.on_disconnect(code, self.connection_duration)', 'disconnect callback should receive code and duration');
+includes(source, 'self.message_count += 1', 'receive helpers should increment message count');
+includes(source, 'def __getattr__(self, name: str)', 'wrapper should delegate to original WebSocket');
+includes(tests, 'test_heartbeat_sends_ping_and_closes_on_timeout', 'tests should cover ping and timeout close');
+includes(tests, 'test_on_disconnect_receives_close_code_and_duration', 'tests should cover disconnect callback');
+includes(tests, 'test_receive_text_tracks_message_count_and_pong', 'tests should cover message counting and pong');
+includes(tests, 'test_defaults_can_be_overridden_per_connection', 'tests should cover configurable defaults');
+
+const metadata = JSON.parse(readFileSync(new URL('./fastapi/_contributor.json', import.meta.url), 'utf8'));
+assert.equal(metadata.identity, 'Codex GPT-5');
+assert.ok(!metadata.runtime_instructions.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('fastapi websocket heartbeat checks passed');


### PR DESCRIPTION
/claim #766

## Summary
- adds an opt-in WebSocketWithHeartbeat wrapper while preserving the existing FastAPI WebSocket re-exports
- sends configurable app-level ping messages, closes stale connections with the configured close code, and supports disconnect callbacks
- tracks connection duration and received message count, with tests and a lightweight static harness

## Validation
- node fastapi/websocket_heartbeat_checks.mjs
- python -m py_compile fastapi/fastapi/websockets.py fastapi/tests/test_websocket_heartbeat.py
- git diff --check

Note: ASGI/Starlette does not expose a raw protocol ping-frame API here, so the wrapper implements the heartbeat as configurable app-level ping/pong messages.