### PR TITLE
Codex GPT-5 [ FastAPI ] Add OAuth2 refresh token support

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
+from .security import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/.provenance.json
+++ b/fastapi/fastapi/security/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex GPT-5",
+  "config_snapshot": "Private system, developer, runtime, and conversation contents are intentionally not included. This file contains safe public metadata for contributor verification.",
+  "created": "2026-06-06T22:45:00Z"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,70 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    This is a dependency class to collect the refresh token form data for an
+    OAuth2 token refresh flow.
+    """
+
+    def __init__(
+        self,
+        *,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 refresh token grant type. It MUST be the fixed string
+                "refresh_token".
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                The refresh token issued by the authorization server.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                A single string with several scopes separated by spaces. Each scope
+                is also a string.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 client id sent as part of the form fields.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                Optional OAuth2 client secret sent as part of the form fields.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +606,74 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password bearer flow that also documents a refresh token endpoint.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        refresh_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new one.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                The OAuth2 scopes that would be required by the path operations that
+                use this dependency.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                Automatically error when the Authorization header is missing or not a
+                bearer token.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            tokenUrl=tokenUrl,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+            refreshUrl=refresh_url,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/oauth2_refresh_checks.mjs
+++ b/fastapi/oauth2_refresh_checks.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+
+const oauth2 = readFileSync("fastapi/fastapi/security/oauth2.py", "utf8");
+const securityInit = readFileSync("fastapi/fastapi/security/__init__.py", "utf8");
+const rootInit = readFileSync("fastapi/fastapi/__init__.py", "utf8");
+const tests = readFileSync("fastapi/tests/test_security_oauth2_refresh.py", "utf8");
+
+const checks = [
+  ["OAuth2PasswordBearerWithRefresh class", /class OAuth2PasswordBearerWithRefresh\(OAuth2PasswordBearer\)/.test(oauth2)],
+  ["refresh_url parameter", /refresh_url: Annotated\[\s*str,/.test(oauth2)],
+  ["refreshUrl forwarded to OpenAPI flow", /refreshUrl=refresh_url/.test(oauth2)],
+  ["OAuth2RefreshRequestForm class", /class OAuth2RefreshRequestForm:/.test(oauth2)],
+  ["refresh grant pattern", /Form\(pattern="\^refresh_token\$"\)/.test(oauth2)],
+  ["refresh token form field", /self\.refresh_token = refresh_token/.test(oauth2)],
+  ["security exports", securityInit.includes("OAuth2PasswordBearerWithRefresh") && securityInit.includes("OAuth2RefreshRequestForm")],
+  ["root exports", rootInit.includes("OAuth2PasswordBearerWithRefresh") && rootInit.includes("OAuth2RefreshRequestForm")],
+  ["OpenAPI test covers refreshUrl", tests.includes('"refreshUrl": "token/refresh"')],
+];
+
+const failed = checks.filter(([, ok]) => !ok);
+if (failed.length) {
+  console.error(failed.map(([name]) => `FAILED: ${name}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(`oauth2 refresh checks passed (${checks.length})`);

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -1,0 +1,76 @@
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import OAuth2PasswordBearerWithRefresh, OAuth2RefreshRequestForm
+from fastapi.testclient import TestClient
+from inline_snapshot import snapshot
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="token",
+    refresh_url="token/refresh",
+    scopes={"items:read": "Read items"},
+)
+
+
+@app.post("/refresh")
+def refresh_token(form_data: OAuth2RefreshRequestForm = Depends()):
+    return form_data
+
+
+@app.get("/users/me")
+def read_current_user(token: str | None = Security(oauth2_scheme)):
+    return {"token": token}
+
+
+client = TestClient(app)
+
+
+def test_token():
+    response = client.get("/users/me", headers={"Authorization": "Bearer testtoken"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"token": "testtoken"}
+
+
+def test_refresh_form():
+    response = client.post(
+        "/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-token-value",
+            "scope": "items:read profile",
+            "client_id": "client",
+            "client_secret": "secret",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-token-value",
+        "scopes": ["items:read", "profile"],
+        "client_id": "client",
+        "client_secret": "secret",
+    }
+
+
+def test_refresh_form_rejects_wrong_grant_type():
+    response = client.post(
+        "/refresh",
+        data={"grant_type": "password", "refresh_token": "refresh-token-value"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["type"] == "string_pattern_mismatch"
+    assert response.json()["detail"][0]["ctx"] == {"pattern": "^refresh_token$"}
+
+
+def test_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json()["components"]["securitySchemes"][
+        "OAuth2PasswordBearerWithRefresh"
+    ]["flows"]["password"] == snapshot(
+        {
+            "refreshUrl": "token/refresh",
+            "scopes": {"items:read": "Read items"},
+            "tokenUrl": "token",
+        }
+    )


### PR DESCRIPTION
/claim #758

## Summary
- Added `OAuth2PasswordBearerWithRefresh` as a password bearer drop-in that accepts `refresh_url` and exposes it as `refreshUrl` in the OAuth2 password flow OpenAPI schema.
- Added `OAuth2RefreshRequestForm` for refresh token form submissions with `grant_type=refresh_token`, `refresh_token`, scopes, and optional client credentials.
- Exported the new helpers and added focused refresh-flow tests plus safe provenance metadata.

## Validation
- `node fastapi/oauth2_refresh_checks.mjs`
- `python -m py_compile fastapi/fastapi/security/oauth2.py fastapi/fastapi/security/__init__.py fastapi/fastapi/__init__.py fastapi/tests/test_security_oauth2_refresh.py`
- `git diff --check`

`python -m pytest fastapi/tests/test_security_oauth2_refresh.py -q` could not run locally because this environment does not have pytest installed.