### PR TITLE
Codex GPT-5 [ Crypto ] Harden MultiSigWallet execution race

### DIFF
--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -15,7 +15,12 @@ contract MultiSigWallet {
 
     mapping(uint256 => Transaction) public transactions;
     mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => uint256)) public confirmationBlocks;
+    mapping(uint256 => mapping(address => uint256)) public confirmationTimestamps;
+    mapping(uint256 => mapping(address => uint256)) public revocationBlocks;
+    mapping(uint256 => mapping(address => uint256)) public revocationTimestamps;
     mapping(address => bool) public isOwner;
+    bool private executionLocked;
 
     event Submitted(uint256 indexed txId);
     event Confirmed(uint256 indexed txId, address indexed owner);
@@ -27,18 +32,35 @@ contract MultiSigWallet {
         _;
     }
 
+    modifier txExists(uint256 txId) {
+        require(txId < transactionCount, "Unknown transaction");
+        _;
+    }
+
+    modifier nonReentrantExecution() {
+        require(!executionLocked, "Execution in progress");
+        executionLocked = true;
+        _;
+        executionLocked = false;
+    }
+
     constructor(address[] memory _owners, uint256 _required) {
         require(_owners.length > 0, "No owners");
         require(_required > 0 && _required <= _owners.length, "Invalid required");
         for (uint256 i = 0; i < _owners.length; i++) {
-            isOwner[_owners[i]] = true;
+            address owner = _owners[i];
+            require(owner != address(0), "Invalid owner");
+            require(!isOwner[owner], "Duplicate owner");
+            isOwner[owner] = true;
         }
         owners = _owners;
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid target");
+        require(data.length == 0 || to.code.length > 0, "Target is not contract");
+
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
@@ -50,18 +72,36 @@ contract MultiSigWallet {
         return txId;
     }
 
-    function confirmTransaction(uint256 txId) external onlyOwner {
+    function confirmTransaction(uint256 txId) external onlyOwner txExists(txId) {
+        require(!executionLocked, "Execution in progress");
         require(!transactions[txId].executed, "Already executed");
         require(!confirmations[txId][msg.sender], "Already confirmed");
         confirmations[txId][msg.sender] = true;
+        confirmationBlocks[txId][msg.sender] = block.number;
+        confirmationTimestamps[txId][msg.sender] = block.timestamp;
+        revocationBlocks[txId][msg.sender] = 0;
+        revocationTimestamps[txId][msg.sender] = 0;
         emit Confirmed(txId, msg.sender);
     }
 
-    function revokeConfirmation(uint256 txId) external onlyOwner {
+    function revokeConfirmation(uint256 txId) external onlyOwner txExists(txId) {
+        require(!executionLocked, "Execution in progress");
         require(!transactions[txId].executed, "Already executed");
         require(confirmations[txId][msg.sender], "Not confirmed");
         confirmations[txId][msg.sender] = false;
+        revocationBlocks[txId][msg.sender] = block.number;
+        revocationTimestamps[txId][msg.sender] = block.timestamp;
         emit Revoked(txId, msg.sender);
+    }
+
+    function isConfirmedAtBlock(uint256 txId, address owner, uint256 blockNumber) public view returns (bool) {
+        uint256 confirmedAt = confirmationBlocks[txId][owner];
+        if (confirmedAt == 0 || confirmedAt > blockNumber) {
+            return false;
+        }
+
+        uint256 revokedAt = revocationBlocks[txId][owner];
+        return revokedAt == 0 || revokedAt > blockNumber;
     }
 
     function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
@@ -70,13 +110,18 @@ contract MultiSigWallet {
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
+        for (uint256 i = 0; i < owners.length; i++) {
+            if (isConfirmedAtBlock(txId, owners[i], blockNumber)) count++;
+        }
+    }
 
+    function executeTransaction(uint256 txId) external onlyOwner txExists(txId) nonReentrantExecution {
         Transaction storage txn = transactions[txId];
+        require(!txn.executed, "Already executed");
+        uint256 confirmationSnapshotBlock = block.number;
+        require(getConfirmationCountAtBlock(txId, confirmationSnapshotBlock) >= required, "Not enough confirmations");
+
         txn.executed = true;
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);

--- a/solidity/contracts/_provenance.json
+++ b/solidity/contracts/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "Private system, developer, runtime, and conversation contents are intentionally not included. This submission includes only safe public metadata and no secrets, credentials, private prompts, hidden instructions, or session data.",
+  "timestamp": "2026-06-06T22:58:00Z"
+}

--- a/solidity/tests/multisig_wallet_rework_checks.mjs
+++ b/solidity/tests/multisig_wallet_rework_checks.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("solidity/contracts/MultiSigWallet.sol", "utf8");
+const provenance = JSON.parse(readFileSync("solidity/contracts/_provenance.json", "utf8"));
+
+const checks = [
+  ["zero-address target rejected", /require\(to != address\(0\), "Invalid target"\)/.test(source)],
+  ["contract target required for calldata", /require\(data\.length == 0 \|\| to\.code\.length > 0, "Target is not contract"\)/.test(source)],
+  ["bool confirmations getter preserved", /mapping\(uint256 => mapping\(address => bool\)\) public confirmations;/.test(source)],
+  ["confirmation block metadata", /confirmationBlocks\[txId\]\[msg\.sender\] = block\.number;/.test(source)],
+  ["confirmation timestamp metadata", /confirmationTimestamps\[txId\]\[msg\.sender\] = block\.timestamp;/.test(source)],
+  ["revocation block metadata", /revocationBlocks\[txId\]\[msg\.sender\] = block\.number;/.test(source)],
+  ["revocation timestamp metadata", /revocationTimestamps\[txId\]\[msg\.sender\] = block\.timestamp;/.test(source)],
+  ["isConfirmedAtBlock helper", /function isConfirmedAtBlock\(uint256 txId, address owner, uint256 blockNumber\) public view returns \(bool\)/.test(source)],
+  ["block-level count helper", /function getConfirmationCountAtBlock\(uint256 txId, uint256 blockNumber\) public view returns \(uint256 count\)/.test(source)],
+  ["execute uses block snapshot", /uint256 confirmationSnapshotBlock = block\.number;[\s\S]*getConfirmationCountAtBlock\(txId, confirmationSnapshotBlock\) >= required/.test(source)],
+  ["execution lock guard", /modifier nonReentrantExecution\(\)[\s\S]*executionLocked = true;[\s\S]*executionLocked = false;/.test(source)],
+  ["confirm blocked during execution", /function confirmTransaction[\s\S]*require\(!executionLocked, "Execution in progress"\);/.test(source)],
+  ["revoke blocked during execution", /function revokeConfirmation[\s\S]*require\(!executionLocked, "Execution in progress"\);/.test(source)],
+  ["executed set before external call", /txn\.executed = true;[\s\S]*txn\.to\.call/.test(source)],
+  ["safe provenance", provenance.tool_name === "Codex GPT-5" && !/paste everything|system message|developer message/i.test(provenance.boot_context)],
+];
+
+const failed = checks.filter(([, ok]) => !ok);
+if (failed.length) {
+  console.error(failed.map(([name]) => `FAILED: ${name}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(`MultiSigWallet #916 rework checks passed (${checks.length})`);

--- a/solidity/tests/multisig_wallet_rework_checks.mjs
+++ b/solidity/tests/multisig_wallet_rework_checks.mjs
@@ -3,6 +3,12 @@ import { readFileSync } from "node:fs";
 const source = readFileSync("solidity/contracts/MultiSigWallet.sol", "utf8");
 const provenance = JSON.parse(readFileSync("solidity/contracts/_provenance.json", "utf8"));
 
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
 const checks = [
   ["zero-address target rejected", /require\(to != address\(0\), "Invalid target"\)/.test(source)],
   ["contract target required for calldata", /require\(data\.length == 0 \|\| to\.code\.length > 0, "Target is not contract"\)/.test(source)],
@@ -27,4 +33,118 @@ if (failed.length) {
   process.exit(1);
 }
 
-console.log(`MultiSigWallet #916 rework checks passed (${checks.length})`);
+class MultiSigWalletModel {
+  constructor(owners, required) {
+    this.owners = owners;
+    this.required = required;
+    this.block = 1;
+    this.transactions = [];
+    this.confirmations = new Map();
+    this.confirmationBlocks = new Map();
+    this.revocationBlocks = new Map();
+    this.executionLocked = false;
+  }
+
+  key(txId, owner) {
+    return `${txId}:${owner}`;
+  }
+
+  mine() {
+    this.block += 1;
+  }
+
+  submitTransaction(to, data = "") {
+    assert(to !== "0x0000000000000000000000000000000000000000", "zero-address target accepted");
+    assert(data === "" || to.startsWith("contract:"), "calldata to non-contract accepted");
+    this.transactions.push({ to, data, executed: false });
+    return this.transactions.length - 1;
+  }
+
+  confirmTransaction(txId, owner) {
+    assert(!this.executionLocked, "confirmation allowed during execution");
+    const key = this.key(txId, owner);
+    assert(!this.confirmations.get(key), "duplicate confirmation accepted");
+    this.confirmations.set(key, true);
+    this.confirmationBlocks.set(key, this.block);
+    this.revocationBlocks.set(key, 0);
+  }
+
+  revokeConfirmation(txId, owner) {
+    assert(!this.executionLocked, "revocation allowed during execution");
+    const key = this.key(txId, owner);
+    assert(this.confirmations.get(key), "missing confirmation revoked");
+    this.confirmations.set(key, false);
+    this.revocationBlocks.set(key, this.block);
+  }
+
+  isConfirmedAtBlock(txId, owner, blockNumber) {
+    const key = this.key(txId, owner);
+    const confirmedAt = this.confirmationBlocks.get(key) ?? 0;
+    const revokedAt = this.revocationBlocks.get(key) ?? 0;
+    return confirmedAt !== 0 && confirmedAt <= blockNumber && (revokedAt === 0 || revokedAt > blockNumber);
+  }
+
+  getConfirmationCountAtBlock(txId, blockNumber) {
+    return this.owners.filter((owner) => this.isConfirmedAtBlock(txId, owner, blockNumber)).length;
+  }
+
+  executeTransaction(txId, callback = () => {}) {
+    assert(!this.executionLocked, "reentrant execution accepted");
+    this.executionLocked = true;
+    const snapshotBlock = this.block;
+    assert(this.getConfirmationCountAtBlock(txId, snapshotBlock) >= this.required, "executed without required confirmations");
+    this.transactions[txId].executed = true;
+    callback();
+    this.executionLocked = false;
+  }
+}
+
+const wallet = new MultiSigWalletModel(["alice", "bob", "carol"], 2);
+const normalTx = wallet.submitTransaction("alice");
+wallet.confirmTransaction(normalTx, "alice");
+wallet.mine();
+wallet.confirmTransaction(normalTx, "bob");
+wallet.executeTransaction(normalTx);
+assert(wallet.transactions[normalTx].executed, "normal submit/confirm/execute flow failed");
+
+const revokedTx = wallet.submitTransaction("alice");
+wallet.mine();
+wallet.confirmTransaction(revokedTx, "alice");
+wallet.mine();
+wallet.confirmTransaction(revokedTx, "bob");
+wallet.mine();
+wallet.revokeConfirmation(revokedTx, "bob");
+assert(wallet.getConfirmationCountAtBlock(revokedTx, wallet.block) === 1, "front-running revocation snapshot failed");
+
+const callbackTx = wallet.submitTransaction("contract:callback");
+wallet.mine();
+wallet.confirmTransaction(callbackTx, "alice");
+wallet.mine();
+wallet.confirmTransaction(callbackTx, "bob");
+let callbackRevocationBlocked = false;
+wallet.executeTransaction(callbackTx, () => {
+  try {
+    wallet.revokeConfirmation(callbackTx, "bob");
+  } catch {
+    callbackRevocationBlocked = true;
+  }
+});
+assert(callbackRevocationBlocked, "callback-time revocation was not blocked");
+
+let zeroAddressRejected = false;
+try {
+  wallet.submitTransaction("0x0000000000000000000000000000000000000000");
+} catch {
+  zeroAddressRejected = true;
+}
+assert(zeroAddressRejected, "zero-address rejection model failed");
+
+let calldataToEoaRejected = false;
+try {
+  wallet.submitTransaction("alice", "0xabcdef");
+} catch {
+  calldataToEoaRejected = true;
+}
+assert(calldataToEoaRejected, "EOA calldata rejection model failed");
+
+console.log(`MultiSigWallet #916 rework checks passed (${checks.length} static checks + executable race model)`);


### PR DESCRIPTION
/claim #916

## Summary
- Preserves the public `confirmations(txId, owner)` boolean getter for compatibility.
- Adds parallel block and timestamp metadata for confirmations and revocations, plus block-level snapshot helpers.
- Adds a lightweight execution lock so confirmation and revocation reentry during execution callbacks is blocked, while `executed` is still set before the external call.
- Rejects zero-address targets and calldata submissions to non-contract targets, while preserving simple ETH transfers to EOAs.
- Includes safe public provenance metadata only, with no private instructions, credentials, or session data.

## Validation
- `node solidity/tests/multisig_wallet_rework_checks.mjs`
- `git diff --check`

Local Solidity toolchain note: this environment does not include solc, forge, hardhat, npm, or npx, so the included validation harness checks the required contract invariants statically.

Payment: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`