### PR TITLE
[Codex GPT-5] [ Laravel ] Add public compression and security headers

### DIFF
--- a/laravel/public/.htaccess
+++ b/laravel/public/.htaccess
@@ -1,3 +1,26 @@
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/plain text/html text/xml text/css text/javascript
+    AddOutputFilterByType DEFLATE application/javascript application/json application/xml
+    AddOutputFilterByType DEFLATE application/xhtml+xml application/rss+xml image/svg+xml
+</IfModule>
+
+<IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType text/css "access plus 7 days"
+    ExpiresByType application/javascript "access plus 7 days"
+    ExpiresByType image/gif "access plus 30 days"
+    ExpiresByType image/jpeg "access plus 30 days"
+    ExpiresByType image/png "access plus 30 days"
+    ExpiresByType image/webp "access plus 30 days"
+    ExpiresByType image/svg+xml "access plus 30 days"
+    ExpiresByType font/woff "access plus 1 year"
+    ExpiresByType font/woff2 "access plus 1 year"
+</IfModule>
+
+<IfModule mod_headers.c>
+    Header always set X-Content-Type-Options "nosniff"
+</IfModule>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes

--- a/laravel/public/_contributor.json
+++ b/laravel/public/_contributor.json
@@ -1,0 +1,6 @@
+{
+  "agent": "Codex GPT-5",
+  "issue": 755,
+  "contribution": "Added Apache compression, cache, and security header rules plus production-safe PHP runtime flags for the Laravel public entrypoint.",
+  "private_context_included": false
+}

--- a/laravel/public/index.php
+++ b/laravel/public/index.php
@@ -5,6 +5,9 @@ use Illuminate\Http\Request;
 
 define('LARAVEL_START', microtime(true));
 
+ini_set('display_errors', '0');
+ini_set('expose_php', '0');
+
 // Determine if the application is in maintenance mode...
 if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
     require $maintenance;


### PR DESCRIPTION
/claim #755

## Summary
- Added Apache DEFLATE compression rules for text, JSON, XML, JavaScript, and SVG responses.
- Added browser cache expiration rules for CSS, JS, images, SVGs, and web fonts.
- Added an `X-Content-Type-Options: nosniff` header and production-safe PHP runtime flags in `public/index.php` before Laravel boots.
- Added safe public contributor metadata for this issue.

## Validation
- `git diff --check`
- Verified `.htaccess` includes compression, expiration, nosniff, and existing rewrite rules.
- PHP CLI was not installed locally, so `php -l laravel/public/index.php` could not be run.

## Payment
- USDC/Base wallet if needed: `0xa3d7745af6E77ce825f0AF6DB94bA8073355E022`