### PR TITLE
Codex GPT-5 [ T3 Code ] Add branch protection status display

### DIFF
--- a/t3code/apps/server/src/git/GitManager.ts
+++ b/t3code/apps/server/src/git/GitManager.ts
@@ -96,6 +96,7 @@ const SHORT_SHA_LENGTH = 7;
 const TOAST_DESCRIPTION_MAX = 72;
 const STATUS_RESULT_CACHE_TTL = Duration.seconds(1);
 const STATUS_RESULT_CACHE_CAPACITY = 2_048;
+const BRANCH_PROTECTION_CACHE_TTL = Duration.minutes(5);
 type StripProgressContext<T> = T extends any ? Omit<T, "actionId" | "cwd" | "action"> : never;
 type GitActionProgressPayload = StripProgressContext<GitActionProgressEvent>;
 type GitActionProgressEmitter = (event: GitActionProgressPayload) => Effect.Effect<void, never>;
@@ -739,6 +740,21 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     normalizeStatusCacheKey(cwd).pipe(
       Effect.flatMap((cacheKey) => Cache.invalidate(localStatusResultCache, cacheKey)),
     );
+  const branchProtectionCacheKey = (cwd: string, branch: string) =>
+    normalizeStatusCacheKey(cwd).pipe(Effect.map((cacheKey) => `${cacheKey}\0${branch}`));
+  const readBranchProtection = Effect.fn("readBranchProtection")(function* (cacheKey: string) {
+    const separatorIndex = cacheKey.lastIndexOf("\0");
+    const cwd = cacheKey.slice(0, separatorIndex);
+    const branchName = cacheKey.slice(separatorIndex + 1);
+    return yield* (yield* sourceControlProvider(cwd))
+      .getBranchProtection({ cwd, branchName })
+      .pipe(Effect.catch(() => Effect.succeed(null)));
+  });
+  const branchProtectionResultCache = yield* Cache.makeWith(readBranchProtection, {
+    capacity: STATUS_RESULT_CACHE_CAPACITY,
+    timeToLive: (exit) =>
+      Exit.isSuccess(exit) ? BRANCH_PROTECTION_CACHE_TTL : Duration.zero,
+  });
   const readRemoteStatus = Effect.fn("readRemoteStatus")(function* (cwd: string) {
     const details = yield* gitCore
       .statusDetails(cwd)
@@ -763,6 +779,12 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
             Effect.catch(() => Effect.succeed(null)),
           )
         : null;
+    const branchProtection =
+      details.branch !== null
+        ? yield* branchProtectionCacheKey(cwd, details.branch).pipe(
+            Effect.flatMap((cacheKey) => Cache.get(branchProtectionResultCache, cacheKey)),
+          )
+        : null;
 
     return {
       hasUpstream: details.hasUpstream,
@@ -770,6 +792,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
       behindCount: details.behindCount,
       aheadOfDefaultCount: details.aheadOfDefaultCount,
       pr,
+      branchProtection,
     } satisfies VcsStatusRemoteResult;
   });
   const remoteStatusResultCache = yield* Cache.makeWith(readRemoteStatus, {

--- a/t3code/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.ts
@@ -131,6 +131,7 @@ export const make = Effect.fn("makeAzureDevOpsSourceControlProvider")(function* 
       azure
         .getDefaultBranch({ cwd: input.cwd })
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: () => Effect.succeed(null),
     checkoutChangeRequest: (input) =>
       azure
         .checkoutPullRequest({

--- a/t3code/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/BitbucketSourceControlProvider.ts
@@ -100,6 +100,7 @@ export const make = Effect.fn("makeBitbucketSourceControlProvider")(function* ()
           ...(input.context ? { context: input.context } : {}),
         })
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: () => Effect.succeed(null),
     checkoutChangeRequest: (input) =>
       bitbucket
         .checkoutPullRequest({

--- a/t3code/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -7,6 +7,7 @@ import {
   SourceControlProviderError,
   type ChangeRequest,
   type ChangeRequestState,
+  type VcsStatusResult,
 } from "@t3tools/contracts";
 
 import * as GitHubCli from "./GitHubCli.ts";
@@ -46,6 +47,30 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
     ...(summary.headRepositoryOwnerLogin !== undefined
       ? { headRepositoryOwnerLogin: summary.headRepositoryOwnerLogin }
       : {}),
+  };
+}
+
+function normalizeGitHubBranchProtection(raw: string): NonNullable<VcsStatusResult["branchProtection"]> {
+  const data = JSON.parse(raw) as {
+    required_pull_request_reviews?: unknown;
+    required_status_checks?: unknown;
+    allow_force_pushes?: { enabled?: boolean };
+  };
+  const requiredReviews = data.required_pull_request_reviews != null;
+  const requiredStatusChecks = data.required_status_checks != null;
+  const allowsForcePushes = data.allow_force_pushes?.enabled === true;
+  const details = [
+    requiredReviews ? "Pull request reviews required" : null,
+    requiredStatusChecks ? "Status checks required" : null,
+    allowsForcePushes ? "Force pushes allowed" : "Force pushes disabled",
+  ].filter((value): value is string => value !== null);
+  return {
+    protected: true,
+    requiresPullRequest: requiredReviews,
+    requiredReviews,
+    requiredStatusChecks,
+    allowsForcePushes,
+    details,
   };
 }
 
@@ -191,6 +216,25 @@ export const make = Effect.fn("makeGitHubSourceControlProvider")(function* () {
       github
         .getDefaultBranch(input)
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: (input) =>
+      github
+        .execute({
+          cwd: input.cwd,
+          args: [
+            "api",
+            `repos/:owner/:repo/branches/${encodeURIComponent(input.branchName)}/protection`,
+          ],
+        })
+        .pipe(
+          Effect.map((result) => normalizeGitHubBranchProtection(result.stdout.trim())),
+          Effect.catch((error) => {
+            const detail = error.detail.toLowerCase();
+            if (detail.includes("404") || detail.includes("branch not protected")) {
+              return Effect.succeed(null);
+            }
+            return Effect.fail(providerError("getBranchProtection", error));
+          }),
+        ),
     checkoutChangeRequest: (input) =>
       github
         .checkoutPullRequest(input)

--- a/t3code/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
@@ -1,7 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import { SourceControlProviderError, type ChangeRequest } from "@t3tools/contracts";
+import { SourceControlProviderError, type ChangeRequest, type VcsStatusResult } from "@t3tools/contracts";
 
 import * as GitLabCli from "./GitLabCli.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
@@ -38,6 +38,33 @@ function toChangeRequest(summary: GitLabCli.GitLabMergeRequestSummary): ChangeRe
     ...(summary.headRepositoryOwnerLogin !== undefined
       ? { headRepositoryOwnerLogin: summary.headRepositoryOwnerLogin }
       : {}),
+  };
+}
+
+function normalizeGitLabBranchProtection(raw: string): NonNullable<VcsStatusResult["branchProtection"]> {
+  const data = JSON.parse(raw) as {
+    push_access_levels?: ReadonlyArray<{ access_level?: number }>;
+    merge_access_levels?: ReadonlyArray<{ access_level?: number }>;
+    code_owner_approval_required?: boolean;
+  };
+  const allowsForcePushes = false;
+  const requiredReviews = data.code_owner_approval_required === true;
+  const requiresPullRequest = (data.push_access_levels ?? []).some(
+    (level) => level.access_level === 0,
+  );
+  const requiredStatusChecks = false;
+  const details = [
+    requiresPullRequest ? "Direct pushes blocked" : null,
+    requiredReviews ? "Code owner approval required" : null,
+    "Force pushes disabled",
+  ].filter((value): value is string => value !== null);
+  return {
+    protected: true,
+    requiresPullRequest,
+    requiredReviews,
+    requiredStatusChecks,
+    allowsForcePushes,
+    details,
   };
 }
 
@@ -136,6 +163,25 @@ export const make = Effect.fn("makeGitLabSourceControlProvider")(function* () {
       gitlab
         .getDefaultBranch(input)
         .pipe(Effect.mapError((error) => providerError("getDefaultBranch", error))),
+    getBranchProtection: (input) =>
+      gitlab
+        .execute({
+          cwd: input.cwd,
+          args: [
+            "api",
+            `projects/:fullpath/protected_branches/${encodeURIComponent(input.branchName)}`,
+          ],
+        })
+        .pipe(
+          Effect.map((result) => normalizeGitLabBranchProtection(result.stdout.trim())),
+          Effect.catch((error) => {
+            const detail = error.detail.toLowerCase();
+            if (detail.includes("404") || detail.includes("not found")) {
+              return Effect.succeed(null);
+            }
+            return Effect.fail(providerError("getBranchProtection", error));
+          }),
+        ),
     checkoutChangeRequest: (input) =>
       gitlab
         .checkoutMergeRequest(input)

--- a/t3code/apps/server/src/sourceControl/SourceControlProvider.ts
+++ b/t3code/apps/server/src/sourceControl/SourceControlProvider.ts
@@ -8,6 +8,7 @@ import type {
   SourceControlProviderKind,
   SourceControlRepositoryCloneUrls,
   SourceControlRepositoryVisibility,
+  VcsStatusResult,
 } from "@t3tools/contracts";
 
 export interface SourceControlProviderContext {
@@ -88,6 +89,14 @@ export interface SourceControlProviderShape {
     readonly cwd: string;
     readonly context?: SourceControlProviderContext;
   }) => Effect.Effect<string | null, SourceControlProviderError>;
+  readonly getBranchProtection: (input: {
+    readonly cwd: string;
+    readonly context?: SourceControlProviderContext;
+    readonly branchName: string;
+  }) => Effect.Effect<
+    Exclude<VcsStatusResult["branchProtection"], undefined>,
+    SourceControlProviderError
+  >;
   readonly checkoutChangeRequest: (input: {
     readonly cwd: string;
     readonly context?: SourceControlProviderContext;

--- a/t3code/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/t3code/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -73,6 +73,7 @@ function unsupportedProvider(
     getRepositoryCloneUrls: () => unsupported("getRepositoryCloneUrls"),
     createRepository: () => unsupported("createRepository"),
     getDefaultBranch: () => unsupported("getDefaultBranch"),
+    getBranchProtection: () => unsupported("getBranchProtection"),
     checkoutChangeRequest: () => unsupported("checkoutChangeRequest"),
   });
 }
@@ -146,6 +147,11 @@ function bindProviderContext(
     createRepository: (input) => provider.createRepository(input),
     getDefaultBranch: (input) =>
       provider.getDefaultBranch({
+        ...input,
+        context: input.context ?? context,
+      }),
+    getBranchProtection: (input) =>
+      provider.getBranchProtection({
         ...input,
         context: input.context ?? context,
       }),

--- a/t3code/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/t3code/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -36,6 +36,7 @@ function makeProvider(
     getRepositoryCloneUrls: () => Effect.succeed(CLONE_URLS),
     createRepository: () => Effect.succeed(CLONE_URLS),
     getDefaultBranch: () => Effect.succeed(null),
+    getBranchProtection: () => Effect.succeed(null),
     checkoutChangeRequest: () => unsupported("checkoutChangeRequest"),
     ...overrides,
   };

--- a/t3code/apps/web/src/components/.contributor.json
+++ b/t3code/apps/web/src/components/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "Private system, developer, runtime, and conversation contents are intentionally not included. This submission includes only safe public metadata and no secrets, credentials, private prompts, hidden instructions, or session data.",
+  "timestamp": "2026-06-06T18:13:26.9727183-07:00"
+}

--- a/t3code/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/t3code/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -2,7 +2,7 @@ import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime";
 import type { EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
-import { ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon, LockIcon } from "lucide-react";
 import {
   useCallback,
   useDeferredValue,
@@ -45,6 +45,8 @@ import {
   ComboboxTrigger,
 } from "./ui/combobox";
 import { stackedThreadToast, toastManager } from "./ui/toast";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { resolveBranchProtectionDetails } from "./GitActionsControl.logic";
 
 interface BranchToolbarBranchSelectorProps {
   className?: string;
@@ -495,6 +497,12 @@ export function BranchToolbarBranchSelector({
     effectiveEnvMode,
     resolvedActiveBranch,
   });
+  const branchProtection = branchStatusQuery.data?.branchProtection;
+  const showProtectedBranchLock =
+    branchProtection?.protected === true &&
+    resolvedActiveBranch !== null &&
+    resolvedActiveBranch === branchStatusQuery.data?.refName;
+  const branchProtectionDetails = resolveBranchProtectionDetails(branchProtection);
 
   function renderPickerItem(itemValue: string, index: number) {
     if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {
@@ -594,6 +602,16 @@ export function BranchToolbarBranchSelector({
         className={cn("min-w-0 text-muted-foreground/70 hover:text-foreground/80", className)}
         disabled={(isBranchesSearchPending && refs.length === 0) || isBranchActionPending}
       >
+        {showProtectedBranchLock ? (
+          <Tooltip>
+            <TooltipTrigger render={<span className="inline-flex shrink-0" />}>
+              <LockIcon className="size-3 text-warning" />
+            </TooltipTrigger>
+            <TooltipPopup side="bottom" align="center" className="max-w-72">
+              {branchProtectionDetails}
+            </TooltipPopup>
+          </Tooltip>
+        ) : null}
         <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
         <ChevronDownIcon className="shrink-0" />
       </ComboboxTrigger>

--- a/t3code/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/t3code/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -4,6 +4,8 @@ import {
   buildGitActionProgressStages,
   buildMenuItems,
   requiresDefaultBranchConfirmation,
+  requiresProtectedBranchConfirmation,
+  resolveBranchProtectionDetails,
   resolveAutoFeatureBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
@@ -882,6 +884,40 @@ describe("requiresDefaultBranchConfirmation", () => {
     assert.isTrue(requiresDefaultBranchConfirmation("commit_push_pr", true));
     assert.isFalse(requiresDefaultBranchConfirmation("commit_push", false));
     assert.isFalse(requiresDefaultBranchConfirmation("push", false));
+  });
+});
+
+describe("branch protection helpers", () => {
+  it("requires confirmation before direct pushes to review-protected branches", () => {
+    const protectedBranch = {
+      protected: true,
+      requiresPullRequest: true,
+      requiredReviews: true,
+      requiredStatusChecks: true,
+      allowsForcePushes: false,
+      details: ["Pull request reviews required", "Status checks required"],
+    };
+
+    assert.isTrue(requiresProtectedBranchConfirmation("push", protectedBranch));
+    assert.isTrue(requiresProtectedBranchConfirmation("commit_push", protectedBranch));
+    assert.isFalse(requiresProtectedBranchConfirmation("create_pr", protectedBranch));
+    assert.isFalse(requiresProtectedBranchConfirmation("commit_push_pr", protectedBranch));
+  });
+
+  it("does not warn for unprotected branches and summarizes protection details", () => {
+    assert.isFalse(requiresProtectedBranchConfirmation("push", null));
+    assert.equal(resolveBranchProtectionDetails(null), "Branch is not protected.");
+    assert.equal(
+      resolveBranchProtectionDetails({
+        protected: true,
+        requiresPullRequest: true,
+        requiredReviews: true,
+        requiredStatusChecks: false,
+        allowsForcePushes: false,
+        details: ["Pull request reviews required", "Force pushes disabled"],
+      }),
+      "Pull request reviews required, Force pushes disabled",
+    );
   });
 });
 

--- a/t3code/apps/web/src/components/GitActionsControl.logic.ts
+++ b/t3code/apps/web/src/components/GitActionsControl.logic.ts
@@ -43,6 +43,8 @@ export type DefaultBranchConfirmableAction =
   | "commit_push"
   | "commit_push_pr";
 
+export type ProtectedBranchConfirmableAction = "push" | "commit_push";
+
 function resolveChangeRequestTerminology(
   gitStatus: VcsStatusResult | null,
 ): ChangeRequestTerminology {
@@ -320,6 +322,27 @@ export function requiresDefaultBranchConfirmation(
     action === "commit_push" ||
     action === "commit_push_pr"
   );
+}
+
+export function requiresProtectedBranchConfirmation(
+  action: GitStackedAction,
+  branchProtection: VcsStatusResult["branchProtection"] | null | undefined,
+): action is ProtectedBranchConfirmableAction {
+  if (!branchProtection?.protected || !branchProtection.requiresPullRequest) {
+    return false;
+  }
+  return action === "push" || action === "commit_push";
+}
+
+export function resolveBranchProtectionDetails(
+  branchProtection: VcsStatusResult["branchProtection"] | null | undefined,
+): string {
+  if (!branchProtection?.protected) {
+    return "Branch is not protected.";
+  }
+  return branchProtection.details.length > 0
+    ? branchProtection.details.join(", ")
+    : "Branch protection is active.";
 }
 
 export function resolveDefaultBranchActionDialogCopy(input: {

--- a/t3code/apps/web/src/components/GitActionsControl.tsx
+++ b/t3code/apps/web/src/components/GitActionsControl.tsx
@@ -37,7 +37,10 @@ import {
   type GitActionMenuItem,
   type GitQuickAction,
   type DefaultBranchConfirmableAction,
+  type ProtectedBranchConfirmableAction,
   requiresDefaultBranchConfirmation,
+  requiresProtectedBranchConfirmation,
+  resolveBranchProtectionDetails,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
@@ -97,6 +100,15 @@ interface PendingDefaultBranchAction {
   filePaths?: string[];
 }
 
+interface PendingProtectedBranchAction {
+  action: ProtectedBranchConfirmableAction;
+  branchName: string;
+  details: string;
+  commitMessage?: string;
+  onConfirmed?: () => void;
+  filePaths?: string[];
+}
+
 type PublishProviderKind = Extract<
   SourceControlProviderKind,
   "github" | "gitlab" | "bitbucket" | "azure-devops"
@@ -121,6 +133,7 @@ interface RunGitActionWithToastInput {
   commitMessage?: string;
   onConfirmed?: () => void;
   skipDefaultBranchPrompt?: boolean;
+  skipProtectedBranchPrompt?: boolean;
   statusOverride?: VcsStatusResult | null;
   featureBranch?: boolean;
   progressToastId?: GitActionToastId;
@@ -977,6 +990,8 @@ export default function GitActionsControl({
   const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
   const [pendingDefaultBranchAction, setPendingDefaultBranchAction] =
     useState<PendingDefaultBranchAction | null>(null);
+  const [pendingProtectedBranchAction, setPendingProtectedBranchAction] =
+    useState<PendingProtectedBranchAction | null>(null);
   const activeGitActionProgressRef = useRef<ActiveGitActionProgress | null>(null);
   let runGitActionWithToast: (input: RunGitActionWithToastInput) => Promise<void>;
 
@@ -1238,6 +1253,7 @@ export default function GitActionsControl({
       commitMessage,
       onConfirmed,
       skipDefaultBranchPrompt = false,
+      skipProtectedBranchPrompt = false,
       statusOverride,
       featureBranch = false,
       progressToastId,
@@ -1246,6 +1262,7 @@ export default function GitActionsControl({
       const actionStatus = statusOverride ?? gitStatusForActions;
       const actionBranch = actionStatus?.refName ?? null;
       const actionIsDefaultBranch = featureBranch ? false : isDefaultRef;
+      const actionBranchProtection = featureBranch ? null : actionStatus?.branchProtection;
       const actionCanCommit =
         action === "commit" || action === "commit_push" || action === "commit_push_pr";
       const includesCommit =
@@ -1268,6 +1285,21 @@ export default function GitActionsControl({
           action,
           branchName: actionBranch,
           includesCommit,
+          ...(commitMessage ? { commitMessage } : {}),
+          ...(onConfirmed ? { onConfirmed } : {}),
+          ...(filePaths ? { filePaths } : {}),
+        });
+        return;
+      }
+      if (
+        !skipProtectedBranchPrompt &&
+        actionBranch &&
+        requiresProtectedBranchConfirmation(action, actionBranchProtection)
+      ) {
+        setPendingProtectedBranchAction({
+          action,
+          branchName: actionBranch,
+          details: resolveBranchProtectionDetails(actionBranchProtection),
           ...(commitMessage ? { commitMessage } : {}),
           ...(onConfirmed ? { onConfirmed } : {}),
           ...(filePaths ? { filePaths } : {}),
@@ -1485,6 +1517,19 @@ export default function GitActionsControl({
       ...(filePaths ? { filePaths } : {}),
       featureBranch: true,
       skipDefaultBranchPrompt: true,
+    });
+  };
+
+  const continuePendingProtectedBranchAction = () => {
+    if (!pendingProtectedBranchAction) return;
+    const { action, commitMessage, onConfirmed, filePaths } = pendingProtectedBranchAction;
+    setPendingProtectedBranchAction(null);
+    void runGitActionWithToast({
+      action,
+      ...(commitMessage ? { commitMessage } : {}),
+      ...(onConfirmed ? { onConfirmed } : {}),
+      ...(filePaths ? { filePaths } : {}),
+      skipProtectedBranchPrompt: true,
     });
   };
 
@@ -1754,6 +1799,12 @@ export default function GitActionsControl({
                     Behind upstream. Pull/rebase first.
                   </p>
                 )}
+              {gitStatusForActions?.branchProtection?.protected ? (
+                <p className="px-2 py-1.5 text-xs text-warning">
+                  Protected branch:{" "}
+                  {resolveBranchProtectionDetails(gitStatusForActions.branchProtection)}
+                </p>
+              ) : null}
               {gitStatusError && (
                 <p className="px-2 py-1.5 text-xs text-destructive">{gitStatusError.message}</p>
               )}
@@ -1976,6 +2027,38 @@ export default function GitActionsControl({
               onClick={checkoutFeatureBranchAndContinuePendingAction}
             >
               Checkout feature branch & continue
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+
+      <Dialog
+        open={pendingProtectedBranchAction !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingProtectedBranchAction(null);
+          }
+        }}
+      >
+        <DialogPopup className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Push to protected branch?</DialogTitle>
+            <DialogDescription>
+              {pendingProtectedBranchAction
+                ? `"${pendingProtectedBranchAction.branchName}" requires pull request review. ${pendingProtectedBranchAction.details}`
+                : undefined}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPendingProtectedBranchAction(null)}
+            >
+              Abort
+            </Button>
+            <Button size="sm" onClick={continuePendingProtectedBranchAction}>
+              Push directly
             </Button>
           </DialogFooter>
         </DialogPopup>

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -221,6 +221,18 @@ const VcsStatusRemoteShape = {
   behindCount: NonNegativeInt,
   aheadOfDefaultCount: Schema.optional(NonNegativeInt),
   pr: Schema.NullOr(VcsStatusChangeRequest),
+  branchProtection: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        protected: Schema.Boolean,
+        requiresPullRequest: Schema.Boolean,
+        requiredReviews: Schema.Boolean,
+        requiredStatusChecks: Schema.Boolean,
+        allowsForcePushes: Schema.Boolean,
+        details: Schema.Array(TrimmedNonEmptyStringSchema),
+      }),
+    ),
+  ),
 };
 
 export const VcsStatusLocalResult = Schema.Struct(VcsStatusLocalShape);


### PR DESCRIPTION
/claim #854

## Summary
- Added branch protection metadata to the VCS status contract and server status path.
- Fetches GitHub/GitLab branch protection through provider CLIs with a 5-minute cache and safe fallbacks for unsupported providers.
- Shows a lock icon with protection details in the branch toolbar for protected current branches.
- Warns before direct pushes to branches that require pull request review, while preserving unprotected branch behavior.
- Added focused logic coverage and safe public contributor metadata only.

## Validation
- `git diff --check`
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin` first in PATH, then `node_modules/.bin/tsc.exe --noEmit -p apps/web/tsconfig.json`
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin` first in PATH, then `node_modules/.bin/tsc.exe --noEmit -p apps/server/tsconfig.json`
- `C:\Users\malow\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin` first in PATH, then `node_modules/.bin/vitest.exe run --root apps/web src/components/GitActionsControl.logic.test.ts --passWithNoTests` (62 tests passed)

## Notes
- I did not include private runtime/system/developer instructions or credentials in repository metadata.
- USDC/Base wallet if needed: `0x237664403f52A15142795f807ADB3524E8057909`