### PR TITLE
Ola SSE Agent [ FastAPI ] Add SSE disconnect filtering and replay manager

### DIFF
--- a/fastapi/.contributor.json
+++ b/fastapi/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Ola SSE Agent",
+  "initialized_with": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#798 requests FastAPI SSE disconnect detection, event_type filtering, Last-Event-ID replay, retry fields, an SSEManager that broadcasts to all or filtered clients, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally redacted and are not safe to publish in a repository.",
+  "timestamp": "2026-06-11T21:37:56Z"
+}

--- a/fastapi/fastapi/sse.py
+++ b/fastapi/fastapi/sse.py
@@ -1,3 +1,7 @@
+import asyncio
+from collections import deque
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
 from typing import Annotated, Any
 
 from annotated_doc import Doc
@@ -220,3 +224,126 @@ KEEPALIVE_COMMENT = b": ping\n\n"
 # Seconds between keep-alive pings when a generator is idle.
 # Private but importable so tests can monkeypatch it.
 _PING_INTERVAL: float = 15.0
+
+
+@dataclass(slots=True, unsafe_hash=True)
+class _SSESubscriber:
+    event_type: str | None
+    queue: asyncio.Queue[ServerSentEvent] = field(
+        default_factory=asyncio.Queue,
+        compare=False,
+        hash=False,
+    )
+
+
+class SSEManager:
+    def __init__(
+        self,
+        *,
+        retry: int | None = None,
+        history_size: int = 100,
+        disconnect_poll_interval: float = 0.1,
+    ) -> None:
+        self.retry = retry
+        self.disconnect_poll_interval = disconnect_poll_interval
+        self._history: deque[ServerSentEvent] = deque(maxlen=max(0, history_size))
+        self._subscribers: set[_SSESubscriber] = set()
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._subscribers)
+
+    async def broadcast(
+        self,
+        data: Any = None,
+        *,
+        event_type: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        raw_data: str | None = None,
+    ) -> ServerSentEvent:
+        event = ServerSentEvent(
+            data=data,
+            raw_data=raw_data,
+            event=event_type,
+            id=id,
+            retry=retry if retry is not None else self.retry,
+        )
+        self._history.append(event)
+        for subscriber in tuple(self._subscribers):
+            if self._matches(subscriber.event_type, event):
+                subscriber.queue.put_nowait(event)
+        return event
+
+    def stream(
+        self,
+        request: Any | None = None,
+        *,
+        event_type: str | None = None,
+        last_event_id: str | None = None,
+        retry: int | None = None,
+    ) -> AsyncIterator[ServerSentEvent]:
+        return self._stream(
+            request=request,
+            event_type=event_type,
+            last_event_id=last_event_id,
+            retry=retry,
+        )
+
+    async def _stream(
+        self,
+        request: Any | None,
+        event_type: str | None,
+        last_event_id: str | None,
+        retry: int | None,
+    ) -> AsyncIterator[ServerSentEvent]:
+        for event in self._events_after(last_event_id):
+            if self._matches(event_type, event):
+                yield self._with_retry(event, retry)
+
+        subscriber = _SSESubscriber(event_type=event_type)
+        self._subscribers.add(subscriber)
+        try:
+            while True:
+                if await self._is_disconnected(request):
+                    break
+                try:
+                    event = await asyncio.wait_for(
+                        subscriber.queue.get(),
+                        timeout=self.disconnect_poll_interval,
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                yield self._with_retry(event, retry)
+        finally:
+            self._subscribers.discard(subscriber)
+
+    def _events_after(self, last_event_id: str | None) -> list[ServerSentEvent]:
+        if last_event_id is None:
+            return []
+        history = list(self._history)
+        for index, event in enumerate(history):
+            if event.id == last_event_id:
+                return history[index + 1 :]
+        return history
+
+    def _matches(self, event_type: str | None, event: ServerSentEvent) -> bool:
+        return event_type is None or event.event == event_type
+
+    def _with_retry(
+        self,
+        event: ServerSentEvent,
+        retry: int | None,
+    ) -> ServerSentEvent:
+        retry_value = retry if retry is not None else event.retry
+        if retry_value is None:
+            return event
+        return event.model_copy(update={"retry": retry_value})
+
+    async def _is_disconnected(self, request: Any | None) -> bool:
+        if request is None:
+            return False
+        is_disconnected = getattr(request, "is_disconnected", None)
+        if is_disconnected is None:
+            return False
+        return bool(await is_disconnected())

--- a/fastapi/tests/test_sse_manager.py
+++ b/fastapi/tests/test_sse_manager.py
@@ -1,0 +1,105 @@
+import asyncio
+
+from fastapi.sse import SSEManager
+
+
+class DisconnectAfter:
+    def __init__(self, checks: int) -> None:
+        self.checks = checks
+        self.calls = 0
+
+    async def is_disconnected(self) -> bool:
+        self.calls += 1
+        return self.calls >= self.checks
+
+
+def test_sse_manager_filters_events_by_type() -> None:
+    async def run() -> None:
+        manager = SSEManager(disconnect_poll_interval=0.01)
+        stream = manager.stream(event_type="metrics")
+        event_task = asyncio.create_task(stream.__anext__())
+        await asyncio.sleep(0)
+
+        await manager.broadcast({"ignored": True}, event_type="logs", id="1")
+        await manager.broadcast({"value": 42}, event_type="metrics", id="2")
+
+        event = await asyncio.wait_for(event_task, timeout=1)
+        assert event.data == {"value": 42}
+        assert event.event == "metrics"
+        await stream.aclose()
+
+    asyncio.run(run())
+
+
+def test_sse_manager_replays_events_after_last_event_id() -> None:
+    async def run() -> None:
+        manager = SSEManager(retry=2500)
+        await manager.broadcast("one", event_type="metrics", id="1")
+        await manager.broadcast("two", event_type="metrics", id="2")
+        await manager.broadcast("three", event_type="logs", id="3")
+
+        stream = manager.stream(event_type="metrics", last_event_id="1")
+        event = await stream.__anext__()
+
+        assert event.data == "two"
+        assert event.id == "2"
+        assert event.retry == 2500
+        await stream.aclose()
+
+    asyncio.run(run())
+
+
+def test_sse_manager_broadcasts_to_concurrent_connections() -> None:
+    async def run() -> None:
+        manager = SSEManager(disconnect_poll_interval=0.01)
+        first_stream = manager.stream()
+        second_stream = manager.stream(event_type="alerts")
+        first_task = asyncio.create_task(first_stream.__anext__())
+        second_task = asyncio.create_task(second_stream.__anext__())
+        await asyncio.sleep(0)
+
+        await manager.broadcast("system-up", event_type="alerts", id="1")
+
+        first = await asyncio.wait_for(first_task, timeout=1)
+        second = await asyncio.wait_for(second_task, timeout=1)
+        assert first.data == "system-up"
+        assert second.data == "system-up"
+        await first_stream.aclose()
+        await second_stream.aclose()
+
+    asyncio.run(run())
+
+
+def test_sse_manager_stops_stream_when_request_disconnects() -> None:
+    async def run() -> None:
+        manager = SSEManager(disconnect_poll_interval=0.01)
+        request = DisconnectAfter(checks=2)
+        stream = manager.stream(request=request)
+
+        try:
+            await stream.__anext__()
+        except StopAsyncIteration:
+            pass
+
+        assert manager.connection_count == 0
+        assert request.calls >= 2
+
+    asyncio.run(run())
+
+
+def test_sse_manager_history_is_bounded() -> None:
+    async def run() -> None:
+        manager = SSEManager(history_size=2)
+        await manager.broadcast("one", id="1")
+        await manager.broadcast("two", id="2")
+        await manager.broadcast("three", id="3")
+
+        stream = manager.stream(last_event_id="missing")
+        first = await stream.__anext__()
+        second = await stream.__anext__()
+
+        assert first.id == "2"
+        assert second.id == "3"
+        await stream.aclose()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Add `SSEManager` for managed SSE subscribers with per-client queues.
- Support event-type filtering, bounded Last-Event-ID replay, retry fields, request disconnect cleanup, and concurrent broadcast fanout.
- Add focused manager tests plus existing SSE regression coverage and safe public contributor metadata only.

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_sse_manager.py -q` -> 5 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_sse.py -q` -> 18 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/sse.py tests/test_sse_manager.py` -> passed
- `git diff --check` -> passed

/claim #798