### PR TITLE
[Codex GPT-5] [ T3 Code ] Add system tray icon

### DIFF
--- a/t3code/apps/desktop/src/app/DesktopApp.ts
+++ b/t3code/apps/desktop/src/app/DesktopApp.ts
@@ -9,6 +9,7 @@ import * as NetService from "@t3tools/shared/Net";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
+import * as ElectronTray from "../electron/ElectronTray.ts";
 import { installDesktopIpcHandlers } from "../ipc/DesktopIpcHandlers.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
@@ -188,6 +189,7 @@ const startup = Effect.gen(function* () {
   const applicationMenu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
   const electronApp = yield* ElectronApp.ElectronApp;
   const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
+  const electronTray = yield* ElectronTray.ElectronTray;
   const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
@@ -214,9 +216,11 @@ const startup = Effect.gen(function* () {
   yield* logStartupInfo("app ready");
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
+  yield* electronTray.configure;
   yield* electronProtocol.registerDesktopFileProtocol;
   yield* updates.configure;
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));
+  yield* electronTray.updateState({ backendStatus: "connected" });
 }).pipe(Effect.withSpan("desktop.startup"));
 
 const scopedProgram = Effect.scoped(

--- a/t3code/apps/desktop/src/electron/ElectronTray.test.ts
+++ b/t3code/apps/desktop/src/electron/ElectronTray.test.ts
@@ -1,0 +1,89 @@
+import { assert, describe, it } from "@effect/vitest";
+import type * as Electron from "electron";
+import { vi } from "vitest";
+
+const { createFromDataURLMock } = vi.hoisted(() => ({
+  createFromDataURLMock: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  nativeImage: {
+    createFromDataURL: createFromDataURLMock,
+  },
+}));
+
+import {
+  buildTrayIcon,
+  buildTrayMenuTemplate,
+  buildTrayTooltip,
+  normalizeRecentProjects,
+  statusColor,
+} from "./ElectronTray.ts";
+
+describe("ElectronTray", () => {
+  it("builds a status-aware tooltip with the active project", () => {
+    assert.equal(
+      buildTrayTooltip({
+        displayName: "T3 Code",
+        state: {
+          backendStatus: "connected",
+          activeProjectName: "acme-web",
+          recentProjects: [],
+        },
+      }),
+      "T3 Code\nStatus: Connected\nProject: acme-web",
+    );
+  });
+
+  it("normalizes recent projects to the newest five unique paths", () => {
+    assert.deepEqual(
+      normalizeRecentProjects([
+        { name: "One", path: "C:\\work\\one" },
+        { name: "Duplicate", path: "C:\\work\\one" },
+        { path: "C:\\work\\two" },
+        { path: "C:\\work\\three" },
+        { path: "C:\\work\\four" },
+        { path: "C:\\work\\five" },
+        { path: "C:\\work\\six" },
+      ]),
+      [
+        { name: "One", path: "C:\\work\\one" },
+        { name: "two", path: "C:\\work\\two" },
+        { name: "three", path: "C:\\work\\three" },
+        { name: "four", path: "C:\\work\\four" },
+        { name: "five", path: "C:\\work\\five" },
+      ],
+    );
+  });
+
+  it("builds the required tray menu entries", () => {
+    const menu = buildTrayMenuTemplate({
+      isWindowVisible: false,
+      recentProjects: [{ name: "Repo", path: "/repo" }],
+      onToggleWindow: () => {},
+      onNewChat: () => {},
+      onOpenRecentProject: () => {},
+      onQuit: () => {},
+    });
+
+    assert.equal(menu[0]?.label, "Show Window");
+    assert.equal(menu[1]?.label, "New Chat");
+    assert.equal(menu[2]?.label, "Open Recent Project");
+    assert.equal((menu[2]?.submenu as Electron.MenuItemConstructorOptions[])[0]?.label, "Repo");
+    assert.equal(menu.at(-1)?.label, "Quit");
+  });
+
+  it("creates colored tray icons for backend status", () => {
+    const resizedImage = {};
+    const image = {
+      resize: vi.fn(() => resizedImage),
+    };
+    createFromDataURLMock.mockReturnValue(image);
+
+    assert.equal(statusColor("connected"), "#16a34a");
+    assert.equal(buildTrayIcon("connected"), resizedImage);
+    const resizeCalls = image.resize.mock.calls as unknown as Array<[Electron.Size]>;
+    assert.equal(resizeCalls[0]?.[0]?.width, 16);
+    assert.include(createFromDataURLMock.mock.calls[0]?.[0], encodeURIComponent("#16a34a"));
+  });
+});

--- a/t3code/apps/desktop/src/electron/ElectronTray.ts
+++ b/t3code/apps/desktop/src/electron/ElectronTray.ts
@@ -1,0 +1,295 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Scope from "effect/Scope";
+
+import * as Electron from "electron";
+
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "./ElectronApp.ts";
+import * as ElectronWindow from "./ElectronWindow.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+
+export type TrayBackendStatus = "connected" | "reconnecting" | "disconnected";
+
+export interface TrayRecentProject {
+  readonly name?: string;
+  readonly path: string;
+}
+
+export interface TrayState {
+  readonly backendStatus: TrayBackendStatus;
+  readonly activeProjectName: string | null;
+  readonly recentProjects: readonly TrayRecentProject[];
+}
+
+export interface ElectronTrayShape {
+  readonly configure: Effect.Effect<void, never, Scope.Scope>;
+  readonly updateState: (patch: Partial<TrayState>) => Effect.Effect<void>;
+  readonly destroy: Effect.Effect<void>;
+}
+
+export class ElectronTray extends Context.Service<ElectronTray, ElectronTrayShape>()(
+  "t3/desktop/electron/Tray",
+) {}
+
+const STATUS_LABELS: Record<TrayBackendStatus, string> = {
+  connected: "Connected",
+  reconnecting: "Reconnecting",
+  disconnected: "Disconnected",
+};
+
+const STATUS_COLORS: Record<TrayBackendStatus, string> = {
+  connected: "#16a34a",
+  reconnecting: "#ca8a04",
+  disconnected: "#dc2626",
+};
+
+const DEFAULT_STATE: TrayState = {
+  backendStatus: "reconnecting",
+  activeProjectName: null,
+  recentProjects: [],
+};
+
+export function statusColor(status: TrayBackendStatus): string {
+  return STATUS_COLORS[status];
+}
+
+export function buildTrayTooltip(input: {
+  readonly displayName: string;
+  readonly state: TrayState;
+}): string {
+  const lines = [
+    input.displayName,
+    `Status: ${STATUS_LABELS[input.state.backendStatus]}`,
+  ];
+  if (input.state.activeProjectName !== null && input.state.activeProjectName.trim().length > 0) {
+    lines.push(`Project: ${input.state.activeProjectName.trim()}`);
+  }
+  return lines.join("\n");
+}
+
+export function normalizeRecentProjects(
+  projects: readonly TrayRecentProject[],
+): readonly Required<TrayRecentProject>[] {
+  const seenPaths = new Set<string>();
+  const normalized: Required<TrayRecentProject>[] = [];
+
+  for (const project of projects) {
+    const projectPath = project.path.trim();
+    if (projectPath.length === 0 || seenPaths.has(projectPath)) {
+      continue;
+    }
+
+    seenPaths.add(projectPath);
+    const rawName = project.name?.trim();
+    normalized.push({
+      path: projectPath,
+      name:
+        rawName && rawName.length > 0
+          ? rawName
+          : projectPath.split(/[\\/]/).at(-1) ?? projectPath,
+    });
+
+    if (normalized.length >= 5) {
+      break;
+    }
+  }
+
+  return normalized;
+}
+
+export function buildTrayIcon(status: TrayBackendStatus): Electron.NativeImage {
+  const color = statusColor(status);
+  const svg = [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">',
+    '<rect width="32" height="32" rx="7" fill="#111827"/>',
+    `<circle cx="23" cy="9" r="5" fill="${color}"/>`,
+    '<path d="M8 10h10v3h-3v11h-4V13H8z" fill="#f9fafb"/>',
+    "</svg>",
+  ].join("");
+  return Electron.nativeImage
+    .createFromDataURL(`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`)
+    .resize({ width: 16, height: 16 });
+}
+
+export function buildTrayMenuTemplate(input: {
+  readonly isWindowVisible: boolean;
+  readonly recentProjects: readonly TrayRecentProject[];
+  readonly onToggleWindow: () => void;
+  readonly onNewChat: () => void;
+  readonly onOpenRecentProject: (projectPath: string) => void;
+  readonly onQuit: () => void;
+}): Electron.MenuItemConstructorOptions[] {
+  const recentProjects = normalizeRecentProjects(input.recentProjects);
+
+  return [
+    {
+      label: input.isWindowVisible ? "Hide Window" : "Show Window",
+      click: input.onToggleWindow,
+    },
+    {
+      label: "New Chat",
+      click: input.onNewChat,
+    },
+    {
+      label: "Open Recent Project",
+      submenu:
+        recentProjects.length > 0
+          ? recentProjects.map((project) => ({
+              label: project.name,
+              click: () => input.onOpenRecentProject(project.path),
+            }))
+          : [{ label: "No recent projects", enabled: false }],
+    },
+    { type: "separator" },
+    {
+      label: "Quit",
+      click: input.onQuit,
+    },
+  ];
+}
+
+const make = Effect.gen(function* () {
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const electronWindow = yield* ElectronWindow.ElectronWindow;
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const desktopState = yield* DesktopState.DesktopState;
+  const context = yield* Effect.context<
+    | DesktopWindow.DesktopWindow
+    | ElectronApp.ElectronApp
+    | ElectronWindow.ElectronWindow
+    | DesktopEnvironment.DesktopEnvironment
+    | DesktopState.DesktopState
+  >();
+  const runPromise = Effect.runPromiseWith(context);
+  const stateRef = yield* Ref.make<TrayState>(DEFAULT_STATE);
+  const trayRef = yield* Ref.make<Option.Option<Electron.Tray>>(Option.none());
+
+  const withTray = <A>(f: (tray: Electron.Tray) => A): Effect.Effect<Option.Option<A>> =>
+    Ref.get(trayRef).pipe(
+      Effect.map((tray) => {
+        if (Option.isNone(tray)) {
+          return Option.none();
+        }
+        return Option.some(f(tray.value));
+      }),
+    );
+
+  const revealMainWindow = desktopWindow.activate;
+
+  const hideMainWindow = Effect.gen(function* () {
+    const currentWindow = yield* electronWindow.currentMainOrFirst;
+    if (Option.isSome(currentWindow) && !currentWindow.value.isDestroyed()) {
+      currentWindow.value.hide();
+    }
+  });
+
+  const toggleMainWindow = Effect.gen(function* () {
+    const currentWindow = yield* electronWindow.currentMainOrFirst;
+    if (Option.isSome(currentWindow) && currentWindow.value.isVisible()) {
+      currentWindow.value.hide();
+      return;
+    }
+    yield* revealMainWindow;
+  });
+
+  const refreshTray = Effect.gen(function* () {
+    const state = yield* Ref.get(stateRef);
+    const visible = yield* electronWindow.currentMainOrFirst.pipe(
+      Effect.map((window) => Option.isSome(window) && window.value.isVisible()),
+    );
+
+    yield* withTray((tray) => {
+      tray.setImage(buildTrayIcon(state.backendStatus));
+      tray.setToolTip(buildTrayTooltip({ displayName: environment.displayName, state }));
+      tray.setContextMenu(
+        Electron.Menu.buildFromTemplate(
+          buildTrayMenuTemplate({
+            isWindowVisible: visible,
+            recentProjects: state.recentProjects,
+            onToggleWindow: () => {
+              void runPromise(visible ? hideMainWindow : revealMainWindow);
+            },
+            onNewChat: () => {
+              void runPromise(desktopWindow.dispatchMenuAction("new-chat"));
+            },
+            onOpenRecentProject: (projectPath) => {
+              void runPromise(desktopWindow.dispatchMenuAction(`open-project:${projectPath}`));
+            },
+            onQuit: () => {
+              void runPromise(
+                Ref.set(desktopState.quitting, true).pipe(Effect.andThen(electronApp.quit)),
+              );
+            },
+          }),
+        ),
+      );
+    });
+  });
+
+  return ElectronTray.of({
+    configure: Effect.gen(function* () {
+      const existingTray = yield* Ref.get(trayRef);
+      if (Option.isSome(existingTray)) {
+        return;
+      }
+
+      const initialState = yield* Ref.get(stateRef);
+      const tray = new Electron.Tray(buildTrayIcon(initialState.backendStatus));
+      yield* Ref.set(trayRef, Option.some(tray));
+
+      tray.on("click", () => {
+        void runPromise(environment.platform === "darwin" ? toggleMainWindow : revealMainWindow);
+      });
+      tray.on("right-click", () => {
+        void runPromise(
+          refreshTray.pipe(Effect.andThen(Effect.sync(() => tray.popUpContextMenu()))),
+        );
+      });
+
+      yield* refreshTray;
+      yield* Effect.addFinalizer(() =>
+        Ref.get(trayRef).pipe(
+          Effect.flatMap(
+            Option.match({
+              onNone: () => Effect.void,
+              onSome: (activeTray) =>
+                Effect.sync(() => {
+                  activeTray.destroy();
+                }),
+            }),
+          ),
+          Effect.andThen(Ref.set(trayRef, Option.none())),
+        ),
+      );
+    }).pipe(Effect.withSpan("desktop.tray.configure")),
+    updateState: (patch) =>
+      Ref.update(stateRef, (current) => ({
+        ...current,
+        ...patch,
+        recentProjects:
+          patch.recentProjects === undefined
+            ? current.recentProjects
+            : normalizeRecentProjects(patch.recentProjects),
+      })).pipe(Effect.andThen(refreshTray)),
+    destroy: Ref.get(trayRef).pipe(
+      Effect.flatMap(
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: (tray) =>
+            Effect.sync(() => {
+              tray.destroy();
+            }),
+        }),
+      ),
+      Effect.andThen(Ref.set(trayRef, Option.none())),
+    ),
+  });
+});
+
+export const layer = Layer.effect(ElectronTray, make);

--- a/t3code/apps/desktop/src/electron/_contributor.json
+++ b/t3code/apps/desktop/src/electron/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "issue": 859,
+  "contribution": "Added an Electron system tray service with status-colored icon, context menu actions, tooltip updates, recent project menu support, startup wiring, and unit coverage."
+}

--- a/t3code/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/t3code/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -40,6 +40,7 @@ import {
   pickFolder,
   setTheme,
   showContextMenu,
+  updateTrayState,
 } from "./methods/window.ts";
 
 export const installDesktopIpcHandlers = Effect.gen(function* () {
@@ -75,6 +76,7 @@ export const installDesktopIpcHandlers = Effect.gen(function* () {
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
+  yield* ipc.handle(updateTrayState);
 
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);

--- a/t3code/apps/desktop/src/ipc/channels.ts
+++ b/t3code/apps/desktop/src/ipc/channels.ts
@@ -3,6 +3,7 @@ export const CONFIRM_CHANNEL = "desktop:confirm";
 export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
+export const UPDATE_TRAY_STATE_CHANNEL = "desktop:update-tray-state";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";

--- a/t3code/apps/desktop/src/ipc/methods/window.ts
+++ b/t3code/apps/desktop/src/ipc/methods/window.ts
@@ -3,6 +3,7 @@ import {
   DesktopAppBrandingSchema,
   DesktopEnvironmentBootstrapSchema,
   DesktopThemeSchema,
+  DesktopTrayStateInputSchema,
   PickFolderOptionsSchema,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
@@ -15,6 +16,7 @@ import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../../electron/ElectronMenu.ts";
 import * as ElectronShell from "../../electron/ElectronShell.ts";
 import * as ElectronTheme from "../../electron/ElectronTheme.ts";
+import * as ElectronTray from "../../electron/ElectronTray.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import * as IpcChannels from "../channels.ts";
 import { makeIpcMethod, makeSyncIpcMethod } from "../DesktopIpc.ts";
@@ -131,5 +133,15 @@ export const openExternal = makeIpcMethod({
   handler: Effect.fn("desktop.ipc.window.openExternal")(function* (url) {
     const shell = yield* ElectronShell.ElectronShell;
     return yield* shell.openExternal(url);
+  }),
+});
+
+export const updateTrayState = makeIpcMethod({
+  channel: IpcChannels.UPDATE_TRAY_STATE_CHANNEL,
+  payload: DesktopTrayStateInputSchema,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.updateTrayState")(function* (state) {
+    const tray = yield* ElectronTray.ElectronTray;
+    yield* tray.updateState(state);
   }),
 });

--- a/t3code/apps/desktop/src/main.ts
+++ b/t3code/apps/desktop/src/main.ts
@@ -44,6 +44,7 @@ import * as DesktopSshRemoteApi from "./ssh/DesktopSshRemoteApi.ts";
 import * as DesktopState from "./app/DesktopState.ts";
 import * as DesktopUpdates from "./updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
+import * as ElectronTray from "./electron/ElectronTray.ts";
 
 const desktopEnvironmentLayer = Layer.unwrap(
   Effect.gen(function* () {
@@ -136,6 +137,7 @@ const desktopBackendLayer = DesktopBackendManager.layer.pipe(
 const desktopApplicationLayer = Layer.mergeAll(
   DesktopLifecycle.layer,
   DesktopApplicationMenu.layer,
+  ElectronTray.layer,
   DesktopShellEnvironment.layer,
   desktopSshLayer,
 ).pipe(Layer.provideMerge(DesktopUpdates.layer), Layer.provideMerge(desktopBackendLayer));

--- a/t3code/apps/desktop/src/preload.ts
+++ b/t3code/apps/desktop/src/preload.ts
@@ -96,6 +96,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
+  updateTrayState: (state) => ipcRenderer.invoke(IpcChannels.UPDATE_TRAY_STATE_CHANNEL, state),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/t3code/apps/web/src/components/Sidebar.tsx
+++ b/t3code/apps/web/src/components/Sidebar.tsx
@@ -2902,6 +2902,62 @@ export default function Sidebar() {
       ) ?? scopedProjectKey(scopeProjectRef(activeThread.environmentId, activeThread.projectId));
     return physicalToLogicalKey.get(physicalKey) ?? physicalKey;
   }, [routeThreadKey, sidebarThreadByKey, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
+  const activeTrayProject =
+    activeRouteProjectKey === null ? null : sidebarProjectByKey.get(activeRouteProjectKey) ?? null;
+
+  useEffect(() => {
+    const updateTrayState = window.desktopBridge?.updateTrayState;
+    if (typeof updateTrayState !== "function") {
+      return;
+    }
+
+    void updateTrayState({
+      activeProjectName: activeTrayProject?.displayName ?? null,
+      recentProjects: sidebarProjects.slice(0, 5).map((project) => ({
+        name: project.displayName,
+        path: project.cwd,
+      })),
+    });
+  }, [activeTrayProject?.displayName, sidebarProjects]);
+
+  useEffect(() => {
+    const onMenuAction = window.desktopBridge?.onMenuAction;
+    if (typeof onMenuAction !== "function") {
+      return;
+    }
+
+    const openProject = (projectPath: string | null) => {
+      const targetProject =
+        projectPath === null
+          ? activeTrayProject ?? sidebarProjects[0] ?? null
+          : (sidebarProjects.find(
+              (project) =>
+                project.cwd === projectPath ||
+                project.memberProjects.some((member) => member.cwd === projectPath),
+            ) ?? null);
+      const member = targetProject?.memberProjects[0];
+      if (!member) {
+        return;
+      }
+      void handleNewThread(scopeProjectRef(member.environmentId, member.id));
+    };
+
+    const unsubscribe = onMenuAction((action) => {
+      if (action === "new-chat") {
+        openProject(null);
+        return;
+      }
+
+      const openProjectPrefix = "open-project:";
+      if (action.startsWith(openProjectPrefix)) {
+        openProject(action.slice(openProjectPrefix.length));
+      }
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [activeTrayProject, handleNewThread, sidebarProjects]);
 
   // Group threads by logical project key so all threads from grouped projects
   // are displayed together.

--- a/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/t3code/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -449,6 +449,7 @@ const createDesktopBridgeStub = (overrides?: {
     setTheme: vi.fn().mockResolvedValue(undefined),
     showContextMenu: vi.fn().mockResolvedValue(null),
     openExternal: vi.fn().mockResolvedValue(true),
+    updateTrayState: vi.fn().mockResolvedValue(undefined),
     onMenuAction: () => () => {},
     getUpdateState: vi.fn().mockResolvedValue(idleUpdateState),
     setUpdateChannel:

--- a/t3code/apps/web/src/localApi.test.ts
+++ b/t3code/apps/web/src/localApi.test.ts
@@ -225,6 +225,7 @@ function makeDesktopBridge(overrides: Partial<DesktopBridge> = {}): DesktopBridg
     setTheme: async () => undefined,
     showContextMenu: async () => null,
     openExternal: async () => true,
+    updateTrayState: async () => undefined,
     onMenuAction: () => () => undefined,
     getUpdateState: async () => {
       throw new Error("getUpdateState not implemented in test");

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -369,6 +369,26 @@ export const PickFolderOptionsSchema = Schema.Struct({
   initialPath: Schema.optionalKey(Schema.NullOr(Schema.String)),
 });
 
+export interface DesktopTrayRecentProject {
+  name: string;
+  path: string;
+}
+
+export const DesktopTrayRecentProjectSchema = Schema.Struct({
+  name: Schema.String,
+  path: Schema.String,
+});
+
+export interface DesktopTrayStateInput {
+  activeProjectName: string | null;
+  recentProjects: readonly DesktopTrayRecentProject[];
+}
+
+export const DesktopTrayStateInputSchema = Schema.Struct({
+  activeProjectName: Schema.NullOr(Schema.String),
+  recentProjects: Schema.Array(DesktopTrayRecentProjectSchema),
+});
+
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
   getLocalEnvironmentBootstrap: () => DesktopEnvironmentBootstrap | null;
@@ -414,6 +434,7 @@ export interface DesktopBridge {
     position?: { x: number; y: number },
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
+  updateTrayState: (state: DesktopTrayStateInput) => Promise<void>;
   onMenuAction: (listener: (action: string) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;


### PR DESCRIPTION
/claim #859

## Summary
- Added an ElectronTray service that creates a status-colored tray icon, tooltip, and context menu.
- Wired tray startup/cleanup into the desktop app lifecycle and marks the tray connected after backend bootstrap.
- Added a desktopBridge updateTrayState IPC path so the web sidebar can feed active project and the latest five projects to the tray.
- Connected tray actions for show/hide, new chat, recent project selection, and quit.
- Added unit coverage for tray tooltip, icon color, menu shape, and recent project normalization.

## Validation
- apps/desktop: vitest run src/electron/ElectronTray.test.ts --passWithNoTests
- apps/desktop: tsc --noEmit
- apps/web: tsc --noEmit
- packages/contracts: tsc --noEmit
- git diff --check