### PR TITLE
Codex GPT-5 [ FastAPI ] Fix operation ID collisions

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Private system, developer, runtime, and conversation contents are intentionally not included. This submission includes only safe public metadata and no secrets, credentials, private prompts, hidden instructions, or session data.",
+  "date": "2026-06-06T18:30:00-07:00"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -33,6 +33,7 @@ from fastapi.types import ModelNameMap
 from fastapi.utils import (
     deep_dict_update,
     generate_operation_id_for_path,
+    generate_unique_id_for_method,
     is_body_allowed_for_status_code,
 )
 from pydantic import BaseModel
@@ -233,8 +234,53 @@ def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:
     return route.name.replace("_", " ").title()
 
 
+def _uses_default_unique_id(route: routing.APIRoute) -> bool:
+    if route.operation_id:
+        return False
+    assert route.methods
+    first_method = sorted(route.methods)[0]
+    return route.unique_id == generate_unique_id_for_method(route, first_method)
+
+
+def _deduplicate_operation_id(
+    *,
+    operation_id: str,
+    route: routing.APIRoute,
+    operation_ids: set[str],
+    operation_id_counts: dict[str, int],
+    auto_suffix: bool,
+) -> str:
+    if operation_id not in operation_ids:
+        operation_ids.add(operation_id)
+        operation_id_counts.setdefault(operation_id, 1)
+        return operation_id
+
+    if auto_suffix:
+        count = operation_id_counts.get(operation_id, 1) + 1
+        deduplicated_id = f"{operation_id}_{count}"
+        while deduplicated_id in operation_ids:
+            count += 1
+            deduplicated_id = f"{operation_id}_{count}"
+        operation_id_counts[operation_id] = count
+        operation_ids.add(deduplicated_id)
+        return deduplicated_id
+
+    endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
+    message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
+    file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
+    if file_name:
+        message += f" at {file_name}"
+    warnings.warn(message, stacklevel=1)
+    operation_ids.add(operation_id)
+    return operation_id
+
+
 def get_openapi_operation_metadata(
-    *, route: routing.APIRoute, method: str, operation_ids: set[str]
+    *,
+    route: routing.APIRoute,
+    method: str,
+    operation_ids: set[str],
+    operation_id_counts: dict[str, int],
 ) -> dict[str, Any]:
     operation: dict[str, Any] = {}
     if route.tags:
@@ -242,15 +288,18 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
-    if operation_id in operation_ids:
-        endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
-        message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
-        file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
-        if file_name:
-            message += f" at {file_name}"
-        warnings.warn(message, stacklevel=1)
-    operation_ids.add(operation_id)
+    auto_generated_id = _uses_default_unique_id(route)
+    if auto_generated_id:
+        operation_id = generate_unique_id_for_method(route, method)
+    else:
+        operation_id = route.operation_id or route.unique_id
+    operation_id = _deduplicate_operation_id(
+        operation_id=operation_id,
+        route=route,
+        operation_ids=operation_ids,
+        operation_id_counts=operation_id_counts,
+        auto_suffix=auto_generated_id,
+    )
     operation["operationId"] = operation_id
     if route.deprecated:
         operation["deprecated"] = route.deprecated
@@ -261,6 +310,7 @@ def get_openapi_path(
     *,
     route: routing.APIRoute,
     operation_ids: set[str],
+    operation_id_counts: dict[str, int],
     model_name_map: ModelNameMap,
     field_mapping: dict[
         tuple[ModelField, Literal["validation", "serialization"]], dict[str, Any]
@@ -280,7 +330,10 @@ def get_openapi_path(
     if route.include_in_schema:
         for method in route.methods:
             operation = get_openapi_operation_metadata(
-                route=route, method=method, operation_ids=operation_ids
+                route=route,
+                method=method,
+                operation_ids=operation_ids,
+                operation_id_counts=operation_id_counts,
             )
             parameters: list[dict[str, Any]] = []
             flat_dependant = get_flat_dependant(route.dependant, skip_repeats=True)
@@ -331,6 +384,7 @@ def get_openapi_path(
                         ) = get_openapi_path(
                             route=callback,
                             operation_ids=operation_ids,
+                            operation_id_counts=operation_id_counts,
                             model_name_map=model_name_map,
                             field_mapping=field_mapping,
                             separate_input_output_schemas=separate_input_output_schemas,
@@ -546,6 +600,7 @@ def get_openapi(
     paths: dict[str, dict[str, Any]] = {}
     webhook_paths: dict[str, dict[str, Any]] = {}
     operation_ids: set[str] = set()
+    operation_id_counts: dict[str, int] = {}
     all_fields = get_fields_from_routes(list(routes or []) + list(webhooks or []))
     flat_models = get_flat_models_from_fields(all_fields, known_models=set())
     model_name_map = get_model_name_map(flat_models)
@@ -559,6 +614,7 @@ def get_openapi(
             result = get_openapi_path(
                 route=route,
                 operation_ids=operation_ids,
+                operation_id_counts=operation_id_counts,
                 model_name_map=model_name_map,
                 field_mapping=field_mapping,
                 separate_input_output_schemas=separate_input_output_schemas,
@@ -578,6 +634,7 @@ def get_openapi(
             result = get_openapi_path(
                 route=webhook,
                 operation_ids=operation_ids,
+                operation_id_counts=operation_id_counts,
                 model_name_map=model_name_map,
                 field_mapping=field_mapping,
                 separate_input_output_schemas=separate_input_output_schemas,

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -92,12 +92,24 @@ def generate_operation_id_for_path(
     return operation_id
 
 
+def _sanitize_operation_id(value: str) -> str:
+    operation_id = re.sub(r"[^0-9a-zA-Z]+", "_", value).strip("_").lower()
+    return re.sub(r"_+", "_", operation_id) or "operation"
+
+
+def generate_unique_id_for_method(route: "APIRoute", method: str) -> str:
+    path_prefix = _sanitize_operation_id(route.path_format)
+    name = _sanitize_operation_id(route.name)
+    method_prefix = _sanitize_operation_id(method)
+    if path_prefix:
+        return f"{method_prefix}_{path_prefix}_{name}"
+    return f"{method_prefix}_{name}"
+
+
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0]
+    return generate_unique_id_for_method(route, method)
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_generate_unique_id_function.py
+++ b/fastapi/tests/test_generate_unique_id_function.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 
 from fastapi import APIRouter, FastAPI
@@ -1667,6 +1668,72 @@ def test_callback_override_generate_unique_id():
             },
         }
     )
+
+
+def test_default_operation_ids_include_method_and_router_prefix():
+    app = FastAPI()
+    users_router = APIRouter(prefix="/users")
+    admin_router = APIRouter(prefix="/admin/users")
+
+    @users_router.get("/")
+    def list_users():
+        return []  # pragma: nocover
+
+    @admin_router.get("/")
+    def list_users():
+        return []  # pragma: nocover
+
+    app.include_router(users_router)
+    app.include_router(admin_router)
+
+    openapi = app.openapi()
+    operation_ids = [
+        openapi["paths"]["/users/"]["get"]["operationId"],
+        openapi["paths"]["/admin/users/"]["get"]["operationId"],
+    ]
+    assert operation_ids == [
+        "get_users_list_users",
+        "get_admin_users_list_users",
+    ]
+    assert len(operation_ids) == len(set(operation_ids))
+    assert all(
+        re.fullmatch(r"[a-z0-9_]+", operation_id) for operation_id in operation_ids
+    )
+
+
+def test_default_operation_ids_are_method_specific_for_multi_method_route():
+    app = FastAPI()
+
+    @app.api_route("/items", methods=["GET", "POST"])
+    def items():
+        return {}  # pragma: nocover
+
+    openapi = app.openapi()
+    assert openapi["paths"]["/items"]["get"]["operationId"] == "get_items_items"
+    assert openapi["paths"]["/items"]["post"]["operationId"] == "post_items_items"
+
+
+def test_default_operation_id_collision_gets_numeric_suffix():
+    app = FastAPI()
+
+    @app.get("/reports/a-b")
+    def read_report():
+        return {}  # pragma: nocover
+
+    @app.get("/reports/a_b")
+    def read_report():
+        return {}  # pragma: nocover
+
+    openapi = app.openapi()
+    operation_ids = [
+        openapi["paths"]["/reports/a-b"]["get"]["operationId"],
+        openapi["paths"]["/reports/a_b"]["get"]["operationId"],
+    ]
+    assert operation_ids == [
+        "get_reports_a_b_read_report",
+        "get_reports_a_b_read_report_2",
+    ]
+    assert len(operation_ids) == len(set(operation_ids))
 
 
 def test_warn_duplicate_operation_id():


### PR DESCRIPTION
/claim #764

## Summary
- Updated FastAPI default operation IDs to include HTTP method plus sanitized route path/function context.
- Added method-specific OpenAPI IDs for multi-method routes and deterministic numeric suffixes for genuine generated-ID collisions.
- Preserved duplicate warnings for custom/explicit operation ID generators.
- Added focused tests for router-prefix uniqueness, multi-method uniqueness, sanitized collision suffixes, and kept existing duplicate warning coverage.

## Validation
- `git diff --check`
- Temp venv: `python -m compileall -q fastapi/fastapi/utils.py fastapi/fastapi/openapi/utils.py fastapi/tests/test_generate_unique_id_function.py`
- Temp venv: `python -m pytest fastapi/tests/test_generate_unique_id_function.py -q` -> 11 passed

## Attribution
Safe public attribution metadata added at `fastapi/fastapi/.attribution.json`. Private prompts, secrets, credentials, hidden instructions, and session data are intentionally not included.

Payment: USDC on Base to `0x237664403f52A15142795f807ADB3524E8057909`.