### PR TITLE
Codex GPT-5 [ T3 Code ] Add runtime provider config validation

### DIFF
--- a/t3code/packages/contracts/src/.attribution.json
+++ b/t3code/packages/contracts/src/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Safe public metadata only. Private system, developer, tool, runtime, and session initialization instructions are intentionally not included.",
+  "date": "2026-06-07T00:05:00Z"
+}

--- a/t3code/packages/contracts/src/index.ts
+++ b/t3code/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@ export * from "./ipc.ts";
 export * from "./terminal.ts";
 export * from "./provider.ts";
 export * from "./providerInstance.ts";
+export * from "./providerConfigValidation.ts";
 export * from "./providerRuntime.ts";
 export * from "./model.ts";
 export * from "./keybindings.ts";

--- a/t3code/packages/contracts/src/providerConfigValidation.test.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+
+import {
+  ProviderConfigError,
+  validateProviderConfigUnknown,
+} from "./providerConfigValidation.ts";
+
+const validConfig = {
+  driver: "codex",
+  environment: [
+    {
+      name: "OPENAI_API_KEY",
+      value: "sk-valid-key-12345",
+      sensitive: true,
+    },
+    {
+      name: "OPENAI_BASE_URL",
+      value: "https://api.openai.com/v1",
+      sensitive: false,
+    },
+  ],
+  config: {
+    endpointUrl: "https://api.example.com",
+    nested: {
+      apiToken: "token-value-12345",
+    },
+  },
+};
+
+function failureMessages(input: unknown): ReadonlyArray<ProviderConfigError> {
+  const result = validateProviderConfigUnknown(input);
+  expect(Result.isFailure(result)).toBe(true);
+  return Option.getOrThrow(Result.getFailure(result));
+}
+
+describe("provider config validation", () => {
+  it("accepts valid provider configuration", () => {
+    const result = validateProviderConfigUnknown(validConfig);
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(Option.getOrThrow(Result.getSuccess(result)).driver).toBe("codex");
+  });
+
+  it("rejects empty and short API keys", () => {
+    const errors = failureMessages({
+      ...validConfig,
+      environment: [{ name: "OPENAI_API_KEY", value: "", sensitive: true }],
+      config: { apiKey: "short" },
+    });
+
+    expect(errors).toHaveLength(2);
+    expect(errors.map((error) => error.field)).toEqual(["environment.OPENAI_API_KEY", "config.apiKey"]);
+    expect(errors.every((error) => error.message.includes("at least 10"))).toBe(true);
+  });
+
+  it("rejects HTTP URLs with a clear HTTPS message", () => {
+    const errors = failureMessages({
+      ...validConfig,
+      config: { endpointUrl: "http://api.example.com" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.field).toBe("config.endpointUrl");
+    expect(errors[0]?.message).toContain("HTTPS");
+  });
+
+  it("rejects malformed endpoint URLs", () => {
+    const errors = failureMessages({
+      ...validConfig,
+      environment: [{ name: "PROVIDER_ENDPOINT", value: "not a url", sensitive: false }],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toContain("malformed");
+  });
+
+  it("returns all validation errors at once", () => {
+    const errors = failureMessages({
+      ...validConfig,
+      environment: [
+        { name: "OPENAI_API_KEY", value: "short", sensitive: true },
+        { name: "OPENAI_BASE_URL", value: "http://api.example.com", sensitive: false },
+      ],
+      config: {
+        endpointUrl: "notaurl",
+        nested: { apiToken: "" },
+      },
+    });
+
+    expect(errors.map((error) => error.field)).toEqual([
+      "environment.OPENAI_API_KEY",
+      "environment.OPENAI_BASE_URL",
+      "config.endpointUrl",
+      "config.nested.apiToken",
+    ]);
+  });
+
+  it("maps Effect Schema decode failures to ProviderConfigError", () => {
+    const errors = failureMessages({ driver: "not a valid driver slug!" });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProviderConfigError);
+    expect(errors[0]?.field).toBe("config");
+    expect(errors[0]?.expected).toBe("ProviderInstanceConfig schema");
+  });
+});

--- a/t3code/packages/contracts/src/providerConfigValidation.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.ts
@@ -1,0 +1,174 @@
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+
+import { ProviderInstanceConfig } from "./providerInstance.ts";
+
+const API_KEY_FIELD_PATTERN = /(?:api[_-]?key|apiKey|token|secret|credential)/i;
+const ENDPOINT_FIELD_PATTERN = /(?:endpoint|url|base[_-]?url|api[_-]?url)/i;
+const API_KEY_MIN_LENGTH = 10;
+
+export class ProviderConfigError extends Schema.TaggedErrorClass<ProviderConfigError>()(
+  "ProviderConfigError",
+  {
+    field: Schema.String,
+    invalidValue: Schema.Unknown,
+    expected: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export type ProviderConfigValidationResult = Result.Result<
+  ProviderInstanceConfig,
+  ReadonlyArray<ProviderConfigError>
+>;
+
+export const ProviderApiKeyValue = Schema.String.check(
+  Schema.isMinLength(API_KEY_MIN_LENGTH),
+);
+
+export const ProviderHttpsEndpointUrl = Schema.String.check(
+  Schema.isPattern(/^https:\/\/[^/\s]+(?:\/.*)?$/),
+);
+
+function makeError(input: {
+  readonly field: string;
+  readonly invalidValue: unknown;
+  readonly expected: string;
+  readonly message: string;
+}): ProviderConfigError {
+  return new ProviderConfigError(input);
+}
+
+function validateApiKey(field: string, value: unknown): ProviderConfigError | null {
+  if (typeof value !== "string") {
+    return makeError({
+      field,
+      invalidValue: value,
+      expected: `string API key with at least ${API_KEY_MIN_LENGTH} characters`,
+      message: "API key fields must be strings.",
+    });
+  }
+
+  if (value.trim().length < API_KEY_MIN_LENGTH) {
+    return makeError({
+      field,
+      invalidValue: value,
+      expected: `non-empty API key with at least ${API_KEY_MIN_LENGTH} characters`,
+      message: `API key must be at least ${API_KEY_MIN_LENGTH} characters long.`,
+    });
+  }
+
+  return null;
+}
+
+function validateEndpoint(field: string, value: unknown): ProviderConfigError | null {
+  if (typeof value !== "string") {
+    return makeError({
+      field,
+      invalidValue: value,
+      expected: "valid HTTPS URL with hostname",
+      message: "Endpoint URL fields must be strings.",
+    });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return makeError({
+      field,
+      invalidValue: value,
+      expected: "valid HTTPS URL with hostname",
+      message: "Endpoint URL is malformed.",
+    });
+  }
+
+  if (parsed.protocol === "http:") {
+    return makeError({
+      field,
+      invalidValue: value,
+      expected: "HTTPS URL",
+      message: "Endpoint URL must use HTTPS, not HTTP.",
+    });
+  }
+
+  if (parsed.protocol !== "https:" || parsed.hostname.trim().length === 0) {
+    return makeError({
+      field,
+      invalidValue: value,
+      expected: "valid HTTPS URL with hostname",
+      message: "Endpoint URL must be a valid HTTPS URL with a hostname.",
+    });
+  }
+
+  return null;
+}
+
+function isPlainObject(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectConfigErrors(
+  value: unknown,
+  path: string,
+  errors: Array<ProviderConfigError>,
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => collectConfigErrors(entry, `${path}[${index}]`, errors));
+    return;
+  }
+
+  if (!isPlainObject(value)) return;
+
+  for (const [key, child] of Object.entries(value)) {
+    const field = path.length > 0 ? `${path}.${key}` : key;
+    if (API_KEY_FIELD_PATTERN.test(key)) {
+      const error = validateApiKey(field, child);
+      if (error) errors.push(error);
+    }
+    if (ENDPOINT_FIELD_PATTERN.test(key)) {
+      const error = validateEndpoint(field, child);
+      if (error) errors.push(error);
+    }
+    collectConfigErrors(child, field, errors);
+  }
+}
+
+function validateDecodedProviderConfig(decoded: ProviderInstanceConfig): ProviderConfigValidationResult {
+  const errors: Array<ProviderConfigError> = [];
+
+  for (const environmentVariable of decoded.environment ?? []) {
+    const field = `environment.${environmentVariable.name}`;
+    if (API_KEY_FIELD_PATTERN.test(environmentVariable.name)) {
+      const error = validateApiKey(field, environmentVariable.value);
+      if (error) errors.push(error);
+    }
+    if (ENDPOINT_FIELD_PATTERN.test(environmentVariable.name)) {
+      const error = validateEndpoint(field, environmentVariable.value);
+      if (error) errors.push(error);
+    }
+  }
+
+  collectConfigErrors(decoded.config, "config", errors);
+
+  return errors.length > 0 ? Result.fail(errors) : Result.succeed(decoded);
+}
+
+export function validateProviderConfig(input: unknown): ProviderConfigValidationResult {
+  try {
+    return validateDecodedProviderConfig(Schema.decodeUnknownSync(ProviderInstanceConfig)(input));
+  } catch (cause) {
+    return Result.fail([
+      makeError({
+        field: "config",
+        invalidValue: input,
+        expected: "ProviderInstanceConfig schema",
+        message: `Provider config failed schema validation: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      }),
+    ]);
+  }
+}
+
+export const validateProviderConfigUnknown = validateProviderConfig;

--- a/t3code/provider_config_validation_checks.mjs
+++ b/t3code/provider_config_validation_checks.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const source = read("packages/contracts/src/providerConfigValidation.ts");
+const tests = read("packages/contracts/src/providerConfigValidation.test.ts");
+const index = read("packages/contracts/src/index.ts");
+
+for (const needle of [
+  "ProviderConfigError",
+  "ProviderApiKeyValue",
+  "ProviderHttpsEndpointUrl",
+  "validateProviderConfig",
+  "Result.fail(errors)",
+  "HTTPS, not HTTP",
+  "ProviderInstanceConfig schema",
+  "invalidValue",
+  "expected",
+  "field",
+]) {
+  assert.ok(source.includes(needle), `${needle} missing from provider config validation`);
+}
+
+for (const testName of [
+  "accepts valid provider configuration",
+  "rejects empty and short API keys",
+  "rejects HTTP URLs",
+  "rejects malformed endpoint URLs",
+  "returns all validation errors at once",
+  "maps Effect Schema decode failures",
+]) {
+  assert.ok(tests.includes(testName), `${testName} test missing`);
+}
+
+assert.ok(index.includes('export * from "./providerConfigValidation.ts";'));
+
+console.log("provider config validation checks passed");


### PR DESCRIPTION
﻿/claim #825

## Summary
- Adds contracts-level provider config runtime validation while preserving the existing opaque provider config envelope.
- Adds `ProviderConfigError`, `ProviderApiKeyValue`, `ProviderHttpsEndpointUrl`, and `validateProviderConfig`.
- Validates API-key-like fields in `environment` and nested `config` payloads, rejecting empty or shorter-than-10-character values.
- Validates endpoint/url-like fields, rejecting malformed URLs and HTTP URLs with a clear HTTPS message.
- Aggregates all validation errors at once and maps schema decode failures to `ProviderConfigError`.
- Exports the validation module from `@t3tools/contracts`.
- Adds safe public `.attribution.json` only; private initialization text is intentionally not included.

## Validation
- `node t3code/provider_config_validation_checks.mjs`
- `node ..\..\node_modules\vitest\vitest.mjs run src/providerConfigValidation.test.ts --passWithNoTests` from `t3code/packages/contracts`
- `node ..\..\node_modules\typescript\bin\tsc --noEmit` from `t3code/packages/contracts`
- `git diff --check`

Payment preference: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`.
