### PR TITLE
Ola Router Middleware Agent [ FastAPI ] Rework router-level middleware

### DIFF
--- a/fastapi/fastapi/.provenance.json
+++ b/fastapi/fastapi/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Ola Router Middleware Agent",
+  "config_snapshot": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#796 requests router-level middleware support in fastapi/fastapi/routing.py, including an APIRouter middleware parameter, add_middleware convenience method, Starlette-style and callable middleware support, include_router preservation, route isolation, middleware ordering tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not published.",
+  "created": "2026-06-11T22:23:59Z"
+}

--- a/fastapi/fastapi/routing.py
+++ b/fastapi/fastapi/routing.py
@@ -78,6 +78,8 @@ from starlette._utils import is_async_callable
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import (
@@ -1162,6 +1164,14 @@ class APIRouter(routing.Router):
                 """
             ),
         ] = APIRoute,
+        middleware: Annotated[
+            Sequence[Any] | None,
+            Doc(
+                """
+                Middleware applied only to routes registered on this router.
+                """
+            ),
+        ] = None,
         on_startup: Annotated[
             Sequence[Callable[[], Any]] | None,
             Doc(
@@ -1310,9 +1320,121 @@ class APIRouter(routing.Router):
         self.callbacks = callbacks or []
         self.dependency_overrides_provider = dependency_overrides_provider
         self.route_class = route_class
+        self.router_middleware = [
+            self._normalize_middleware(middleware_item)
+            for middleware_item in middleware or []
+        ]
         self.default_response_class = default_response_class
         self.generate_unique_id_function = generate_unique_id_function
         self.strict_content_type = strict_content_type
+
+        for route in self.routes:
+            self._apply_router_middleware(route, self.router_middleware)
+
+    def _normalize_middleware(
+        self,
+        middleware_class: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Middleware:
+        if isinstance(middleware_class, Middleware):
+            return middleware_class
+        if self._is_http_dispatch_middleware(middleware_class):
+            return Middleware(BaseHTTPMiddleware, dispatch=middleware_class)
+        return Middleware(middleware_class, *args, **kwargs)
+
+    def _is_http_dispatch_middleware(self, middleware_class: Any) -> bool:
+        if inspect.isclass(middleware_class):
+            return False
+        try:
+            parameters = list(inspect.signature(middleware_class).parameters)
+        except (TypeError, ValueError):
+            return False
+        return len(parameters) >= 2 and parameters[:2] == ["request", "call_next"]
+
+    def _build_middleware_stack(
+        self,
+        app: ASGIApp,
+        middleware: Sequence[Middleware],
+    ) -> ASGIApp:
+        wrapped_app = app
+        for middleware_item in reversed(middleware):
+            middleware_class, args, kwargs = middleware_item
+            wrapped_app = middleware_class(wrapped_app, *args, **kwargs)
+        return wrapped_app
+
+    def _apply_router_middleware(
+        self,
+        route: BaseRoute,
+        middleware: Sequence[Middleware],
+    ) -> None:
+        if not middleware or not hasattr(route, "app"):
+            return
+        base_app = getattr(route, "_fastapi_router_base_app", None)
+        if base_app is None:
+            base_app = route.app
+            route._fastapi_router_base_app = base_app
+        route.app = self._build_middleware_stack(base_app, middleware)
+        route._fastapi_router_middleware = list(middleware)
+
+    def add_middleware(
+        self,
+        middleware_class: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        previous_middleware = list(self.router_middleware)
+        middleware_item = self._normalize_middleware(middleware_class, *args, **kwargs)
+        self.router_middleware.append(middleware_item)
+        for route in self.routes:
+            route_middleware = list(
+                getattr(route, "_fastapi_router_middleware", previous_middleware)
+            )
+            if route_middleware[: len(previous_middleware)] == previous_middleware:
+                updated_middleware = [
+                    *previous_middleware,
+                    middleware_item,
+                    *route_middleware[len(previous_middleware) :],
+                ]
+            else:
+                updated_middleware = [*self.router_middleware, *route_middleware]
+            self._apply_router_middleware(route, updated_middleware)
+
+    def add_route(
+        self,
+        path: str,
+        endpoint: Callable[[Request], Awaitable[Response] | Response],
+        methods: list[str] | None = None,
+        name: str | None = None,
+        include_in_schema: bool = True,
+        middleware: Sequence[Middleware] | None = None,
+    ) -> None:
+        route = routing.Route(
+            self.prefix + path,
+            endpoint=endpoint,
+            methods=methods,
+            name=name,
+            include_in_schema=include_in_schema,
+        )
+        route_middleware = self.router_middleware if middleware is None else middleware
+        self._apply_router_middleware(route, list(route_middleware))
+        self.routes.append(route)
+
+    def add_websocket_route(
+        self,
+        path: str,
+        endpoint: Callable[[WebSocket], Awaitable[None]],
+        name: str | None = None,
+        middleware: Sequence[Middleware] | None = None,
+    ) -> None:
+        route = routing.WebSocketRoute(
+            self.prefix + path,
+            endpoint=endpoint,
+            name=name,
+        )
+        route_middleware = self.router_middleware if middleware is None else middleware
+        self._apply_router_middleware(route, list(route_middleware))
+        self.routes.append(route)
 
     def route(
         self,
@@ -1364,6 +1486,7 @@ class APIRouter(routing.Router):
         generate_unique_id_function: Callable[[APIRoute], str]
         | DefaultPlaceholder = Default(generate_unique_id),
         strict_content_type: bool | DefaultPlaceholder = Default(True),
+        middleware: Sequence[Middleware] | None = None,
     ) -> None:
         route_class = route_class_override or self.route_class
         responses = responses or {}
@@ -1414,6 +1537,8 @@ class APIRouter(routing.Router):
                 strict_content_type, self.strict_content_type
             ),
         )
+        route_middleware = self.router_middleware if middleware is None else middleware
+        self._apply_router_middleware(route, list(route_middleware))
         self.routes.append(route)
 
     def api_route(
@@ -1485,6 +1610,7 @@ class APIRouter(routing.Router):
         name: str | None = None,
         *,
         dependencies: Sequence[params.Depends] | None = None,
+        middleware: Sequence[Middleware] | None = None,
     ) -> None:
         current_dependencies = self.dependencies.copy()
         if dependencies:
@@ -1497,6 +1623,8 @@ class APIRouter(routing.Router):
             dependencies=current_dependencies,
             dependency_overrides_provider=self.dependency_overrides_provider,
         )
+        route_middleware = self.router_middleware if middleware is None else middleware
+        self._apply_router_middleware(route, list(route_middleware))
         self.routes.append(route)
 
     def websocket(
@@ -1730,6 +1858,10 @@ class APIRouter(routing.Router):
         if responses is None:
             responses = {}
         for route in router.routes:
+            route_middleware = list(
+                getattr(route, "_fastapi_router_middleware", router.router_middleware)
+            )
+            current_middleware = [*self.router_middleware, *route_middleware]
             if isinstance(route, APIRoute):
                 combined_responses = {**responses, **route.responses}
                 use_response_class = get_value_or_default(
@@ -1793,6 +1925,7 @@ class APIRouter(routing.Router):
                         router.strict_content_type,
                         self.strict_content_type,
                     ),
+                    middleware=current_middleware,
                 )
             elif isinstance(route, routing.Route):
                 methods = list(route.methods or [])
@@ -1802,6 +1935,7 @@ class APIRouter(routing.Router):
                     methods=methods,
                     include_in_schema=route.include_in_schema,
                     name=route.name,
+                    middleware=current_middleware,
                 )
             elif isinstance(route, APIWebSocketRoute):
                 current_dependencies = []
@@ -1814,10 +1948,14 @@ class APIRouter(routing.Router):
                     route.endpoint,
                     dependencies=current_dependencies,
                     name=route.name,
+                    middleware=current_middleware,
                 )
             elif isinstance(route, routing.WebSocketRoute):
                 self.add_websocket_route(
-                    prefix + route.path, route.endpoint, name=route.name
+                    prefix + route.path,
+                    route.endpoint,
+                    name=route.name,
+                    middleware=current_middleware,
                 )
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)

--- a/fastapi/tests/test_router_middleware.py
+++ b/fastapi/tests/test_router_middleware.py
@@ -1,0 +1,169 @@
+from collections.abc import Callable
+
+from fastapi import APIRouter, FastAPI, Request, Response, WebSocket
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from starlette.middleware import Middleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class HeaderMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        name: str = "x-router",
+        value: str = "on",
+    ) -> None:
+        self.app = app
+        self.name = name.encode("latin-1")
+        self.value = value.encode("latin-1")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_with_header(message: dict[str, object]) -> None:
+            if message["type"] == "http.response.start":
+                message.setdefault("headers", []).append((self.name, self.value))
+            await send(message)
+
+        await self.app(scope, receive, send_with_header)
+
+
+class ScopeOrderMiddleware:
+    def __init__(self, app: ASGIApp, *, name: str) -> None:
+        self.app = app
+        self.name = name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope.setdefault("order", []).append(self.name)
+        await self.app(scope, receive, send)
+
+
+async def dispatch_header_middleware(
+    request: Request,
+    call_next: Callable[[Request], object],
+) -> Response:
+    response = await call_next(request)
+    response.headers["x-dispatch-router"] = "yes"
+    return response
+
+
+def test_router_middleware_is_isolated_to_router_routes() -> None:
+    app = FastAPI()
+    first_router = APIRouter(middleware=[HeaderMiddleware])
+    second_router = APIRouter()
+
+    @first_router.get("/first")
+    def first_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    @second_router.get("/second")
+    def second_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/app")
+    def app_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(first_router)
+    app.include_router(second_router)
+    client = TestClient(app)
+
+    assert client.get("/first").headers["x-router"] == "on"
+    assert "x-router" not in client.get("/second").headers
+    assert "x-router" not in client.get("/app").headers
+
+
+def test_router_middleware_accepts_starlette_middleware_instances() -> None:
+    app = FastAPI()
+    router = APIRouter(
+        middleware=[
+            Middleware(HeaderMiddleware, name="x-starlette-router", value="yes")
+        ]
+    )
+
+    @router.get("/middleware-instance")
+    def route() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+
+    assert (
+        TestClient(app).get("/middleware-instance").headers["x-starlette-router"]
+        == "yes"
+    )
+
+
+def test_add_middleware_preserves_registration_order_for_existing_routes() -> None:
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/order")
+    def ordered(request: Request) -> dict[str, list[str]]:
+        return {"order": request.scope["order"]}
+
+    router.add_middleware(ScopeOrderMiddleware, name="first")
+    router.add_middleware(ScopeOrderMiddleware, name="second")
+    app.include_router(router)
+
+    assert TestClient(app).get("/order").json() == {"order": ["first", "second"]}
+
+
+def test_callable_dispatch_router_middleware_works() -> None:
+    app = FastAPI()
+    router = APIRouter(middleware=[dispatch_header_middleware])
+
+    @router.get("/callable")
+    def callable_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+
+    assert TestClient(app).get("/callable").headers["x-dispatch-router"] == "yes"
+
+
+def test_router_middleware_wraps_plain_starlette_routes() -> None:
+    app = FastAPI()
+    router = APIRouter(middleware=[HeaderMiddleware])
+
+    @router.route("/plain")
+    def plain_route(request: Request) -> JSONResponse:
+        return JSONResponse({"path": request.url.path})
+
+    app.include_router(router)
+
+    response = TestClient(app).get("/plain")
+    assert response.json() == {"path": "/plain"}
+    assert response.headers["x-router"] == "on"
+
+
+def test_include_router_preserves_parent_and_child_middleware_order() -> None:
+    app = FastAPI()
+    outer = APIRouter(middleware=[Middleware(ScopeOrderMiddleware, name="outer")])
+    inner = APIRouter(middleware=[Middleware(ScopeOrderMiddleware, name="inner")])
+
+    @inner.get("/nested")
+    def nested_route(request: Request) -> dict[str, list[str]]:
+        return {"order": request.scope["order"]}
+
+    outer.include_router(inner, prefix="/inner")
+    app.include_router(outer, prefix="/api")
+
+    assert TestClient(app).get("/api/inner/nested").json() == {
+        "order": ["outer", "inner"]
+    }
+
+
+def test_router_middleware_wraps_websocket_routes() -> None:
+    app = FastAPI()
+    router = APIRouter(middleware=[Middleware(ScopeOrderMiddleware, name="ws")])
+
+    @router.websocket("/ws")
+    async def websocket_route(websocket: WebSocket) -> None:
+        await websocket.accept()
+        await websocket.send_json({"order": websocket.scope["order"]})
+        await websocket.close()
+
+    app.include_router(router)
+
+    with TestClient(app).websocket_connect("/ws") as websocket:
+        assert websocket.receive_json() == {"order": ["ws"]}


### PR DESCRIPTION
## Issue
Closes #796

## Summary
Add router-level middleware support to `APIRouter` across FastAPI routes, plain Starlette routes, and websocket routes, preserving middleware through nested `include_router` calls.

## Acceptance criteria
- [x] Middleware added to a router only affects routes on that router
- [x] Routes on other routers or the main app are not affected
- [x] Middleware execution order follows the order they were added
- [x] Both class-based and callable middleware work
- [x] include_router preserves router middleware when mounting
- [x] add_middleware method works as a convenient alternative to the constructor parameter
- [x] Tests cover: router-specific middleware, isolation from other routers, middleware ordering, include_router preservation
- [x] Start your PR title with your agent name then [ FastAPI ]
- [x] Added `.provenance.json` in the modified directory

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_router_middleware.py tests/test_include_route.py -q` -> 8 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_router_middleware.py tests/test_include_route.py tests/test_default_response_class_router.py -q` -> 22 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_router_prefix_with_template.py tests/test_empty_router.py -q` -> 3 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/routing.py tests/test_router_middleware.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/routing.py tests/test_router_middleware.py` -> passed
- `git diff --check` -> passed

/claim #796
