### PR TITLE
Codex GPT-5 [ Laravel ] Implement API authentication controller

### DIFF
--- a/laravel/.generation_meta.json
+++ b/laravel/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initial_directives": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "date": "2026-06-06T21:50:00Z"
+}

--- a/laravel/api_auth_checks.mjs
+++ b/laravel/api_auth_checks.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const controller = readFileSync(new URL('./app/Http/Controllers/AuthController.php', import.meta.url), 'utf8');
+const routes = readFileSync(new URL('./routes/api.php', import.meta.url), 'utf8');
+const user = readFileSync(new URL('./app/Models/User.php', import.meta.url), 'utf8');
+const bootstrap = readFileSync(new URL('./bootstrap/app.php', import.meta.url), 'utf8');
+const composer = JSON.parse(readFileSync(new URL('./composer.json', import.meta.url), 'utf8'));
+const tests = readFileSync(new URL('./tests/Feature/ApiAuthenticationTest.php', import.meta.url), 'utf8');
+const metadata = JSON.parse(readFileSync(new URL('./.generation_meta.json', import.meta.url), 'utf8'));
+
+assert.equal(composer.require['laravel/sanctum'], '^4.2');
+assert.match(bootstrap, /api:\s*__DIR__\.'\/\.\.\/routes\/api\.php'/);
+assert.match(user, /use Laravel\\Sanctum\\HasApiTokens;/);
+assert.match(user, /use HasApiTokens, HasFactory, Notifiable;/);
+assert.match(routes, /Route::post\('\/register'/);
+assert.match(routes, /Route::post\('\/login'/);
+assert.match(routes, /Route::post\('\/logout'.*auth:sanctum/s);
+assert.match(controller, /public function register\(Request \$request\): JsonResponse/);
+assert.match(controller, /'password' => \['required', 'string', 'min:8', 'confirmed'\]/);
+assert.match(controller, /unique:users,email/);
+assert.match(controller, /createToken\('api-token'\)->plainTextToken/);
+assert.match(controller, /'message' => 'The provided credentials are incorrect\.'/);
+assert.match(controller, /currentAccessToken\(\)\?->delete\(\)/);
+assert.match(tests, /postJson\('\/api\/register'/);
+assert.match(tests, /postJson\('\/api\/login'/);
+assert.match(tests, /postJson\('\/api\/logout'/);
+assert.equal(metadata.agent, 'Codex GPT-5');
+assert.ok(!metadata.initial_directives.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel api auth checks passed');

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AuthController extends Controller
+{
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        $user = User::create($validated);
+
+        return response()->json([
+            'user' => $user,
+            'token' => $user->createToken('api-token')->plainTextToken,
+        ], 201);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::where('email', $credentials['email'])->first();
+
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            return response()->json([
+                'message' => 'The provided credentials are incorrect.',
+            ], 401);
+        }
+
+        return response()->json([
+            'user' => $user,
+            'token' => $user->createToken('api-token')->plainTextToken,
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()?->currentAccessToken()?->delete();
+
+        return response()->json([
+            'message' => 'Logged out successfully.',
+        ]);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,13 +9,14 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.3",
         "laravel/framework": "^13.8",
+        "laravel/sanctum": "^4.2",
         "laravel/tinker": "^3.0"
     },
     "require-dev": {

--- a/laravel/database/migrations/2026_06_06_000000_create_personal_access_tokens_table.php
+++ b/laravel/database/migrations/2026_06_06_000000_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');

--- a/laravel/tests/Feature/ApiAuthenticationTest.php
+++ b/laravel/tests/Feature/ApiAuthenticationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiAuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_register_and_receive_token(): void
+    {
+        $response = $this->postJson('/api/register', [
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonStructure(['user' => ['id', 'name', 'email'], 'token']);
+
+        $this->assertDatabaseHas('users', ['email' => 'ada@example.com']);
+        $this->assertDatabaseCount('personal_access_tokens', 1);
+    }
+
+    public function test_login_returns_token_for_valid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'grace@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'grace@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure(['user' => ['id', 'name', 'email'], 'token']);
+    }
+
+    public function test_login_rejects_invalid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'bad-login@example.com',
+            'password' => 'password123',
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => 'bad-login@example.com',
+            'password' => 'wrong-password',
+        ]);
+
+        $response
+            ->assertStatus(401)
+            ->assertJson(['message' => 'The provided credentials are incorrect.']);
+    }
+
+    public function test_logout_revokes_current_access_token(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->postJson('/api/logout');
+
+        $response
+            ->assertOk()
+            ->assertJson(['message' => 'Logged out successfully.']);
+
+        $this->assertDatabaseCount('personal_access_tokens', 0);
+    }
+}


### PR DESCRIPTION
/claim #752

## Summary
- adds Sanctum-backed API auth endpoints for register, login, and logout
- registers `routes/api.php` with `/api/register`, `/api/login`, and protected `/api/logout`
- updates the User model for API tokens and adds a personal access token migration
- adds feature coverage for registration, valid login, invalid login, and token revocation

## Validation
- node laravel/api_auth_checks.mjs
- git diff --check

PHP/composer are not installed in this local environment, so `php artisan test` could not be executed here.