### PR TITLE
[OpenAI Codex] [ Laravel ] Add log cleanup command and schedule

### DIFF
--- a/laravel/routes/_generation.json
+++ b/laravel/routes/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Redacted: private system, developer, runtime, and user context cannot be published. This submission includes only safe public metadata.",
+  "timestamp": "2026-06-06T19:37:00-07:00"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,54 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Delete log files older than this many days}', function () {
+    $days = max(0, (int) $this->option('days'));
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $logsPath = storage_path('logs');
+    $deletedFiles = 0;
+    $freedBytes = 0;
+    $formatBytes = function (int $bytes): string {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $value = (float) $bytes;
+        $unitIndex = 0;
+
+        while ($value >= 1024 && $unitIndex < count($units) - 1) {
+            $value /= 1024;
+            $unitIndex++;
+        }
+
+        return sprintf(
+            '%s %s',
+            rtrim(rtrim(number_format($value, 2), '0'), '.'),
+            $units[$unitIndex],
+        );
+    };
+
+    File::ensureDirectoryExists($logsPath);
+
+    foreach (File::files($logsPath) as $file) {
+        if ($file->getMTime() >= $cutoff) {
+            continue;
+        }
+
+        $freedBytes += $file->getSize();
+        File::delete($file->getPathname());
+        $deletedFiles++;
+    }
+
+    $this->info(sprintf(
+        'Deleted %d log file%s and freed %s.',
+        $deletedFiles,
+        $deletedFiles === 1 ? '' : 's',
+        $formatBytes($freedBytes),
+    ));
+})->purpose('Delete old log files from storage/logs');
+
+Schedule::command('logs:clear')->dailyAt('00:00');


### PR DESCRIPTION
/claim #753

## Summary
- Adds `logs:clear {--days=7}` as a closure Artisan command in `laravel/routes/console.php`.
- Deletes log files older than the configured retention period and reports deleted file count plus freed space.
- Registers the command to run daily at `00:00`.

## Tests
- `git diff --check`
- Runtime PHP checks could not be run in this environment because PHP is not installed and `laravel/vendor` is absent.

## Provenance
- Includes `_generation.json` with safe public metadata only; private runtime/session instructions are intentionally redacted.