### PR TITLE
Codex GPT-5 [ FastAPI ] Add BackgroundTasks retry handling

### DIFF
--- a/fastapi/.contributor.json
+++ b/fastapi/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "Private system, developer, runtime, and conversation contents are intentionally not included. This submission includes only safe public metadata and no secrets, credentials, private prompts, hidden instructions, or session data.",
+  "timestamp": "2026-06-06T23:08:00Z"
+}

--- a/fastapi/background_retry_checks.mjs
+++ b/fastapi/background_retry_checks.mjs
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("fastapi/fastapi/background.py", "utf8");
+const tests = readFileSync("fastapi/tests/test_background_tasks_retry.py", "utf8");
+const contributor = JSON.parse(readFileSync("fastapi/.contributor.json", "utf8"));
+
+const checks = [
+  ["custom BackgroundTask wrapper", /class BackgroundTask\(StarletteBackgroundTask\)/.test(source)],
+  ["logger imported", /from fastapi\.logger import logger/.test(source)],
+  ["task_results initialized", /self\.task_results: list\[dict\[str, Any\]\] = \[\]/.test(source)],
+  ["max_retries parameter", /max_retries: Annotated\[\s*int,/.test(source)],
+  ["on_error parameter", /on_error: Annotated\[\s*Callable\[\[Exception, str\], Any\] \| None,/.test(source)],
+  ["exception logging", /logger\.exception/.test(source)],
+  ["callback called with exception and task name", /self\.on_error\(exc, self\.task_name\)/.test(source)],
+  ["async callback supported", /from inspect import isawaitable/.test(source) && /await callback_result/.test(source)],
+  ["success result stored", /"status": "success"/.test(source) && /"retry_count": retry_count/.test(source)],
+  ["failure result stored", /"status": "failed"/.test(source) && /"exception": str\(exc\)/.test(source)],
+  ["retry loop present", /while True:/.test(source) && /retry_count \+= 1/.test(source)],
+  ["test covers success", /test_background_task_success_records_result/.test(tests)],
+  ["test covers failure", /test_background_task_failure_is_recorded_without_raising/.test(tests)],
+  ["test covers retry success", /test_background_task_retries_until_success/.test(tests)],
+  ["test covers retry exhaustion", /test_background_task_retry_exhaustion_records_final_failure/.test(tests)],
+  ["safe contributor metadata", contributor.agent === "Codex GPT-5" && !/paste complete text|system message|developer message/i.test(contributor.initialized_with)],
+];
+
+const failed = checks.filter(([, ok]) => !ok);
+if (failed.length) {
+  console.error(failed.map(([name]) => `FAILED: ${name}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(`BackgroundTasks retry checks passed (${checks.length})`);

--- a/fastapi/fastapi/background.py
+++ b/fastapi/fastapi/background.py
@@ -1,11 +1,72 @@
 from collections.abc import Callable
+from inspect import isawaitable
 from typing import Annotated, Any
 
 from annotated_doc import Doc
+from fastapi.logger import logger
+from starlette.background import BackgroundTask as StarletteBackgroundTask
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
 from typing_extensions import ParamSpec
 
 P = ParamSpec("P")
+
+
+class BackgroundTask(StarletteBackgroundTask):
+    def __init__(
+        self,
+        func: Callable[P, Any],
+        *args: P.args,
+        task_results: list[dict[str, Any]],
+        max_retries: int = 0,
+        on_error: Callable[[Exception, str], Any] | None = None,
+        **kwargs: P.kwargs,
+    ) -> None:
+        super().__init__(func, *args, **kwargs)
+        if max_retries < 0:
+            raise ValueError("max_retries must be greater than or equal to 0")
+        self.task_results = task_results
+        self.max_retries = max_retries
+        self.on_error = on_error
+
+    @property
+    def task_name(self) -> str:
+        return getattr(self.func, "__name__", self.func.__class__.__name__)
+
+    async def __call__(self) -> None:
+        retry_count = 0
+        while True:
+            try:
+                await super().__call__()
+                self.task_results.append(
+                    {
+                        "status": "success",
+                        "task_name": self.task_name,
+                        "exception": None,
+                        "retry_count": retry_count,
+                    }
+                )
+                return
+            except Exception as exc:
+                logger.exception(
+                    "Background task %s failed on attempt %s",
+                    self.task_name,
+                    retry_count + 1,
+                )
+                if self.on_error is not None:
+                    callback_result = self.on_error(exc, self.task_name)
+                    if isawaitable(callback_result):
+                        await callback_result
+                if retry_count >= self.max_retries:
+                    self.task_results.append(
+                        {
+                            "status": "failed",
+                            "task_name": self.task_name,
+                            "exception": str(exc),
+                            "retry_count": retry_count,
+                        }
+                    )
+                    return
+                retry_count += 1
 
 
 class BackgroundTasks(StarletteBackgroundTasks):
@@ -37,6 +98,10 @@ class BackgroundTasks(StarletteBackgroundTasks):
     ```
     """
 
+    def __init__(self, tasks: list[BackgroundTask] | None = None):
+        self.task_results: list[dict[str, Any]] = []
+        super().__init__(tasks=tasks)
+
     def add_task(
         self,
         func: Annotated[
@@ -50,6 +115,23 @@ class BackgroundTasks(StarletteBackgroundTasks):
             ),
         ],
         *args: P.args,
+        max_retries: Annotated[
+            int,
+            Doc(
+                """
+                Number of times to retry the task after the initial attempt fails.
+                """
+            ),
+        ] = 0,
+        on_error: Annotated[
+            Callable[[Exception, str], Any] | None,
+            Doc(
+                """
+                Optional callback called with the exception and task function name
+                whenever an attempt fails.
+                """
+            ),
+        ] = None,
         **kwargs: P.kwargs,
     ) -> None:
         """
@@ -58,4 +140,12 @@ class BackgroundTasks(StarletteBackgroundTasks):
         Read more about it in the
         [FastAPI docs for Background Tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/).
         """
-        return super().add_task(func, *args, **kwargs)
+        task = BackgroundTask(
+            func,
+            *args,
+            task_results=self.task_results,
+            max_retries=max_retries,
+            on_error=on_error,
+            **kwargs,
+        )
+        self.tasks.append(task)

--- a/fastapi/tests/test_background_tasks_retry.py
+++ b/fastapi/tests/test_background_tasks_retry.py
@@ -1,0 +1,103 @@
+from fastapi import BackgroundTasks
+
+
+def test_background_task_success_records_result():
+    tasks = BackgroundTasks()
+    values = []
+
+    def task(value: str) -> None:
+        values.append(value)
+
+    tasks.add_task(task, "ok")
+
+    import anyio
+
+    anyio.run(tasks)
+
+    assert values == ["ok"]
+    assert tasks.task_results == [
+        {
+            "status": "success",
+            "task_name": "task",
+            "exception": None,
+            "retry_count": 0,
+        }
+    ]
+
+
+def test_background_task_failure_is_recorded_without_raising():
+    tasks = BackgroundTasks()
+    callback_calls = []
+
+    def task() -> None:
+        raise RuntimeError("boom")
+
+    def on_error(exc: Exception, task_name: str) -> None:
+        callback_calls.append((str(exc), task_name))
+
+    tasks.add_task(task, on_error=on_error)
+
+    import anyio
+
+    anyio.run(tasks)
+
+    assert callback_calls == [("boom", "task")]
+    assert tasks.task_results == [
+        {
+            "status": "failed",
+            "task_name": "task",
+            "exception": "boom",
+            "retry_count": 0,
+        }
+    ]
+
+
+def test_background_task_retries_until_success():
+    tasks = BackgroundTasks()
+    attempts = []
+
+    def task() -> None:
+        attempts.append("attempt")
+        if len(attempts) < 3:
+            raise RuntimeError("retry me")
+
+    tasks.add_task(task, max_retries=2)
+
+    import anyio
+
+    anyio.run(tasks)
+
+    assert len(attempts) == 3
+    assert tasks.task_results == [
+        {
+            "status": "success",
+            "task_name": "task",
+            "exception": None,
+            "retry_count": 2,
+        }
+    ]
+
+
+def test_background_task_retry_exhaustion_records_final_failure():
+    tasks = BackgroundTasks()
+    attempts = []
+
+    def task() -> None:
+        attempts.append("attempt")
+        raise RuntimeError("still broken")
+
+    tasks.add_task(task, max_retries=2)
+
+    import anyio
+
+    anyio.run(tasks)
+
+    assert len(attempts) == 3
+    assert tasks.task_results == [
+        {
+            "status": "failed",
+            "task_name": "task",
+            "exception": "still broken",
+            "retry_count": 2,
+        }
+    ]


### PR DESCRIPTION
/claim #760

## Summary
- Added a FastAPI `BackgroundTask` wrapper that catches and logs failed task attempts instead of letting failures disappear without task-level tracking.
- Added opt-in `max_retries` and `on_error(exception, task_name)` support to `BackgroundTasks.add_task`.
- Added `task_results` records with `status`, `task_name`, `exception`, and `retry_count` for success and failure inspection.
- Added focused tests for successful tasks, caught failures, callback invocation, retry success, and retry exhaustion.
- Included safe public `.contributor.json` metadata only, without private instructions, credentials, or session data.

## Validation
- `node fastapi/background_retry_checks.mjs`
- `python -m py_compile fastapi/fastapi/background.py fastapi/tests/test_background_tasks_retry.py`
- `git diff --check`

Local environment notes: `python -m pytest fastapi/tests/test_background_tasks_retry.py -q` could not run because pytest is not installed, and importing FastAPI directly is blocked because this local runtime does not include Starlette.

Payment preference: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`