### PR TITLE
Ola Test Client Agent [ FastAPI ] Add auth helpers to test client

### DIFF
--- a/fastapi/.audit.json
+++ b/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Ola Test Client Agent",
+  "environment_config": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#804 requests an opt-in FastAPITestClient in fastapi/fastapi/testclient.py with bearer/basic auth helpers, reset_auth, WebSocket connection convenience with custom headers and subprotocols, assert_status, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally redacted and are not safe to publish in a repository.",
+  "completed_at": "2026-06-11T21:34:58Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,57 @@
+import base64
+from typing import Any
+
 from starlette.testclient import TestClient as TestClient  # noqa
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> "FastAPITestClient":
+        self.headers["Authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(
+        self,
+        username: str,
+        password: str,
+    ) -> "FastAPITestClient":
+        credentials = f"{username}:{password}".encode("utf-8")
+        encoded = base64.b64encode(credentials).decode("ascii")
+        self.headers["Authorization"] = f"Basic {encoded}"
+        return self
+
+    def reset_auth(self) -> "FastAPITestClient":
+        self.headers.pop("Authorization", None)
+        return self
+
+    def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        subprotocols: list[str] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        merged_headers = dict(self.headers)
+        if headers:
+            merged_headers.update(headers)
+        return self.websocket_connect(
+            url,
+            subprotocols=subprotocols,
+            headers=merged_headers,
+            **kwargs,
+        )
+
+    def assert_status(
+        self,
+        method: str,
+        url: str,
+        expected_status: int,
+        **kwargs: Any,
+    ) -> Any:
+        response = self.request(method, url, **kwargs)
+        if response.status_code != expected_status:
+            raise AssertionError(
+                f"Expected {expected_status} for {method.upper()} {url}, "
+                f"got {response.status_code}: {response.text}"
+            )
+        return response

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,102 @@
+import base64
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI, Header, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+
+
+app = FastAPI()
+
+
+def authorization_header(
+    authorization: Annotated[str | None, Header()] = None,
+) -> str | None:
+    return authorization
+
+
+@app.get("/auth")
+def read_auth(
+    authorization: Annotated[str | None, Depends(authorization_header)] = None,
+) -> dict[str, str | None]:
+    return {"authorization": authorization}
+
+
+@app.get("/status/{status_code}")
+def read_status(status_code: int) -> dict[str, int]:
+    return {"status_code": status_code}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept(subprotocol=websocket.scope["subprotocols"][0])
+    await websocket.send_json(
+        {
+            "authorization": websocket.headers.get("authorization"),
+            "client": websocket.headers.get("x-client"),
+            "subprotocol": websocket.scope["subprotocols"][0],
+        }
+    )
+    await websocket.close()
+
+
+def test_existing_testclient_export_is_unchanged() -> None:
+    assert TestClient is not FastAPITestClient
+    assert issubclass(FastAPITestClient, TestClient)
+
+
+def test_authenticate_sets_and_replaces_bearer_token() -> None:
+    client = FastAPITestClient(app)
+
+    client.authenticate("first-token")
+    assert client.get("/auth").json() == {"authorization": "Bearer first-token"}
+
+    client.authenticate("second-token")
+    assert client.get("/auth").json() == {"authorization": "Bearer second-token"}
+
+
+def test_authenticate_basic_sets_basic_header() -> None:
+    client = FastAPITestClient(app)
+    expected = base64.b64encode(b"alice:s3cret").decode("ascii")
+
+    client.authenticate_basic("alice", "s3cret")
+
+    assert client.get("/auth").json() == {"authorization": f"Basic {expected}"}
+
+
+def test_reset_auth_clears_authorization_header() -> None:
+    client = FastAPITestClient(app)
+
+    client.authenticate("token").reset_auth()
+
+    assert client.get("/auth").json() == {"authorization": None}
+
+
+def test_ws_connect_merges_auth_custom_headers_and_subprotocols() -> None:
+    client = FastAPITestClient(app).authenticate("ws-token")
+
+    with client.ws_connect(
+        "/ws",
+        headers={"x-client": "test-suite"},
+        subprotocols=["chat"],
+    ) as websocket:
+        assert websocket.receive_json() == {
+            "authorization": "Bearer ws-token",
+            "client": "test-suite",
+            "subprotocol": "chat",
+        }
+
+
+def test_assert_status_returns_response_on_expected_status() -> None:
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("GET", "/status/204", 200)
+
+    assert response.json() == {"status_code": 204}
+
+
+def test_assert_status_raises_helpful_message() -> None:
+    client = FastAPITestClient(app)
+
+    with pytest.raises(AssertionError, match="Expected 201 for GET /auth, got 200"):
+        client.assert_status("GET", "/auth", 201)


### PR DESCRIPTION
## Summary
- Add an opt-in `FastAPITestClient` subclass while preserving the existing `TestClient` re-export.
- Add bearer auth, basic auth, reset_auth, `ws_connect`, and `assert_status` helpers.
- Cover helper behavior with focused tests and safe public audit metadata only.

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_fastapi_testclient.py -q` -> 7 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_query.py -q` -> 29 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/testclient.py tests/test_fastapi_testclient.py` -> passed
- `git diff --check` -> passed

Note: broader snapshot-based smoke tests require `inline_snapshot`, which is not installed in this bundled runtime.

/claim #804