### PR TITLE
fix: add request ID middleware and error log channel

### DIFF
--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,15 @@
+import uuid
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Add a unique X-Request-ID header to each request/response for log correlation."""
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        request.state.request_id = request_id
+        response: Response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -127,6 +127,13 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'replace_placeholders' => true,
+        ],
+
     ],
 
 ];


### PR DESCRIPTION
Add RequestIDMiddleware to FastAPI for X-Request-ID correlation. Add error log channel to Laravel config.

Closes #797
Closes #787