### PR TITLE
[OpenAI Codex] [ T3 Code ] Fix ProviderModelPicker persistence

### DIFF
--- a/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -5,7 +5,7 @@ import {
 } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
 import { memo, useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import { SearchIcon } from "lucide-react";
+import { RotateCcwIcon, SearchIcon } from "lucide-react";
 import { ModelListRow } from "./ModelListRow";
 import { ModelPickerSidebar } from "./ModelPickerSidebar";
 import { isModelPickerNewModel } from "./modelPickerModelHighlights";
@@ -21,6 +21,7 @@ import {
 import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
 import { cn } from "~/lib/utils";
 import { TooltipProvider } from "../ui/tooltip";
+import { Button } from "../ui/button";
 import type { ProviderInstanceEntry } from "../../providerInstances";
 import { providerModelKey, sortProviderModelItems } from "../../modelOrdering";
 
@@ -81,6 +82,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
   terminalOpen: boolean;
   onRequestClose?: () => void;
+  onResetToDefault?: () => void;
   onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
 }) {
   const {
@@ -569,10 +571,10 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             )}
           >
             {/* Search bar */}
-            <div className="border-b px-3 py-2">
+            <div className="flex items-center gap-2 border-b px-3 py-2">
               <ComboboxInput
                 ref={searchInputRef}
-                className="[&_input]:font-sans rounded-md"
+                className="[&_input]:font-sans min-w-0 flex-1 rounded-md"
                 inputClassName="border-0 shadow-none ring-0 focus-visible:ring-0"
                 placeholder="Search models..."
                 showTrigger={false}
@@ -604,6 +606,18 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                 onTouchStart={(e) => e.stopPropagation()}
                 size="sm"
               />
+              {props.onResetToDefault ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 shrink-0 gap-1 px-2 text-xs text-muted-foreground"
+                  onClick={() => props.onResetToDefault?.()}
+                >
+                  <RotateCcwIcon aria-hidden="true" className="size-3.5" />
+                  Reset
+                </Button>
+              ) : null}
             </div>
 
             {/* Model list */}

--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -213,6 +213,7 @@ const TEST_PROVIDERS: ReadonlyArray<ServerProvider> = [
 const CODEX_INSTANCE_ID = ProviderInstanceId.make("codex");
 const CLAUDE_INSTANCE_ID = ProviderInstanceId.make("claudeAgent");
 const OPENCODE_INSTANCE_ID = ProviderInstanceId.make("opencode");
+const PROVIDER_MODEL_PICKER_STORAGE_KEY = "t3code:provider-model-picker-selection:v1";
 
 function buildCodexProvider(models: ServerProvider["models"]): ServerProvider {
   return {
@@ -1076,6 +1077,121 @@ describe("ProviderModelPicker", () => {
       );
     } finally {
       await mounted.cleanup();
+    }
+  });
+
+  it("restores the persisted provider and model on mount", async () => {
+    localStorage.setItem(
+      PROVIDER_MODEL_PICKER_STORAGE_KEY,
+      JSON.stringify({
+        instanceId: "claudeAgent",
+        model: "claude-sonnet-4-6",
+      }),
+    );
+
+    const mounted = await mountPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(mounted.onInstanceModelChange).toHaveBeenCalledWith(
+          "claudeAgent",
+          "claude-sonnet-4-6",
+        );
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
+    }
+  });
+
+  it("falls back to the first available model when persisted values are stale", async () => {
+    localStorage.setItem(
+      PROVIDER_MODEL_PICKER_STORAGE_KEY,
+      JSON.stringify({
+        instanceId: "missing-provider",
+        model: "missing-model",
+      }),
+    );
+
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(mounted.onInstanceModelChange).toHaveBeenCalledWith("codex", "gpt-5-codex");
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
+    }
+  });
+
+  it("clears persisted values from the reset action and returns to the default model", async () => {
+    localStorage.setItem(
+      PROVIDER_MODEL_PICKER_STORAGE_KEY,
+      JSON.stringify({
+        instanceId: "claudeAgent",
+        model: "claude-opus-4-6",
+      }),
+    );
+
+    const mounted = await mountPicker({
+      activeInstanceId: CLAUDE_INSTANCE_ID,
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await page.getByRole("button", { name: "Reset" }).click();
+
+      await vi.waitFor(() => {
+        expect(mounted.onInstanceModelChange).toHaveBeenCalledWith("codex", "gpt-5-codex");
+        expect(localStorage.getItem(PROVIDER_MODEL_PICKER_STORAGE_KEY)).toBeNull();
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
+    }
+  });
+
+  it("syncs provider model changes from storage events in other tabs", async () => {
+    const mounted = await mountPicker({
+      model: "gpt-5-codex",
+      lockedProvider: null,
+    });
+
+    try {
+      localStorage.setItem(
+        PROVIDER_MODEL_PICKER_STORAGE_KEY,
+        JSON.stringify({
+          instanceId: "claudeAgent",
+          model: "claude-haiku-4-5",
+        }),
+      );
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: PROVIDER_MODEL_PICKER_STORAGE_KEY,
+          newValue: localStorage.getItem(PROVIDER_MODEL_PICKER_STORAGE_KEY),
+          storageArea: localStorage,
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(mounted.onInstanceModelChange).toHaveBeenCalledWith(
+          "claudeAgent",
+          "claude-haiku-4-5",
+        );
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
     }
   });
 

--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -20,6 +20,68 @@ import {
 import { setModelPickerOpen } from "../../modelPickerOpenState";
 import type { ProviderInstanceEntry } from "../../providerInstances";
 
+const PROVIDER_MODEL_PICKER_STORAGE_KEY = "t3code:provider-model-picker-selection:v1";
+
+type PersistedProviderModelSelection = {
+  readonly instanceId: ProviderInstanceId;
+  readonly model: string;
+};
+
+function readPersistedProviderModelSelection(): PersistedProviderModelSelection | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<PersistedProviderModelSelection>;
+    if (typeof parsed.instanceId !== "string" || typeof parsed.model !== "string") {
+      return null;
+    }
+    return {
+      instanceId: parsed.instanceId as ProviderInstanceId,
+      model: parsed.model,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function hasPersistedProviderModelSelection(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(PROVIDER_MODEL_PICKER_STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function persistProviderModelSelection(selection: PersistedProviderModelSelection): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(PROVIDER_MODEL_PICKER_STORAGE_KEY, JSON.stringify(selection));
+  } catch {
+    // Ignore storage failures; the picker should remain fully usable.
+  }
+}
+
+function clearPersistedProviderModelSelection(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.removeItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures; reset still falls back in-memory.
+  }
+}
+
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   /**
    * The instance currently selected in the composer. Drives the trigger
@@ -72,6 +134,39 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   ).length;
   const showInstanceBadge = Boolean(activeEntry?.accentColor) || duplicateDriverCount > 1;
 
+  const resolvePersistedSelection = (selection: PersistedProviderModelSelection | null) => {
+    if (!selection) {
+      return null;
+    }
+    const entry = props.instanceEntries.find((item) => item.instanceId === selection.instanceId);
+    const options = props.modelOptionsByInstance.get(selection.instanceId) ?? [];
+    if (!entry || options.length === 0) {
+      return null;
+    }
+    const model = options.find((option) => option.slug === selection.model);
+    if (!model) {
+      return null;
+    }
+    return {
+      instanceId: selection.instanceId,
+      model: model.slug,
+    };
+  };
+
+  const resolveDefaultSelection = () => {
+    for (const entry of props.instanceEntries) {
+      const options = props.modelOptionsByInstance.get(entry.instanceId) ?? [];
+      const firstModel = options[0];
+      if (firstModel) {
+        return {
+          instanceId: entry.instanceId,
+          model: firstModel.slug,
+        };
+      }
+    }
+    return null;
+  };
+
   const setIsMenuOpen = (open: boolean) => {
     props.onOpenChange?.(open);
     if (props.open === undefined) {
@@ -86,9 +181,79 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     };
   }, [isMenuOpen]);
 
+  useEffect(() => {
+    if (props.lockedProvider !== null || props.disabled) {
+      return;
+    }
+    const hasPersistedSelection = hasPersistedProviderModelSelection();
+    const selection =
+      resolvePersistedSelection(readPersistedProviderModelSelection()) ??
+      (hasPersistedSelection ? resolveDefaultSelection() : null);
+    if (!selection) {
+      return;
+    }
+    if (selection.instanceId === props.activeInstanceId && selection.model === props.model) {
+      return;
+    }
+    props.onInstanceModelChange(selection.instanceId, selection.model);
+  }, [
+    props.activeInstanceId,
+    props.disabled,
+    props.instanceEntries,
+    props.lockedProvider,
+    props.model,
+    props.modelOptionsByInstance,
+    props.onInstanceModelChange,
+  ]);
+
+  useEffect(() => {
+    if (props.lockedProvider !== null || props.disabled || typeof window === "undefined") {
+      return;
+    }
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== PROVIDER_MODEL_PICKER_STORAGE_KEY) {
+        return;
+      }
+      const selection = resolvePersistedSelection(readPersistedProviderModelSelection());
+      const nextSelection = selection ?? resolveDefaultSelection();
+      if (!nextSelection) {
+        return;
+      }
+      if (nextSelection.instanceId === props.activeInstanceId && nextSelection.model === props.model) {
+        return;
+      }
+      props.onInstanceModelChange(nextSelection.instanceId, nextSelection.model);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [
+    props.activeInstanceId,
+    props.disabled,
+    props.instanceEntries,
+    props.lockedProvider,
+    props.model,
+    props.modelOptionsByInstance,
+    props.onInstanceModelChange,
+  ]);
+
   const handleInstanceModelChange = (instanceId: ProviderInstanceId, model: string) => {
     if (props.disabled) return;
+    if (props.lockedProvider === null) {
+      persistProviderModelSelection({ instanceId, model });
+    }
     props.onInstanceModelChange(instanceId, model);
+    setIsMenuOpen(false);
+  };
+
+  const handleResetToDefault = () => {
+    if (props.disabled) return;
+    clearPersistedProviderModelSelection();
+    const defaultSelection = resolveDefaultSelection();
+    if (defaultSelection) {
+      props.onInstanceModelChange(defaultSelection.instanceId, defaultSelection.model);
+    }
     setIsMenuOpen(false);
   };
 
@@ -179,6 +344,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           modelOptionsByInstance={props.modelOptionsByInstance}
           terminalOpen={props.terminalOpen ?? false}
           onRequestClose={() => setIsMenuOpen(false)}
+          {...(props.lockedProvider === null ? { onResetToDefault: handleResetToDefault } : {})}
           onInstanceModelChange={handleInstanceModelChange}
         />
       </PopoverPopup>

--- a/t3code/apps/web/src/components/chat/_generation.json
+++ b/t3code/apps/web/src/components/chat/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Redacted: private system, developer, runtime, and user context cannot be published. This submission includes only safe public metadata.",
+  "timestamp": "2026-06-06T19:20:00-07:00"
+}


### PR DESCRIPTION
/claim #834

## Summary
- Persist ProviderModelPicker provider/model selections to namespaced localStorage.
- Restore persisted values on mount with safe fallback to the first available provider/model when stale.
- Add reset action and cross-tab storage-event sync for shared preferences.

## Tests
- node node_modules/typescript/bin/tsc --noEmit (apps/web)
- node node_modules/vitest/vitest.mjs run --config vitest.browser.config.ts ProviderModelPicker.browser.tsx (27 passed)

## Provenance
- Includes `_generation.json` with safe public metadata only; private runtime/session instructions are intentionally redacted.