### PR TITLE
Ola Test Client Agent [ FastAPI ] Add auth helpers to test client

### DIFF
--- a/fastapi/fastapi/.audit.json
+++ b/fastapi/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Ola Test Client Agent",
+  "environment_config": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#804 requests an opt-in FastAPITestClient in fastapi/fastapi/testclient.py with bearer/basic auth helpers, reset_auth, WebSocket connection convenience with custom headers and subprotocols, assert_status, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not disclosed.",
+  "completed_at": "2026-06-11T22:10:41Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,68 @@
+import base64
+from collections.abc import Sequence
+from typing import Any
+
+import httpx
 from starlette.testclient import TestClient as TestClient  # noqa
+
+
+class FastAPITestClient(TestClient):
+    def authenticate(self, token: str) -> "FastAPITestClient":
+        self.headers["Authorization"] = f"Bearer {token}"
+        return self
+
+    def authenticate_basic(
+        self,
+        username: str,
+        password: str,
+    ) -> "FastAPITestClient":
+        credentials = f"{username}:{password}".encode()
+        encoded = base64.b64encode(credentials).decode("ascii")
+        self.headers["Authorization"] = f"Basic {encoded}"
+        return self
+
+    def reset_auth(self) -> "FastAPITestClient":
+        self.headers.pop("Authorization", None)
+        return self
+
+    def ws_connect(
+        self,
+        url: str,
+        *,
+        headers: Any | None = None,
+        subprotocols: Sequence[str] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        merged_headers = httpx.Headers(self.headers)
+        if headers is not None:
+            merged_headers.update(headers)
+        return self.websocket_connect(
+            url,
+            subprotocols=subprotocols,
+            headers=dict(merged_headers),
+            **kwargs,
+        )
+
+    def assert_status(
+        self,
+        method: str,
+        url: Any,
+        expected_status: int | None = None,
+        *,
+        status_code: int | None = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        if expected_status is None:
+            if status_code is None:
+                raise TypeError("expected_status is required")
+            expected_status = status_code
+        elif status_code is not None:
+            raise TypeError("pass either expected_status or status_code, not both")
+
+        response = self.request(method, url, **kwargs)
+        if response.status_code != expected_status:
+            raise AssertionError(
+                f"Expected status code {expected_status} for {method.upper()} {url}; "
+                f"actual status code {response.status_code}. Response body: {response.text}"
+            )
+        return response

--- a/fastapi/tests/test_fastapi_testclient.py
+++ b/fastapi/tests/test_fastapi_testclient.py
@@ -1,0 +1,138 @@
+import base64
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI, Header, Response, WebSocket
+from fastapi.testclient import FastAPITestClient, TestClient
+from starlette.testclient import TestClient as StarletteTestClient
+
+app = FastAPI()
+
+
+def authorization_header(
+    authorization: Annotated[str | None, Header()] = None,
+) -> str | None:
+    return authorization
+
+
+@app.get("/auth")
+def read_auth(
+    authorization: Annotated[str | None, Depends(authorization_header)] = None,
+) -> dict[str, str | None]:
+    return {"authorization": authorization}
+
+
+@app.get("/status/{status_code}")
+def read_status(status_code: int) -> Response:
+    return Response(status_code=status_code)
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    subprotocol = websocket.scope["subprotocols"][0]
+    await websocket.accept(subprotocol=subprotocol)
+    await websocket.send_json(
+        {
+            "authorization": websocket.headers.get("authorization"),
+            "client": websocket.headers.get("x-client"),
+            "subprotocol": subprotocol,
+        }
+    )
+    await websocket.close()
+
+
+def test_existing_testclient_export_and_behavior_are_unchanged() -> None:
+    assert TestClient is StarletteTestClient
+    assert TestClient is not FastAPITestClient
+    assert issubclass(FastAPITestClient, TestClient)
+    assert not hasattr(TestClient, "authenticate")
+
+    client = TestClient(app)
+    assert client.get("/auth").json() == {"authorization": None}
+
+
+def test_authenticate_sets_and_replaces_bearer_token() -> None:
+    client = FastAPITestClient(app)
+
+    client.authenticate("first-token")
+    assert client.get("/auth").json() == {"authorization": "Bearer first-token"}
+
+    client.authenticate("second-token")
+    assert client.get("/auth").json() == {"authorization": "Bearer second-token"}
+
+
+def test_authenticate_basic_sets_basic_header() -> None:
+    client = FastAPITestClient(app)
+    expected = base64.b64encode(b"alice:s3cret").decode("ascii")
+
+    client.authenticate_basic("alice", "s3cret")
+
+    assert client.get("/auth").json() == {"authorization": f"Basic {expected}"}
+
+
+def test_reset_auth_clears_authorization_header_without_losing_other_headers() -> None:
+    client = FastAPITestClient(app, headers={"x-client": "suite"})
+
+    client.authenticate("token").reset_auth()
+
+    assert client.get("/auth").json() == {"authorization": None}
+    assert client.headers["x-client"] == "suite"
+
+
+def test_ws_connect_merges_auth_custom_headers_and_subprotocols() -> None:
+    client = FastAPITestClient(app).authenticate("ws-token")
+
+    with client.ws_connect(
+        "/ws",
+        headers={"x-client": "test-suite"},
+        subprotocols=("chat",),
+    ) as websocket:
+        assert websocket.receive_json() == {
+            "authorization": "Bearer ws-token",
+            "client": "test-suite",
+            "subprotocol": "chat",
+        }
+        assert websocket.accepted_subprotocol == "chat"
+
+
+def test_ws_connect_custom_headers_can_override_auth_case_insensitively() -> None:
+    client = FastAPITestClient(app).authenticate("default-token")
+
+    with client.ws_connect(
+        "/ws",
+        headers=[("authorization", "Bearer override-token"), ("x-client", "tuple")],
+        subprotocols=["updates"],
+    ) as websocket:
+        assert websocket.receive_json() == {
+            "authorization": "Bearer override-token",
+            "client": "tuple",
+            "subprotocol": "updates",
+        }
+
+
+def test_assert_status_returns_response_on_expected_status() -> None:
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("GET", "/status/204", 204)
+
+    assert response.status_code == 204
+
+
+def test_assert_status_accepts_named_status_code() -> None:
+    client = FastAPITestClient(app)
+
+    response = client.assert_status("GET", "/status/201", status_code=201)
+
+    assert response.status_code == 201
+
+
+def test_assert_status_raises_helpful_message() -> None:
+    client = FastAPITestClient(app)
+
+    with pytest.raises(
+        AssertionError,
+        match=(
+            "Expected status code 201 for GET /auth; actual status code 200"
+        ),
+    ):
+        client.assert_status("GET", "/auth", 201)


### PR DESCRIPTION
## Issue
Closes #804

## Summary
Adds an opt-in `FastAPITestClient` subclass while preserving the existing `TestClient` re-export as Starlette's original class. The helper supports persistent bearer/basic auth, auth reset, WebSocket connections with merged custom headers and subprotocols, and one-call status assertions with clearer failures.

## Acceptance criteria
- [x] `authenticate` sets Bearer token for all following requests on that client instance
- [x] `authenticate_basic` properly encodes and sets the Authorization header
- [x] `ws_connect` supports custom headers and subprotocols
- [x] `assert_status` raises `AssertionError` with helpful message showing expected vs actual status
- [x] Calling `authenticate` again replaces the previous token
- [x] `reset_auth` clears the authentication state
- [x] Existing `TestClient` import and behavior is not changed
- [x] Tests demonstrate each helper method
- [x] `.audit.json` is included in the changed package directory

## Tests
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_fastapi_testclient.py tests/test_ws_router.py tests/test_query.py -q` -> 50 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/testclient.py tests/test_fastapi_testclient.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/testclient.py tests/test_fastapi_testclient.py` -> passed
- `git diff --check` -> passed

/claim #804
