### PR TITLE
Codex GPT-5 [ Laravel ] Add email verification flow

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "environment_config": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "completed_at": "2026-06-06T21:54:00Z"
+}

--- a/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
+++ b/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureEmailIsVerified
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail()) {
+            if ($request->expectsJson()) {
+                abort(403, 'Your email address is not verified.');
+            }
+
+            return redirect()->route('verification.notice');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,8 +2,9 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Notifications\CustomVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail as MustVerifyEmailContract;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,10 +13,15 @@ use Illuminate\Notifications\Notifiable;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmailContract
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify(new CustomVerifyEmail());
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Notifications/CustomVerifyEmail.php
+++ b/laravel/app/Notifications/CustomVerifyEmail.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomVerifyEmail extends VerifyEmail
+{
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage())
+            ->subject('Verify your email address')
+            ->view('emails.verify-email', [
+                'user' => $notifiable,
+                'verificationUrl' => $this->verificationUrl($notifiable),
+            ]);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'verified.email' => \App\Http\Middleware\EnsureEmailIsVerified::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/config/mail.php
+++ b/laravel/config/mail.php
@@ -14,7 +14,8 @@ return [
     |
     */
 
-    'default' => env('MAIL_MAILER', 'log'),
+    'default' => env('MAIL_MAILER', 'primary_with_fallback'),
+    'fallback_mailer' => env('MAIL_FALLBACK_MAILER', 'log'),
 
     /*
     |--------------------------------------------------------------------------
@@ -36,6 +37,15 @@ return [
     */
 
     'mailers' => [
+
+        'primary_with_fallback' => [
+            'transport' => 'failover',
+            'mailers' => [
+                env('MAIL_PRIMARY_MAILER', 'smtp'),
+                env('MAIL_FALLBACK_MAILER', 'log'),
+            ],
+            'retry_after' => 60,
+        ],
 
         'smtp' => [
             'transport' => 'smtp',

--- a/laravel/email_verification_checks.mjs
+++ b/laravel/email_verification_checks.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const user = readFileSync(new URL('./app/Models/User.php', import.meta.url), 'utf8');
+const routes = readFileSync(new URL('./routes/web.php', import.meta.url), 'utf8');
+const mail = readFileSync(new URL('./config/mail.php', import.meta.url), 'utf8');
+const middleware = readFileSync(new URL('./app/Http/Middleware/EnsureEmailIsVerified.php', import.meta.url), 'utf8');
+const notification = readFileSync(new URL('./app/Notifications/CustomVerifyEmail.php', import.meta.url), 'utf8');
+const noticeView = readFileSync(new URL('./resources/views/auth/verify-email.blade.php', import.meta.url), 'utf8');
+const emailView = readFileSync(new URL('./resources/views/emails/verify-email.blade.php', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/Feature/EmailVerificationFlowTest.php', import.meta.url), 'utf8');
+const metadata = JSON.parse(readFileSync(new URL('./.audit.json', import.meta.url), 'utf8'));
+
+assert.match(user, /implements MustVerifyEmailContract/);
+assert.match(user, /sendEmailVerificationNotification/);
+assert.match(user, /new CustomVerifyEmail\(\)/);
+assert.match(routes, /\/email\/verify\/\{id\}\/\{hash\}/);
+assert.match(routes, /EmailVerificationRequest/);
+assert.match(routes, /throttle:1,1/);
+assert.match(routes, /verification-link-sent/);
+assert.match(mail, /'fallback_mailer' => env\('MAIL_FALLBACK_MAILER', 'log'\)/);
+assert.match(mail, /'primary_with_fallback'/);
+assert.match(mail, /'transport' => 'failover'/);
+assert.match(middleware, /redirect\(\)->route\('verification.notice'\)/);
+assert.match(notification, /extends VerifyEmail/);
+assert.match(notification, /emails.verify-email/);
+assert.match(noticeView, /route\('verification.send'\)/);
+assert.match(emailView, /Verify email address/);
+assert.match(tests, /temporarySignedRoute/);
+assert.match(tests, /Notification::assertSentTo\(\$user, CustomVerifyEmail::class\)/);
+assert.match(tests, /middleware\('verified.email'\)/);
+assert.equal(metadata.contributor, 'Codex GPT-5');
+assert.ok(!metadata.environment_config.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel email verification checks passed');

--- a/laravel/resources/views/auth/verify-email.blade.php
+++ b/laravel/resources/views/auth/verify-email.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Verify email</title>
+</head>
+<body>
+    <main>
+        <h1>Verify your email address</h1>
+
+        @if (session('status') === 'verification-link-sent')
+            <p>A fresh verification link has been sent to your email address.</p>
+        @endif
+
+        <p>Please verify your email before continuing.</p>
+
+        <form method="POST" action="{{ route('verification.send') }}">
+            @csrf
+            <button type="submit">Send verification link</button>
+        </form>
+    </main>
+</body>
+</html>

--- a/laravel/resources/views/emails/verify-email.blade.php
+++ b/laravel/resources/views/emails/verify-email.blade.php
@@ -1,0 +1,13 @@
+<x-mail::message>
+# Verify your email address
+
+Hello {{ $user->name }},
+
+Please confirm your email address to finish setting up your account.
+
+<x-mail::button :url="$verificationUrl">
+Verify email address
+</x-mail::button>
+
+If you did not create this account, no further action is required.
+</x-mail::message>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,29 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\Request;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/email/verify', function () {
+    return view('auth.verify-email');
+})->middleware('auth')->name('verification.notice');
+
+Route::get('/email/verify/{id}/{hash}', function (EmailVerificationRequest $request) {
+    $request->fulfill();
+
+    return redirect('/');
+})->middleware(['auth', 'signed'])->name('verification.verify');
+
+Route::post('/email/verification-notification', function (Request $request) {
+    if ($request->user()->hasVerifiedEmail()) {
+        return redirect('/');
+    }
+
+    $request->user()->sendEmailVerificationNotification();
+
+    return back()->with('status', 'verification-link-sent');
+})->middleware(['auth', 'throttle:1,1'])->name('verification.send');

--- a/laravel/tests/Feature/EmailVerificationFlowTest.php
+++ b/laravel/tests/Feature/EmailVerificationFlowTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\CustomVerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class EmailVerificationFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_verification_link_marks_user_email_as_verified(): void
+    {
+        $user = User::factory()->unverified()->create();
+        $url = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->getKey(), 'hash' => sha1($user->getEmailForVerification())],
+        );
+
+        $this->actingAs($user)->get($url)->assertRedirect('/');
+
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_resend_verification_notification_sends_custom_notification(): void
+    {
+        Notification::fake();
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertSessionHas('status', 'verification-link-sent');
+
+        Notification::assertSentTo($user, CustomVerifyEmail::class);
+    }
+
+    public function test_unverified_user_is_redirected_by_email_verification_middleware(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        $this->app['router']->get('/verified-only', fn () => 'ok')->middleware('verified.email');
+
+        $this->actingAs($user)
+            ->get('/verified-only')
+            ->assertRedirect(route('verification.notice'));
+    }
+}


### PR DESCRIPTION
/claim #756

## Summary
- enables email verification on the User model and sends a custom branded verification notification
- adds verification notice, signed verification, and throttled resend routes
- adds an email verification middleware alias and notice/email blade templates
- wires mail fallback through a `fallback_mailer` key and failover mailer
- adds feature tests for signed verification, resend notification, and middleware redirect behavior

## Validation
- node laravel/email_verification_checks.mjs
- git diff --check

PHP/composer are not installed in this local environment, so `php artisan test` could not be executed here.