### PR TITLE
Ola OAuth Refresh Agent [ FastAPI ] Add OAuth2 token refresh support

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
+from .security import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/.provenance.json
+++ b/fastapi/fastapi/security/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Ola OAuth Refresh Agent",
+  "config_snapshot": "Public contributor metadata for issue #758. Private system, developer, tool, and session instructions are intentionally not disclosed.",
+  "created": "2026-06-11T21:54:29Z"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,74 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    This is a dependency class to collect the OAuth2 refresh token grant form data.
+
+    The OAuth2 specification requires refresh token requests to use the
+    `refresh_token` grant type and include a `refresh_token` field.
+    """
+
+    def __init__(
+        self,
+        *,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 spec requires this field to be the fixed string
+                "refresh_token" for refresh token requests.
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                The refresh token previously issued by the authorization server.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 scopes separated by spaces, allowing the client to
+                request a reduced scope for the refreshed access token.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 client ID. OAuth2 recommends sending client
+                credentials with HTTP Basic authentication when possible.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                Optional OAuth2 client secret. OAuth2 recommends sending client
+                credentials with HTTP Basic authentication when possible.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +610,78 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password bearer flow with an advertised refresh token endpoint.
+
+    This works as a drop-in replacement for `OAuth2PasswordBearer` while adding the
+    OAuth2 `refreshUrl` value to the generated OpenAPI security scheme.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        refresh_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new one.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                The OAuth2 scopes that would be required by the path operations that
+                use this dependency.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if no HTTP Authorization header is provided, required for
+                OAuth2 authentication, it will automatically cancel the request and
+                send the client an error.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            tokenUrl=tokenUrl,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+            refreshUrl=refresh_url,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/tests/test_oauth2_refresh.py
+++ b/fastapi/tests/test_oauth2_refresh.py
@@ -1,0 +1,109 @@
+from typing import Annotated
+
+import fastapi
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import (
+    OAuth2PasswordBearer,
+    OAuth2PasswordBearerWithRefresh,
+    OAuth2RefreshRequestForm,
+)
+from fastapi.testclient import TestClient
+
+
+app = FastAPI()
+
+oauth2_standard = OAuth2PasswordBearer(tokenUrl="/token")
+oauth2_with_refresh = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="/token",
+    refresh_url="/refresh",
+    scopes={"items": "Read items"},
+)
+
+
+@app.get("/standard")
+def read_standard(token: Annotated[str, Security(oauth2_standard)]):
+    return {"token": token}
+
+
+@app.get("/with-refresh")
+def read_with_refresh(token: Annotated[str, Security(oauth2_with_refresh)]):
+    return {"token": token}
+
+
+@app.post("/refresh")
+def refresh(form_data: Annotated[OAuth2RefreshRequestForm, Depends()]):
+    return {
+        "grant_type": form_data.grant_type,
+        "refresh_token": form_data.refresh_token,
+        "scopes": form_data.scopes,
+        "client_id": form_data.client_id,
+        "client_secret": form_data.client_secret,
+    }
+
+
+client = TestClient(app)
+
+
+def test_oauth2_password_bearer_with_refresh_is_drop_in():
+    response = client.get(
+        "/with-refresh", headers={"Authorization": "Bearer refreshed-token"}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"token": "refreshed-token"}
+
+
+def test_oauth2_password_bearer_with_refresh_openapi():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    schemes = response.json()["components"]["securitySchemes"]
+
+    standard_flow = schemes["OAuth2PasswordBearer"]["flows"]["password"]
+    refresh_flow = schemes["OAuth2PasswordBearerWithRefresh"]["flows"]["password"]
+
+    assert "refreshUrl" not in standard_flow
+    assert refresh_flow["tokenUrl"] == "/token"
+    assert refresh_flow["refreshUrl"] == "/refresh"
+    assert refresh_flow["scopes"] == {"items": "Read items"}
+
+
+def test_oauth2_refresh_request_form():
+    response = client.post(
+        "/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-secret",
+            "scope": "items profile",
+            "client_id": "client",
+            "client_secret": "secret",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-secret",
+        "scopes": ["items", "profile"],
+        "client_id": "client",
+        "client_secret": "secret",
+    }
+
+
+def test_oauth2_refresh_request_form_rejects_wrong_grant_type():
+    response = client.post(
+        "/refresh",
+        data={"grant_type": "password", "refresh_token": "refresh-secret"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == [
+        {
+            "type": "string_pattern_mismatch",
+            "loc": ["body", "grant_type"],
+            "msg": "String should match pattern '^refresh_token$'",
+            "input": "password",
+            "ctx": {"pattern": "^refresh_token$"},
+        }
+    ]
+
+
+def test_oauth2_refresh_exports_from_root_package():
+    assert fastapi.OAuth2PasswordBearerWithRefresh is OAuth2PasswordBearerWithRefresh
+    assert fastapi.OAuth2RefreshRequestForm is OAuth2RefreshRequestForm


### PR DESCRIPTION
## Summary
- add OAuth2RefreshRequestForm for refresh_token grant validation
- add OAuth2PasswordBearerWithRefresh as a drop-in password bearer security helper with refreshUrl in OpenAPI
- export the new helpers from fastapi.security and the root fastapi package

## Tests
- python -m pytest tests/test_oauth2_refresh.py
- python -m pytest tests/test_dependency_paramless.py
- python -m py_compile fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py
- git diff --check

/claim #758
Closes #758