### PR TITLE
fix: User model password cast respects bcrypt rounds from config (fixes #745)

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -26,7 +26,15 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Set the password attribute using bcrypt with configured rounds.
+     */
+    public function setPasswordAttribute(string $value): void
+    {
+        $rounds = (int) config('hashing.bcrypt.rounds', 10);
+        $this->attributes['password'] = bcrypt($value, ['rounds' => $rounds]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,67 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Hash Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default hash driver that will be used to hash
+    | passwords for your application. By default, the bcrypt algorithm is
+    | used; however, you remain free to modify this option if you wish.
+    |
+    | Supported: "bcrypt", "argon", "argon2id"
+    |
+    */
+
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bcrypt Options
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the configuration options that should be used when
+    | passwords are hashed using the Bcrypt algorithm. This will allow you
+    | to control the amount of time it takes to hash the given password.
+    |
+    */
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 10),
+        'verify' => env('BCRYPT_VERIFY', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Argon Options
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the configuration options that should be used when
+    | passwords are hashed using the Argon algorithm. These will allow you
+    | to control the amount of time it takes to hash the given password.
+    |
+    */
+
+    'argon' => [
+        'memory' => env('ARGON_MEMORY', 65536),
+        'threads' => env('ARGON_THREADS', 1),
+        'time' => env('ARGON_TIME', 4),
+        'verify' => env('ARGON_VERIFY', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rehash On Login
+    |--------------------------------------------------------------------------
+    |
+    | Setting this to true will tell Laravel to automatically rehash the
+    | user's password on login if the configured work factor has changed
+    | since the password was last hashed.
+    |
+    */
+
+    'rehash_on_login' => true,
+
+];


### PR DESCRIPTION
## Summary

The User model used the `'password' => 'hashed'` cast which does not respect custom `BCRYPT_ROUNDS` from config. When `BCRYPT_ROUNDS` is set to e.g. 12, passwords were still hashed with the default 10 rounds.

## Changes
- **Replaced** `'password' => 'hashed'` cast with a custom `setPasswordAttribute` mutator
- Mutator explicitly reads `config('hashing.bcrypt.rounds', 10)` and passes it to `bcrypt()`
- **Added** missing `config/hashing.php` with standard Laravel hashing configuration including `bcrypt.rounds`

## Verification
The mutator correctly uses the configured rounds value when hashing passwords.

Fixes #745