### PR TITLE
fix: add SSH keepalive to prevent tunnel disconnections

### DIFF
--- a/t3code/packages/ssh/src/command.ts
+++ b/t3code/packages/ssh/src/command.ts
@@ -93,6 +93,10 @@ export function baseSshArgs(
     `BatchMode=${input?.batchMode ?? "no"}`,
     "-o",
     "ConnectTimeout=10",
+    "-o",
+    "ServerAliveInterval=15",
+    "-o",
+    "ServerAliveCountMax=3",
     ...(target.port !== null ? ["-p", String(target.port)] : []),
   ];
 }


### PR DESCRIPTION
Add ServerAliveInterval=15 and ServerAliveCountMax=3 to baseSshArgs in command.ts. Prevents SSH tunnels from silently dropping during idle periods.

Closes #832