### PR TITLE
Codex GPT-5 [ Cobol ] Handle escaped commas in Subject DN parsing

### DIFF
--- a/cobol/TLS-CERT-VALIDATOR.cbl
+++ b/cobol/TLS-CERT-VALIDATOR.cbl
@@ -93,6 +93,16 @@
                88  WS-CERT-IS-EXPIRED  VALUE 'Y'.
                88  WS-CERT-NOT-EXPIRED VALUE 'N'.
        01  WS-EXPECTED-HOSTNAME        PIC X(255).
+       01  WS-PARSED-CN                PIC X(64).
+       01  WS-SUBJECT-DN-WORK          PIC X(256).
+       01  WS-RDN-COUNT                PIC 9(2)  VALUE 0.
+       01  WS-RDN-INDEX                PIC 9(2)  VALUE 0.
+       01  WS-DN-SRC-IDX               PIC 9(3)  VALUE 1.
+       01  WS-DN-DST-IDX               PIC 9(3)  VALUE 1.
+       01  WS-CN-CHAR-IDX              PIC 9(2)  VALUE 1.
+       01  WS-ESCAPED-COMMA-MARK       PIC X     VALUE X'1F'.
+       01  WS-RDN-TABLE.
+           05  WS-RDN-ENTRY            PIC X(128) OCCURS 20 TIMES.
        01  WS-HOSTNAME-TALLY           PIC 9(5)  VALUE 0.
        01  WS-WILDCARD-POS             PIC 9(3)  VALUE 0.
        01  WS-HOSTNAME-MATCH-FLAG      PIC X(1).
@@ -130,6 +140,7 @@
            PERFORM 2000-VALIDATE-CERT-CHAIN
            PERFORM 3000-CHECK-EXPIRY-DATE
            PERFORM 4000-VERIFY-SIGNATURE
+           PERFORM 3500-PARSE-SUBJECT-DN
            PERFORM 5000-MATCH-HOSTNAME
            PERFORM 6000-CHECK-REVOCATION-STATUS
            PERFORM 7000-DETERMINE-FINAL-RESULT
@@ -253,6 +264,78 @@
            SET WS-SIG-VALID TO TRUE
            .
        4000-EXIT.
+           EXIT.
+       3500-PARSE-SUBJECT-DN.
+           MOVE SPACES TO WS-PARSED-CN
+           MOVE SPACES TO WS-SUBJECT-DN-WORK
+           MOVE SPACES TO WS-RDN-TABLE
+           MOVE 0 TO WS-RDN-COUNT
+           MOVE 1 TO WS-DN-SRC-IDX
+           MOVE 1 TO WS-DN-DST-IDX
+           PERFORM UNTIL WS-DN-SRC-IDX > 256
+               IF WS-DN-SRC-IDX < 256
+                   AND WS-SUBJECT-COMMON-NAME(WS-DN-SRC-IDX:2)
+                       = '\,'
+                   MOVE WS-ESCAPED-COMMA-MARK
+                       TO WS-SUBJECT-DN-WORK(WS-DN-DST-IDX:1)
+                   ADD 2 TO WS-DN-SRC-IDX
+               ELSE
+                   MOVE WS-SUBJECT-COMMON-NAME(WS-DN-SRC-IDX:1)
+                       TO WS-SUBJECT-DN-WORK(WS-DN-DST-IDX:1)
+                   ADD 1 TO WS-DN-SRC-IDX
+               END-IF
+               ADD 1 TO WS-DN-DST-IDX
+               IF WS-DN-DST-IDX > 256
+                   MOVE 257 TO WS-DN-SRC-IDX
+               END-IF
+           END-PERFORM
+           UNSTRING WS-SUBJECT-DN-WORK DELIMITED BY ','
+               INTO WS-RDN-ENTRY(1)
+                    WS-RDN-ENTRY(2)
+                    WS-RDN-ENTRY(3)
+                    WS-RDN-ENTRY(4)
+                    WS-RDN-ENTRY(5)
+                    WS-RDN-ENTRY(6)
+                    WS-RDN-ENTRY(7)
+                    WS-RDN-ENTRY(8)
+                    WS-RDN-ENTRY(9)
+                    WS-RDN-ENTRY(10)
+                    WS-RDN-ENTRY(11)
+                    WS-RDN-ENTRY(12)
+                    WS-RDN-ENTRY(13)
+                    WS-RDN-ENTRY(14)
+                    WS-RDN-ENTRY(15)
+                    WS-RDN-ENTRY(16)
+                    WS-RDN-ENTRY(17)
+                    WS-RDN-ENTRY(18)
+                    WS-RDN-ENTRY(19)
+                    WS-RDN-ENTRY(20)
+               TALLYING IN WS-RDN-COUNT
+           END-UNSTRING
+           PERFORM VARYING WS-RDN-INDEX FROM 1 BY 1
+               UNTIL WS-RDN-INDEX > WS-RDN-COUNT
+               INSPECT WS-RDN-ENTRY(WS-RDN-INDEX)
+                   CONVERTING WS-ESCAPED-COMMA-MARK TO ','
+               IF WS-RDN-ENTRY(WS-RDN-INDEX)(1:3) = 'CN='
+                   MOVE WS-RDN-ENTRY(WS-RDN-INDEX)(4:64)
+                       TO WS-PARSED-CN
+               END-IF
+           END-PERFORM
+           IF WS-PARSED-CN(1:1) = '"'
+               MOVE WS-PARSED-CN(2:63) TO WS-PARSED-CN(1:63)
+               MOVE SPACE TO WS-PARSED-CN(64:1)
+           END-IF
+           PERFORM VARYING WS-CN-CHAR-IDX FROM 1 BY 1
+               UNTIL WS-CN-CHAR-IDX > 64
+               IF WS-PARSED-CN(WS-CN-CHAR-IDX:1) = '"'
+                   MOVE SPACE TO WS-PARSED-CN(WS-CN-CHAR-IDX:1)
+               END-IF
+           END-PERFORM
+           IF WS-PARSED-CN NOT = SPACES
+               MOVE WS-PARSED-CN TO WS-SUBJECT-COMMON-NAME
+           END-IF
+           .
+       3500-EXIT.
            EXIT.
        5000-MATCH-HOSTNAME.
            INSPECT WS-SUBJECT-COMMON-NAME

--- a/cobol/_contributor.json
+++ b/cobol/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex GPT-5",
+  "runtime_instructions": "Private system, developer, runtime, and conversation contents are intentionally not included. This submission includes only safe public metadata and no secrets, credentials, private prompts, hidden instructions, or session data.",
+  "timestamp": "2026-06-06T23:16:00Z"
+}

--- a/cobol/subject_dn_escaped_comma_checks.mjs
+++ b/cobol/subject_dn_escaped_comma_checks.mjs
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("cobol/TLS-CERT-VALIDATOR.cbl", "utf8");
+const tests = readFileSync("cobol/tests/subject_dn_escaped_comma_cases.txt", "utf8");
+const contributor = JSON.parse(readFileSync("cobol/_contributor.json", "utf8"));
+
+const checks = [
+  ["parse step called before hostname match", /PERFORM 3500-PARSE-SUBJECT-DN[\s\S]*PERFORM 5000-MATCH-HOSTNAME/.test(source)],
+  ["parsed CN field exists", /01  WS-PARSED-CN\s+PIC X\(64\)/.test(source)],
+  ["RDN table exists", /01  WS-RDN-TABLE\.[\s\S]*WS-RDN-ENTRY\s+PIC X\(128\) OCCURS 20 TIMES/.test(source)],
+  ["RDN table cleared before parse", /MOVE SPACES TO WS-RDN-TABLE/.test(source)],
+  ["escaped comma marker defined", /WS-ESCAPED-COMMA-MARK\s+PIC X\s+VALUE X'1F'/.test(source)],
+  ["escaped comma protected before unstring", source.includes("= '\\,'") && /TO WS-SUBJECT-DN-WORK/.test(source)],
+  ["UNSTRING splits on real commas", /UNSTRING WS-SUBJECT-DN-WORK DELIMITED BY ','/.test(source)],
+  ["RDN count tallied", /TALLYING IN WS-RDN-COUNT/.test(source)],
+  ["escaped commas restored after split", /CONVERTING WS-ESCAPED-COMMA-MARK TO ','/.test(source)],
+  ["CN extracted into parsed field", /IF WS-RDN-ENTRY\(WS-RDN-INDEX\)\(1:3\) = 'CN='[\s\S]*TO WS-PARSED-CN/.test(source)],
+  ["leading quote stripped by shifting content", /IF WS-PARSED-CN\(1:1\) = '"'\s+MOVE WS-PARSED-CN\(2:63\) TO WS-PARSED-CN\(1:63\)/.test(source)],
+  ["parsed CN used by hostname match", /MOVE WS-PARSED-CN TO WS-SUBJECT-COMMON-NAME/.test(source)],
+  ["single comma case documented", tests.includes('CN="Smith\\, John"') && tests.includes("parsed: Smith, John")],
+  ["multiple comma case documented", tests.includes('CN="Smith\\, John\\, Esq"') && tests.includes("parsed: Smith, John, Esq")],
+  ["no comma case documented", tests.includes("CN=payments.example.com") && tests.includes("parsed: payments.example.com")],
+  ["safe contributor metadata", contributor.identity === "Codex GPT-5" && !/paste verbatim|system message|developer message/i.test(contributor.runtime_instructions)],
+];
+
+const failed = checks.filter(([, ok]) => !ok);
+if (failed.length) {
+  console.error(failed.map(([name]) => `FAILED: ${name}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(`COBOL Subject DN escaped comma checks passed (${checks.length})`);

--- a/cobol/tests/subject_dn_escaped_comma_cases.txt
+++ b/cobol/tests/subject_dn_escaped_comma_cases.txt
@@ -1,0 +1,14 @@
+single escaped comma:
+  input:  CN="Smith\, John",OU=Legal,O=Bank
+  parsed: Smith, John
+  count:  3
+
+multiple escaped commas:
+  input:  CN="Smith\, John\, Esq",OU=Legal,O=Bank
+  parsed: Smith, John, Esq
+  count:  3
+
+no escaped commas:
+  input:  CN=payments.example.com,OU=Gateway,O=Bank
+  parsed: payments.example.com
+  count:  3


### PR DESCRIPTION
```text
Private system, developer, runtime, and conversation contents are intentionally not included. This PR includes safe public contributor metadata only and does not publish secrets, hidden instructions, credentials, or session data.
```

/claim #521

## Summary
- Adds `3500-PARSE-SUBJECT-DN` before hostname matching to protect escaped commas before `UNSTRING` and restore them after splitting.
- Clears `WS-RDN-TABLE` and resets `WS-RDN-COUNT` before every parse to prevent stale RDN leakage.
- Extracts `CN=` into `WS-PARSED-CN`, strips quote artifacts, and moves the parsed CN into `WS-SUBJECT-COMMON-NAME` for existing hostname matching.
- Adds focused regression case documentation for single escaped comma, multiple escaped commas, and no escaped comma.
- Includes safe public `_contributor.json` metadata only.

## Validation
- `node cobol/subject_dn_escaped_comma_checks.mjs`
- `git diff --check`

Local environment note: no COBOL compiler (`cobc`) is installed here, so validation is static/structural.

Payment preference: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`