### PR TITLE
Ola WebSocket Heartbeat Agent [ FastAPI ] Add WebSocket heartbeat support

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -23,3 +23,4 @@ from .responses import Response as Response
 from .routing import APIRouter as APIRouter
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect
+from .websockets import WebSocketWithHeartbeat as WebSocketWithHeartbeat

--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Ola WebSocket Heartbeat Agent",
+  "runtime_instructions": "Public contributor metadata for issue #766. Private system, developer, tool, and session instructions are intentionally not disclosed.",
+  "timestamp": "2026-06-11T21:57:57Z"
+}

--- a/fastapi/fastapi/websockets.py
+++ b/fastapi/fastapi/websockets.py
@@ -1,3 +1,183 @@
-from starlette.websockets import WebSocket as WebSocket  # noqa
+import asyncio
+import inspect
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from starlette.websockets import WebSocket as StarletteWebSocket
 from starlette.websockets import WebSocketDisconnect as WebSocketDisconnect  # noqa
 from starlette.websockets import WebSocketState as WebSocketState  # noqa
+
+WebSocket = StarletteWebSocket
+
+DisconnectCallback = Callable[[int, float], Any | Awaitable[Any]]
+
+
+class WebSocketWithHeartbeat:
+    """
+    Wrap a WebSocket with opt-in heartbeat messages and connection metrics.
+
+    ASGI does not expose protocol-level ping/pong control frames to applications,
+    so this helper sends application-level heartbeat messages and treats the
+    configured pong message as liveness confirmation.
+    """
+
+    def __init__(
+        self,
+        websocket: WebSocket,
+        *,
+        ping_interval: float = 30.0,
+        pong_timeout: float = 10.0,
+        on_disconnect: DisconnectCallback | None = None,
+        ping_message: Any = "__fastapi_ping__",
+        pong_message: Any = "__fastapi_pong__",
+    ) -> None:
+        if ping_interval <= 0:
+            raise ValueError("ping_interval must be greater than 0")
+        if pong_timeout <= 0:
+            raise ValueError("pong_timeout must be greater than 0")
+
+        self.websocket = websocket
+        self.ping_interval = ping_interval
+        self.pong_timeout = pong_timeout
+        self.on_disconnect = on_disconnect
+        self.ping_message = ping_message
+        self.pong_message = pong_message
+        self.started_at = time.monotonic()
+        self._message_count = 0
+        self._pong_event = asyncio.Event()
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._disconnect_notified = False
+        self._closed = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.websocket, name)
+
+    @property
+    def connection_duration(self) -> float:
+        return time.monotonic() - self.started_at
+
+    @property
+    def message_count(self) -> int:
+        return self._message_count
+
+    async def accept(self, *args: Any, **kwargs: Any) -> None:
+        await self.websocket.accept(*args, **kwargs)
+        self.start_heartbeat()
+
+    def start_heartbeat(self) -> None:
+        if self._heartbeat_task is None or self._heartbeat_task.done():
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def stop_heartbeat(self) -> None:
+        task = self._heartbeat_task
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def record_pong(self) -> None:
+        self._pong_event.set()
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self._closed = True
+        await self.stop_heartbeat()
+        if reason is None:
+            await self.websocket.close(code=code)
+        else:
+            await self.websocket.close(code=code, reason=reason)
+        await self._notify_disconnect(code)
+
+    async def receive_text(self) -> str:
+        while True:
+            try:
+                message = await self.websocket.receive_text()
+            except WebSocketDisconnect as exc:
+                await self._handle_disconnect(exc.code)
+                raise
+            if self._is_pong(message):
+                await self.record_pong()
+                continue
+            self._record_message()
+            return message
+
+    async def receive_bytes(self) -> bytes:
+        while True:
+            try:
+                message = await self.websocket.receive_bytes()
+            except WebSocketDisconnect as exc:
+                await self._handle_disconnect(exc.code)
+                raise
+            if self._is_pong(message):
+                await self.record_pong()
+                continue
+            self._record_message()
+            return message
+
+    async def receive_json(self, *args: Any, **kwargs: Any) -> Any:
+        while True:
+            try:
+                message = await self.websocket.receive_json(*args, **kwargs)
+            except WebSocketDisconnect as exc:
+                await self._handle_disconnect(exc.code)
+                raise
+            if self._is_pong(message):
+                await self.record_pong()
+                continue
+            self._record_message()
+            return message
+
+    async def send_ping(self) -> None:
+        if isinstance(self.ping_message, bytes):
+            await self.websocket.send_bytes(self.ping_message)
+        elif isinstance(self.ping_message, str):
+            await self.websocket.send_text(self.ping_message)
+        else:
+            await self.websocket.send_json(self.ping_message)
+
+    def _record_message(self) -> None:
+        self._message_count += 1
+
+    def _is_pong(self, message: Any) -> bool:
+        return message == self.pong_message
+
+    async def _heartbeat_loop(self) -> None:
+        while not self._closed:
+            await asyncio.sleep(self.ping_interval)
+            if self._closed:
+                return
+            self._pong_event.clear()
+            try:
+                await self.send_ping()
+                await asyncio.wait_for(
+                    self._pong_event.wait(), timeout=self.pong_timeout
+                )
+            except asyncio.TimeoutError:
+                await self._close_for_timeout()
+                return
+            except WebSocketDisconnect as exc:
+                await self._handle_disconnect(exc.code)
+                return
+
+    async def _close_for_timeout(self) -> None:
+        self._closed = True
+        await self.websocket.close(code=1001)
+        await self._notify_disconnect(1001)
+
+    async def _handle_disconnect(self, code: int) -> None:
+        self._closed = True
+        await self.stop_heartbeat()
+        await self._notify_disconnect(code)
+
+    async def _notify_disconnect(self, code: int) -> None:
+        if self._disconnect_notified:
+            return
+        self._disconnect_notified = True
+        if self.on_disconnect is None:
+            return
+        result = self.on_disconnect(code, self.connection_duration)
+        if inspect.isawaitable(result):
+            await result

--- a/fastapi/tests/test_websocket_heartbeat.py
+++ b/fastapi/tests/test_websocket_heartbeat.py
@@ -1,0 +1,93 @@
+import asyncio
+
+import pytest
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, WebSocketWithHeartbeat
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+disconnect_events: list[tuple[int, float]] = []
+
+
+def record_disconnect(code: int, duration: float) -> None:
+    disconnect_events.append((code, duration))
+
+
+@app.websocket("/heartbeat")
+async def heartbeat_endpoint(websocket: WebSocket):
+    heartbeat = WebSocketWithHeartbeat(
+        websocket,
+        ping_interval=0.01,
+        pong_timeout=0.5,
+        on_disconnect=record_disconnect,
+    )
+    await heartbeat.accept()
+    message = await heartbeat.receive_text()
+    await heartbeat.send_json(
+        {
+            "message": message,
+            "message_count": heartbeat.message_count,
+            "has_duration": heartbeat.connection_duration > 0,
+        }
+    )
+    await heartbeat.close()
+
+
+@app.websocket("/heartbeat-timeout")
+async def heartbeat_timeout_endpoint(websocket: WebSocket):
+    heartbeat = WebSocketWithHeartbeat(
+        websocket,
+        ping_interval=0.01,
+        pong_timeout=0.02,
+        on_disconnect=record_disconnect,
+    )
+    await heartbeat.accept()
+    await asyncio.sleep(0.08)
+
+
+@app.websocket("/plain")
+async def plain_websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    await websocket.send_text("plain")
+    await websocket.close()
+
+
+client = TestClient(app)
+
+
+def test_websocket_with_heartbeat_sends_ping_and_tracks_messages():
+    disconnect_events.clear()
+
+    with client.websocket_connect("/heartbeat") as websocket:
+        assert websocket.receive_text() == "__fastapi_ping__"
+        websocket.send_text("__fastapi_pong__")
+        websocket.send_text("payload")
+        assert websocket.receive_json() == {
+            "message": "payload",
+            "message_count": 1,
+            "has_duration": True,
+        }
+
+    assert disconnect_events
+    code, duration = disconnect_events[-1]
+    assert code == 1000
+    assert duration > 0
+
+
+def test_websocket_with_heartbeat_closes_when_pong_times_out():
+    disconnect_events.clear()
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/heartbeat-timeout") as websocket:
+            assert websocket.receive_text() == "__fastapi_ping__"
+            websocket.receive_text()
+
+    assert exc_info.value.code == 1001
+    assert disconnect_events
+    code, duration = disconnect_events[-1]
+    assert code == 1001
+    assert duration > 0
+
+
+def test_websocket_without_heartbeat_still_works():
+    with client.websocket_connect("/plain") as websocket:
+        assert websocket.receive_text() == "plain"


### PR DESCRIPTION
## Summary
- add an opt-in WebSocketWithHeartbeat wrapper while preserving the existing WebSocket export
- send configurable heartbeat messages, close stale connections with code 1001, and call on_disconnect with code and duration
- track connection duration and application message count, with focused WebSocket tests

## Tests
- python -m pytest tests/test_websocket_heartbeat.py tests/test_ws_router.py
- python -m py_compile fastapi/websockets.py fastapi/__init__.py
- git diff --check

/claim #766
Closes #766