### PR TITLE
Ola Dynamic CORS Agent [ FastAPI ] Rework dynamic CORS validation

### DIFF
--- a/fastapi/fastapi/middleware/_generation.json
+++ b/fastapi/fastapi/middleware/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Ola Dynamic CORS Agent",
+  "pre_task_context": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#763 requests DynamicCORSMiddleware in fastapi/fastapi/middleware/cors.py, with sync/async allow_origin_func callbacks, fallback to static allow_origins, cors_max_age support, unchanged CORSMiddleware export, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not published.",
+  "timestamp": "2026-06-11T22:27:54Z"
+}

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,137 @@
+import functools
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+AllowOriginFunc = Callable[[str], bool | Awaitable[bool]]
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        allow_origin_func: AllowOriginFunc | None = None,
+        allow_origins: Sequence[str] = (),
+        allow_methods: Sequence[str] = ("GET",),
+        allow_headers: Sequence[str] = (),
+        allow_credentials: bool = False,
+        allow_origin_regex: str | None = None,
+        expose_headers: Sequence[str] = (),
+        cors_max_age: int = 600,
+    ) -> None:
+        self.allow_origin_func = allow_origin_func
+        static_allow_origins = () if allow_origin_func is not None else allow_origins
+        static_allow_origin_regex = (
+            None if allow_origin_func is not None else allow_origin_regex
+        )
+        super().__init__(
+            app,
+            allow_origins=static_allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=static_allow_origin_regex,
+            expose_headers=expose_headers,
+            max_age=cors_max_age,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":  # pragma: no cover
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+
+        if origin is None:
+            await self.app(scope, receive, send)
+            return
+
+        if method == "OPTIONS" and "access-control-request-method" in headers:
+            response = await self.preflight_response_async(request_headers=headers)
+            await response(scope, receive, send)
+            return
+
+        await self.simple_response(scope, receive, send, request_headers=headers)
+
+    async def is_allowed_origin_async(self, origin: str) -> bool:
+        if self.allow_origin_func is None:
+            return super().is_allowed_origin(origin)
+        result = self.allow_origin_func(origin)
+        if inspect.isawaitable(result):
+            result = await result
+        return bool(result)
+
+    async def preflight_response_async(self, request_headers: Headers) -> Response:
+        requested_origin = request_headers["origin"]
+        requested_method = request_headers["access-control-request-method"]
+        requested_headers = request_headers.get("access-control-request-headers")
+
+        headers = dict(self.preflight_headers)
+        failures = []
+
+        if await self.is_allowed_origin_async(origin=requested_origin):
+            if self.preflight_explicit_allow_origin:
+                headers["Access-Control-Allow-Origin"] = requested_origin
+        else:
+            failures.append("origin")
+
+        if requested_method not in self.allow_methods:
+            failures.append("method")
+
+        if self.allow_all_headers and requested_headers is not None:
+            headers["Access-Control-Allow-Headers"] = requested_headers
+        elif requested_headers is not None:
+            for header in [h.lower() for h in requested_headers.split(",")]:
+                if header.strip() not in self.allow_headers:
+                    failures.append("headers")
+                    break
+
+        if failures:
+            failure_text = "Disallowed CORS " + ", ".join(failures)
+            return PlainTextResponse(failure_text, status_code=400, headers=headers)
+
+        return PlainTextResponse("OK", status_code=200, headers=headers)
+
+    async def simple_response(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        request_headers: Headers,
+    ) -> None:
+        send = functools.partial(
+            self.send,
+            send=send,
+            request_headers=request_headers,
+        )
+        await self.app(scope, receive, send)
+
+    async def send(
+        self,
+        message: Message,
+        send: Send,
+        request_headers: Headers,
+    ) -> None:
+        if message["type"] != "http.response.start":
+            await send(message)
+            return
+
+        message.setdefault("headers", [])
+        headers = MutableHeaders(scope=message)
+        headers.update(self.simple_headers)
+        origin = request_headers["Origin"]
+        has_cookie = "cookie" in request_headers
+
+        if self.allow_all_origins and has_cookie:
+            self.allow_explicit_origin(headers, origin)
+        elif not self.allow_all_origins and await self.is_allowed_origin_async(origin):
+            self.allow_explicit_origin(headers, origin)
+
+        await send(message)

--- a/fastapi/tests/test_dynamic_cors.py
+++ b/fastapi/tests/test_dynamic_cors.py
@@ -1,0 +1,121 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware, DynamicCORSMiddleware
+from fastapi.testclient import TestClient
+
+
+def create_app(**middleware_kwargs) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(DynamicCORSMiddleware, **middleware_kwargs)
+
+    @app.get("/")
+    def read_root() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post("/")
+    def write_root() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+def test_existing_corsmiddleware_export_is_unchanged() -> None:
+    assert CORSMiddleware is not DynamicCORSMiddleware
+
+
+def test_dynamic_cors_allows_origin_from_sync_callback() -> None:
+    seen_origins: list[str] = []
+
+    def allow_origin(origin: str) -> bool:
+        seen_origins.append(origin)
+        return origin.endswith(".example.com")
+
+    app = create_app(allow_origin_func=allow_origin)
+    response = TestClient(app).get("/", headers={"Origin": "https://api.example.com"})
+
+    assert seen_origins == ["https://api.example.com"]
+    assert response.headers["access-control-allow-origin"] == (
+        "https://api.example.com"
+    )
+    assert response.headers["vary"] == "Origin"
+
+
+def test_dynamic_cors_denies_origin_even_when_static_wildcard_is_configured() -> None:
+    app = create_app(
+        allow_origin_func=lambda origin: False,
+        allow_origins=["*"],
+    )
+    response = TestClient(app).get("/", headers={"Origin": "https://blocked.test"})
+
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_dynamic_cors_awaits_async_callback_for_preflight() -> None:
+    seen_origins: list[str] = []
+
+    async def allow_origin(origin: str) -> bool:
+        seen_origins.append(origin)
+        return origin == "https://allowed.test"
+
+    app = create_app(
+        allow_origin_func=allow_origin,
+        allow_methods=["POST"],
+        allow_headers=["x-token"],
+        cors_max_age=123,
+    )
+    response = TestClient(app).options(
+        "/",
+        headers={
+            "Origin": "https://allowed.test",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "x-token",
+        },
+    )
+
+    assert seen_origins == ["https://allowed.test"]
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://allowed.test"
+    assert response.headers["access-control-max-age"] == "123"
+
+
+def test_dynamic_cors_awaits_async_callback_for_simple_response() -> None:
+    async def allow_origin(origin: str) -> bool:
+        return origin == "https://simple.test"
+
+    app = create_app(allow_origin_func=allow_origin)
+    response = TestClient(app).get("/", headers={"Origin": "https://simple.test"})
+
+    assert response.headers["access-control-allow-origin"] == "https://simple.test"
+
+
+def test_dynamic_cors_denies_preflight_origin() -> None:
+    app = create_app(
+        allow_origin_func=lambda origin: False,
+        allow_methods=["POST"],
+        cors_max_age=321,
+    )
+    response = TestClient(app).options(
+        "/",
+        headers={
+            "Origin": "https://blocked.test",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in response.headers
+    assert response.headers["access-control-max-age"] == "321"
+
+
+def test_dynamic_cors_falls_back_to_static_allow_origins() -> None:
+    app = create_app(allow_origins=["https://static.test"])
+    response = TestClient(app).get("/", headers={"Origin": "https://static.test"})
+
+    assert response.headers["access-control-allow-origin"] == "https://static.test"
+
+
+def test_dynamic_cors_static_wildcard_behaves_like_starlette_cors() -> None:
+    app = create_app(allow_origins=["*"])
+    response = TestClient(app).get("/", headers={"Origin": "https://any.test"})
+
+    assert response.headers["access-control-allow-origin"] == "*"


### PR DESCRIPTION
## Issue
Closes #763

## Summary
Add `DynamicCORSMiddleware` with sync/async origin callbacks, static fallback when no callback is provided, and `cors_max_age` support while preserving the existing `CORSMiddleware` re-export.

## Acceptance criteria
- [x] DynamicCORSMiddleware calls the provided function to check each origin
- [x] Async callbacks are properly awaited
- [x] When allow_origin_func is not provided, it falls back to the static allow_origins list
- [x] The cors_max_age header is set correctly in preflight responses
- [x] Existing CORSMiddleware import and behavior is not affected
- [x] Tests cover: dynamic allow, dynamic deny, async callback, fallback to static list
- [x] PR title starts with agent name + [ FastAPI ]
- [x] Added `_generation.json` alongside the changes

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_dynamic_cors.py tests/test_tutorial/test_cors/test_tutorial001.py -q` -> 9 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/middleware/cors.py tests/test_dynamic_cors.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/middleware/cors.py tests/test_dynamic_cors.py` -> passed
- `git diff --check` -> passed

/claim #763
