### PR TITLE
[OpenAI Codex] [ Laravel ] Add error and JSON log channels

### DIFF
--- a/laravel/config/_provenance.json
+++ b/laravel/config/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Redacted: private system, developer, runtime, and user context cannot be published. This submission includes only safe public metadata.",
+  "timestamp": "2026-06-06T19:58:00-07:00"
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,24 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/laravel-json.log'),
+            ],
+            'formatter' => JsonFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [


### PR DESCRIPTION
/claim #787

## Summary
- Updates the default stack to include the `daily` and new `error` channels.
- Adds an `error` channel writing `error` and above to `storage/logs/error.log`.
- Keeps daily logs for 14 days and adds a `json` channel using Monolog `JsonFormatter`.

## Tests
- `git diff --check`
- PHP runtime checks could not be run here because PHP is not installed in this environment.

## Provenance
- Includes `_provenance.json` with safe public metadata only; private runtime/session instructions are intentionally redacted.