### PR TITLE
Codex GPT-5 [ T3 Code ] Add rebase conflict handling

### DIFF
--- a/t3code/apps/server/src/git/GitManager.ts
+++ b/t3code/apps/server/src/git/GitManager.ts
@@ -29,6 +29,9 @@ import {
   type VcsStatusRemoteResult,
   VcsStatusResult,
   ModelSelection,
+  type VcsRebaseConflictStatusResult,
+  type VcsRebaseInput,
+  type VcsRebaseResult,
 } from "@t3tools/contracts";
 import {
   detectSourceControlProviderFromGitRemoteUrl,
@@ -71,6 +74,14 @@ export interface GitManagerShape {
   readonly remoteStatus: (
     input: VcsStatusInput,
   ) => Effect.Effect<VcsStatusRemoteResult | null, GitManagerServiceError>;
+  readonly rebaseCurrentBranch: (
+    input: VcsRebaseInput,
+  ) => Effect.Effect<VcsRebaseResult, GitManagerServiceError>;
+  readonly getRebaseConflictStatus: (
+    cwd: string,
+  ) => Effect.Effect<VcsRebaseConflictStatusResult, GitManagerServiceError>;
+  readonly abortRebase: (cwd: string) => Effect.Effect<void, GitManagerServiceError>;
+  readonly continueRebase: (cwd: string) => Effect.Effect<void, GitManagerServiceError>;
   readonly invalidateLocalStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly invalidateRemoteStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly invalidateStatus: (cwd: string) => Effect.Effect<void, never>;
@@ -1375,6 +1386,39 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     },
   );
 
+  const rebaseCurrentBranch: GitManagerShape["rebaseCurrentBranch"] = Effect.fn(
+    "rebaseCurrentBranch",
+  )(function* (input) {
+    return yield* gitCore.rebaseCurrentBranch(input).pipe(
+      Effect.mapError((cause) => gitManagerError("rebaseCurrentBranch", cause.message, cause)),
+      Effect.ensuring(invalidateStatus(input.cwd)),
+    );
+  });
+
+  const getRebaseConflictStatus: GitManagerShape["getRebaseConflictStatus"] = Effect.fn(
+    "getRebaseConflictStatus",
+  )(function* (cwd) {
+    return yield* gitCore
+      .getRebaseConflictStatus(cwd)
+      .pipe(Effect.mapError((cause) => gitManagerError("getRebaseConflictStatus", cause.message, cause)));
+  });
+
+  const abortRebase: GitManagerShape["abortRebase"] = Effect.fn("abortRebase")(function* (cwd) {
+    return yield* gitCore.abortRebase(cwd).pipe(
+      Effect.mapError((cause) => gitManagerError("abortRebase", cause.message, cause)),
+      Effect.ensuring(invalidateStatus(cwd)),
+    );
+  });
+
+  const continueRebase: GitManagerShape["continueRebase"] = Effect.fn("continueRebase")(
+    function* (cwd) {
+      return yield* gitCore.continueRebase(cwd).pipe(
+        Effect.mapError((cause) => gitManagerError("continueRebase", cause.message, cause)),
+        Effect.ensuring(invalidateStatus(cwd)),
+      );
+    },
+  );
+
   const resolvePullRequest: GitManagerShape["resolvePullRequest"] = Effect.fn("resolvePullRequest")(
     function* (input) {
       const pullRequest = yield* (yield* sourceControlProvider(input.cwd))
@@ -1772,6 +1816,10 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     localStatus,
     remoteStatus,
     status,
+    rebaseCurrentBranch,
+    getRebaseConflictStatus,
+    abortRebase,
+    continueRebase,
     invalidateLocalStatus,
     invalidateRemoteStatus,
     invalidateStatus,

--- a/t3code/apps/server/src/git/GitWorkflowService.ts
+++ b/t3code/apps/server/src/git/GitWorkflowService.ts
@@ -26,6 +26,9 @@ import {
   type VcsStatusLocalResult,
   type VcsStatusRemoteResult,
   type VcsStatusResult,
+  type VcsRebaseConflictStatusResult,
+  type VcsRebaseInput,
+  type VcsRebaseResult,
 } from "@t3tools/contracts";
 
 import { GitManager, type GitRunStackedActionOptions } from "./GitManager.ts";
@@ -46,6 +49,14 @@ export interface GitWorkflowServiceShape {
   readonly invalidateRemoteStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly invalidateStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly pullCurrentBranch: (cwd: string) => Effect.Effect<VcsPullResult, GitCommandError>;
+  readonly rebaseCurrentBranch: (
+    input: VcsRebaseInput,
+  ) => Effect.Effect<VcsRebaseResult, GitManagerServiceError>;
+  readonly getRebaseConflictStatus: (
+    cwd: string,
+  ) => Effect.Effect<VcsRebaseConflictStatusResult, GitManagerServiceError>;
+  readonly abortRebase: (cwd: string) => Effect.Effect<void, GitManagerServiceError>;
+  readonly continueRebase: (cwd: string) => Effect.Effect<void, GitManagerServiceError>;
   readonly runStackedAction: (
     input: GitRunStackedActionInput,
     options?: GitRunStackedActionOptions,
@@ -271,6 +282,22 @@ export const make = Effect.fn("makeGitWorkflowService")(function* () {
     pullCurrentBranch: (cwd) =>
       ensureGitCommand("GitWorkflowService.pullCurrentBranch", cwd).pipe(
         Effect.andThen(git.pullCurrentBranch(cwd)),
+      ),
+    rebaseCurrentBranch: (input) =>
+      ensureGit("GitWorkflowService.rebaseCurrentBranch", input.cwd).pipe(
+        Effect.andThen(gitManager.rebaseCurrentBranch(input)),
+      ),
+    getRebaseConflictStatus: (cwd) =>
+      ensureGit("GitWorkflowService.getRebaseConflictStatus", cwd).pipe(
+        Effect.andThen(gitManager.getRebaseConflictStatus(cwd)),
+      ),
+    abortRebase: (cwd) =>
+      ensureGit("GitWorkflowService.abortRebase", cwd).pipe(
+        Effect.andThen(gitManager.abortRebase(cwd)),
+      ),
+    continueRebase: (cwd) =>
+      ensureGit("GitWorkflowService.continueRebase", cwd).pipe(
+        Effect.andThen(gitManager.continueRebase(cwd)),
       ),
     runStackedAction: (input, options) =>
       ensureGit("GitWorkflowService.runStackedAction", input.cwd).pipe(

--- a/t3code/apps/server/src/vcs/.generation_meta.json
+++ b/t3code/apps/server/src/vcs/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initial_directives": "Public-safe provenance for Git rebase conflict detection bounty #823. Private startup directives, hidden system/developer instructions, credentials, session configuration, and non-public runtime context are intentionally not included.",
+  "date": "2026-06-06T17:21:00-07:00"
+}

--- a/t3code/apps/server/src/vcs/GitVcsDriver.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriver.ts
@@ -22,6 +22,9 @@ import {
   type VcsListRefsInput,
   type VcsListRefsResult,
   type VcsPullResult,
+  type VcsRebaseConflictStatusResult,
+  type VcsRebaseInput,
+  type VcsRebaseResult,
   type VcsRemoveWorktreeInput,
   type VcsStatusInput,
   type VcsStatusResult,
@@ -185,6 +188,15 @@ export interface GitVcsDriverShape {
   ) => Effect.Effect<string | null, GitCommandError>;
   readonly listRefs: (input: VcsListRefsInput) => Effect.Effect<VcsListRefsResult, GitCommandError>;
   readonly pullCurrentBranch: (cwd: string) => Effect.Effect<VcsPullResult, GitCommandError>;
+  readonly rebaseCurrentBranch: (
+    input: VcsRebaseInput,
+  ) => Effect.Effect<VcsRebaseResult, GitCommandError>;
+  readonly getConflictFiles: (cwd: string) => Effect.Effect<string[], GitCommandError>;
+  readonly getRebaseConflictStatus: (
+    cwd: string,
+  ) => Effect.Effect<VcsRebaseConflictStatusResult, GitCommandError>;
+  readonly abortRebase: (cwd: string) => Effect.Effect<void, GitCommandError>;
+  readonly continueRebase: (cwd: string) => Effect.Effect<void, GitCommandError>;
   readonly createWorktree: (
     input: VcsCreateWorktreeInput,
   ) => Effect.Effect<VcsCreateWorktreeResult, GitCommandError>;

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -313,6 +313,93 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("remote operations", () => {
+    it.effect("rebases a branch without conflicts and reports the result", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* git(cwd, ["branch", "-M", "main"]);
+        yield* git(cwd, ["checkout", "-b", "feature/rebase-clean"]);
+        yield* writeTextFile(cwd, "feature.txt", "feature\n");
+        yield* git(cwd, ["add", "feature.txt"]);
+        yield* git(cwd, ["commit", "-m", "feature commit"]);
+        yield* git(cwd, ["checkout", "main"]);
+        yield* writeTextFile(cwd, "main.txt", "main\n");
+        yield* git(cwd, ["add", "main.txt"]);
+        yield* git(cwd, ["commit", "-m", "main commit"]);
+        yield* git(cwd, ["checkout", "feature/rebase-clean"]);
+
+        const result = yield* driver.rebaseCurrentBranch({ cwd, upstreamRef: "main" });
+
+        assert.equal(result.status, "rebased");
+        assert.equal(result.refName, "feature/rebase-clean");
+        assert.equal(result.upstreamRef, "main");
+        assert.equal(yield* git(cwd, ["log", "-1", "--pretty=%s"]), "feature commit");
+      }),
+    );
+
+    it.effect("detects rebase conflicts and reports unmerged files", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* git(cwd, ["branch", "-M", "main"]);
+        yield* git(cwd, ["checkout", "-b", "feature/rebase-conflict"]);
+        yield* writeTextFile(cwd, "README.md", "# test\nfeature\n");
+        yield* git(cwd, ["add", "README.md"]);
+        yield* git(cwd, ["commit", "-m", "feature edit"]);
+        yield* git(cwd, ["checkout", "main"]);
+        yield* writeTextFile(cwd, "README.md", "# test\nmain\n");
+        yield* git(cwd, ["add", "README.md"]);
+        yield* git(cwd, ["commit", "-m", "main edit"]);
+        yield* git(cwd, ["checkout", "feature/rebase-conflict"]);
+
+        const result = yield* driver.rebaseCurrentBranch({ cwd, upstreamRef: "main" });
+        const conflictStatus = yield* driver.getRebaseConflictStatus(cwd);
+
+        assert.equal(result.status, "conflicts");
+        assert.deepStrictEqual(result.conflicts?.files, ["README.md"]);
+        assert.equal(conflictStatus.inProgress, true);
+        assert.deepStrictEqual(conflictStatus.conflicts.files, ["README.md"]);
+
+        yield* driver.abortRebase(cwd);
+        const afterAbort = yield* driver.getRebaseConflictStatus(cwd);
+        assert.equal(afterAbort.inProgress, false);
+        assert.equal(yield* git(cwd, ["branch", "--show-current"]), "feature/rebase-conflict");
+      }),
+    );
+
+    it.effect("continues a rebase after conflicts are resolved", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* git(cwd, ["config", "core.editor", "true"]);
+        yield* git(cwd, ["branch", "-M", "main"]);
+        yield* git(cwd, ["checkout", "-b", "feature/rebase-continue"]);
+        yield* writeTextFile(cwd, "README.md", "# test\nfeature\n");
+        yield* git(cwd, ["add", "README.md"]);
+        yield* git(cwd, ["commit", "-m", "feature edit"]);
+        yield* git(cwd, ["checkout", "main"]);
+        yield* writeTextFile(cwd, "README.md", "# test\nmain\n");
+        yield* git(cwd, ["add", "README.md"]);
+        yield* git(cwd, ["commit", "-m", "main edit"]);
+        yield* git(cwd, ["checkout", "feature/rebase-continue"]);
+
+        const result = yield* driver.rebaseCurrentBranch({ cwd, upstreamRef: "main" });
+        assert.equal(result.status, "conflicts");
+        yield* writeTextFile(cwd, "README.md", "# test\nmain\nfeature\n");
+        yield* git(cwd, ["add", "README.md"]);
+
+        yield* driver.continueRebase(cwd);
+
+        const conflictStatus = yield* driver.getRebaseConflictStatus(cwd);
+        assert.equal(conflictStatus.inProgress, false);
+        assert.equal(yield* git(cwd, ["branch", "--show-current"]), "feature/rebase-continue");
+        assert.equal(yield* git(cwd, ["log", "-1", "--pretty=%s"]), "feature edit");
+      }),
+    );
+
     it.effect("pushes with upstream setup and skips when already up to date", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1586,6 +1586,147 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     };
   });
 
+  const resolveGitPath = Effect.fn("GitVcsDriver.resolveGitPath")(function* (
+    cwd: string,
+    gitPath: string,
+  ) {
+    const resolved = yield* runGitStdout(
+      "GitVcsDriver.resolveGitPath",
+      cwd,
+      ["rev-parse", "--git-path", gitPath],
+      true,
+    ).pipe(Effect.map((stdout) => stdout.trim()));
+    if (resolved.length === 0) {
+      return path.join(cwd, ".git", gitPath);
+    }
+    return path.isAbsolute(resolved) ? resolved : path.join(cwd, resolved);
+  });
+
+  const isRebaseInProgress = Effect.fn("GitVcsDriver.isRebaseInProgress")(function* (
+    cwd: string,
+  ) {
+    const [rebaseHeadPath, rebaseMergePath, rebaseApplyPath] = yield* Effect.all([
+      resolveGitPath(cwd, "REBASE_HEAD"),
+      resolveGitPath(cwd, "rebase-merge"),
+      resolveGitPath(cwd, "rebase-apply"),
+    ]);
+    const [hasRebaseHead, hasRebaseMerge, hasRebaseApply] = yield* Effect.all([
+      fileSystem.exists(rebaseHeadPath).pipe(Effect.orElseSucceed(() => false)),
+      fileSystem.exists(rebaseMergePath).pipe(Effect.orElseSucceed(() => false)),
+      fileSystem.exists(rebaseApplyPath).pipe(Effect.orElseSucceed(() => false)),
+    ]);
+    return hasRebaseHead && (hasRebaseMerge || hasRebaseApply);
+  });
+
+  const getConflictFiles: GitVcsDriver.GitVcsDriverShape["getConflictFiles"] = Effect.fn(
+    "getConflictFiles",
+  )(function* (cwd) {
+    const stdout = yield* runGitStdout(
+      "GitVcsDriver.getConflictFiles",
+      cwd,
+      ["diff", "--name-only", "--diff-filter=U"],
+      true,
+    );
+    return stdout
+      .split(/\r?\n/g)
+      .map((line) => line.trim())
+      .filter((line, index, lines) => line.length > 0 && lines.indexOf(line) === index);
+  });
+
+  const getRebaseConflictStatus: GitVcsDriver.GitVcsDriverShape["getRebaseConflictStatus"] =
+    Effect.fn("getRebaseConflictStatus")(function* (cwd) {
+      const inProgress = yield* isRebaseInProgress(cwd);
+      const files = inProgress ? yield* getConflictFiles(cwd) : [];
+      return {
+        inProgress,
+        conflicts: {
+          cwd,
+          files,
+        },
+      };
+    });
+
+  const rebaseCurrentBranch: GitVcsDriver.GitVcsDriverShape["rebaseCurrentBranch"] = Effect.fn(
+    "rebaseCurrentBranch",
+  )(function* (input) {
+    const details = yield* statusDetails(input.cwd);
+    const refName = details.branch;
+    if (!refName) {
+      return yield* createGitCommandError(
+        "GitVcsDriver.rebaseCurrentBranch",
+        input.cwd,
+        ["rebase", input.upstreamRef],
+        "Cannot rebase from detached HEAD.",
+      );
+    }
+
+    const beforeSha = yield* runGitStdout(
+      "GitVcsDriver.rebaseCurrentBranch.beforeSha",
+      input.cwd,
+      ["rev-parse", "HEAD"],
+      true,
+    ).pipe(Effect.map((stdout) => stdout.trim()));
+    const result = yield* executeGit(
+      "GitVcsDriver.rebaseCurrentBranch.rebase",
+      input.cwd,
+      ["rebase", input.upstreamRef],
+      {
+        timeoutMs: 60_000,
+        allowNonZeroExit: true,
+      },
+    );
+
+    if (result.exitCode !== 0) {
+      const conflictStatus = yield* getRebaseConflictStatus(input.cwd);
+      if (conflictStatus.inProgress) {
+        return {
+          status: "conflicts" as const,
+          refName,
+          upstreamRef: input.upstreamRef,
+          conflicts: conflictStatus.conflicts,
+        };
+      }
+
+      return yield* createGitCommandError(
+        "GitVcsDriver.rebaseCurrentBranch",
+        input.cwd,
+        ["rebase", input.upstreamRef],
+        result.stderr.trim() || "git rebase failed",
+      );
+    }
+
+    const afterSha = yield* runGitStdout(
+      "GitVcsDriver.rebaseCurrentBranch.afterSha",
+      input.cwd,
+      ["rev-parse", "HEAD"],
+      true,
+    ).pipe(Effect.map((stdout) => stdout.trim()));
+
+    return {
+      status: beforeSha.length > 0 && beforeSha === afterSha ? "skipped_up_to_date" : "rebased",
+      refName,
+      upstreamRef: input.upstreamRef,
+    };
+  });
+
+  const abortRebase: GitVcsDriver.GitVcsDriverShape["abortRebase"] = Effect.fn("abortRebase")(
+    function* (cwd) {
+      yield* executeGit("GitVcsDriver.abortRebase", cwd, ["rebase", "--abort"], {
+        timeoutMs: 30_000,
+        fallbackErrorMessage: "git rebase --abort failed",
+      });
+    },
+  );
+
+  const continueRebase: GitVcsDriver.GitVcsDriverShape["continueRebase"] = Effect.fn(
+    "continueRebase",
+  )(function* (cwd) {
+    yield* executeGit("GitVcsDriver.continueRebase", cwd, ["rebase", "--continue"], {
+      timeoutMs: 60_000,
+      fallbackErrorMessage: "git rebase --continue failed",
+    });
+  });
+
   const readRangeContext: GitVcsDriver.GitVcsDriverShape["readRangeContext"] = Effect.fn(
     "readRangeContext",
   )(function* (cwd, baseRef) {
@@ -2123,6 +2264,11 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     commit,
     pushCurrentBranch,
     pullCurrentBranch,
+    rebaseCurrentBranch,
+    getConflictFiles,
+    getRebaseConflictStatus,
+    abortRebase,
+    continueRebase,
     readRangeContext,
     readConfigValue,
     listRefs,

--- a/t3code/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/t3code/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -232,7 +232,20 @@ export const layer = Layer.effect(
       const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
       yield* workflow.invalidateLocalStatus(cwd);
       const local = yield* workflow.localStatus({ cwd });
-      return yield* updateCachedLocalStatus(cwd, local, { publish: true });
+      const updated = yield* updateCachedLocalStatus(cwd, local, { publish: true });
+      const rebaseStatus = yield* workflow
+        .getRebaseConflictStatus(cwd)
+        .pipe(Effect.catch(() => Effect.succeed(null)));
+      if (rebaseStatus?.inProgress && rebaseStatus.conflicts.files.length > 0) {
+        yield* PubSub.publish(changesPubSub, {
+          cwd,
+          event: {
+            _tag: "rebaseConflicts",
+            conflicts: rebaseStatus.conflicts,
+          },
+        });
+      }
+      return updated;
     });
 
     const refreshRemoteStatus = Effect.fn("VcsStatusBroadcaster.refreshRemoteStatus")(function* (

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -1027,6 +1027,46 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             ),
             { "rpc.aggregate": "git" },
           ),
+        [WS_METHODS.vcsRebase]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsRebase,
+            gitWorkflow.rebaseCurrentBranch(input).pipe(
+              Effect.matchCauseEffect({
+                onFailure: (cause) => Effect.failCause(cause),
+                onSuccess: (result) =>
+                  refreshGitStatus(input.cwd).pipe(Effect.ignore({ log: true }), Effect.as(result)),
+              }),
+            ),
+            { "rpc.aggregate": "git" },
+          ),
+        [WS_METHODS.vcsRebaseAbort]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsRebaseAbort,
+            gitWorkflow.abortRebase(input.cwd).pipe(
+              Effect.matchCauseEffect({
+                onFailure: (cause) => Effect.failCause(cause),
+                onSuccess: () => refreshGitStatus(input.cwd).pipe(Effect.ignore({ log: true })),
+              }),
+            ),
+            { "rpc.aggregate": "git" },
+          ),
+        [WS_METHODS.vcsRebaseContinue]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsRebaseContinue,
+            gitWorkflow.continueRebase(input.cwd).pipe(
+              Effect.matchCauseEffect({
+                onFailure: (cause) => Effect.failCause(cause),
+                onSuccess: () => refreshGitStatus(input.cwd).pipe(Effect.ignore({ log: true })),
+              }),
+            ),
+            { "rpc.aggregate": "git" },
+          ),
+        [WS_METHODS.vcsRebaseConflicts]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsRebaseConflicts,
+            gitWorkflow.getRebaseConflictStatus(input.cwd),
+            { "rpc.aggregate": "git" },
+          ),
         [WS_METHODS.gitRunStackedAction]: (input) =>
           observeRpcStream(
             WS_METHODS.gitRunStackedAction,

--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -86,6 +86,10 @@ export interface WsRpcClient {
   };
   readonly vcs: {
     readonly pull: RpcUnaryMethod<typeof WS_METHODS.vcsPull>;
+    readonly rebase: RpcUnaryMethod<typeof WS_METHODS.vcsRebase>;
+    readonly abortRebase: RpcUnaryMethod<typeof WS_METHODS.vcsRebaseAbort>;
+    readonly continueRebase: RpcUnaryMethod<typeof WS_METHODS.vcsRebaseContinue>;
+    readonly getRebaseConflicts: RpcUnaryMethod<typeof WS_METHODS.vcsRebaseConflicts>;
     readonly refreshStatus: RpcUnaryMethod<typeof WS_METHODS.vcsRefreshStatus>;
     readonly onStatus: (
       input: RpcInput<typeof WS_METHODS.subscribeVcsStatus>,
@@ -199,6 +203,13 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
     },
     vcs: {
       pull: (input) => transport.request((client) => client[WS_METHODS.vcsPull](input)),
+      rebase: (input) => transport.request((client) => client[WS_METHODS.vcsRebase](input)),
+      abortRebase: (input) =>
+        transport.request((client) => client[WS_METHODS.vcsRebaseAbort](input)),
+      continueRebase: (input) =>
+        transport.request((client) => client[WS_METHODS.vcsRebaseContinue](input)),
+      getRebaseConflicts: (input) =>
+        transport.request((client) => client[WS_METHODS.vcsRebaseConflicts](input)),
       refreshStatus: (input) =>
         transport.request((client) => client[WS_METHODS.vcsRefreshStatus](input)),
       onStatus: (input, listener, options) => {

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -131,6 +131,17 @@ export const VcsListRefsInput = Schema.Struct({
 });
 export type VcsListRefsInput = typeof VcsListRefsInput.Type;
 
+export const VcsRebaseInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+  upstreamRef: TrimmedNonEmptyStringSchema,
+});
+export type VcsRebaseInput = typeof VcsRebaseInput.Type;
+
+export const VcsRebaseControlInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type VcsRebaseControlInput = typeof VcsRebaseControlInput.Type;
+
 export const VcsCreateWorktreeInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   refName: TrimmedNonEmptyStringSchema,
@@ -246,6 +257,12 @@ export const VcsStatusStreamEvent = Schema.Union([
   Schema.TaggedStruct("remoteUpdated", {
     remote: Schema.NullOr(VcsStatusRemoteResult),
   }),
+  Schema.TaggedStruct("rebaseConflicts", {
+    conflicts: Schema.Struct({
+      cwd: TrimmedNonEmptyStringSchema,
+      files: Schema.Array(TrimmedNonEmptyStringSchema),
+    }),
+  }),
 ]);
 export type VcsStatusStreamEvent = typeof VcsStatusStreamEvent.Type;
 
@@ -315,6 +332,26 @@ export const VcsPullResult = Schema.Struct({
   upstreamRef: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
 });
 export type VcsPullResult = typeof VcsPullResult.Type;
+
+export const VcsRebaseConflicts = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+  files: Schema.Array(TrimmedNonEmptyStringSchema),
+});
+export type VcsRebaseConflicts = typeof VcsRebaseConflicts.Type;
+
+export const VcsRebaseConflictStatusResult = Schema.Struct({
+  inProgress: Schema.Boolean,
+  conflicts: VcsRebaseConflicts,
+});
+export type VcsRebaseConflictStatusResult = typeof VcsRebaseConflictStatusResult.Type;
+
+export const VcsRebaseResult = Schema.Struct({
+  status: Schema.Literals(["rebased", "skipped_up_to_date", "conflicts"]),
+  refName: TrimmedNonEmptyStringSchema,
+  upstreamRef: TrimmedNonEmptyStringSchema,
+  conflicts: Schema.optional(VcsRebaseConflicts),
+});
+export type VcsRebaseResult = typeof VcsRebaseResult.Type;
 
 // RPC / domain errors
 export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()("GitCommandError", {

--- a/t3code/packages/contracts/src/rpc.ts
+++ b/t3code/packages/contracts/src/rpc.ts
@@ -27,6 +27,10 @@ import {
   VcsPullInput,
   GitPullRequestRefInput,
   VcsPullResult,
+  VcsRebaseControlInput,
+  VcsRebaseConflictStatusResult,
+  VcsRebaseInput,
+  VcsRebaseResult,
   VcsRemoveWorktreeInput,
   GitResolvePullRequestResult,
   GitRunStackedActionInput,
@@ -115,6 +119,10 @@ export const WS_METHODS = {
 
   // VCS methods
   vcsPull: "vcs.pull",
+  vcsRebase: "vcs.rebase",
+  vcsRebaseAbort: "vcs.rebase.abort",
+  vcsRebaseContinue: "vcs.rebase.continue",
+  vcsRebaseConflicts: "vcs.rebase.conflicts",
   vcsRefreshStatus: "vcs.refreshStatus",
   vcsListRefs: "vcs.listRefs",
   vcsCreateWorktree: "vcs.createWorktree",
@@ -298,6 +306,28 @@ export const WsVcsPullRpc = Rpc.make(WS_METHODS.vcsPull, {
   payload: VcsPullInput,
   success: VcsPullResult,
   error: GitCommandError,
+});
+
+export const WsVcsRebaseRpc = Rpc.make(WS_METHODS.vcsRebase, {
+  payload: VcsRebaseInput,
+  success: VcsRebaseResult,
+  error: GitManagerServiceError,
+});
+
+export const WsVcsRebaseAbortRpc = Rpc.make(WS_METHODS.vcsRebaseAbort, {
+  payload: VcsRebaseControlInput,
+  error: GitManagerServiceError,
+});
+
+export const WsVcsRebaseContinueRpc = Rpc.make(WS_METHODS.vcsRebaseContinue, {
+  payload: VcsRebaseControlInput,
+  error: GitManagerServiceError,
+});
+
+export const WsVcsRebaseConflictsRpc = Rpc.make(WS_METHODS.vcsRebaseConflicts, {
+  payload: VcsRebaseControlInput,
+  success: VcsRebaseConflictStatusResult,
+  error: GitManagerServiceError,
 });
 
 export const WsVcsRefreshStatusRpc = Rpc.make(WS_METHODS.vcsRefreshStatus, {
@@ -494,6 +524,10 @@ export const WsRpcGroup = RpcGroup.make(
   WsFilesystemBrowseRpc,
   WsSubscribeVcsStatusRpc,
   WsVcsPullRpc,
+  WsVcsRebaseRpc,
+  WsVcsRebaseAbortRpc,
+  WsVcsRebaseContinueRpc,
+  WsVcsRebaseConflictsRpc,
   WsVcsRefreshStatusRpc,
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,

--- a/t3code/packages/shared/src/git.ts
+++ b/t3code/packages/shared/src/git.ts
@@ -266,5 +266,28 @@ export function applyGitStatusStreamEvent(
         );
       }
       return mergeGitStatusParts(toLocalStatusPart(current), event.remote);
+    case "rebaseConflicts":
+      return (
+        current ??
+        mergeGitStatusParts(
+          {
+            isRepo: true,
+            hasPrimaryRemote: false,
+            isDefaultRef: false,
+            refName: null,
+            hasWorkingTreeChanges: true,
+            workingTree: {
+              files: event.conflicts.files.map((file) => ({
+                path: file,
+                insertions: 0,
+                deletions: 0,
+              })),
+              insertions: 0,
+              deletions: 0,
+            },
+          },
+          null,
+        )
+      );
   }
 }


### PR DESCRIPTION
/claim #823

Implemented rebase conflict handling for the T3 Code Git stack:

- Added typed rebase contract schemas for rebase, conflict status, abort, and continue operations.
- Added GitVcsDriver rebase support that detects `.git/REBASE_HEAD` plus active rebase metadata after non-zero `git rebase`, then reports `git diff --name-only --diff-filter=U` conflict files.
- Exposed `abortRebase`, `continueRebase`, and conflict query methods through GitManager, GitWorkflowService, websocket RPC, and the web RPC client.
- Added `rebaseConflicts` status stream events so the UI/RPC layer can surface conflict markers.
- Preserved non-conflicting rebase flow and wrapped failures in typed GitManager/GitCommand errors.
- Included safe public `.generation_meta.json` provenance only.

Validation:

- `node ..\..\node_modules\typescript\bin\tsc --noEmit` from `t3code/apps/server`
- `node ..\..\node_modules\typescript\bin\tsc --noEmit` from `t3code/apps/web`
- `node ..\..\node_modules\typescript\bin\tsc --noEmit` from `t3code/packages/contracts`
- `node ..\..\node_modules\typescript\bin\tsc --noEmit` from `t3code/packages/shared`
- `node ..\..\node_modules\vitest\vitest.mjs run src/vcs/GitVcsDriverCore.test.ts --passWithNoTests` from `t3code/apps/server`
- `node ..\..\node_modules\vitest\vitest.mjs run src/git.test.ts --passWithNoTests` from `t3code/packages/shared`
- `node ..\..\node_modules\vitest\vitest.mjs run src/git.test.ts --passWithNoTests` from `t3code/packages/contracts`
- `git diff --check`

Payment preference: USDC on Base to 0x237664403f52A15142795f807ADB3524E8057909