### PR TITLE
Codex GPT-5 [ Laravel ] Fix DatabaseSeeder idempotency

### DIFF
--- a/laravel/.provenance.json
+++ b/laravel/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex GPT-5",
+  "config_snapshot": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "created": "2026-06-06T22:20:00Z"
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word(),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_06_06_000001_create_roles_table.php
+++ b/laravel/database/migrations/2026_06_06_000001_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -17,9 +17,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            User::factory()->make([
+                'name' => 'Test User',
+                'email' => 'test@example.com',
+            ])->toArray(),
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the application's default roles.
+     */
+    public function run(): void
+    {
+        $roles = [
+            'admin' => 'Full administrative access.',
+            'editor' => 'Can create and update content.',
+            'viewer' => 'Read-only access.',
+        ];
+
+        foreach ($roles as $name => $description) {
+            Role::firstOrCreate(
+                ['name' => $name],
+                ['description' => $description],
+            );
+        }
+    }
+}

--- a/laravel/seeders_checks.mjs
+++ b/laravel/seeders_checks.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const databaseSeeder = readFileSync(new URL('./database/seeders/DatabaseSeeder.php', import.meta.url), 'utf8');
+const roleSeeder = readFileSync(new URL('./database/seeders/RoleSeeder.php', import.meta.url), 'utf8');
+const roleModel = readFileSync(new URL('./app/Models/Role.php', import.meta.url), 'utf8');
+const roleFactory = readFileSync(new URL('./database/factories/RoleFactory.php', import.meta.url), 'utf8');
+const migration = readFileSync(new URL('./database/migrations/2026_06_06_000001_create_roles_table.php', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/Feature/DatabaseSeederTest.php', import.meta.url), 'utf8');
+const metadata = JSON.parse(readFileSync(new URL('./.provenance.json', import.meta.url), 'utf8'));
+
+assert.match(databaseSeeder, /User::firstOrCreate/);
+assert.match(databaseSeeder, /\['email' => 'test@example\.com'\]/);
+assert.match(databaseSeeder, /'email' => 'test@example\.com'/);
+assert.match(databaseSeeder, /\$this->call\(RoleSeeder::class\)/);
+assert.match(roleSeeder, /Role::firstOrCreate/);
+assert.match(roleSeeder, /'admin'/);
+assert.match(roleSeeder, /'editor'/);
+assert.match(roleSeeder, /'viewer'/);
+assert.match(roleModel, /class Role extends Model/);
+assert.match(roleFactory, /class RoleFactory extends Factory/);
+assert.match(migration, /Schema::create\('roles'/);
+assert.match(migration, /\$table->string\('name'\)->unique\(\)/);
+assert.match(migration, /\$table->string\('description'\)/);
+assert.match(tests, /test_database_seeder_is_idempotent/);
+assert.match(tests, /test_role_seeder_creates_default_roles_once/);
+assert.match(tests, /test_role_factory_generates_valid_roles/);
+assert.equal(metadata.agent_name, 'Codex GPT-5');
+assert.ok(!metadata.config_snapshot.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('laravel seeders checks passed');

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_is_idempotent(): void
+    {
+        $this->seed();
+        $this->seed();
+
+        $this->assertDatabaseCount('users', 1);
+        $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
+    }
+
+    public function test_role_seeder_creates_default_roles_once(): void
+    {
+        $this->seed();
+        $this->seed();
+
+        $this->assertDatabaseCount('roles', 3);
+        $this->assertDatabaseHas('roles', ['name' => 'admin']);
+        $this->assertDatabaseHas('roles', ['name' => 'editor']);
+        $this->assertDatabaseHas('roles', ['name' => 'viewer']);
+    }
+
+    public function test_role_factory_generates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertNotEmpty($role->name);
+        $this->assertNotEmpty($role->description);
+    }
+}


### PR DESCRIPTION
/claim #746

## Summary
- changes the test user seeding from `create()` to `firstOrCreate()` to avoid duplicate `test@example.com` failures
- adds a Role model, roles migration, role factory, and idempotent RoleSeeder
- wires RoleSeeder from DatabaseSeeder after the test user is ensured
- adds feature coverage for repeated seeding, default roles, and Role factory output

## Validation
- node laravel/seeders_checks.mjs
- git diff --check

PHP is not installed in this local environment, so `php artisan test` could not be executed here.