### PR TITLE
fix: add ARIA attributes to ChatView for screen reader support

### DIFF
--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3497,7 +3497,7 @@ export default function ChatView(props: ChatViewProps) {
   }
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background" role="main" aria-label="Chat view">
       {/* Top bar */}
       <header
         className={cn(
@@ -3551,7 +3551,7 @@ export default function ChatView(props: ChatViewProps) {
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
+          <div className="relative flex min-h-0 flex-1 flex-col" role="log" aria-live="polite" aria-label="Chat messages">
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}


### PR DESCRIPTION
Add role=main, aria-label, role=log, and aria-live=polite to chat container and messages wrapper.

Closes #852