### PR TITLE
Ola CSV Agent [ FastAPI ] Add StreamingCSVResponse

### DIFF
--- a/fastapi/fastapi/contributor_meta.json
+++ b/fastapi/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ola CSV Agent",
+  "session_init": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#799 requests StreamingCSVResponse in fastapi/fastapi/responses.py, text/csv streaming, configurable Content-Disposition filename, optional CSV headers, RFC 4180 escaping, custom delimiters, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not published.",
+  "ts": "2026-06-11T22:31:31Z"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,8 +1,14 @@
+import csv
 import importlib
+import io
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from typing import Any, Protocol, cast
+from urllib.parse import quote
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
+from starlette.background import BackgroundTask
+from starlette.concurrency import iterate_in_threadpool
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
 from starlette.responses import JSONResponse as JSONResponse  # noqa
@@ -24,6 +30,9 @@ class _OrjsonModule(Protocol):
     def dumps(self, __obj: Any, *, option: int = ...) -> bytes: ...
 
 
+CSVRow = Sequence[Any] | Mapping[str, Any]
+
+
 try:
     ujson = cast(_UjsonModule, importlib.import_module("ujson"))
 except ModuleNotFoundError:  # pragma: nocover
@@ -34,6 +43,93 @@ try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
 except ModuleNotFoundError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
+
+
+class StreamingCSVResponse(StreamingResponse):
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        content: AsyncIterable[CSVRow] | Iterable[CSVRow],
+        *,
+        headers: Sequence[str] | Mapping[str, str] | None = None,
+        filename: str = "export.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        media_type: str | None = None,
+        background: BackgroundTask | None = None,
+        response_headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if len(delimiter) != 1:
+            raise ValueError("delimiter must be a single character")
+        csv_headers: Sequence[str] | None
+        http_headers = dict(response_headers or {})
+        if isinstance(headers, Mapping):
+            csv_headers = None
+            http_headers.update(headers)
+        else:
+            csv_headers = headers
+        http_headers.setdefault(
+            "Content-Disposition",
+            self._content_disposition(filename),
+        )
+        super().__init__(
+            self._stream_csv(content, csv_headers=csv_headers, delimiter=delimiter),
+            status_code=status_code,
+            headers=http_headers,
+            media_type=media_type or self.media_type,
+            background=background,
+        )
+
+    async def _stream_csv(
+        self,
+        content: AsyncIterable[CSVRow] | Iterable[CSVRow],
+        *,
+        csv_headers: Sequence[str] | None,
+        delimiter: str,
+    ) -> AsyncIterable[bytes]:
+        if csv_headers is not None:
+            yield self._render_row(csv_headers, delimiter=delimiter)
+
+        if isinstance(content, AsyncIterable):
+            async for row in content:
+                yield self._render_row(
+                    self._normalize_row(row, headers=csv_headers),
+                    delimiter=delimiter,
+                )
+        else:
+            async for row in iterate_in_threadpool(iter(content)):
+                yield self._render_row(
+                    self._normalize_row(row, headers=csv_headers),
+                    delimiter=delimiter,
+                )
+
+    def _normalize_row(
+        self,
+        row: CSVRow,
+        *,
+        headers: Sequence[str] | None,
+    ) -> Sequence[Any]:
+        if isinstance(row, Mapping):
+            if headers is not None:
+                return [row.get(header, "") for header in headers]
+            return list(row.values())
+        if isinstance(row, str | bytes):
+            return [row]
+        return row
+
+    def _render_row(self, row: Sequence[Any], *, delimiter: str) -> bytes:
+        buffer = io.StringIO(newline="")
+        writer = csv.writer(buffer, delimiter=delimiter, lineterminator="\r\n")
+        writer.writerow(row)
+        return buffer.getvalue().encode("utf-8")
+
+    def _content_disposition(self, filename: str) -> str:
+        quoted_filename = quote(filename)
+        if quoted_filename != filename:
+            return f"attachment; filename*=utf-8''{quoted_filename}"
+        escaped_filename = filename.replace("\\", "\\\\").replace('"', '\\"')
+        return f'attachment; filename="{escaped_filename}"'
 
 
 @deprecated(

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,102 @@
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+
+def test_streaming_csv_response_writes_headers_and_escapes_values() -> None:
+    app = FastAPI()
+
+    async def rows() -> AsyncIterator[dict[str, str]]:
+        yield {"name": "Ada", "note": "comma, inside"}
+        yield {"name": 'Grace "G"', "note": "line\nbreak"}
+
+    @app.get("/export")
+    def export() -> StreamingCSVResponse:
+        return StreamingCSVResponse(
+            rows(),
+            headers=["name", "note"],
+            filename="people.csv",
+        )
+
+    response = TestClient(app).get("/export")
+
+    assert response.headers["content-type"] == "text/csv; charset=utf-8"
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="people.csv"'
+    )
+    assert response.content == (
+        b"name,note\r\n"
+        b'Ada,"comma, inside"\r\n'
+        b'"Grace ""G""","line\nbreak"\r\n'
+    )
+
+
+def test_streaming_csv_response_supports_custom_delimiter() -> None:
+    app = FastAPI()
+
+    @app.get("/export")
+    def export() -> StreamingCSVResponse:
+        return StreamingCSVResponse(
+            [["Ada", "math;logic"], ["Grace", "compiler"]],
+            headers=["name", "field"],
+            delimiter=";",
+        )
+
+    response = TestClient(app).get("/export")
+
+    assert response.text == 'name;field\r\nAda;"math;logic"\r\nGrace;compiler\r\n'
+
+
+def test_streaming_csv_response_works_as_response_class() -> None:
+    app = FastAPI()
+
+    @app.get("/export", response_class=StreamingCSVResponse)
+    async def export() -> AsyncIterator[list[str]]:
+        yield ["Ada", "math"]
+        yield ["Grace", "compiler"]
+
+    response = TestClient(app).get("/export")
+
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="export.csv"'
+    )
+    assert response.text == "Ada,math\r\nGrace,compiler\r\n"
+
+
+def test_streaming_csv_response_does_not_consume_generator_up_front() -> None:
+    consumed: list[int] = []
+
+    async def rows() -> AsyncIterator[list[int]]:
+        for value in range(3):
+            consumed.append(value)
+            yield [value]
+
+    async def run() -> None:
+        response = StreamingCSVResponse(rows())
+        first_chunk = await response.body_iterator.__anext__()
+        assert first_chunk == b"0\r\n"
+        assert consumed == [0]
+        await response.body_iterator.aclose()
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_streaming_csv_response_accepts_http_headers_mapping() -> None:
+    response = StreamingCSVResponse(
+        [["Ada"]],
+        headers={"x-export": "people"},
+        response_headers={"x-owner": "analytics"},
+    )
+
+    assert response.headers["x-export"] == "people"
+    assert response.headers["x-owner"] == "analytics"
+
+
+def test_streaming_csv_response_rejects_invalid_delimiter() -> None:
+    with pytest.raises(ValueError, match="delimiter"):
+        StreamingCSVResponse([["Ada"]], delimiter="::")


### PR DESCRIPTION
## Issue
Closes #799

## Summary
Add `StreamingCSVResponse` for streaming CSV exports from async or sync row iterables with optional CSV column headers, RFC 4180 escaping, custom delimiters, and configurable attachment filenames.

## Acceptance criteria
- [x] StreamingCSVResponse streams rows without loading entire dataset in memory
- [x] Column headers are written as the first row when provided
- [x] Values containing commas are wrapped in double quotes
- [x] Values containing double quotes have them escaped by doubling
- [x] Custom delimiters work correctly
- [x] Filename in Content-Disposition header is configurable
- [x] Tests verify streaming behavior, escaping, and header output
- [x] PR title format: [Agent Name] [ FastAPI ] Add StreamingCSVResponse...
- [x] Included `contributor_meta.json` with the changes

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_streaming_csv_response.py tests/test_response_change_status_code.py -q` -> 7 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/responses.py tests/test_streaming_csv_response.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/responses.py tests/test_streaming_csv_response.py` -> passed
- `git diff --check` -> passed

/claim #799
