### PR TITLE
Ola Router Middleware Agent [ FastAPI ] Add router-level middleware support

### DIFF
--- a/fastapi/fastapi/.provenance.json
+++ b/fastapi/fastapi/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Ola Router Middleware Agent",
+  "config_snapshot": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#796 requests router-level middleware support in fastapi/fastapi/routing.py, including an APIRouter middleware parameter, add_middleware convenience method, Starlette-style and callable middleware support, include_router preservation, isolated router scope, ordering tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally redacted and are not safe to publish in a repository.",
+  "created": "2026-06-11T21:43:20Z"
+}

--- a/fastapi/fastapi/routing.py
+++ b/fastapi/fastapi/routing.py
@@ -78,6 +78,7 @@ from starlette._utils import is_async_callable
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
+from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import (
@@ -1162,6 +1163,14 @@ class APIRouter(routing.Router):
                 """
             ),
         ] = APIRoute,
+        middleware: Annotated[
+            Sequence[Any] | None,
+            Doc(
+                """
+                Middleware applied only to routes registered on this router.
+                """
+            ),
+        ] = None,
         on_startup: Annotated[
             Sequence[Callable[[], Any]] | None,
             Doc(
@@ -1310,9 +1319,56 @@ class APIRouter(routing.Router):
         self.callbacks = callbacks or []
         self.dependency_overrides_provider = dependency_overrides_provider
         self.route_class = route_class
+        self.router_middleware = [
+            self._normalize_middleware(middleware_item)
+            for middleware_item in middleware or []
+        ]
         self.default_response_class = default_response_class
         self.generate_unique_id_function = generate_unique_id_function
         self.strict_content_type = strict_content_type
+
+        for route in self.routes:
+            self._apply_router_middleware(route, self.router_middleware)
+
+    def _normalize_middleware(
+        self,
+        middleware_class: Any,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        if isinstance(middleware_class, Middleware):
+            return middleware_class.cls, dict(middleware_class.options)
+        return middleware_class, dict(options or {})
+
+    def _build_middleware_stack(
+        self,
+        app: ASGIApp,
+        middleware: Sequence[tuple[Any, dict[str, Any]]],
+    ) -> ASGIApp:
+        wrapped_app = app
+        for middleware_class, options in reversed(middleware):
+            wrapped_app = middleware_class(wrapped_app, **options)
+        return wrapped_app
+
+    def _apply_router_middleware(
+        self,
+        route: BaseRoute,
+        middleware: Sequence[tuple[Any, dict[str, Any]]],
+    ) -> None:
+        if not middleware or not hasattr(route, "app"):
+            return
+        base_app = getattr(route, "_fastapi_router_base_app", None)
+        if base_app is None:
+            base_app = route.app
+            route._fastapi_router_base_app = base_app
+        route.app = self._build_middleware_stack(base_app, middleware)
+        route._fastapi_router_middleware = list(middleware)
+
+    def add_middleware(self, middleware_class: Any, **options: Any) -> None:
+        self.router_middleware.append(
+            self._normalize_middleware(middleware_class, options)
+        )
+        for route in self.routes:
+            self._apply_router_middleware(route, self.router_middleware)
 
     def route(
         self,
@@ -1364,6 +1420,7 @@ class APIRouter(routing.Router):
         generate_unique_id_function: Callable[[APIRoute], str]
         | DefaultPlaceholder = Default(generate_unique_id),
         strict_content_type: bool | DefaultPlaceholder = Default(True),
+        middleware: Sequence[tuple[Any, dict[str, Any]]] | None = None,
     ) -> None:
         route_class = route_class_override or self.route_class
         responses = responses or {}
@@ -1414,6 +1471,8 @@ class APIRouter(routing.Router):
                 strict_content_type, self.strict_content_type
             ),
         )
+        current_middleware = list(middleware or self.router_middleware)
+        self._apply_router_middleware(route, current_middleware)
         self.routes.append(route)
 
     def api_route(
@@ -1759,6 +1818,10 @@ class APIRouter(routing.Router):
                     generate_unique_id_function,
                     self.generate_unique_id_function,
                 )
+                current_middleware = [
+                    *self.router_middleware,
+                    *getattr(route, "_fastapi_router_middleware", []),
+                ]
                 self.add_api_route(
                     prefix + route.path,
                     route.endpoint,
@@ -1793,6 +1856,7 @@ class APIRouter(routing.Router):
                         router.strict_content_type,
                         self.strict_content_type,
                     ),
+                    middleware=current_middleware,
                 )
             elif isinstance(route, routing.Route):
                 methods = list(route.methods or [])

--- a/fastapi/tests/test_router_middleware.py
+++ b/fastapi/tests/test_router_middleware.py
@@ -1,0 +1,117 @@
+from collections.abc import Callable
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class HeaderMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        name: str = "x-router",
+        value: str = "on",
+    ) -> None:
+        self.app = app
+        self.name = name.encode("latin-1")
+        self.value = value.encode("latin-1")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                message.setdefault("headers", []).append((self.name, self.value))
+            await send(message)
+
+        await self.app(scope, receive, send_with_header)
+
+
+class ScopeOrderMiddleware:
+    def __init__(self, app: ASGIApp, *, name: str) -> None:
+        self.app = app
+        self.name = name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope.setdefault("order", []).append(self.name)
+        await self.app(scope, receive, send)
+
+
+def callable_header_middleware(
+    app: ASGIApp,
+    *,
+    value: str,
+) -> Callable[[Scope, Receive, Send], object]:
+    async def wrapped(scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                message.setdefault("headers", []).append(
+                    (b"x-callable-router", value.encode("latin-1"))
+                )
+            await send(message)
+
+        await app(scope, receive, send_with_header)
+
+    return wrapped
+
+
+def test_router_middleware_is_isolated_to_router_routes() -> None:
+    app = FastAPI()
+    router = APIRouter(middleware=[HeaderMiddleware])
+
+    @router.get("/router")
+    def router_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/app")
+    def app_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+    client = TestClient(app)
+
+    assert client.get("/router").headers["x-router"] == "on"
+    assert "x-router" not in client.get("/app").headers
+
+
+def test_add_middleware_preserves_registration_order() -> None:
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/order")
+    def ordered(request: Request) -> dict[str, list[str]]:
+        return {"order": request.scope["order"]}
+
+    router.add_middleware(ScopeOrderMiddleware, name="first")
+    router.add_middleware(ScopeOrderMiddleware, name="second")
+    app.include_router(router)
+
+    assert TestClient(app).get("/order").json() == {"order": ["first", "second"]}
+
+
+def test_callable_router_middleware_works() -> None:
+    app = FastAPI()
+    router = APIRouter()
+    router.add_middleware(callable_header_middleware, value="yes")
+
+    @router.get("/callable")
+    def callable_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+
+    assert TestClient(app).get("/callable").headers["x-callable-router"] == "yes"
+
+
+def test_include_router_preserves_nested_router_middleware() -> None:
+    app = FastAPI()
+    outer = APIRouter()
+    inner = APIRouter(middleware=[HeaderMiddleware])
+
+    @inner.get("/nested")
+    def nested_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    outer.include_router(inner, prefix="/inner")
+    app.include_router(outer, prefix="/api")
+
+    assert TestClient(app).get("/api/inner/nested").headers["x-router"] == "on"


### PR DESCRIPTION
## Summary
- Add APIRouter-level middleware support by wrapping route ASGI apps.
- Preserve router middleware through `include_router`, including nested routers.
- Add `router.add_middleware(...)` and support Starlette-style middleware classes plus callable middleware factories.
- Cover router isolation, ordering, callable middleware, nested include preservation, and safe public provenance.

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_router_middleware.py -q` -> 4 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_include_route.py -q` -> 1 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/routing.py tests/test_router_middleware.py` -> passed
- `git diff --check` -> passed

/claim #796