### PR TITLE
Bounty #803: Add run_concurrently with semaphore limiting and timeout

### DIFF
--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,9 +1,10 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Coroutine, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import anyio.to_thread
+import asyncio
 from anyio import CapacityLimiter
 from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
 from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa
@@ -39,3 +40,70 @@ async def contextmanager_in_threadpool(
         await anyio.to_thread.run_sync(
             cm.__exit__, None, None, None, limiter=exit_limiter
         )
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more coroutines in ``run_concurrently`` fail.
+
+    Attributes:
+        results: Results from coroutines that completed successfully.
+        exceptions: List of ``(index, exception)`` tuples for failed coroutines.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        results: list[Any],
+        exceptions: list[tuple[int, BaseException]],
+    ) -> None:
+        self.results = results
+        self.exceptions = exceptions
+        super().__init__(message)
+
+
+async def run_concurrently(
+    coros: Sequence[Coroutine[Any, Any, _T]],
+    max_concurrency: int = 5,
+    timeout: float | None = None,
+) -> list[_T]:
+    """Run multiple coroutines concurrently with a concurrency limit.
+
+    Uses an ``asyncio.Semaphore`` to cap the number of concurrently executing
+    coroutines.  Results are returned in the same order as the input coroutines.
+
+    Args:
+        coros: Sequence of coroutines to execute.
+        max_concurrency: Maximum number of coroutines to run at once.
+        timeout: Optional per-coroutine timeout in seconds.  If a coroutine
+            does not complete within this time it is cancelled.
+
+    Returns:
+        List of results in the same order as the input coroutines.
+
+    Raises:
+        ConcurrencyError: If **any** coroutine raised an exception.  The
+            exception contains both partial results and the list of failures.
+    """
+    sem = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coros)
+    failures: list[tuple[int, BaseException]] = []
+
+    async def _run_one(idx: int, coro: Coroutine[Any, Any, _T]) -> None:
+        async with sem:
+            try:
+                if timeout is not None:
+                    results[idx] = await asyncio.wait_for(coro, timeout=timeout)
+                else:
+                    results[idx] = await coro
+            except BaseException as exc:
+                failures.append((idx, exc))
+
+    tasks = [asyncio.create_task(_run_one(i, c)) for i, c in enumerate(coros)]
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    if failures:
+        msg = f"{len(failures)} of {len(coros)} coroutines failed"
+        raise ConcurrencyError(msg, results=results, exceptions=failures)
+    return results


### PR DESCRIPTION
## Summary

Automated PR for branch `bounty-803`.

## Commits

```
c1aee59 [FastAPI] Add run_concurrently with semaphore limiting and timeout (#803)
```

---
_Generated by Hermes cron job_