### PR TITLE
Codex GPT-5 [ Laravel ] Add web rate limiting and session fallback

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "timestamp": "2026-06-06T22:16:00Z"
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('web', function (Request $request) {
+            $user = $request->user();
+
+            return Limit::perMinute(60)->by(
+                $user ? 'user:'.$user->getAuthIdentifier() : 'ip:'.$request->ip()
+            );
+        });
     }
 }

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -19,6 +19,7 @@ return [
     */
 
     'driver' => env('SESSION_DRIVER', 'database'),
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------

--- a/laravel/rate_limit_session_checks.mjs
+++ b/laravel/rate_limit_session_checks.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const provider = readFileSync(new URL('./app/Providers/AppServiceProvider.php', import.meta.url), 'utf8');
+const routes = readFileSync(new URL('./routes/web.php', import.meta.url), 'utf8');
+const session = readFileSync(new URL('./config/session.php', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/Feature/WebRateLimitTest.php', import.meta.url), 'utf8');
+const metadata = JSON.parse(readFileSync(new URL('./.contributor.json', import.meta.url), 'utf8'));
+
+assert.match(provider, /RateLimiter::for\('web'/);
+assert.match(provider, /Limit::perMinute\(60\)->by/);
+assert.match(provider, /user:\'\.\$user->getAuthIdentifier\(\)/);
+assert.match(provider, /'ip:'\.\$request->ip\(\)/);
+assert.match(routes, /Route::middleware\('throttle:web'\)->group/);
+assert.match(routes, /\/debug\/rate-limit/);
+assert.match(routes, /x-ratelimit-limit/);
+assert.match(routes, /X-RateLimit-Remaining/);
+assert.match(session, /'fallback' => env\('SESSION_FALLBACK_DRIVER', 'file'\)/);
+assert.match(tests, /assertTooManyRequests/);
+assert.match(tests, /RateLimiter::limiter\('web'\)/);
+assert.match(tests, /assertHeader\('X-RateLimit-Limit', '60'\)/);
+assert.match(tests, /config\('session.fallback'\)/);
+assert.equal(metadata.agent, 'Codex GPT-5');
+assert.ok(!metadata.initialized_with.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel rate limit session checks passed');

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,31 @@
 <?php
 
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('throttle:web')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/debug/rate-limit', function () {
+        $request = request();
+        $user = $request->user();
+        $key = $user ? 'user:'.$user->getAuthIdentifier() : 'ip:'.$request->ip();
+        $remaining = RateLimiter::remaining('web:'.$key, 60);
+
+        return response()->json([
+            'key' => $key,
+            'limit' => 60,
+            'remaining' => $remaining,
+            'window' => '1 minute',
+            'headers' => [
+                'x-ratelimit-limit' => '60',
+                'x-ratelimit-remaining' => (string) $remaining,
+            ],
+        ])->withHeaders([
+            'X-RateLimit-Limit' => '60',
+            'X-RateLimit-Remaining' => (string) $remaining,
+        ]);
+    })->name('debug.rate-limit');
 });

--- a/laravel/tests/Feature/WebRateLimitTest.php
+++ b/laravel/tests/Feature/WebRateLimitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class WebRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_web_routes_are_rate_limited_after_sixty_requests(): void
+    {
+        for ($i = 0; $i < 60; $i++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')->assertTooManyRequests();
+    }
+
+    public function test_rate_limiter_uses_user_id_or_ip(): void
+    {
+        $guestRequest = request();
+        $guestRequest->server->set('REMOTE_ADDR', '203.0.113.10');
+
+        $guestLimit = RateLimiter::limiter('web')($guestRequest);
+        $this->assertSame('ip:203.0.113.10', $guestLimit->key);
+
+        $user = User::factory()->create();
+        $userRequest = request();
+        $userRequest->setUserResolver(fn () => $user);
+
+        $userLimit = RateLimiter::limiter('web')($userRequest);
+        $this->assertSame('user:'.$user->getAuthIdentifier(), $userLimit->key);
+    }
+
+    public function test_debug_route_returns_rate_limit_metadata(): void
+    {
+        $this->get('/debug/rate-limit')
+            ->assertOk()
+            ->assertJsonPath('limit', 60)
+            ->assertJsonPath('window', '1 minute')
+            ->assertHeader('X-RateLimit-Limit', '60');
+    }
+
+    public function test_session_fallback_driver_defaults_to_file(): void
+    {
+        $this->assertSame('file', config('session.fallback'));
+    }
+}


### PR DESCRIPTION
/claim #749

## Summary
- registers a custom `web` rate limiter keyed by authenticated user id or guest IP
- wraps web routes with `throttle:web`
- adds `/debug/rate-limit` JSON endpoint with rate limit metadata and headers
- adds `session.fallback` defaulting to `file`
- adds feature coverage for 429 behavior, limiter keying, debug metadata, and fallback config

## Validation
- node laravel/rate_limit_session_checks.mjs
- git diff --check

PHP is not installed in this local environment, so `php artisan test` could not be executed here.