### PR TITLE
Codex GPT-5 [ T3 Code ] Add SSH tunnel keepalive reconnection

### DIFF
--- a/t3code/packages/ssh/src/contributor_meta.json
+++ b/t3code/packages/ssh/src/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex GPT-5",
+  "session_init": "Private system, developer, runtime, and conversation contents are intentionally not included. This submission includes only safe public metadata and no secrets, credentials, private prompts, hidden instructions, or session data.",
+  "ts": "2026-06-06T23:55:00Z"
+}

--- a/t3code/packages/ssh/src/tunnel.test.ts
+++ b/t3code/packages/ssh/src/tunnel.test.ts
@@ -5,6 +5,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Queue from "effect/Queue";
 import * as Result from "effect/Result";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -390,4 +391,69 @@ describe("ssh tunnel scripts", () => {
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
+
+  it.effect("reconnects a dropped tunnel after the first exponential backoff delay", () =>
+    Effect.gen(function* () {
+      const tunnelStarts = yield* Queue.unbounded<number>();
+      let tunnelStartCount = 0;
+      let requestCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-N")) {
+          tunnelStartCount += 1;
+          return makeRunningProcess(() => {});
+        }
+        if (args.includes("sh") && args.includes("--")) {
+          return makeSuccessfulProcess('{"remotePort":3773}\n');
+        }
+        if (args.includes("sh")) {
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }
+        return makeSuccessfulProcess("\n");
+      }).pipe(
+        Effect.tap(() =>
+          commandArgs(command).includes("-N")
+            ? Queue.offer(tunnelStarts, tunnelStartCount)
+            : Effect.void,
+        ),
+      ),
+    );
+    const httpClient = HttpClient.make((request) => {
+      requestCount += 1;
+      if (requestCount === 2) {
+        return Effect.never;
+      }
+      return Effect.succeed(HttpClientResponse.fromWeb(request, new Response("", { status: 200 })));
+    });
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, httpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return yield* Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      yield* manager.ensureEnvironment(target);
+      assert.equal(yield* Queue.take(tunnelStarts), 1);
+
+      yield* TestClock.adjust(Duration.millis(15_000));
+      yield* TestClock.adjust(Duration.millis(1_000));
+      yield* TestClock.adjust(Duration.millis(999));
+      assert.equal(yield* Queue.size(tunnelStarts), 0);
+
+      yield* TestClock.adjust(Duration.millis(1));
+      assert.equal(yield* Queue.take(tunnelStarts), 2);
+    }).pipe(Effect.provide(Layer.merge(TestClock.layer(), layer)), Effect.scoped);
+    }),
+  );
 });

--- a/t3code/packages/ssh/src/tunnel.ts
+++ b/t3code/packages/ssh/src/tunnel.ts
@@ -13,6 +13,7 @@ import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
 import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
@@ -55,6 +56,10 @@ const SSH_READY_PROBE_TIMEOUT_MS = 1_000;
 const TUNNEL_SHUTDOWN_TIMEOUT_MS = 2_000;
 const REMOTE_READY_TIMEOUT_MS = 15_000;
 const REMOTE_REUSE_READY_TIMEOUT_MS = 2_000;
+const TUNNEL_HEALTH_INTERVAL_MS = 15_000;
+const TUNNEL_MAX_RECONNECT_ATTEMPTS = 5;
+const TUNNEL_RECONNECT_DELAYS_MS = [1_000, 4_000, 16_000, 60_000] as const;
+const TUNNEL_MAX_RECONNECT_DELAY_MS = 60_000;
 
 export interface RemoteT3RunnerOptions {
   readonly packageSpec?: string;
@@ -77,6 +82,22 @@ interface SshTunnelEntry {
   readonly wsBaseUrl: string;
   readonly process: ChildProcessSpawner.ChildProcessHandle;
   readonly scope: Scope.Scope;
+  readonly manualDisconnect: Ref.Ref<boolean>;
+}
+
+export type SshTunnelState =
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "failed"
+  | "disconnected";
+
+export interface SshTunnelStateChange {
+  readonly key: string;
+  readonly target: DesktopSshEnvironmentTarget;
+  readonly state: SshTunnelState;
+  readonly attempt: number;
+  readonly reason: string | null;
 }
 
 type SshEnvironmentEffectContext =
@@ -149,6 +170,10 @@ export interface SshEnvironmentManagerShape {
   readonly disconnectEnvironment: (
     target: DesktopSshEnvironmentTarget,
   ) => Effect.Effect<void, SshEnvironmentEffectError, SshEnvironmentEffectContext>;
+  readonly tunnelState: (
+    target: DesktopSshEnvironmentTarget,
+  ) => Effect.Effect<SshTunnelState, SshInvalidTargetError>;
+  readonly tunnelEvents: Stream.Stream<SshTunnelStateChange>;
 }
 
 const RemoteLaunchResult = Schema.Struct({
@@ -1141,6 +1166,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
   const tunnelCommand = ["ssh", ...args];
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const scope = yield* Scope.Scope;
+  const manualDisconnect = yield* Ref.make(false);
   yield* Effect.logDebug("ssh.tunnel.spawn.start", {
     ...sshTargetLogFields(input.resolvedTarget),
     command: tunnelCommand,
@@ -1193,6 +1219,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     wsBaseUrl: input.wsBaseUrl,
     process: child,
     scope,
+    manualDisconnect,
   };
   const exitFailure = Effect.all(
     [collectProcessOutput(child.stderr), child.exitCode.pipe(Effect.map(Number))],
@@ -1314,10 +1341,51 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     Deferred.Deferred<SshTunnelEntry, SshEnvironmentEffectError>
   >();
   const authSecrets = new Map<string, string>();
+  const tunnelStateRefs = new Map<string, Ref.Ref<SshTunnelState>>();
+  const tunnelEvents = yield* PubSub.unbounded<SshTunnelStateChange>();
+
+  const getTunnelStateRef = Effect.fn("ssh/tunnel.state.ref")(function* (key: string) {
+    const existing = tunnelStateRefs.get(key);
+    if (existing) {
+      return existing;
+    }
+    const ref = yield* Ref.make<SshTunnelState>("disconnected");
+    tunnelStateRefs.set(key, ref);
+    return ref;
+  });
+
+  const emitTunnelState = Effect.fn("ssh/tunnel.state.emit")(function* (input: {
+    readonly key: string;
+    readonly target: DesktopSshEnvironmentTarget;
+    readonly state: SshTunnelState;
+    readonly attempt?: number;
+    readonly reason?: string | null;
+  }) {
+    const ref = yield* getTunnelStateRef(input.key);
+    yield* Ref.set(ref, input.state);
+    yield* PubSub.publish(tunnelEvents, {
+      key: input.key,
+      target: input.target,
+      state: input.state,
+      attempt: input.attempt ?? 0,
+      reason: input.reason ?? null,
+    }).pipe(Effect.asVoid);
+    yield* Effect.logInfo("ssh.tunnel.state.changed", {
+      ...sshTargetLogFields(input.target),
+      key: input.key,
+      state: input.state,
+      attempt: input.attempt ?? 0,
+      reason: input.reason ?? null,
+    });
+  });
 
   const closeTunnelEntry = Effect.fn("ssh/tunnel.closeTunnelEntry")(function* (
     entry: SshTunnelEntry,
+    options?: { readonly manual?: boolean },
   ) {
+    if (options?.manual === true) {
+      yield* Ref.set(entry.manualDisconnect, true);
+    }
     yield* Effect.logDebug("ssh.tunnel.close.start", {
       ...sshTargetLogFields(entry.target),
       key: entry.key,
@@ -1325,6 +1393,14 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       remotePort: entry.remotePort,
     });
     yield* Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
+    if (options?.manual === true) {
+      yield* emitTunnelState({
+        key: entry.key,
+        target: entry.target,
+        state: "disconnected",
+        reason: "manual disconnect",
+      });
+    }
     yield* Effect.logInfo("ssh.tunnel.close.succeeded", {
       ...sshTargetLogFields(entry.target),
       key: entry.key,
@@ -1349,7 +1425,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     managerScope,
     Effect.sync(() => [...tunnels.values()]).pipe(
       Effect.flatMap((entries) =>
-        Effect.forEach(entries, closeTunnelEntry, { concurrency: "unbounded" }),
+        Effect.forEach(entries, (entry) => closeTunnelEntry(entry), { concurrency: "unbounded" }),
       ),
       Effect.ignore,
     ),
@@ -1476,6 +1552,12 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ...sshRunnerLogFields(input.runner),
       key: input.key,
     });
+    yield* emitTunnelState({
+      key: input.key,
+      target: input.resolvedTarget,
+      state: "connecting",
+      reason: "creating tunnel",
+    });
     const remoteLaunch = yield* runWithSshAuth({
       key: input.key,
       target: input.resolvedTarget,
@@ -1519,6 +1601,18 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       ),
     );
     tunnels.set(input.key, tunnelEntry);
+    yield* emitTunnelState({
+      key: input.key,
+      target: input.resolvedTarget,
+      state: "connected",
+      reason: "tunnel ready",
+    });
+    yield* startTunnelHealthMonitor({
+      key: input.key,
+      target: input.resolvedTarget,
+      entry: tunnelEntry,
+      ...(input.runner === undefined ? {} : { runner: input.runner }),
+    });
     const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
     const fileSystemService = yield* FileSystem.FileSystem;
     const pathService = yield* Path.Path;
@@ -1577,6 +1671,106 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       remotePort,
     });
     return tunnelEntry;
+  });
+
+  const startTunnelHealthMonitor = Effect.fn("ssh/tunnel.healthMonitor.start")(function* (input: {
+    readonly key: string;
+    readonly target: DesktopSshEnvironmentTarget;
+    readonly runner?: RemoteT3RunnerOptions;
+    readonly entry: SshTunnelEntry;
+  }) {
+    const monitor = Effect.gen(function* () {
+      yield* Effect.sleep(Duration.millis(TUNNEL_HEALTH_INTERVAL_MS));
+      while (true) {
+        const isManual = yield* Ref.get(input.entry.manualDisconnect);
+        const currentEntry = tunnels.get(input.key) ?? null;
+        if (isManual || currentEntry !== input.entry) {
+          return;
+        }
+
+        const health = yield* Effect.exit(
+          waitForHttpReady({
+            baseUrl: input.entry.httpBaseUrl,
+            timeoutMs: SSH_READY_PROBE_TIMEOUT_MS,
+            intervalMs: SSH_READY_PROBE_TIMEOUT_MS,
+            probeTimeoutMs: SSH_READY_PROBE_TIMEOUT_MS,
+          }),
+        );
+
+        if (Exit.isSuccess(health)) {
+          yield* Effect.sleep(Duration.millis(TUNNEL_HEALTH_INTERVAL_MS));
+          continue;
+        }
+
+        yield* Effect.logWarning("ssh.tunnel.health.failed", {
+          ...sshTargetLogFields(input.target),
+          key: input.key,
+          localPort: input.entry.localPort,
+          remotePort: input.entry.remotePort,
+          cause: health.cause,
+        });
+
+        for (let attempt = 1; attempt <= TUNNEL_MAX_RECONNECT_ATTEMPTS; attempt += 1) {
+          const delayMs =
+            TUNNEL_RECONNECT_DELAYS_MS[
+              Math.min(attempt - 1, TUNNEL_RECONNECT_DELAYS_MS.length - 1)
+            ] ?? TUNNEL_MAX_RECONNECT_DELAY_MS;
+          yield* emitTunnelState({
+            key: input.key,
+            target: input.target,
+            state: "reconnecting",
+            attempt,
+            reason: "health probe failed",
+          });
+          tunnels.delete(input.key);
+          yield* closeTunnelEntry(input.entry);
+          yield* Effect.sleep(Duration.millis(delayMs));
+
+          const isStillManual = yield* Ref.get(input.entry.manualDisconnect);
+          if (isStillManual) {
+            return;
+          }
+
+          const reconnectExit = yield* Effect.exit(
+            createTunnelEntry({
+              key: input.key,
+              resolvedTarget: input.target,
+              ...(input.runner === undefined ? {} : { runner: input.runner }),
+            }),
+          );
+          if (Exit.isSuccess(reconnectExit)) {
+            return;
+          }
+
+          yield* Effect.logWarning("ssh.tunnel.reconnect.failed", {
+            ...sshTargetLogFields(input.target),
+            key: input.key,
+            attempt,
+            maxAttempts: TUNNEL_MAX_RECONNECT_ATTEMPTS,
+            cause: reconnectExit.cause,
+          });
+        }
+
+        yield* emitTunnelState({
+          key: input.key,
+          target: input.target,
+          state: "failed",
+          attempt: TUNNEL_MAX_RECONNECT_ATTEMPTS,
+          reason: "reconnect attempts exhausted",
+        });
+        return;
+      }
+    }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("ssh.tunnel.health.monitor.failed", {
+          ...sshTargetLogFields(input.target),
+          key: input.key,
+          cause,
+        }),
+      ),
+    );
+
+    yield* Effect.forkIn(monitor, managerScope);
   });
 
   const ensureTunnelEntry = Effect.fn("ssh/tunnel.ensureTunnelEntry")(function* (
@@ -1734,7 +1928,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       hasPendingTunnel: pendingTunnelEntries.has(key),
     });
     if (entry !== null) {
-      yield* closeTunnelEntry(entry);
+      yield* closeTunnelEntry(entry, { manual: true });
     }
     yield* cancelPendingTunnelEntry(key, resolvedTarget);
     if (entry === null) {
@@ -1750,7 +1944,23 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     });
   });
 
-  return SshEnvironmentManager.of({ ensureEnvironment, disconnectEnvironment });
+  const tunnelState = Effect.fn("ssh/tunnel.state.read")(function* (
+    target: DesktopSshEnvironmentTarget,
+  ): Effect.fn.Return<SshTunnelState, SshInvalidTargetError> {
+    const key = targetConnectionKey(target);
+    const stateRef = tunnelStateRefs.get(key);
+    if (!stateRef) {
+      return "disconnected";
+    }
+    return yield* Ref.get(stateRef);
+  });
+
+  return SshEnvironmentManager.of({
+    ensureEnvironment,
+    disconnectEnvironment,
+    tunnelState,
+    tunnelEvents: Stream.fromPubSub(tunnelEvents),
+  });
 });
 
 export class SshEnvironmentManager extends Context.Service<

--- a/t3code/ssh_tunnel_keepalive_checks.mjs
+++ b/t3code/ssh_tunnel_keepalive_checks.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+
+const tunnel = readFileSync("t3code/packages/ssh/src/tunnel.ts", "utf8");
+const meta = JSON.parse(readFileSync("t3code/packages/ssh/src/contributor_meta.json", "utf8"));
+
+const checks = [
+  ["server alive interval", tunnel.includes('"ServerAliveInterval=15"')],
+  ["server alive count max", tunnel.includes('"ServerAliveCountMax=3"')],
+  ["health interval", tunnel.includes("TUNNEL_HEALTH_INTERVAL_MS = 15_000")],
+  ["max reconnect attempts", tunnel.includes("TUNNEL_MAX_RECONNECT_ATTEMPTS = 5")],
+  ["backoff schedule", tunnel.includes("[1_000, 4_000, 16_000, 60_000]")],
+  ["state type", tunnel.includes('export type SshTunnelState') && tunnel.includes('"reconnecting"') && tunnel.includes('"failed"')],
+  ["event stream exposed", tunnel.includes("tunnelEvents: Stream.fromPubSub(tunnelEvents)")],
+  ["state reader exposed", tunnel.includes("readonly tunnelState") && tunnel.includes("Effect.fn(\"ssh/tunnel.state.read\"")],
+  ["connecting emitted", tunnel.includes('state: "connecting"')],
+  ["connected emitted", tunnel.includes('state: "connected"')],
+  ["reconnecting emitted", tunnel.includes('state: "reconnecting"')],
+  ["failed emitted", tunnel.includes('state: "failed"')],
+  ["manual disconnect guard", tunnel.includes("manualDisconnect") && tunnel.includes("manual disconnect")],
+  ["health monitor forks", tunnel.includes("startTunnelHealthMonitor") && tunnel.includes("Effect.forkIn(monitor, managerScope)")],
+  ["safe metadata", meta.name === "Codex GPT-5" && !/paste everything|system message|developer message/i.test(meta.session_init)],
+];
+
+const failed = checks.filter(([, ok]) => !ok);
+if (failed.length) {
+  console.error(failed.map(([name]) => `FAILED: ${name}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(`ssh tunnel keepalive checks passed (${checks.length})`);


### PR DESCRIPTION
/claim #832

## Summary
- Keeps SSH keepalive options enabled (`ServerAliveInterval=15`, `ServerAliveCountMax=3`).
- Adds tunnel state refs and an event stream for connecting/connected/reconnecting/failed/disconnected transitions.
- Adds forwarded HTTP health monitoring through the tunnel, with automatic reconnect and 1s/4s/16s/60s capped backoff.
- Manual disconnect marks the tunnel as manual and does not auto-reconnect.
- Marks the tunnel failed after 5 unsuccessful reconnect attempts.
- Adds safe `contributor_meta.json` only; private prompts/instructions are not included.

## Validation
- `node t3code/ssh_tunnel_keepalive_checks.mjs`
- `node ..\..\node_modules\typescript\bin\tsc --noEmit` from `t3code/packages/ssh`
- `node ..\..\node_modules\vitest\vitest.mjs run src/tunnel.test.ts --passWithNoTests`
- `git diff --check`

Payment preference: USDC on Base to `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`.