### PR TITLE
Codex GPT-5 [ T3 Code ] Standardize server error types

### DIFF
--- a/t3code/apps/server/src/_meta.json
+++ b/t3code/apps/server/src/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "generation_context": "Safe public metadata only. Private system, developer, tool, runtime, and session initialization instructions are intentionally not included.",
+  "completed_at": "2026-06-06T23:59:00Z"
+}

--- a/t3code/apps/server/src/bootstrap.ts
+++ b/t3code/apps/server/src/bootstrap.ts
@@ -4,18 +4,13 @@ import * as Net from "node:net";
 import * as readline from "node:readline";
 import type { Readable } from "node:stream";
 
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
-
-class BootstrapError extends Data.TaggedError("BootstrapError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+import { BootstrapError } from "./errors.ts";
 
 export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function* <A, I>(
   schema: Schema.Codec<A, I>,

--- a/t3code/apps/server/src/errors.test.ts
+++ b/t3code/apps/server/src/errors.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Match from "effect/Match";
+
+import {
+  AuthError,
+  ConfigError,
+  DatabaseError,
+  GitError,
+  NetworkError,
+  ValidationError,
+  errorToLog,
+  errorToResponse,
+  makeAuthError,
+  makeConfigError,
+  makeDatabaseError,
+  makeGitError,
+  makeNetworkError,
+  makeValidationError,
+  ProcessTimeoutError,
+} from "./errors.ts";
+
+const fixedTimestamp = "2026-06-06T23:59:00.000Z";
+
+describe("server errors", () => {
+  it("maps all standard server error tags to HTTP responses", () => {
+    const errors = [
+      [new AuthError({ message: "auth", timestamp: fixedTimestamp }), 401],
+      [new ValidationError({ message: "validation", timestamp: fixedTimestamp }), 400],
+      [new DatabaseError({ message: "database", timestamp: fixedTimestamp }), 500],
+      [new NetworkError({ message: "network", timestamp: fixedTimestamp }), 502],
+      [new ConfigError({ message: "config", timestamp: fixedTimestamp }), 500],
+      [new GitError({ message: "git", timestamp: fixedTimestamp }), 422],
+    ] as const;
+
+    for (const [error, status] of errors) {
+      expect(errorToResponse(error)).toEqual({
+        status,
+        body: {
+          error: error._tag,
+          message: error.message,
+          timestamp: fixedTimestamp,
+        },
+      });
+    }
+  });
+
+  it("constructors attach timestamps and preserve cause chains", () => {
+    const cause = new Error("root cause");
+    const error = makeDatabaseError({
+      message: "database unavailable",
+      cause,
+      timestamp: fixedTimestamp,
+    });
+
+    expect(error._tag).toBe("DatabaseError");
+    expect(error.cause).toBe(cause);
+    expect(error.timestamp).toBe(fixedTimestamp);
+  });
+
+  it("formats structured log records with tag, message, stack, cause, and timestamp", () => {
+    const cause = { code: "ECONNREFUSED" };
+    const error = makeNetworkError({
+      message: "upstream failed",
+      cause,
+      timestamp: fixedTimestamp,
+    });
+    const log = errorToLog(error);
+
+    expect(log).toMatchObject({
+      tag: "NetworkError",
+      category: "NetworkError",
+      message: "upstream failed",
+      timestamp: fixedTimestamp,
+      cause,
+    });
+    expect(typeof log.stack).toBe("string");
+  });
+
+  it("supports Effect.Match pattern matching by error tag", () => {
+    const classify = (error:
+      | AuthError
+      | ValidationError
+      | DatabaseError
+      | NetworkError
+      | ConfigError
+      | GitError) =>
+      Match.value(error).pipe(
+        Match.tag("AuthError", () => "auth"),
+        Match.tag("ValidationError", () => "validation"),
+        Match.tag("DatabaseError", () => "database"),
+        Match.tag("NetworkError", () => "network"),
+        Match.tag("ConfigError", () => "config"),
+        Match.tag("GitError", () => "git"),
+        Match.exhaustive,
+      );
+
+    expect(classify(makeAuthError({ message: "auth", timestamp: fixedTimestamp }))).toBe("auth");
+    expect(
+      classify(makeValidationError({ message: "validation", timestamp: fixedTimestamp })),
+    ).toBe("validation");
+    expect(classify(makeDatabaseError({ message: "database", timestamp: fixedTimestamp }))).toBe(
+      "database",
+    );
+    expect(classify(makeNetworkError({ message: "network", timestamp: fixedTimestamp }))).toBe(
+      "network",
+    );
+    expect(classify(makeConfigError({ message: "config", timestamp: fixedTimestamp }))).toBe(
+      "config",
+    );
+    expect(classify(makeGitError({ message: "git", timestamp: fixedTimestamp }))).toBe("git");
+  });
+
+  it("keeps migrated process errors tagged for existing process matching while adding category metadata", () => {
+    const error = new ProcessTimeoutError({
+      command: "git",
+      args: ["status"],
+      timeoutMs: 15000,
+      timestamp: fixedTimestamp,
+    });
+
+    expect(error._tag).toBe("ProcessTimeoutError");
+    expect(error.category).toBe("NetworkError");
+    expect(error.timestamp).toBe(fixedTimestamp);
+  });
+});

--- a/t3code/apps/server/src/errors.ts
+++ b/t3code/apps/server/src/errors.ts
@@ -1,0 +1,253 @@
+import * as Data from "effect/Data";
+
+// Effect v4 exposes Data.TaggedError at runtime; this module centralizes the
+// server error tagged union that issue text describes as Effect.Data.TaggedEnum.
+export type ServerErrorCategory =
+  | "AuthError"
+  | "ValidationError"
+  | "DatabaseError"
+  | "NetworkError"
+  | "ConfigError"
+  | "GitError";
+
+export interface ServerErrorFields {
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly timestamp: string;
+}
+
+export class AuthError extends Data.TaggedError("AuthError")<ServerErrorFields> {}
+export class ValidationError extends Data.TaggedError("ValidationError")<ServerErrorFields> {}
+export class DatabaseError extends Data.TaggedError("DatabaseError")<ServerErrorFields> {}
+export class NetworkError extends Data.TaggedError("NetworkError")<ServerErrorFields> {}
+export class ConfigError extends Data.TaggedError("ConfigError")<ServerErrorFields> {}
+export class GitError extends Data.TaggedError("GitError")<ServerErrorFields> {}
+
+export type StandardServerError =
+  | AuthError
+  | ValidationError
+  | DatabaseError
+  | NetworkError
+  | ConfigError
+  | GitError;
+
+export interface ServerHttpErrorResponse {
+  readonly status: 400 | 401 | 422 | 500 | 502;
+  readonly body: {
+    readonly error: ServerErrorCategory;
+    readonly message: string;
+    readonly timestamp: string;
+  };
+}
+
+export interface ServerErrorLogRecord {
+  readonly tag: string;
+  readonly category: ServerErrorCategory;
+  readonly message: string;
+  readonly timestamp: string;
+  readonly stack?: string;
+  readonly cause?: unknown;
+}
+
+export const nowTimestamp = (): string => new Date().toISOString();
+
+export const makeAuthError = (
+  input: Omit<ServerErrorFields, "timestamp"> & { readonly timestamp?: string },
+): AuthError => new AuthError({ ...input, timestamp: input.timestamp ?? nowTimestamp() });
+
+export const makeValidationError = (
+  input: Omit<ServerErrorFields, "timestamp"> & { readonly timestamp?: string },
+): ValidationError =>
+  new ValidationError({ ...input, timestamp: input.timestamp ?? nowTimestamp() });
+
+export const makeDatabaseError = (
+  input: Omit<ServerErrorFields, "timestamp"> & { readonly timestamp?: string },
+): DatabaseError =>
+  new DatabaseError({ ...input, timestamp: input.timestamp ?? nowTimestamp() });
+
+export const makeNetworkError = (
+  input: Omit<ServerErrorFields, "timestamp"> & { readonly timestamp?: string },
+): NetworkError => new NetworkError({ ...input, timestamp: input.timestamp ?? nowTimestamp() });
+
+export const makeConfigError = (
+  input: Omit<ServerErrorFields, "timestamp"> & { readonly timestamp?: string },
+): ConfigError => new ConfigError({ ...input, timestamp: input.timestamp ?? nowTimestamp() });
+
+export const makeGitError = (
+  input: Omit<ServerErrorFields, "timestamp"> & { readonly timestamp?: string },
+): GitError => new GitError({ ...input, timestamp: input.timestamp ?? nowTimestamp() });
+
+export function errorToResponse(error: StandardServerError): ServerHttpErrorResponse {
+  const statusByTag: Record<ServerErrorCategory, ServerHttpErrorResponse["status"]> = {
+    AuthError: 401,
+    ValidationError: 400,
+    DatabaseError: 500,
+    NetworkError: 502,
+    ConfigError: 500,
+    GitError: 422,
+  };
+
+  return {
+    status: statusByTag[error._tag],
+    body: {
+      error: error._tag,
+      message: error.message,
+      timestamp: error.timestamp,
+    },
+  };
+}
+
+export function errorToLog(error: StandardServerError): ServerErrorLogRecord {
+  return {
+    tag: error._tag,
+    category: error._tag,
+    message: error.message,
+    timestamp: error.timestamp,
+    ...(error.stack ? { stack: error.stack } : {}),
+    ...(error.cause !== undefined ? { cause: error.cause } : {}),
+  };
+}
+
+export class BootstrapError extends ConfigError {
+  constructor(input: Omit<ServerErrorFields, "timestamp"> & { readonly timestamp?: string }) {
+    super({ ...input, timestamp: input.timestamp ?? nowTimestamp() });
+  }
+}
+
+export class DecodeOtlpTraceRecordsError extends ValidationError {
+  readonly bodyJson: unknown;
+
+  constructor(input: Omit<ServerErrorFields, "timestamp"> & { readonly bodyJson: unknown }) {
+    super({ message: input.message, cause: input.cause, timestamp: nowTimestamp() });
+    this.bodyJson = input.bodyJson;
+  }
+}
+
+export class ProcessSpawnError extends Data.TaggedError("ProcessSpawnError")<{
+  readonly category: "NetworkError";
+  readonly message: string;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string | undefined;
+  readonly cause: unknown;
+  readonly timestamp: string;
+}> {
+  constructor(input: {
+    readonly command: string;
+    readonly args: ReadonlyArray<string>;
+    readonly cwd?: string | undefined;
+    readonly cause: unknown;
+    readonly timestamp?: string;
+  }) {
+    super({
+      ...input,
+      category: "NetworkError",
+      message: `Failed to spawn process: ${input.command}`,
+      timestamp: input.timestamp ?? nowTimestamp(),
+    });
+  }
+}
+
+export class ProcessStdinError extends Data.TaggedError("ProcessStdinError")<{
+  readonly category: "NetworkError";
+  readonly message: string;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string | undefined;
+  readonly cause: unknown;
+  readonly timestamp: string;
+}> {
+  constructor(input: {
+    readonly command: string;
+    readonly args: ReadonlyArray<string>;
+    readonly cwd?: string | undefined;
+    readonly cause: unknown;
+    readonly timestamp?: string;
+  }) {
+    super({
+      ...input,
+      category: "NetworkError",
+      message: `Failed to write stdin for process: ${input.command}`,
+      timestamp: input.timestamp ?? nowTimestamp(),
+    });
+  }
+}
+
+export class ProcessOutputLimitError extends Data.TaggedError("ProcessOutputLimitError")<{
+  readonly category: "NetworkError";
+  readonly message: string;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string | undefined;
+  readonly stream: "stdout" | "stderr";
+  readonly maxBytes: number;
+  readonly timestamp: string;
+}> {
+  constructor(input: {
+    readonly command: string;
+    readonly args: ReadonlyArray<string>;
+    readonly cwd?: string | undefined;
+    readonly stream: "stdout" | "stderr";
+    readonly maxBytes: number;
+    readonly timestamp?: string;
+  }) {
+    super({
+      ...input,
+      category: "NetworkError",
+      message: `Process ${input.stream} exceeded ${input.maxBytes} bytes: ${input.command}`,
+      timestamp: input.timestamp ?? nowTimestamp(),
+    });
+  }
+}
+
+export class ProcessReadError extends Data.TaggedError("ProcessReadError")<{
+  readonly category: "NetworkError";
+  readonly message: string;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string | undefined;
+  readonly stream: "stdout" | "stderr" | "exitCode";
+  readonly cause: unknown;
+  readonly timestamp: string;
+}> {
+  constructor(input: {
+    readonly command: string;
+    readonly args: ReadonlyArray<string>;
+    readonly cwd?: string | undefined;
+    readonly stream: "stdout" | "stderr" | "exitCode";
+    readonly cause: unknown;
+    readonly timestamp?: string;
+  }) {
+    super({
+      ...input,
+      category: "NetworkError",
+      message: `Failed to read process ${input.stream}: ${input.command}`,
+      timestamp: input.timestamp ?? nowTimestamp(),
+    });
+  }
+}
+
+export class ProcessTimeoutError extends Data.TaggedError("ProcessTimeoutError")<{
+  readonly category: "NetworkError";
+  readonly message: string;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string | undefined;
+  readonly timeoutMs: number;
+  readonly timestamp: string;
+}> {
+  constructor(input: {
+    readonly command: string;
+    readonly args: ReadonlyArray<string>;
+    readonly cwd?: string | undefined;
+    readonly timeoutMs: number;
+    readonly timestamp?: string;
+  }) {
+    super({
+      ...input,
+      category: "NetworkError",
+      message: `Process timed out after ${input.timeoutMs}ms: ${input.command}`,
+      timestamp: input.timestamp ?? nowTimestamp(),
+    });
+  }
+}

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,6 +1,5 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -33,6 +32,7 @@ import {
   browserApiCorsAllowedMethods,
   browserApiCorsHeaders,
 } from "./httpCors.ts";
+import { DecodeOtlpTraceRecordsError } from "./errors.ts";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
@@ -81,11 +81,6 @@ export const serverEnvironmentRouteLayer = HttpRouter.add(
   }),
 );
 
-class DecodeOtlpTraceRecordsError extends Data.TaggedError("DecodeOtlpTraceRecordsError")<{
-  readonly cause: unknown;
-  readonly bodyJson: OtlpTracer.TraceData;
-}> {}
-
 export const otlpTracesProxyRouteLayer = HttpRouter.add(
   "POST",
   OTLP_TRACES_PROXY_PATH,
@@ -100,7 +95,12 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),
-      catch: (cause) => new DecodeOtlpTraceRecordsError({ cause, bodyJson }),
+      catch: (cause) =>
+        new DecodeOtlpTraceRecordsError({
+          message: "Failed to decode browser OTLP traces.",
+          cause,
+          bodyJson,
+        }),
     }).pipe(
       Effect.flatMap((records) => browserTraceCollector.record(records)),
       Effect.catch((cause) =>

--- a/t3code/apps/server/src/processRunner.ts
+++ b/t3code/apps/server/src/processRunner.ts
@@ -1,4 +1,3 @@
-import * as Data from "effect/Data";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -12,6 +11,13 @@ import {
   collectUint8StreamText,
   type CollectedUint8StreamText,
 } from "./stream/collectUint8StreamText.ts";
+import {
+  ProcessOutputLimitError,
+  ProcessReadError,
+  ProcessSpawnError,
+  ProcessStdinError,
+  ProcessTimeoutError,
+} from "./errors.ts";
 
 export interface ProcessRunInput {
   readonly command: string;
@@ -41,42 +47,13 @@ export interface ProcessRunOutput {
   readonly stderrTruncated: boolean;
 }
 
-export class ProcessSpawnError extends Data.TaggedError("ProcessSpawnError")<{
-  readonly command: string;
-  readonly args: ReadonlyArray<string>;
-  readonly cwd?: string | undefined;
-  readonly cause: unknown;
-}> {}
-
-export class ProcessStdinError extends Data.TaggedError("ProcessStdinError")<{
-  readonly command: string;
-  readonly args: ReadonlyArray<string>;
-  readonly cwd?: string | undefined;
-  readonly cause: unknown;
-}> {}
-
-export class ProcessOutputLimitError extends Data.TaggedError("ProcessOutputLimitError")<{
-  readonly command: string;
-  readonly args: ReadonlyArray<string>;
-  readonly cwd?: string | undefined;
-  readonly stream: "stdout" | "stderr";
-  readonly maxBytes: number;
-}> {}
-
-export class ProcessReadError extends Data.TaggedError("ProcessReadError")<{
-  readonly command: string;
-  readonly args: ReadonlyArray<string>;
-  readonly cwd?: string | undefined;
-  readonly stream: "stdout" | "stderr" | "exitCode";
-  readonly cause: unknown;
-}> {}
-
-export class ProcessTimeoutError extends Data.TaggedError("ProcessTimeoutError")<{
-  readonly command: string;
-  readonly args: ReadonlyArray<string>;
-  readonly cwd?: string | undefined;
-  readonly timeoutMs: number;
-}> {}
+export {
+  ProcessOutputLimitError,
+  ProcessReadError,
+  ProcessSpawnError,
+  ProcessStdinError,
+  ProcessTimeoutError,
+} from "./errors.ts";
 
 export type ProcessRunError =
   | ProcessSpawnError

--- a/t3code/server_errors_checks.mjs
+++ b/t3code/server_errors_checks.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const errors = read("apps/server/src/errors.ts");
+const bootstrap = read("apps/server/src/bootstrap.ts");
+const processRunner = read("apps/server/src/processRunner.ts");
+const http = read("apps/server/src/http.ts");
+const tests = read("apps/server/src/errors.test.ts");
+
+for (const tag of [
+  "AuthError",
+  "ValidationError",
+  "DatabaseError",
+  "NetworkError",
+  "ConfigError",
+  "GitError",
+]) {
+  assert.match(errors, new RegExp(`class ${tag} extends Data\\.TaggedError\\("${tag}"\\)`));
+  assert.match(errors, new RegExp(`${tag}:\\s*(401|400|422|500|502)`));
+  assert.match(tests, new RegExp(`${tag}`));
+}
+
+assert.match(errors, /function errorToResponse/);
+assert.match(errors, /function errorToLog/);
+assert.match(errors, /readonly timestamp: string/);
+assert.match(errors, /readonly cause\?: unknown/);
+assert.match(tests, /Match\.tag\("AuthError"/);
+assert.match(tests, /cause chains/);
+
+assert.match(bootstrap, /import \{ BootstrapError \} from "\.\/errors\.ts";/);
+assert.match(processRunner, /from "\.\/errors\.ts";/);
+assert.match(http, /import \{ DecodeOtlpTraceRecordsError \} from "\.\/errors\.ts";/);
+
+console.log("server error standardization checks passed");


### PR DESCRIPTION
﻿/claim #861

## Summary
- Adds `t3code/apps/server/src/errors.ts` as the centralized server error module with Auth, Validation, Database, Network, Config, and Git categories.
- Adds `errorToResponse` and `errorToLog` helpers with the requested status-code mapping and structured log shape.
- Migrates three server modules to the centralized error definitions: bootstrap, process runner, and HTTP OTLP trace decode handling.
- Keeps existing process error `_tag` values for compatibility while adding category/timestamp metadata.
- Adds tests for all mappings, cause preservation, structured logs, and Effect.Match tag matching.
- Adds safe public `_meta.json` only; private initialization text is intentionally not included.

## Validation
- `node t3code/server_errors_checks.mjs`
- `node ..\..\node_modules\vitest\vitest.mjs run src/errors.test.ts src/processRunner.test.ts --passWithNoTests` from `t3code/apps/server`
- `node ..\..\node_modules\typescript\bin\tsc --noEmit` from `t3code/apps/server`
- `git diff --check`

Note: `src/bootstrap.test.ts` has existing Windows-only local failures because it opens `/dev/null` and shells out to `mkfifo`, which are unavailable in this environment; the server typecheck and focused tests above pass.

Payment preference: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`.
