### PR TITLE
Codex GPT-5 [ FastAPI ] Add HTTPBasic brute force protection

### DIFF
--- a/fastapi/fastapi/security/.generation_meta.json
+++ b/fastapi/fastapi/security/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initial_directives": "Private system, developer, runtime, and hidden session instructions are intentionally not included. This public metadata file records only non-sensitive provenance for UnsafeLabs/Bounty-Hunters issue #800.",
+  "date": "2026-06-11T14:00:16.1319891+08:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,12 @@
 import binascii
+import hashlib
+import hmac
+import math
+import secrets
+import time
 from base64 import b64decode
+from collections.abc import Callable
+from threading import RLock
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +17,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -217,6 +224,244 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    """
+    HTTP Basic authentication with optional brute-force protection.
+
+    `HTTPBasicWithProtection` preserves the behavior of `HTTPBasic` unless a
+    `credentials_verifier` is provided. When configured, failed authentications
+    are tracked per client IP in a bounded in-memory window and clients are
+    temporarily locked out with a `Retry-After` header after too many failures.
+    """
+
+    def __init__(
+        self,
+        *,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        realm: Annotated[
+            str | None,
+            Doc(
+                """
+                HTTP Basic authentication realm.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+
+                It will be included in the generated OpenAPI (e.g. visible at `/docs`).
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if the HTTP Basic authentication is not provided (a
+                header), `HTTPBasicWithProtection` will automatically cancel the
+                request and send the client an error.
+
+                If `auto_error` is set to `False`, when the HTTP Basic authentication
+                is not available, instead of erroring out, the dependency result will
+                be `None`.
+                """
+            ),
+        ] = True,
+        max_attempts: Annotated[
+            int,
+            Doc(
+                """
+                Maximum failed authentication attempts allowed per client IP inside
+                the configured time window before returning 429 responses.
+                """
+            ),
+        ] = 5,
+        window_seconds: Annotated[
+            int,
+            Doc(
+                """
+                Number of seconds failed attempts remain in the in-memory window.
+                The same value is used to calculate the lockout `Retry-After`.
+                """
+            ),
+        ] = 60,
+        credentials_verifier: Annotated[
+            Callable[[HTTPBasicCredentials], bool] | None,
+            Doc(
+                """
+                Optional callable that validates parsed HTTP Basic credentials.
+                When it returns `False`, the failed attempt is tracked for the
+                current client IP.
+                """
+            ),
+        ] = None,
+    ):
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+        if window_seconds < 1:
+            raise ValueError("window_seconds must be at least 1")
+        super().__init__(
+            scheme_name=scheme_name,
+            realm=realm,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self.credentials_verifier = credentials_verifier
+        self._failed_attempts: dict[str, list[float]] = {}
+        self._attempts_lock = RLock()
+        self._clock: Callable[[], float] = time.monotonic
+
+    @staticmethod
+    def hash_password(
+        password: str, *, salt: bytes | str | None = None, iterations: int = 390_000
+    ) -> str:
+        """
+        Hash a password with PBKDF2-HMAC-SHA256 for use with `verify_password`.
+        """
+
+        if iterations < 1:
+            raise ValueError("iterations must be at least 1")
+        if salt is None:
+            salt_bytes = secrets.token_bytes(16)
+        elif isinstance(salt, str):
+            salt_bytes = salt.encode("utf-8")
+        else:
+            salt_bytes = salt
+        digest = hashlib.pbkdf2_hmac(
+            "sha256", password.encode("utf-8"), salt_bytes, iterations
+        ).hex()
+        return f"pbkdf2_sha256${iterations}${salt_bytes.hex()}${digest}"
+
+    @staticmethod
+    def verify_password(password: str, stored_password: str) -> bool:
+        """
+        Verify a password using timing-safe comparison.
+
+        PBKDF2-HMAC-SHA256 hashes generated by `hash_password` are supported.
+        Other stored values are compared as plain text to support applications
+        migrating incrementally from the existing `HTTPBasic` examples.
+        """
+
+        algorithm, separator, password_hash = stored_password.partition("$")
+        if separator and algorithm == "pbkdf2_sha256":
+            try:
+                iterations_text, salt_hex, expected_digest = password_hash.split("$", 2)
+                iterations = int(iterations_text)
+                salt = bytes.fromhex(salt_hex)
+            except ValueError:
+                return False
+            computed_digest = hashlib.pbkdf2_hmac(
+                "sha256", password.encode("utf-8"), salt, iterations
+            ).hex()
+            return hmac.compare_digest(computed_digest, expected_digest)
+        return hmac.compare_digest(
+            password.encode("utf-8"), stored_password.encode("utf-8")
+        )
+
+    def _get_client_key(self, request: Request) -> str:
+        if request.client and request.client.host:
+            return request.client.host
+        return "unknown"
+
+    def _prune_attempts(self, client_key: str, now: float) -> list[float]:
+        window_started_at = now - self.window_seconds
+        attempts = [
+            failed_at
+            for failed_at in self._failed_attempts.get(client_key, [])
+            if failed_at > window_started_at
+        ]
+        if attempts:
+            self._failed_attempts[client_key] = attempts
+        else:
+            self._failed_attempts.pop(client_key, None)
+        return attempts
+
+    def _locked_until(self, client_key: str, now: float) -> float | None:
+        with self._attempts_lock:
+            attempts = self._prune_attempts(client_key, now)
+            if len(attempts) < self.max_attempts:
+                return None
+            locked_until = attempts[0] + self.window_seconds
+            if locked_until <= now:
+                self._failed_attempts.pop(client_key, None)
+                return None
+            return locked_until
+
+    def _record_failed_attempt(self, client_key: str, now: float) -> float | None:
+        with self._attempts_lock:
+            attempts = self._prune_attempts(client_key, now)
+            attempts.append(now)
+            self._failed_attempts[client_key] = attempts
+            if len(attempts) >= self.max_attempts:
+                return attempts[0] + self.window_seconds
+            return None
+
+    def _reset_attempts(self, client_key: str) -> None:
+        with self._attempts_lock:
+            self._failed_attempts.pop(client_key, None)
+
+    def make_too_many_attempts_error(self, retry_after: int) -> HTTPException:
+        return HTTPException(
+            status_code=HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many authentication attempts",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        if self.credentials_verifier is None:
+            return await super().__call__(request)
+
+        client_key = self._get_client_key(request)
+        now = self._clock()
+        locked_until = self._locked_until(client_key, now)
+        if locked_until is not None:
+            retry_after = max(1, math.ceil(locked_until - now))
+            raise self.make_too_many_attempts_error(retry_after)
+
+        authorization = request.headers.get("Authorization")
+        scheme, _ = get_authorization_scheme_param(authorization)
+        has_basic_authorization = bool(authorization and scheme.lower() == "basic")
+
+        try:
+            credentials = await super().__call__(request)
+        except HTTPException:
+            if has_basic_authorization:
+                failed_at = self._clock()
+                locked_until = self._record_failed_attempt(client_key, failed_at)
+                if locked_until is not None:
+                    retry_after = max(1, math.ceil(locked_until - failed_at))
+                    raise self.make_too_many_attempts_error(retry_after) from None
+            raise
+        if credentials is None or self.credentials_verifier is None:
+            return credentials
+        if self.credentials_verifier(credentials):
+            self._reset_attempts(client_key)
+            return credentials
+
+        failed_at = self._clock()
+        locked_until = self._record_failed_attempt(client_key, failed_at)
+        if locked_until is not None:
+            retry_after = max(1, math.ceil(locked_until - failed_at))
+            raise self.make_too_many_attempts_error(retry_after)
+        raise self.make_not_authenticated_error()
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_security_http_basic_protection.py
+++ b/fastapi/tests/test_security_http_basic_protection.py
@@ -1,0 +1,151 @@
+from base64 import b64encode
+
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+
+def get_basic_auth_header(username: str, password: str) -> dict[str, str]:
+    payload = b64encode(f"{username}:{password}".encode("ascii")).decode("ascii")
+    return {"Authorization": f"Basic {payload}"}
+
+
+def get_client(
+    security: HTTPBasicWithProtection,
+    *,
+    host: str = "testclient",
+) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/users/me")
+    def read_current_user(
+        credentials: HTTPBasicCredentials = Security(security),
+    ):
+        return {"username": credentials.username}
+
+    return TestClient(app, client=(host, 50000))
+
+
+def test_security_http_basic_with_protection_tracks_failed_attempts():
+    password_hash = HTTPBasicWithProtection.hash_password("secret", salt="tests")
+    security = HTTPBasicWithProtection(
+        max_attempts=2,
+        window_seconds=60,
+        credentials_verifier=lambda credentials: credentials.username == "john"
+        and HTTPBasicWithProtection.verify_password(
+            credentials.password, password_hash
+        ),
+    )
+    client = get_client(security)
+
+    response = client.get(
+        "/users/me", headers=get_basic_auth_header("john", "incorrect")
+    )
+
+    assert response.status_code == 401, response.text
+    assert len(security._failed_attempts["testclient"]) == 1
+
+
+def test_security_http_basic_with_protection_returns_429_during_lockout():
+    security = HTTPBasicWithProtection(
+        max_attempts=2,
+        window_seconds=30,
+        credentials_verifier=lambda credentials: credentials.password == "secret",
+    )
+    security._clock = iter([100.0, 100.0, 105.0, 105.0, 110.0]).__next__
+    client = get_client(security)
+
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "bad"))
+    assert response.status_code == 401, response.text
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "bad"))
+    assert response.status_code == 429, response.text
+    assert response.headers["Retry-After"] == "25"
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "secret"))
+
+    assert response.status_code == 429, response.text
+    assert response.headers["Retry-After"] == "20"
+    assert response.json() == {"detail": "Too many authentication attempts"}
+
+
+def test_security_http_basic_with_protection_unlocks_after_window():
+    security = HTTPBasicWithProtection(
+        max_attempts=2,
+        window_seconds=30,
+        credentials_verifier=lambda credentials: credentials.password == "secret",
+    )
+    security._clock = iter([100.0, 100.0, 105.0, 105.0, 131.0]).__next__
+    client = get_client(security)
+
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "bad"))
+    assert response.status_code == 401, response.text
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "bad"))
+    assert response.status_code == 429, response.text
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "secret"))
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "john"}
+
+
+def test_security_http_basic_with_protection_resets_attempts_on_success():
+    security = HTTPBasicWithProtection(
+        max_attempts=2,
+        window_seconds=60,
+        credentials_verifier=lambda credentials: credentials.password == "secret",
+    )
+    client = get_client(security)
+
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "bad"))
+    assert response.status_code == 401, response.text
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "secret"))
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "john"}
+    response = client.get("/users/me", headers=get_basic_auth_header("john", "bad"))
+
+    assert response.status_code == 401, response.text
+
+
+def test_security_http_basic_with_protection_tracks_attempts_per_ip():
+    security = HTTPBasicWithProtection(
+        max_attempts=1,
+        window_seconds=60,
+        credentials_verifier=lambda credentials: credentials.password == "secret",
+    )
+    client_one = get_client(security, host="10.0.0.1")
+    client_two = get_client(security, host="10.0.0.2")
+
+    response = client_one.get("/users/me", headers=get_basic_auth_header("john", "bad"))
+    assert response.status_code == 429, response.text
+    response = client_one.get(
+        "/users/me", headers=get_basic_auth_header("john", "secret")
+    )
+    assert response.status_code == 429, response.text
+    response = client_two.get(
+        "/users/me", headers=get_basic_auth_header("john", "secret")
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "john"}
+
+
+def test_security_http_basic_with_protection_uses_timing_safe_password_check(
+    monkeypatch,
+):
+    compare_digest_calls: list[tuple[str | bytes, str | bytes]] = []
+
+    def compare_digest(first: str | bytes, second: str | bytes) -> bool:
+        compare_digest_calls.append((first, second))
+        return True
+
+    monkeypatch.setattr("fastapi.security.http.hmac.compare_digest", compare_digest)
+
+    assert HTTPBasicWithProtection.verify_password("secret", "secret") is True
+    assert compare_digest_calls == [(b"secret", b"secret")]
+
+
+def test_security_http_basic_with_protection_verifies_hashlib_passwords():
+    password_hash = HTTPBasicWithProtection.hash_password(
+        "secret", salt="tests", iterations=10
+    )
+
+    assert HTTPBasicWithProtection.verify_password("secret", password_hash) is True
+    assert HTTPBasicWithProtection.verify_password("wrong", password_hash) is False


### PR DESCRIPTION
/claim #800

## Summary
- Added opt-in `HTTPBasicWithProtection` while leaving existing `HTTPBasic` behavior unchanged.
- Tracks failed credential-verifier attempts per client IP in a configurable in-memory window.
- Returns `429 Too Many Requests` with `Retry-After` when `max_attempts` is reached, unlocks after the window, and resets the counter after successful authentication.
- Added `hash_password` / `verify_password` helpers using `hashlib.pbkdf2_hmac` and timing-safe `hmac.compare_digest`.

## Demo
- https://github.com/crhywun/Bounty-Hunters/releases/download/bounty-800-demo-20260611/httpbasic-protection-800-demo.mp4

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_timeout tests/test_security_http_basic_protection.py tests/test_security_http_basic_optional.py tests/test_security_http_basic_realm.py tests/test_security_http_basic_realm_description.py -q` -> 22 passed
- `python -m ruff check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py` -> passed
- `python -m ruff format --check fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py` -> passed
- `python -m compileall -q fastapi/security/http.py fastapi/security/__init__.py tests/test_security_http_basic_protection.py` -> passed
- `git diff --check` -> passed

## Provenance
- `.generation_meta.json` contains safe public provenance only.
- Private system, developer, runtime, hidden session, and startup instructions are not published in repository files or PR text.
