### PR TITLE
Ola Concurrency Agent [ FastAPI ] Rework concurrent task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Ola Concurrency Agent",
+  "runtime_instructions": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#803 requests run_concurrently in fastapi/fastapi/concurrency.py with semaphore limiting, ordered results, ConcurrencyError failure aggregation, timeout cancellation with partial results, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not published.",
+  "timestamp": "2026-06-11T22:21:43Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,9 @@
-from collections.abc import AsyncGenerator
+import asyncio
+import inspect
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +14,100 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        failures: Sequence[BaseException],
+        *,
+        partial_results: Sequence[Any] | None = None,
+        completed_indexes: set[int] | None = None,
+    ) -> None:
+        self.failures = list(failures)
+        self.exceptions = self.failures
+        self.errors = self.failures
+        self.partial_results = list(partial_results or [])
+        self.completed_indexes = set(completed_indexes or set())
+        message = f"{len(self.failures)} concurrent task(s) failed"
+        super().__init__(message)
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    *,
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        for coroutine in coroutines:
+            _close_unstarted_coroutine(coroutine)
+        raise ValueError("max_concurrency must be at least 1")
+    if not coroutines:
+        return []
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[Any] = [None] * len(coroutines)
+    completed_indexes: set[int] = set()
+
+    async def run_one(coroutine: Awaitable[_T]) -> _T:
+        started = False
+        try:
+            async with semaphore:
+                started = True
+                return await coroutine
+        finally:
+            if not started:
+                _close_unstarted_coroutine(coroutine)
+
+    tasks = [
+        asyncio.create_task(run_one(coroutine))
+        for coroutine in coroutines
+    ]
+    task_indexes = {task: index for index, task in enumerate(tasks)}
+
+    try:
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+    failures: list[BaseException] = []
+    if pending:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    for task in sorted(done, key=lambda done_task: task_indexes[done_task]):
+        index = task_indexes[task]
+        try:
+            results[index] = task.result()
+            completed_indexes.add(index)
+        except BaseException as exc:
+            failures.append(exc)
+
+    if pending:
+        failures.append(
+            asyncio.TimeoutError(
+                f"run_concurrently timed out after {timeout} second(s)"
+            )
+        )
+
+    if failures:
+        raise ConcurrencyError(
+            failures,
+            partial_results=results,
+            completed_indexes=completed_indexes,
+        )
+
+    return cast(list[_T], results)
+
+
+def _close_unstarted_coroutine(coroutine: Awaitable[Any]) -> None:
+    if inspect.iscoroutine(coroutine):
+        coroutine.close()
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency_run_concurrently.py
+++ b/fastapi/tests/test_concurrency_run_concurrently.py
@@ -1,0 +1,189 @@
+import asyncio
+import warnings
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+def test_run_concurrently_limits_concurrency_and_preserves_order() -> None:
+    async def run() -> None:
+        active = 0
+        max_seen = 0
+
+        async def worker(value: int, delay: float) -> int:
+            nonlocal active, max_seen
+            active += 1
+            max_seen = max(max_seen, active)
+            await asyncio.sleep(delay)
+            active -= 1
+            return value
+
+        results = await run_concurrently(
+            [
+                worker(1, 0.03),
+                worker(2, 0.01),
+                worker(3, 0),
+            ],
+            max_concurrency=2,
+        )
+
+        assert results == [1, 2, 3]
+        assert max_seen == 2
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_max_concurrency_one_is_sequential() -> None:
+    async def run() -> None:
+        order: list[str] = []
+
+        async def worker(value: str) -> str:
+            order.append(f"start:{value}")
+            await asyncio.sleep(0)
+            order.append(f"end:{value}")
+            return value
+
+        results = await run_concurrently(
+            [worker("a"), worker("b")],
+            max_concurrency=1,
+        )
+
+        assert results == ["a", "b"]
+        assert order == ["start:a", "end:a", "start:b", "end:b"]
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_collects_exceptions_in_input_order() -> None:
+    class FirstError(Exception):
+        pass
+
+    class SecondError(Exception):
+        pass
+
+    async def fail_late(exc: Exception, delay: float) -> None:
+        await asyncio.sleep(delay)
+        raise exc
+
+    async def run() -> None:
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(
+                [
+                    fail_late(FirstError(), 0.02),
+                    fail_late(SecondError(), 0),
+                ],
+                max_concurrency=2,
+            )
+
+        failures = exc_info.value.failures
+        assert [type(failure) for failure in failures] == [FirstError, SecondError]
+        assert exc_info.value.exceptions == failures
+        assert exc_info.value.errors == failures
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_timeout_cancels_pending_and_keeps_partial_results() -> None:
+    cancelled = False
+
+    async def worker(value: int, delay: float) -> int:
+        nonlocal cancelled
+        try:
+            await asyncio.sleep(delay)
+            return value
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+
+    async def run() -> None:
+        with pytest.raises(ConcurrencyError) as exc_info:
+            await run_concurrently(
+                [worker(1, 0), worker(2, 1)],
+                max_concurrency=2,
+                timeout=0.05,
+            )
+
+        assert exc_info.value.partial_results == [1, None]
+        assert exc_info.value.completed_indexes == {0}
+        assert any(
+            isinstance(failure, asyncio.TimeoutError)
+            for failure in exc_info.value.failures
+        )
+        assert cancelled is True
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_closes_unstarted_coroutines_on_timeout() -> None:
+    async def worker() -> int:
+        await asyncio.sleep(1)
+        return 1
+
+    async def run() -> None:
+        coroutines = [worker(), worker()]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(ConcurrencyError):
+                await run_concurrently(
+                    coroutines,
+                    max_concurrency=1,
+                    timeout=0.01,
+                )
+
+        assert not [
+            warning
+            for warning in caught
+            if "was never awaited" in str(warning.message)
+        ]
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_allows_concurrency_above_task_count() -> None:
+    async def run() -> None:
+        active = 0
+        max_seen = 0
+
+        async def worker(value: int) -> int:
+            nonlocal active, max_seen
+            active += 1
+            max_seen = max(max_seen, active)
+            await asyncio.sleep(0)
+            active -= 1
+            return value
+
+        results = await run_concurrently(
+            [worker(1), worker(2), worker(3)],
+            max_concurrency=10,
+        )
+
+        assert results == [1, 2, 3]
+        assert max_seen == 3
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_returns_empty_list_for_no_tasks() -> None:
+    async def run() -> None:
+        assert await run_concurrently([], max_concurrency=3) == []
+
+    asyncio.run(run())
+
+
+def test_run_concurrently_rejects_invalid_concurrency_without_warnings() -> None:
+    async def worker() -> None:
+        await asyncio.sleep(0)
+
+    async def run() -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(ValueError, match="max_concurrency"):
+                await run_concurrently([worker()], max_concurrency=0)
+
+        assert not [
+            warning
+            for warning in caught
+            if "was never awaited" in str(warning.message)
+        ]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Issue
Closes #803

## Summary
Add `run_concurrently` with semaphore-limited execution, ordered results, deterministic failure aggregation, timeout cancellation, and partial-result details on `ConcurrencyError`.

## Acceptance criteria
- [x] Coroutines execute with the specified concurrency limit
- [x] Results maintain input order regardless of completion order
- [x] ConcurrencyError contains all failed task exceptions
- [x] Timeout cancels remaining tasks and returns partial results plus timeout error
- [x] max_concurrency of 1 executes tasks sequentially
- [x] max_concurrency greater than task count runs all tasks at once
- [x] Tests verify concurrency limiting, ordering, error collection, and timeout
- [x] Agent name + [ FastAPI ] required in your PR title
- [x] Added `_contributor.json` to the directory containing the main changes

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_concurrency_run_concurrently.py tests/test_dependency_wrapped.py -q` -> 36 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/concurrency.py tests/test_concurrency_run_concurrently.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/concurrency.py tests/test_concurrency_run_concurrently.py` -> passed
- `git diff --check` -> passed

/claim #803
