### PR TITLE
Ola Operation ID Agent [ FastAPI ] Fix generated operation IDs

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Ola Operation ID Agent",
+  "platform_config": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#764 requests updating fastapi/fastapi/utils.py generate_unique_id to include HTTP method and route prefix, sanitize IDs to lowercase alphanumeric/underscores, append numeric suffixes for genuine collisions, add uniqueness tests across routers, and use a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not published.",
+  "date": "2026-06-11T22:33:44Z"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -33,6 +33,7 @@ from fastapi.types import ModelNameMap
 from fastapi.utils import (
     deep_dict_update,
     generate_operation_id_for_path,
+    generate_unique_id,
     is_body_allowed_for_status_code,
 )
 from pydantic import BaseModel
@@ -244,12 +245,25 @@ def get_openapi_operation_metadata(
         operation["description"] = route.description
     operation_id = route.operation_id or route.unique_id
     if operation_id in operation_ids:
-        endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
-        message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
-        file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
-        if file_name:
-            message += f" at {file_name}"
-        warnings.warn(message, stacklevel=1)
+        generate_unique_id_function = route.generate_unique_id_function
+        is_default_generated_id = generate_unique_id_function is generate_unique_id or (
+            isinstance(generate_unique_id_function, DefaultPlaceholder)
+            and generate_unique_id_function.value is generate_unique_id
+        )
+        if route.operation_id or not is_default_generated_id:
+            endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
+            message = (
+                f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
+            )
+            file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
+            if file_name:
+                message += f" at {file_name}"
+            warnings.warn(message, stacklevel=1)
+        base_operation_id = operation_id
+        suffix = 2
+        while operation_id in operation_ids:
+            operation_id = f"{base_operation_id}_{suffix}"
+            suffix += 1
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -93,11 +93,13 @@ def generate_operation_id_for_path(
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    method = sorted(route.methods)[0].lower()
+    path = route.path_format.strip("/")
+    operation_id = "_".join(part for part in (method, path, route.name) if part)
+    operation_id = re.sub(r"[^0-9a-zA-Z_]+", "_", operation_id)
+    operation_id = re.sub(r"_+", "_", operation_id).strip("_")
+    return operation_id.lower()
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_unique_operation_id_collisions.py
+++ b/fastapi/tests/test_unique_operation_id_collisions.py
@@ -1,0 +1,89 @@
+import re
+import warnings
+
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+
+def list_users() -> dict[str, bool]:
+    return {"ok": True}
+
+
+def read() -> dict[str, bool]:
+    return {"ok": True}
+
+
+def operation_ids(app: FastAPI) -> list[str]:
+    schema = TestClient(app).get("/openapi.json").json()
+    ids: list[str] = []
+    for path_item in schema["paths"].values():
+        for operation in path_item.values():
+            ids.append(operation["operationId"])
+    return ids
+
+
+def test_generate_unique_id_includes_method_and_router_prefix() -> None:
+    app = FastAPI()
+    first_router = APIRouter()
+    second_router = APIRouter()
+
+    first_router.get("/users")(list_users)
+    second_router.get("/users")(list_users)
+    app.include_router(first_router, prefix="/api/v1")
+    app.include_router(second_router, prefix="/api/v2")
+
+    ids = operation_ids(app)
+
+    assert "get_api_v1_users_list_users" in ids
+    assert "get_api_v2_users_list_users" in ids
+    assert len(ids) == len(set(ids))
+
+
+def test_generate_unique_id_is_lowercase_alphanumeric_with_underscores() -> None:
+    app = FastAPI()
+    app.get("/Items/{item_id}/sub-items")(read)
+
+    [operation_id] = operation_ids(app)
+
+    assert re.fullmatch(r"[a-z0-9_]+", operation_id)
+    assert operation_id == "get_items_item_id_sub_items_read"
+
+
+def test_openapi_generation_suffixes_generated_collisions_without_warning() -> None:
+    app = FastAPI()
+    app.get("/items/a-b")(read)
+    app.get("/items/a_b")(read)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ids = operation_ids(app)
+
+    duplicate_warnings = [
+        warning
+        for warning in caught
+        if "Duplicate Operation ID" in str(warning.message)
+    ]
+    assert duplicate_warnings == []
+    assert ids == ["get_items_a_b_read", "get_items_a_b_read_2"]
+
+
+def test_custom_unique_id_collisions_warn_and_receive_suffixes() -> None:
+    def duplicate_unique_id(route: APIRoute) -> str:
+        return "same_id"
+
+    app = FastAPI(generate_unique_id_function=duplicate_unique_id)
+    app.get("/first")(read)
+    app.get("/second")(read)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ids = operation_ids(app)
+
+    duplicate_warnings = [
+        warning
+        for warning in caught
+        if "Duplicate Operation ID" in str(warning.message)
+    ]
+    assert duplicate_warnings
+    assert ids == ["same_id", "same_id_2"]


### PR DESCRIPTION
## Issue
Closes #764

## Summary
Update default operation ID generation to use sanitized method/path/name IDs and add OpenAPI-time numeric suffixing for genuine collisions after sanitization.

## Acceptance criteria
- [x] Generated IDs include HTTP method and route prefix
- [x] No duplicate operation IDs when same function name used in different routers
- [x] IDs contain only lowercase alphanumeric and underscores
- [x] Numeric suffix appended for genuine collisions after including method and prefix
- [x] Existing routes without prefix generate IDs in the same format for consistency
- [x] Tests verify uniqueness across multiple routers with identical function names
- [x] Agent name + [ FastAPI ] in PR title
- [x] Created `.attribution.json` in the same directory as the primary code change

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_unique_operation_id_collisions.py -q` -> 4 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/utils.py fastapi/openapi/utils.py tests/test_unique_operation_id_collisions.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/utils.py fastapi/openapi/utils.py tests/test_unique_operation_id_collisions.py` -> passed
- `git diff --check` -> passed

/claim #764
