### PR TITLE
[ T3 Code ] Ola ACP Refresh Agent: implement automatic ACP token refresh

### DIFF
--- a/t3code/packages/effect-acp/.provenance.json
+++ b/t3code/packages/effect-acp/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Ola ACP Refresh Agent",
+  "config_snapshot": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#829 requests automatic token refresh in t3code/packages/effect-acp/src/client.ts, including 401/auth-expiry detection, one re-auth retry schedule, refresh-token reuse, onSessionExpired callback, old-session cleanup, queued concurrent request replay, typed authentication failure, tests, and a PR title containing [ T3 Code ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally redacted and are not safe to publish in a repository.",
+  "created": "2026-06-11T21:01:48Z"
+}

--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -41,6 +41,60 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
       return yield* spawner.spawn(command);
     });
 
+  const installPromptHandlers = (acp: AcpClient.AcpClientShape) =>
+    Effect.gen(function* () {
+      yield* acp.handleRequestPermission(() =>
+        Effect.succeed({
+          outcome: {
+            outcome: "selected",
+            optionId: "allow",
+          },
+        }),
+      );
+      yield* acp.handleElicitation(() =>
+        Effect.succeed({
+          action: {
+            action: "accept",
+            content: {
+              approved: true,
+            },
+          },
+        }),
+      );
+      yield* acp.handleExtRequest(
+        "x/typed_request",
+        Schema.Struct({ message: Schema.String }),
+        () => Effect.succeed({ ok: true }),
+      );
+      yield* acp.handleExtNotification(
+        "x/typed_notification",
+        Schema.Struct({ count: Schema.Number }),
+        () => Effect.void,
+      );
+    });
+
+  const initializeAuthenticateAndCreateSession = (acp: AcpClient.AcpClientShape) =>
+    Effect.gen(function* () {
+      yield* acp.agent.initialize({
+        protocolVersion: 1,
+        clientCapabilities: {
+          fs: { readTextFile: false, writeTextFile: false },
+          terminal: false,
+        },
+        clientInfo: {
+          name: "effect-acp-test",
+          version: "0.0.0",
+        },
+      });
+
+      yield* acp.agent.authenticate({ methodId: "cursor_login" });
+
+      return yield* acp.agent.createSession({
+        cwd: process.cwd(),
+        mcpServers: [],
+      });
+    });
+
   it.effect("initializes, prompts, receives updates, and handles permission requests", () =>
     Effect.gen(function* () {
       const updates = yield* Ref.make<Array<unknown>>([]);
@@ -144,6 +198,125 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
         },
       });
     }),
+  );
+
+  it.effect("refreshes an expired session and replays the failed prompt", () =>
+    Effect.gen(function* () {
+      const expiredSessions = yield* Ref.make<Array<string>>([]);
+      const handle = yield* makeHandle({ ACP_MOCK_EXPIRE_PROMPT_COUNT: "1" });
+      const scope = yield* Scope.make();
+      const acpLayer = AcpClient.layerChildProcess(handle, {
+        onSessionExpired: (sessionId) =>
+          Ref.update(expiredSessions, (current) => [...current, sessionId]),
+      });
+      const context = yield* Layer.buildWithScope(acpLayer, scope);
+
+      yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.AcpClient;
+        yield* installPromptHandlers(acp);
+
+        const session = yield* initializeAuthenticateAndCreateSession(acp);
+        const prompt = yield* acp.agent.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hello after refresh" }],
+        });
+
+        assert.equal(prompt.stopReason, "end_turn");
+        assert.deepEqual(yield* Ref.get(expiredSessions), [session.sessionId]);
+
+        const state = (yield* acp.raw.request("x/acp_mock_state", {})) as {
+          authenticateCount: number;
+          promptCount: number;
+          authenticateMetas: Array<unknown>;
+          closedSessions: Array<string>;
+        };
+        assert.equal(state.authenticateCount, 2);
+        assert.equal(state.promptCount, 2);
+        assert.deepEqual(state.closedSessions, [session.sessionId]);
+        assert.deepEqual(state.authenticateMetas[1], {
+          refreshToken: "mock-refresh-token-1",
+        });
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+    }),
+  );
+
+  it.effect("queues concurrent expired prompts behind a single re-authentication", () =>
+    Effect.gen(function* () {
+      const expiredSessions = yield* Ref.make<Array<string>>([]);
+      const handle = yield* makeHandle({
+        ACP_MOCK_EXPIRE_PROMPT_COUNT: "2",
+        ACP_MOCK_REFRESH_DELAY_MS: "50",
+      });
+      const scope = yield* Scope.make();
+      const acpLayer = AcpClient.layerChildProcess(handle, {
+        onSessionExpired: (sessionId) =>
+          Ref.update(expiredSessions, (current) => [...current, sessionId]),
+      });
+      const context = yield* Layer.buildWithScope(acpLayer, scope);
+
+      yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.AcpClient;
+        yield* installPromptHandlers(acp);
+
+        const session = yield* initializeAuthenticateAndCreateSession(acp);
+        const makePrompt = (text: string) =>
+          acp.agent.prompt({
+            sessionId: session.sessionId,
+            prompt: [{ type: "text", text }],
+          });
+
+        const results = yield* Effect.all([makePrompt("one"), makePrompt("two")], {
+          concurrency: "unbounded",
+        });
+
+        assert.deepEqual(
+          results.map((result) => result.stopReason),
+          ["end_turn", "end_turn"],
+        );
+        assert.deepEqual(yield* Ref.get(expiredSessions), [session.sessionId]);
+
+        const state = (yield* acp.raw.request("x/acp_mock_state", {})) as {
+          authenticateCount: number;
+          promptCount: number;
+          closedSessions: Array<string>;
+        };
+        assert.equal(state.authenticateCount, 2);
+        assert.equal(state.promptCount, 4);
+        assert.deepEqual(state.closedSessions, [session.sessionId]);
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+    }),
+  );
+
+  it.effect(
+    "fails queued requests with a typed authentication error when re-authentication fails",
+    () =>
+      Effect.gen(function* () {
+        const handle = yield* makeHandle({
+          ACP_MOCK_EXPIRE_PROMPT_COUNT: "1",
+          ACP_MOCK_FAIL_REFRESH: "1",
+        });
+        const scope = yield* Scope.make();
+        const acpLayer = AcpClient.layerChildProcess(handle);
+        const context = yield* Layer.buildWithScope(acpLayer, scope);
+
+        const result = yield* Effect.gen(function* () {
+          const acp = yield* AcpClient.AcpClient;
+          yield* installPromptHandlers(acp);
+
+          const session = yield* initializeAuthenticateAndCreateSession(acp);
+          return yield* Effect.exit(
+            acp.agent.prompt({
+              sessionId: session.sessionId,
+              prompt: [{ type: "text", text: "refresh should fail" }],
+            }),
+          );
+        }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+        if (result._tag !== "Failure") {
+          assert.fail("Expected prompt to fail when refresh token is rejected");
+        }
+        assert.include(Cause.pretty(result.cause), "AcpAuthenticationError");
+      }),
   );
 
   it.effect(

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -1,7 +1,10 @@
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Stdio from "effect/Stdio";
 import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
@@ -26,6 +29,7 @@ export interface AcpClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
+  readonly onSessionExpired?: (sessionId: AcpSchema.SessionId) => Effect.Effect<void, never>;
 }
 
 type AcpClientRaw = {
@@ -306,6 +310,83 @@ interface BufferedNotificationHandler<A> {
   readonly pending: Array<A>;
 }
 
+type AuthRefreshState =
+  | { readonly _tag: "Idle" }
+  | {
+      readonly _tag: "Refreshing";
+      readonly deferred: Deferred.Deferred<void, AcpError.AcpAuthenticationError>;
+    };
+
+type AuthRefreshAction =
+  | {
+      readonly _tag: "Await";
+      readonly deferred: Deferred.Deferred<void, AcpError.AcpAuthenticationError>;
+    }
+  | {
+      readonly _tag: "Start";
+      readonly deferred: Deferred.Deferred<void, AcpError.AcpAuthenticationError>;
+    };
+
+interface StoredAuthentication {
+  readonly payload: AcpSchema.AuthenticateRequest;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getSessionId = (payload: unknown): AcpSchema.SessionId | undefined => {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+  const sessionId = payload.sessionId;
+  return typeof sessionId === "string" ? sessionId : undefined;
+};
+
+const getHttpStatus = (data: unknown): number | undefined => {
+  if (!isRecord(data)) {
+    return undefined;
+  }
+  const status = data.status ?? data.statusCode ?? data.httpStatus;
+  if (typeof status === "number") {
+    return status;
+  }
+  if (typeof status === "string") {
+    const parsed = Number(status);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+const extractRefreshToken = (meta: unknown): unknown => {
+  if (!isRecord(meta)) {
+    return undefined;
+  }
+  return meta.refreshToken ?? meta.refresh_token;
+};
+
+const isAcpRequestError = Schema.is(AcpError.AcpRequestError);
+
+const isAuthenticationExpired = (error: AcpError.AcpError) => {
+  if (!isAcpRequestError(error)) {
+    return false;
+  }
+  const message = error.errorMessage.toLowerCase();
+  return (
+    error.code === -32000 ||
+    getHttpStatus(error.data) === 401 ||
+    message.includes("401") ||
+    message.includes("unauthorized") ||
+    message.includes("authentication required") ||
+    message.includes("session expired")
+  );
+};
+
+const makeAuthenticationError = (error: AcpError.AcpError | undefined, detail: string) =>
+  new AcpError.AcpAuthenticationError({
+    detail,
+    ...(error ? { cause: error } : {}),
+  });
+
 export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpClientOptions = {},
@@ -330,6 +411,10 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   let unknownExtNotificationHandler:
     | ((method: string, params: unknown) => Effect.Effect<void, AcpError.AcpError>)
     | undefined;
+  let storedAuthentication: StoredAuthentication | undefined;
+  let refreshToken: unknown;
+  const authGeneration = yield* Ref.make(0);
+  const authRefreshState = yield* Ref.make<AuthRefreshState>({ _tag: "Idle" });
 
   const runNotificationHandlers = <A>(
     registration: BufferedNotificationHandler<A>,
@@ -456,6 +541,143 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     generateRequestId: () => nextRpcRequestId++ as never,
   }).pipe(Effect.provideService(RpcClient.Protocol, transport.clientProtocol));
 
+  const rememberAuthentication = (
+    payload: AcpSchema.AuthenticateRequest,
+    response: AcpSchema.AuthenticateResponse,
+  ): Effect.Effect<void> =>
+    Effect.gen(function* () {
+      storedAuthentication = { payload };
+      const nextRefreshToken = extractRefreshToken(response._meta);
+      if (nextRefreshToken !== undefined) {
+        refreshToken = nextRefreshToken;
+      }
+      yield* Ref.update(authGeneration, (current) => current + 1);
+    });
+
+  const authenticate = (payload: AcpSchema.AuthenticateRequest) =>
+    callRpc(rpc[AGENT_METHODS.authenticate](payload)).pipe(
+      Effect.tap((response) => rememberAuthentication(payload, response)),
+    );
+
+  const makeRefreshPayload = (): AcpSchema.AuthenticateRequest | undefined => {
+    if (!storedAuthentication) {
+      return undefined;
+    }
+    if (refreshToken === undefined) {
+      return storedAuthentication.payload;
+    }
+    const originalMeta = isRecord(storedAuthentication.payload._meta)
+      ? storedAuthentication.payload._meta
+      : {};
+    return {
+      ...storedAuthentication.payload,
+      _meta: {
+        ...originalMeta,
+        refreshToken,
+      },
+    };
+  };
+
+  const cleanupExpiredSession = (sessionId: AcpSchema.SessionId | undefined): Effect.Effect<void> =>
+    sessionId
+      ? callRpc(rpc[AGENT_METHODS.session_close]({ sessionId })).pipe(Effect.ignore)
+      : Effect.void;
+
+  const runAuthRefresh = (
+    sessionId: AcpSchema.SessionId | undefined,
+  ): Effect.Effect<void, AcpError.AcpAuthenticationError> =>
+    Effect.gen(function* () {
+      const refreshPayload = makeRefreshPayload();
+      if (!refreshPayload) {
+        return yield* makeAuthenticationError(
+          undefined,
+          "cannot refresh before authenticate succeeds",
+        );
+      }
+
+      if (sessionId && options.onSessionExpired) {
+        yield* options.onSessionExpired(sessionId);
+      }
+
+      const response = yield* Effect.acquireUseRelease(
+        Effect.succeed(sessionId),
+        (expiredSessionId): Effect.Effect<AcpSchema.AuthenticateResponse, AcpError.AcpError> =>
+          cleanupExpiredSession(expiredSessionId).pipe(
+            Effect.andThen(callRpc(rpc[AGENT_METHODS.authenticate](refreshPayload))),
+          ),
+        () => Effect.void,
+      ).pipe(
+        Effect.retry(Schedule.recurs(1)),
+        Effect.mapError((error) =>
+          makeAuthenticationError(error, "re-authentication failed after session expiry"),
+        ),
+      );
+
+      yield* rememberAuthentication(refreshPayload, response);
+    });
+
+  const ensureAuthRefreshed = (
+    sessionId: AcpSchema.SessionId | undefined,
+    observedGeneration: number,
+  ): Effect.Effect<void, AcpError.AcpAuthenticationError> =>
+    Effect.gen(function* () {
+      const currentGeneration = yield* Ref.get(authGeneration);
+      if (currentGeneration !== observedGeneration) {
+        return;
+      }
+
+      const deferred = yield* Deferred.make<void, AcpError.AcpAuthenticationError>();
+      const action = yield* Ref.modify<AuthRefreshState, AuthRefreshAction>(
+        authRefreshState,
+        (state): readonly [AuthRefreshAction, AuthRefreshState] => {
+          if (state._tag === "Refreshing") {
+            return [{ _tag: "Await", deferred: state.deferred }, state];
+          }
+          return [
+            { _tag: "Start", deferred },
+            { _tag: "Refreshing", deferred },
+          ];
+        },
+      );
+
+      if (action._tag === "Await") {
+        return yield* Deferred.await(action.deferred);
+      }
+
+      return yield* runAuthRefresh(sessionId).pipe(
+        Effect.matchEffect({
+          onFailure: (error) =>
+            Effect.gen(function* () {
+              yield* Deferred.fail(action.deferred, error);
+              return yield* error;
+            }),
+          onSuccess: () => Deferred.succeed(action.deferred, undefined).pipe(Effect.asVoid),
+        }),
+        Effect.ensuring(
+          Ref.update(authRefreshState, (state) =>
+            state._tag === "Refreshing" && state.deferred === action.deferred
+              ? { _tag: "Idle" as const }
+              : state,
+          ),
+        ),
+      );
+    });
+
+  const withAuthRefresh = <A>(
+    payload: unknown,
+    operation: Effect.Effect<A, AcpError.AcpError>,
+  ): Effect.Effect<A, AcpError.AcpError> =>
+    Effect.gen(function* () {
+      const observedGeneration = yield* Ref.get(authGeneration);
+      return yield* operation.pipe(
+        Effect.catchIf(isAuthenticationExpired, (error) =>
+          ensureAuthRefreshed(getSessionId(payload), observedGeneration).pipe(
+            Effect.andThen(operation),
+          ),
+        ),
+      );
+    });
+
   return AcpClient.of({
     raw: {
       notifications: transport.incoming,
@@ -464,18 +686,26 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     },
     agent: {
       initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
-      authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
+      authenticate,
       logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
-      closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      createSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_new](payload))),
+      loadSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_load](payload))),
+      listSessions: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_list](payload))),
+      forkSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_fork](payload))),
+      resumeSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_resume](payload))),
+      closeSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_close](payload))),
+      setSessionModel: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_set_model](payload))),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_set_config_option](payload))),
+      prompt: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_prompt](payload))),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>

--- a/t3code/packages/effect-acp/src/errors.ts
+++ b/t3code/packages/effect-acp/src/errors.ts
@@ -47,6 +47,18 @@ export class AcpTransportError extends Schema.TaggedErrorClass<AcpTransportError
   },
 ) {}
 
+export class AcpAuthenticationError extends Schema.TaggedErrorClass<AcpAuthenticationError>()(
+  "AcpAuthenticationError",
+  {
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {
+  override get message() {
+    return `ACP authentication failed: ${this.detail}`;
+  }
+}
+
 export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()("AcpRequestError", {
   code: AcpSchema.ErrorCode,
   errorMessage: Schema.String,
@@ -134,6 +146,7 @@ export const AcpError = Schema.Union([
   AcpProcessExitedError,
   AcpProtocolParseError,
   AcpTransportError,
+  AcpAuthenticationError,
 ]);
 
 export type AcpError = typeof AcpError.Type;

--- a/t3code/packages/effect-acp/test/fixtures/acp-mock-peer.ts
+++ b/t3code/packages/effect-acp/test/fixtures/acp-mock-peer.ts
@@ -5,6 +5,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 
 import * as AcpAgent from "../../src/agent.ts";
+import * as AcpError from "../../src/errors.ts";
 
 if (process.env.ACP_MOCK_MALFORMED_OUTPUT === "1") {
   process.stdout.write("{not-json}\n");
@@ -16,6 +17,15 @@ if (process.env.ACP_MOCK_EXIT_IMMEDIATELY_CODE !== undefined) {
 }
 
 const sessionId = "mock-session-1";
+let authenticateCount = 0;
+let promptCount = 0;
+const authenticateMetas: Array<unknown> = [];
+const closedSessions: Array<string> = [];
+const expirePromptCount = Number(process.env.ACP_MOCK_EXPIRE_PROMPT_COUNT ?? "0");
+const failRefresh = process.env.ACP_MOCK_FAIL_REFRESH === "1";
+const refreshDelayMs = Number(process.env.ACP_MOCK_REFRESH_DELAY_MS ?? "0");
+
+const sleep = (ms: number) => (ms > 0 ? Effect.sleep(`${ms} millis`) : Effect.void);
 
 const program = Effect.gen(function* () {
   const agent = yield* AcpAgent.AcpAgent;
@@ -35,7 +45,26 @@ const program = Effect.gen(function* () {
     }),
   );
 
-  yield* agent.handleAuthenticate(() => Effect.succeed({}));
+  yield* agent.handleAuthenticate((request) =>
+    Effect.gen(function* () {
+      authenticateCount++;
+      authenticateMetas.push(request._meta ?? null);
+      if (authenticateCount > 1) {
+        yield* sleep(refreshDelayMs);
+      }
+      if (failRefresh && authenticateCount > 1) {
+        return yield* AcpError.AcpRequestError.authRequired("Refresh token rejected", {
+          status: 401,
+          sessionId,
+        });
+      }
+      return {
+        _meta: {
+          refreshToken: `mock-refresh-token-${authenticateCount}`,
+        },
+      };
+    }),
+  );
   yield* agent.handleLogout(() => Effect.succeed({}));
   yield* agent.handleCreateSession(() =>
     Effect.succeed({
@@ -54,8 +83,22 @@ const program = Effect.gen(function* () {
     }),
   );
 
+  yield* agent.handleCloseSession((request) =>
+    Effect.sync(() => {
+      closedSessions.push(request.sessionId);
+    }).pipe(Effect.as({})),
+  );
+
   yield* agent.handlePrompt(() =>
     Effect.gen(function* () {
+      promptCount++;
+      if (promptCount <= expirePromptCount) {
+        return yield* AcpError.AcpRequestError.authRequired("Session expired", {
+          status: 401,
+          sessionId,
+        });
+      }
+
       yield* agent.client.requestPermission({
         sessionId,
         options: [
@@ -121,10 +164,17 @@ const program = Effect.gen(function* () {
   );
 
   yield* agent.handleUnknownExtRequest((method, params) =>
-    Effect.succeed({
-      echoedMethod: method,
-      echoedParams: params ?? null,
-    }),
+    method === "x/acp_mock_state"
+      ? Effect.succeed({
+          authenticateCount,
+          promptCount,
+          authenticateMetas,
+          closedSessions,
+        })
+      : Effect.succeed({
+          echoedMethod: method,
+          echoedParams: params ?? null,
+        }),
   );
 
   return yield* Effect.never;


### PR DESCRIPTION
/claim #829

Summary:
- Added ACP auth-expiry detection for auth-required / 401-style request errors on session calls.
- Store the refresh token from authenticate response metadata separately and reuse it in re-auth metadata.
- Added `onSessionExpired(sessionId)`, old-session cleanup before re-auth, and a single-flight Deferred queue so concurrent expired requests wait behind one refresh.
- Added typed `AcpAuthenticationError` for refresh failure paths.
- Expanded the mock ACP peer and tests for replay, concurrent queueing, and rejected refresh tokens.

Validation:
- `bun --filter effect-acp typecheck`
- `bun --filter effect-acp test` (19 tests passing)
- `git diff --check`

Demo evidence:
- The new mock-peer tests simulate an expired session, refresh-token re-auth, queued concurrent prompts, replay after refresh, and typed failure when refresh is rejected.

Provenance:
- `.provenance.json` is included with public task context. Private runtime/system/developer/user instructions and secrets are redacted instead of being published to the repository.