### PR TITLE
Ola Concurrency Agent [ FastAPI ] Add concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Ola Concurrency Agent",
+  "runtime_instructions": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#803 requests run_concurrently in fastapi/fastapi/concurrency.py with asyncio.Semaphore concurrency limiting, input-order result preservation, ConcurrencyError failure aggregation, total timeout cancellation with partial results, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally redacted and are not safe to publish in a repository.",
+  "timestamp": "2026-06-11T21:40:35Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,9 @@
+import asyncio
+from collections.abc import Awaitable, Sequence
 from collections.abc import AsyncGenerator
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +14,67 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        failures: Sequence[BaseException],
+        *,
+        partial_results: Sequence[Any] | None = None,
+    ) -> None:
+        self.failures = list(failures)
+        self.partial_results = list(partial_results or [])
+        message = f"{len(self.failures)} concurrent task(s) failed"
+        super().__init__(message)
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    *,
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be at least 1")
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coroutines)
+
+    async def run_one(index: int, coroutine: Awaitable[_T]) -> _T:
+        async with semaphore:
+            return await coroutine
+
+    tasks = [
+        asyncio.create_task(run_one(index, coroutine))
+        for index, coroutine in enumerate(coroutines)
+    ]
+    task_indexes = {task: index for index, task in enumerate(tasks)}
+
+    done, pending = await asyncio.wait(tasks, timeout=timeout)
+    failures: list[BaseException] = []
+
+    if pending:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        failures.append(
+            asyncio.TimeoutError(
+                f"run_concurrently timed out after {timeout} second(s)"
+            )
+        )
+
+    for task in done:
+        index = task_indexes[task]
+        try:
+            results[index] = task.result()
+        except BaseException as exc:
+            failures.append(exc)
+
+    if failures:
+        raise ConcurrencyError(failures, partial_results=results)
+
+    return results
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency_run_concurrently.py
+++ b/fastapi/tests/test_concurrency_run_concurrently.py
@@ -1,0 +1,119 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+def test_run_concurrently_limits_concurrency_and_preserves_order() -> None:
+    async def run() -> None:
+        active = 0
+        max_seen = 0
+
+        async def worker(value: int) -> int:
+            nonlocal active, max_seen
+            active += 1
+            max_seen = max(max_seen, active)
+            await asyncio.sleep(0.01 * (4 - value))
+            active -= 1
+            return value
+
+        results = await run_concurrently(
+            [worker(1), worker(2), worker(3)],
+            max_concurrency=2,
+        )
+
+        assert results == [1, 2, 3]
+        assert max_seen == 2
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_max_concurrency_one_is_sequential() -> None:
+    async def run() -> None:
+        order: list[str] = []
+
+        async def worker(value: str) -> str:
+            order.append(f"start:{value}")
+            await asyncio.sleep(0)
+            order.append(f"end:{value}")
+            return value
+
+        results = await run_concurrently(
+            [worker("a"), worker("b")],
+            max_concurrency=1,
+        )
+
+        assert results == ["a", "b"]
+        assert order == ["start:a", "end:a", "start:b", "end:b"]
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_collects_all_task_exceptions() -> None:
+    class FirstError(Exception):
+        pass
+
+    class SecondError(Exception):
+        pass
+
+    async def fail(exc: Exception) -> None:
+        await asyncio.sleep(0)
+        raise exc
+
+    async def run() -> None:
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(
+                [fail(FirstError()), fail(SecondError())],
+                max_concurrency=2,
+            )
+
+        failures = exc_info.value.failures
+        assert {type(failure) for failure in failures} == {FirstError, SecondError}
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_timeout_cancels_pending_and_keeps_partial_results() -> None:
+    async def worker(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    async def run() -> None:
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(
+                [worker(1, 0), worker(2, 1)],
+                max_concurrency=2,
+                timeout=0.05,
+            )
+
+        assert exc_info.value.partial_results[0] == 1
+        assert exc_info.value.partial_results[1] is None
+        assert any(
+            isinstance(failure, asyncio.TimeoutError)
+            for failure in exc_info.value.failures
+        )
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_allows_concurrency_above_task_count() -> None:
+    async def worker(value: int) -> int:
+        return value
+
+    async def run() -> None:
+        results = await run_concurrently(
+            [worker(1), worker(2)],
+            max_concurrency=10,
+        )
+
+        assert results == [1, 2]
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_rejects_invalid_concurrency() -> None:
+    async def run() -> None:
+        with pytest.raises(ValueError, match="max_concurrency"):
+            await run_concurrently([], max_concurrency=0)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Add `run_concurrently` with semaphore-limited async execution.
- Preserve result ordering, aggregate failures in `ConcurrencyError`, and retain partial results on timeout.
- Add focused coverage for concurrency limits, sequential execution, ordering, error aggregation, timeout cancellation, and oversized concurrency.
- Include safe public contributor metadata only.

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_concurrency_run_concurrently.py -q` -> 6 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_dependency_wrapped.py -q` -> 28 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/concurrency.py tests/test_concurrency_run_concurrently.py` -> passed
- `git diff --check` -> passed

/claim #803