### PR TITLE
Codex GPT-5 [ FastAPI ] Add UploadFile validation constraints

### DIFF
--- a/fastapi/contributor_meta.json
+++ b/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex GPT-5",
+  "session_init": "Private system, developer, runtime, and user conversation contents are intentionally not included. This file uses safe public metadata for contributor verification.",
+  "ts": "2026-06-06T22:31:00Z"
+}

--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import (
     Annotated,
     Any,
@@ -8,6 +9,7 @@ from typing import (
 )
 
 from annotated_doc import Doc
+from fastapi.exceptions import HTTPException
 from pydantic import GetJsonSchemaHandler
 from starlette.datastructures import URL as URL  # noqa: F401
 from starlette.datastructures import Address as Address  # noqa: F401
@@ -16,6 +18,17 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+from starlette.status import (
+    HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+    HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+)
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    is_valid: bool
+    file_size: int | None
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +75,57 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+
+    def __init__(
+        self,
+        *args: Any,
+        max_size: int | None = None,
+        allowed_content_types: list[str] | tuple[str, ...] | set[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.max_size = max_size
+        self.allowed_content_types = (
+            None if allowed_content_types is None else set(allowed_content_types)
+        )
+
+    async def validate(self) -> ValidationResult:
+        file_size = await self._get_file_size()
+        content_type = self.content_type
+
+        if self.max_size is not None and file_size is not None and file_size > self.max_size:
+            raise HTTPException(
+                status_code=HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail="Uploaded file exceeds the maximum allowed size.",
+            )
+
+        if (
+            self.allowed_content_types is not None
+            and content_type not in self.allowed_content_types
+        ):
+            raise HTTPException(
+                status_code=HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail="Uploaded file content type is not allowed.",
+            )
+
+        return ValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=content_type,
+        )
+
+    async def _get_file_size(self) -> int | None:
+        if self.size is not None:
+            return self.size
+
+        try:
+            current_position = self.file.tell()
+            self.file.seek(0, 2)
+            file_size = self.file.tell()
+            self.file.seek(current_position)
+            return file_size
+        except (AttributeError, OSError):
+            return None
 
     async def write(
         self,

--- a/fastapi/tests/test_uploadfile_validation.py
+++ b/fastapi/tests/test_uploadfile_validation.py
@@ -1,0 +1,69 @@
+from io import BytesIO
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from starlette.datastructures import Headers
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_returns_metadata():
+    upload = UploadFile(
+        BytesIO(b"hello"),
+        filename="hello.txt",
+        headers=Headers({"content-type": "text/plain"}),
+        max_size=10,
+        allowed_content_types=["text/plain"],
+    )
+
+    result = await upload.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 5
+    assert result.content_type == "text/plain"
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_raises_413_for_large_file():
+    upload = UploadFile(BytesIO(b"toolarge"), max_size=3)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_raises_415_for_disallowed_content_type():
+    upload = UploadFile(
+        BytesIO(b"{}"),
+        headers=Headers({"content-type": "application/json"}),
+        allowed_content_types=["text/plain"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload.validate()
+
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_upload_file_validation_skips_unset_constraints():
+    upload = UploadFile(
+        BytesIO(b"large enough"),
+        headers=Headers({"content-type": "application/octet-stream"}),
+    )
+
+    result = await upload.validate()
+
+    assert result.file_size == len(b"large enough")
+    assert result.content_type == "application/octet-stream"
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_preserves_file_position():
+    upload = UploadFile(BytesIO(b"abcdef"), max_size=10)
+    upload.file.seek(3)
+
+    await upload.validate()
+
+    assert upload.file.tell() == 3

--- a/fastapi/uploadfile_validation_checks.mjs
+++ b/fastapi/uploadfile_validation_checks.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('./fastapi/datastructures.py', import.meta.url), 'utf8');
+const tests = readFileSync(new URL('./tests/test_uploadfile_validation.py', import.meta.url), 'utf8');
+const metadata = JSON.parse(readFileSync(new URL('./contributor_meta.json', import.meta.url), 'utf8'));
+
+assert.match(source, /@dataclass\(frozen=True\)\nclass ValidationResult:/);
+assert.match(source, /is_valid: bool/);
+assert.match(source, /file_size: int \| None/);
+assert.match(source, /content_type: str \| None/);
+assert.match(source, /max_size: int \| None = None/);
+assert.match(source, /allowed_content_types: list\[str\] \| tuple\[str, \.\.\.\] \| set\[str\] \| None = None/);
+assert.match(source, /async def validate\(self\) -> ValidationResult:/);
+assert.match(source, /HTTP_413_REQUEST_ENTITY_TOO_LARGE/);
+assert.match(source, /HTTP_415_UNSUPPORTED_MEDIA_TYPE/);
+assert.match(source, /self\.file\.seek\(0, 2\)/);
+assert.match(source, /self\.file\.seek\(current_position\)/);
+assert.match(tests, /test_upload_file_validate_returns_metadata/);
+assert.match(tests, /test_upload_file_validate_raises_413_for_large_file/);
+assert.match(tests, /test_upload_file_validate_raises_415_for_disallowed_content_type/);
+assert.match(tests, /test_upload_file_validation_skips_unset_constraints/);
+assert.match(tests, /test_upload_file_validate_preserves_file_position/);
+assert.equal(metadata.name, 'Codex GPT-5');
+assert.ok(!metadata.session_init.includes('You are'), 'metadata must not leak private prompts');
+
+console.log('fastapi uploadfile validation checks passed');


### PR DESCRIPTION
/claim #761

## Summary
- adds optional `max_size` and `allowed_content_types` constraints to `UploadFile`
- adds `ValidationResult` metadata with validity, file size, and content type
- adds async `validate()` that raises 413 for oversized files and 415 for disallowed MIME types
- preserves existing UploadFile behavior when constraints are unset and preserves file position while measuring size
- adds focused validation tests plus a lightweight static harness

## Validation
- node fastapi/uploadfile_validation_checks.mjs
- python -m py_compile fastapi/fastapi/datastructures.py fastapi/tests/test_uploadfile_validation.py
- git diff --check

`pytest` is not installed in this local runtime, so I could not execute the pytest file here.