### PR TITLE
Ola SSE Agent [ FastAPI ] Rework SSE manager filtering and replay

### DIFF
--- a/fastapi/fastapi/.contributor.json
+++ b/fastapi/fastapi/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Ola SSE Agent",
+  "initialized_with": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#798 requests FastAPI SSE disconnect detection, event_type filtering, Last-Event-ID replay, retry fields, an SSEManager for broadcast fanout, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not published.",
+  "timestamp": "2026-06-11T22:17:49Z"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -3,6 +3,7 @@ from typing import Any, Protocol, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
+from fastapi.sse import SSEManager as SSEManager  # noqa
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
 from starlette.responses import JSONResponse as JSONResponse  # noqa

--- a/fastapi/fastapi/sse.py
+++ b/fastapi/fastapi/sse.py
@@ -1,6 +1,12 @@
+import asyncio
+import json
+from collections import deque
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import Annotated, Any
 
 from annotated_doc import Doc
+from fastapi.encoders import jsonable_encoder
 from pydantic import AfterValidator, BaseModel, Field, model_validator
 from starlette.responses import StreamingResponse
 
@@ -220,3 +226,240 @@ KEEPALIVE_COMMENT = b": ping\n\n"
 # Seconds between keep-alive pings when a generator is idle.
 # Private but importable so tests can monkeypatch it.
 _PING_INTERVAL: float = 15.0
+
+
+@dataclass(slots=True, eq=False)
+class _SSESubscriber:
+    event_type: str | None
+    queue: asyncio.Queue[ServerSentEvent]
+
+
+class SSEManager:
+    """Manage SSE subscribers, replay history, and fan out broadcast events."""
+
+    def __init__(
+        self,
+        *,
+        retry: int | None = None,
+        history_size: int = 100,
+        disconnect_poll_interval: float = 0.1,
+        queue_size: int = 100,
+    ) -> None:
+        if retry is not None and retry < 0:
+            raise ValueError("retry must be a non-negative integer")
+        if history_size < 0:
+            raise ValueError("history_size must be greater than or equal to 0")
+        if disconnect_poll_interval <= 0:
+            raise ValueError("disconnect_poll_interval must be greater than 0")
+        if queue_size <= 0:
+            raise ValueError("queue_size must be greater than 0")
+        self.retry = retry
+        self.disconnect_poll_interval = disconnect_poll_interval
+        self.queue_size = queue_size
+        self._history: deque[ServerSentEvent] = deque(maxlen=history_size)
+        self._subscribers: set[_SSESubscriber] = set()
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._subscribers)
+
+    async def broadcast(
+        self,
+        data: Any = None,
+        *,
+        event_type: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        raw_data: str | None = None,
+    ) -> ServerSentEvent:
+        event = ServerSentEvent(
+            data=data,
+            raw_data=raw_data,
+            event=event_type,
+            id=id,
+            retry=retry if retry is not None else self.retry,
+        )
+        self._history.append(event)
+        for subscriber in tuple(self._subscribers):
+            if self._matches(subscriber.event_type, event):
+                self._queue_event(subscriber, event)
+        return event
+
+    def stream(
+        self,
+        request: Any | None = None,
+        *,
+        event_type: str | None = None,
+        last_event_id: str | None = None,
+        retry: int | None = None,
+    ) -> AsyncIterator[ServerSentEvent]:
+        return self._stream(
+            request=request,
+            event_type=event_type,
+            last_event_id=last_event_id,
+            retry=retry,
+        )
+
+    def response(
+        self,
+        request: Any | None = None,
+        *,
+        event_type: str | None = None,
+        last_event_id: str | None = None,
+        retry: int | None = None,
+    ) -> EventSourceResponse:
+        response = EventSourceResponse(
+            self._encoded_stream(
+                request=request,
+                event_type=event_type,
+                last_event_id=last_event_id,
+                retry=retry,
+            )
+        )
+        response.headers["Cache-Control"] = "no-cache"
+        response.headers["X-Accel-Buffering"] = "no"
+        return response
+
+    async def _encoded_stream(
+        self,
+        request: Any | None,
+        event_type: str | None,
+        last_event_id: str | None,
+        retry: int | None,
+    ) -> AsyncIterator[bytes]:
+        async for event in self.stream(
+            request=request,
+            event_type=event_type,
+            last_event_id=last_event_id,
+            retry=retry,
+        ):
+            yield self._format_event(event)
+
+    async def _stream(
+        self,
+        request: Any | None,
+        event_type: str | None,
+        last_event_id: str | None,
+        retry: int | None,
+    ) -> AsyncIterator[ServerSentEvent]:
+        resolved_event_type = self._resolve_event_type(request, event_type)
+        resolved_last_event_id = self._resolve_last_event_id(request, last_event_id)
+        subscriber = _SSESubscriber(
+            event_type=resolved_event_type,
+            queue=asyncio.Queue(maxsize=self.queue_size),
+        )
+        self._subscribers.add(subscriber)
+        replayed_ids: set[str] = set()
+        try:
+            for event in self._events_after(resolved_last_event_id):
+                if self._matches(resolved_event_type, event):
+                    if event.id is not None:
+                        replayed_ids.add(event.id)
+                    yield self._with_retry(event, retry)
+
+            while True:
+                if await self._is_disconnected(request):
+                    break
+                try:
+                    event = await asyncio.wait_for(
+                        subscriber.queue.get(),
+                        timeout=self.disconnect_poll_interval,
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                if event.id is not None and event.id in replayed_ids:
+                    continue
+                yield self._with_retry(event, retry)
+        finally:
+            self._subscribers.discard(subscriber)
+
+    def _events_after(self, last_event_id: str | None) -> list[ServerSentEvent]:
+        if last_event_id is None:
+            return []
+        history = list(self._history)
+        for index, event in enumerate(history):
+            if event.id == last_event_id:
+                return history[index + 1 :]
+        return []
+
+    def _matches(self, event_type: str | None, event: ServerSentEvent) -> bool:
+        return event_type is None or event.event == event_type
+
+    def _queue_event(
+        self,
+        subscriber: _SSESubscriber,
+        event: ServerSentEvent,
+    ) -> None:
+        try:
+            subscriber.queue.put_nowait(event)
+        except asyncio.QueueFull:
+            try:
+                subscriber.queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            subscriber.queue.put_nowait(event)
+
+    def _with_retry(
+        self,
+        event: ServerSentEvent,
+        retry: int | None,
+    ) -> ServerSentEvent:
+        if retry is None or event.retry == retry:
+            return event
+        return event.model_copy(update={"retry": retry})
+
+    def _resolve_event_type(
+        self,
+        request: Any | None,
+        event_type: str | None,
+    ) -> str | None:
+        if event_type is not None:
+            return event_type or None
+        query_params = getattr(request, "query_params", None)
+        if query_params is None:
+            return None
+        value = query_params.get("event_type")
+        if value == "":
+            return None
+        return value
+
+    def _resolve_last_event_id(
+        self,
+        request: Any | None,
+        last_event_id: str | None,
+    ) -> str | None:
+        if last_event_id is not None:
+            return last_event_id
+        headers = getattr(request, "headers", None)
+        if headers is None:
+            return None
+        value = headers.get("last-event-id")
+        if value is None:
+            value = headers.get("Last-Event-ID")
+        return value
+
+    def _format_event(self, event: ServerSentEvent) -> bytes:
+        if event.raw_data is not None:
+            data_str: str | None = event.raw_data
+        elif event.data is not None:
+            if hasattr(event.data, "model_dump_json"):
+                data_str = event.data.model_dump_json()
+            else:
+                data_str = json.dumps(jsonable_encoder(event.data))
+        else:
+            data_str = None
+        return format_sse_event(
+            data_str=data_str,
+            event=event.event,
+            id=event.id,
+            retry=event.retry,
+            comment=event.comment,
+        )
+
+    async def _is_disconnected(self, request: Any | None) -> bool:
+        if request is None:
+            return False
+        is_disconnected = getattr(request, "is_disconnected", None)
+        if is_disconnected is None:
+            return False
+        return bool(await is_disconnected())

--- a/fastapi/tests/test_sse_manager.py
+++ b/fastapi/tests/test_sse_manager.py
@@ -1,0 +1,169 @@
+import asyncio
+from collections.abc import AsyncIterator
+
+from fastapi.responses import EventSourceResponse, SSEManager
+
+
+class FakeRequest:
+    def __init__(
+        self,
+        *,
+        event_type: str | None = None,
+        last_event_id: str | None = None,
+        disconnect_after: int | None = None,
+    ) -> None:
+        self.query_params: dict[str, str] = {}
+        if event_type is not None:
+            self.query_params["event_type"] = event_type
+        self.headers: dict[str, str] = {}
+        if last_event_id is not None:
+            self.headers["Last-Event-ID"] = last_event_id
+        self.disconnect_after = disconnect_after
+        self.disconnect_checks = 0
+
+    async def is_disconnected(self) -> bool:
+        self.disconnect_checks += 1
+        if self.disconnect_after is None:
+            return False
+        return self.disconnect_checks >= self.disconnect_after
+
+
+async def wait_for_connections(manager: SSEManager, count: int) -> None:
+    for _ in range(10):
+        if manager.connection_count == count:
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"Expected {count} SSE connections")
+
+
+async def close_stream(stream: AsyncIterator[object]) -> None:
+    aclose = getattr(stream, "aclose", None)
+    if aclose is not None:
+        await aclose()
+
+
+def test_sse_manager_filters_by_request_query_param() -> None:
+    async def run() -> None:
+        manager = SSEManager(disconnect_poll_interval=0.01)
+        stream = manager.stream(request=FakeRequest(event_type="metrics"))
+        next_event = asyncio.create_task(stream.__anext__())
+        await wait_for_connections(manager, 1)
+
+        await manager.broadcast({"ignored": True}, event_type="logs", id="1")
+        await manager.broadcast({"value": 42}, event_type="metrics", id="2")
+
+        event = await asyncio.wait_for(next_event, timeout=1)
+        assert event.data == {"value": 42}
+        assert event.event == "metrics"
+        await close_stream(stream)
+
+    asyncio.run(run())
+
+
+def test_sse_manager_replays_after_last_event_id_header() -> None:
+    async def run() -> None:
+        manager = SSEManager(retry=2500)
+        await manager.broadcast("one", event_type="metrics", id="1")
+        await manager.broadcast("two", event_type="metrics", id="2")
+        await manager.broadcast("three", event_type="logs", id="3")
+
+        request = FakeRequest(event_type="metrics", last_event_id="1")
+        stream = manager.stream(request=request)
+        event = await stream.__anext__()
+
+        assert event.data == "two"
+        assert event.id == "2"
+        assert event.retry == 2500
+        await close_stream(stream)
+
+    asyncio.run(run())
+
+
+def test_sse_manager_broadcasts_to_all_and_filtered_connections() -> None:
+    async def run() -> None:
+        manager = SSEManager(disconnect_poll_interval=0.01)
+        all_stream = manager.stream()
+        metrics_stream = manager.stream(event_type="metrics")
+        all_event = asyncio.create_task(all_stream.__anext__())
+        metrics_event = asyncio.create_task(metrics_stream.__anext__())
+        await wait_for_connections(manager, 2)
+
+        await manager.broadcast("first", event_type="logs", id="1")
+        await manager.broadcast("second", event_type="metrics", id="2")
+
+        first = await asyncio.wait_for(all_event, timeout=1)
+        second = await asyncio.wait_for(metrics_event, timeout=1)
+        assert first.data == "first"
+        assert first.event == "logs"
+        assert second.data == "second"
+        assert second.event == "metrics"
+        await close_stream(all_stream)
+        await close_stream(metrics_stream)
+
+    asyncio.run(run())
+
+
+def test_sse_manager_stops_stream_when_request_disconnects() -> None:
+    async def run() -> None:
+        manager = SSEManager(disconnect_poll_interval=0.01)
+        request = FakeRequest(disconnect_after=1)
+        stream = manager.stream(request=request)
+
+        try:
+            await stream.__anext__()
+        except StopAsyncIteration:
+            pass
+
+        assert manager.connection_count == 0
+        assert request.disconnect_checks == 1
+
+    asyncio.run(run())
+
+
+def test_sse_manager_response_encodes_retry_and_sets_sse_headers() -> None:
+    async def run() -> None:
+        manager = SSEManager(retry=3000)
+        await manager.broadcast("ready", event_type="metrics", id="1")
+        await manager.broadcast({"value": 42}, event_type="metrics", id="2")
+
+        response = manager.response(
+            request=FakeRequest(event_type="metrics", last_event_id="1")
+        )
+        assert isinstance(response, EventSourceResponse)
+        assert response.media_type == "text/event-stream"
+        assert response.headers["cache-control"] == "no-cache"
+        assert response.headers["x-accel-buffering"] == "no"
+
+        chunk = await response.body_iterator.__anext__()
+        assert b"event: metrics\n" in chunk
+        assert b'data: {"value": 42}\n' in chunk
+        assert b"id: 2\n" in chunk
+        assert b"retry: 3000\n" in chunk
+        await close_stream(response.body_iterator)
+
+    asyncio.run(run())
+
+
+def test_sse_manager_history_is_bounded_and_precise() -> None:
+    async def run() -> None:
+        manager = SSEManager(history_size=2)
+        await manager.broadcast("one", id="1")
+        await manager.broadcast("two", id="2")
+        await manager.broadcast("three", id="3")
+
+        stream = manager.stream(last_event_id="2")
+        request = FakeRequest(disconnect_after=1)
+        missing_stream = manager.stream(request=request, last_event_id="1")
+
+        try:
+            await missing_stream.__anext__()
+        except StopAsyncIteration:
+            pass
+        else:
+            raise AssertionError("Stale Last-Event-ID should not replay history")
+
+        first = await stream.__anext__()
+        assert first.data == "three"
+        await close_stream(stream)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Issue
Closes #798

## Summary
Add an `SSEManager` that supports managed SSE subscribers, request-derived `event_type` filtering, `Last-Event-ID` replay, retry fields, disconnect cleanup, and direct encoded SSE responses.

## Acceptance criteria
- [x] Event generator stops cleanly when client disconnects without raising exceptions
- [x] Clients can filter events by type using a query parameter
- [x] Last-Event-ID header is read and events since that ID are replayed on reconnect
- [x] Retry field is included in the SSE stream with configurable value
- [x] SSEManager can broadcast to all clients and to filtered subsets
- [x] Concurrent connections are handled without blocking
- [x] Tests cover disconnect, filtering, replay, and broadcast scenarios
- [x] Agent name + [ FastAPI ] in PR title
- [x] Created `.contributor.json` in the root of the modified `fastapi/fastapi` directory

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_sse_manager.py tests/test_sse.py -q` -> 24 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/sse.py fastapi/responses.py tests/test_sse_manager.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/sse.py fastapi/responses.py tests/test_sse_manager.py` -> passed
- `git diff --check` -> passed

/claim #798
