### PR TITLE
Ola Upload Validation Agent [ FastAPI ] Add UploadFile validation

### DIFF
--- a/fastapi/fastapi/contributor_meta.json
+++ b/fastapi/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ola Upload Validation Agent",
+  "session_init": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#761 requests UploadFile max_size and allowed_content_types parameters, a validate async method returning ValidationResult metadata, HTTP 413 for oversized files, HTTP 415 for disallowed content types, unchanged existing UploadFile usage, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally redacted and are not safe to publish in a repository.",
+  "ts": "2026-06-11T21:50:56Z"
+}

--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -8,7 +8,9 @@ from typing import (
 )
 
 from annotated_doc import Doc
+from fastapi.exceptions import HTTPException
 from pydantic import GetJsonSchemaHandler
+from pydantic import BaseModel
 from starlette.datastructures import URL as URL  # noqa: F401
 from starlette.datastructures import Address as Address  # noqa: F401
 from starlette.datastructures import FormData as FormData  # noqa: F401
@@ -16,6 +18,12 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+
+
+class ValidationResult(BaseModel):
+    is_valid: bool
+    file_size: int | None
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +70,63 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+    max_size: Annotated[int | None, Doc("Maximum allowed file size in bytes.")]
+    allowed_content_types: Annotated[
+        list[str] | None,
+        Doc("Allowed MIME content types for this uploaded file."),
+    ]
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: list[str] | None = None,
+    ) -> None:
+        super().__init__(
+            file=file,
+            size=size,
+            filename=filename,
+            headers=headers,
+        )
+        self.max_size = max_size
+        self.allowed_content_types = allowed_content_types
+
+    async def validate(self) -> ValidationResult:
+        file_size = self.size if self.size is not None else self._measure_file_size()
+        content_type = self.content_type
+
+        if self.max_size is not None and file_size is not None:
+            if file_size > self.max_size:
+                raise HTTPException(
+                    status_code=413,
+                    detail="Uploaded file exceeds maximum allowed size",
+                )
+
+        if self.allowed_content_types is not None:
+            if content_type not in self.allowed_content_types:
+                raise HTTPException(
+                    status_code=415,
+                    detail="Uploaded file content type is not allowed",
+                )
+
+        return ValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=content_type,
+        )
+
+    def _measure_file_size(self) -> int | None:
+        if not hasattr(self.file, "tell") or not hasattr(self.file, "seek"):
+            return None
+        current_position = self.file.tell()
+        self.file.seek(0, 2)
+        file_size = self.file.tell()
+        self.file.seek(current_position)
+        return file_size
 
     async def write(
         self,

--- a/fastapi/tests/test_uploadfile_validation.py
+++ b/fastapi/tests/test_uploadfile_validation.py
@@ -1,0 +1,90 @@
+from io import BytesIO
+
+import pytest
+from fastapi import FastAPI, File, UploadFile
+from fastapi.datastructures import Headers
+from fastapi.exceptions import HTTPException
+from fastapi.testclient import TestClient
+
+
+def upload_file(
+    content: bytes = b"hello",
+    *,
+    content_type: str = "text/plain",
+    max_size: int | None = None,
+    allowed_content_types: list[str] | None = None,
+) -> UploadFile:
+    return UploadFile(
+        file=BytesIO(content),
+        filename="example.txt",
+        headers=Headers({"content-type": content_type}),
+        max_size=max_size,
+        allowed_content_types=allowed_content_types,
+    )
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_returns_file_metadata() -> None:
+    file = upload_file(
+        b"hello",
+        max_size=10,
+        allowed_content_types=["text/plain"],
+    )
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 5
+    assert result.content_type == "text/plain"
+    assert await file.read() == b"hello"
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_raises_413_when_file_is_too_large() -> None:
+    file = upload_file(b"toolarge", max_size=3)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_raises_415_for_disallowed_content_type() -> None:
+    file = upload_file(
+        b"hello",
+        content_type="application/octet-stream",
+        allowed_content_types=["text/plain"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_skips_unset_constraints() -> None:
+    file = upload_file(b"any-size", content_type="application/octet-stream")
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 8
+    assert result.content_type == "application/octet-stream"
+
+
+def test_existing_uploadfile_route_usage_still_works() -> None:
+    app = FastAPI()
+
+    @app.post("/upload")
+    async def upload(file: UploadFile = File()):
+        return {"filename": file.filename, "content": (await file.read()).decode()}
+
+    response = TestClient(app).post(
+        "/upload",
+        files={"file": ("hello.txt", b"hello", "text/plain")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"filename": "hello.txt", "content": "hello"}


### PR DESCRIPTION
## Summary
- Extend `UploadFile` with optional `max_size` and `allowed_content_types` constraints.
- Add async `validate()` returning `ValidationResult` metadata.
- Raise HTTP 413 for oversized files and HTTP 415 for disallowed content types.
- Preserve existing `UploadFile` behavior when constraints are not provided.
- Include safe public contributor metadata only.

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_uploadfile_validation.py -q` -> 5 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_datastructures.py -q` -> 5 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/datastructures.py tests/test_uploadfile_validation.py` -> passed
- `git diff --check` -> passed

/claim #761