### PR TITLE
[OpenAI Codex] [ Laravel ] Fix welcome CSRF meta and security headers

### DIFF
--- a/laravel/app/Http/Middleware/SecurityHeaders.php
+++ b/laravel/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        return $response;
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->web(append: [
+            SecurityHeaders::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Redacted: private system, developer, runtime, and user context cannot be published. This submission includes only safe public metadata.",
+  "ts": "2026-06-06T20:05:00-07:00"
+}

--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 

--- a/laravel/tests/Feature/SecurityHeadersTest.php
+++ b/laravel/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    public function test_welcome_page_includes_csrf_meta_tag_and_security_headers(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="csrf-token"', false);
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('X-Frame-Options', 'DENY');
+        $response->assertHeader('X-XSS-Protection', '1; mode=block');
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
+}


### PR DESCRIPTION
/claim #751

## Summary
- Added the CSRF token meta tag to the Laravel welcome page head.
- Added a SecurityHeaders middleware that applies the requested browser security headers to web responses.
- Registered the middleware on the web middleware stack and added a feature test covering the welcome page headers and CSRF meta tag.

## Tests
- `git diff --check`
- Not run: PHPUnit/Pest, because PHP is not installed in this execution environment.

## Provenance
- Added `contributor_meta.json` with redacted safe public metadata only; private session/system/developer/runtime context is not publishable.