### PR TITLE
Ola Operation ID Agent [ FastAPI ] Fix duplicate generated operation IDs

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Ola Operation ID Agent",
+  "platform_config": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#764 requests updating fastapi/fastapi/utils.py generate_unique_id to include HTTP method and route prefix, sanitize IDs to lowercase alphanumeric/underscores, append numeric suffixes for genuine collisions, add uniqueness tests across routers, and use a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally redacted and are not safe to publish in a repository.",
+  "date": "2026-06-11T21:49:13Z"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -250,6 +250,11 @@ def get_openapi_operation_metadata(
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        base_operation_id = operation_id
+        suffix = 2
+        while operation_id in operation_ids:
+            operation_id = f"{base_operation_id}_{suffix}"
+            suffix += 1
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -93,11 +93,13 @@ def generate_operation_id_for_path(
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0].lower()
+    path = route.path_format.strip("/")
+    operation_id = "_".join(part for part in (method, path, route.name) if part)
+    operation_id = re.sub(r"[^0-9a-zA-Z_]+", "_", operation_id)
+    operation_id = re.sub(r"_+", "_", operation_id).strip("_")
+    return operation_id.lower()
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_unique_operation_id_collisions.py
+++ b/fastapi/tests/test_unique_operation_id_collisions.py
@@ -1,0 +1,58 @@
+import re
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+
+def list_users() -> dict[str, bool]:
+    return {"ok": True}
+
+
+def read() -> dict[str, bool]:
+    return {"ok": True}
+
+
+def operation_ids(app: FastAPI) -> list[str]:
+    schema = TestClient(app).get("/openapi.json").json()
+    ids: list[str] = []
+    for path_item in schema["paths"].values():
+        for operation in path_item.values():
+            ids.append(operation["operationId"])
+    return ids
+
+
+def test_generate_unique_id_includes_method_and_router_prefix() -> None:
+    app = FastAPI()
+    first_router = APIRouter()
+    second_router = APIRouter()
+
+    first_router.get("/users")(list_users)
+    second_router.get("/users")(list_users)
+    app.include_router(first_router, prefix="/api/v1")
+    app.include_router(second_router, prefix="/api/v2")
+
+    ids = operation_ids(app)
+
+    assert "get_api_v1_users_list_users" in ids
+    assert "get_api_v2_users_list_users" in ids
+    assert len(ids) == len(set(ids))
+
+
+def test_generate_unique_id_is_lowercase_alphanumeric_with_underscores() -> None:
+    app = FastAPI()
+    app.get("/items/{item_id}/sub-items")(read)
+
+    [operation_id] = operation_ids(app)
+
+    assert re.fullmatch(r"[a-z0-9_]+", operation_id)
+    assert operation_id == "get_items_item_id_sub_items_read"
+
+
+def test_openapi_generation_suffixes_genuine_collisions() -> None:
+    app = FastAPI()
+    app.get("/items/a-b")(read)
+    app.get("/items/a_b")(read)
+
+    ids = operation_ids(app)
+
+    assert ids == ["get_items_a_b_read", "get_items_a_b_read_2"]


### PR DESCRIPTION
## Summary
- Update `generate_unique_id` to build deterministic lowercase method/path/name IDs.
- Sanitize IDs to lowercase alphanumeric plus underscores.
- Add OpenAPI-time numeric suffixing for genuine collisions after sanitization.
- Add focused tests for cross-router uniqueness, sanitization, and collision suffixing.
- Include safe public attribution metadata only.

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_unique_operation_id_collisions.py -q` -> 3 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/utils.py fastapi/openapi/utils.py tests/test_unique_operation_id_collisions.py` -> passed
- `git diff --check` -> passed

/claim #764