### PR TITLE
fix: add dependency graph to turbo.json for incremental builds

### DIFF
--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -48,6 +48,38 @@
       "dependsOn": ["^build"],
       "cache": false,
       "outputs": []
+    },
+    "apps/web#build": {
+      "dependsOn": ["packages/contracts#build", "packages/client-runtime#build"],
+      "outputs": ["dist/**"]
+    },
+    "apps/server#build": {
+      "dependsOn": [
+        "packages/contracts#build",
+        "packages/shared#build",
+        "packages/effect-acp#build",
+        "packages/effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "apps/desktop#build": {
+      "dependsOn": ["apps/web#build", "apps/server#build"],
+      "outputs": ["dist/**", "dist-electron/**"]
+    },
+    "packages/contracts#build": {
+      "outputs": ["dist/**"]
+    },
+    "packages/shared#build": {
+      "outputs": ["dist/**"]
+    },
+    "packages/client-runtime#build": {
+      "outputs": ["dist/**"]
+    },
+    "packages/effect-acp#build": {
+      "outputs": ["dist/**"]
+    },
+    "packages/effect-codex-app-server#build": {
+      "outputs": ["dist/**"]
     }
   }
 }


### PR DESCRIPTION
Define per-package dependsOn chains for all apps. Also add cache output configs.

Closes #828