### PR TITLE
Ola Upload Validation Agent [ FastAPI ] Add UploadFile validation

### DIFF
--- a/fastapi/fastapi/contributor_meta.json
+++ b/fastapi/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ola Upload Validation Agent",
+  "session_init": "Public task context: GitHub issue UnsafeLabs/Bounty-Hunters#761 requests UploadFile max_size and allowed_content_types parameters, a validate async method returning ValidationResult metadata, HTTP 413 for oversized files, HTTP 415 for disallowed content types, unchanged existing UploadFile usage, tests, and a PR title containing [ FastAPI ]. Private system, developer, tool, account, credential, and user-specific instructions are intentionally not published.",
+  "ts": "2026-06-11T22:36:24Z"
+}

--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -8,7 +8,8 @@ from typing import (
 )
 
 from annotated_doc import Doc
-from pydantic import GetJsonSchemaHandler
+from fastapi.exceptions import HTTPException
+from pydantic import BaseModel, GetJsonSchemaHandler
 from starlette.datastructures import URL as URL  # noqa: F401
 from starlette.datastructures import Address as Address  # noqa: F401
 from starlette.datastructures import FormData as FormData  # noqa: F401
@@ -16,6 +17,12 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+
+
+class ValidationResult(BaseModel):
+    is_valid: bool
+    file_size: int | None
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +69,78 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+    max_size: Annotated[int | None, Doc("Maximum allowed file size in bytes.")]
+    allowed_content_types: Annotated[
+        list[str] | None,
+        Doc("Allowed MIME content types for this uploaded file."),
+    ]
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: list[str] | None = None,
+    ) -> None:
+        if max_size is not None and max_size < 0:
+            raise ValueError("max_size must be greater than or equal to 0")
+        super().__init__(
+            file=file,
+            size=size,
+            filename=filename,
+            headers=headers,
+        )
+        self.max_size = max_size
+        self.allowed_content_types = allowed_content_types
+
+    async def validate(self) -> ValidationResult:
+        file_size = self.size if self.size is not None else self._measure_file_size()
+        content_type = self.content_type
+
+        if self.max_size is not None and file_size is not None:
+            if file_size > self.max_size:
+                raise HTTPException(
+                    status_code=413,
+                    detail="Uploaded file exceeds maximum allowed size",
+                )
+
+        if self.allowed_content_types is not None:
+            normalized_content_type = self._normalize_content_type(content_type)
+            allowed_content_types = {
+                self._normalize_content_type(allowed_content_type)
+                for allowed_content_type in self.allowed_content_types
+            }
+            if normalized_content_type not in allowed_content_types:
+                raise HTTPException(
+                    status_code=415,
+                    detail="Uploaded file content type is not allowed",
+                )
+
+        return ValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=content_type,
+        )
+
+    def _measure_file_size(self) -> int | None:
+        if not hasattr(self.file, "tell") or not hasattr(self.file, "seek"):
+            return None
+        try:
+            current_position = self.file.tell()
+            self.file.seek(0, 2)
+            file_size = self.file.tell()
+            self.file.seek(current_position)
+        except (OSError, ValueError):
+            return None
+        return file_size
+
+    def _normalize_content_type(self, content_type: str | None) -> str | None:
+        if content_type is None:
+            return None
+        return content_type.split(";", 1)[0].strip().lower()
 
     async def write(
         self,

--- a/fastapi/tests/test_uploadfile_validation.py
+++ b/fastapi/tests/test_uploadfile_validation.py
@@ -1,0 +1,120 @@
+from io import BytesIO
+
+import pytest
+from fastapi import FastAPI, File, UploadFile
+from fastapi.datastructures import Headers
+from fastapi.exceptions import HTTPException
+from fastapi.testclient import TestClient
+
+
+def upload_file(
+    content: bytes = b"hello",
+    *,
+    content_type: str = "text/plain",
+    size: int | None = None,
+    max_size: int | None = None,
+    allowed_content_types: list[str] | None = None,
+) -> UploadFile:
+    return UploadFile(
+        file=BytesIO(content),
+        size=size,
+        filename="example.txt",
+        headers=Headers({"content-type": content_type}),
+        max_size=max_size,
+        allowed_content_types=allowed_content_types,
+    )
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_returns_file_metadata_and_preserves_position() -> None:
+    file = upload_file(
+        b"hello",
+        max_size=10,
+        allowed_content_types=["text/plain"],
+    )
+    await file.seek(2)
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 5
+    assert result.content_type == "text/plain"
+    assert await file.read() == b"llo"
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_uses_tracked_size_when_available() -> None:
+    file = upload_file(b"hello", size=5, max_size=5)
+
+    result = await file.validate()
+
+    assert result.file_size == 5
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_raises_413_when_file_is_too_large() -> None:
+    file = upload_file(b"toolarge", max_size=3)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_raises_415_for_disallowed_content_type() -> None:
+    file = upload_file(
+        b"hello",
+        content_type="application/octet-stream",
+        allowed_content_types=["text/plain"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_accepts_content_type_parameters() -> None:
+    file = upload_file(
+        b"hello",
+        content_type="text/plain; charset=utf-8",
+        allowed_content_types=["text/plain"],
+    )
+
+    result = await file.validate()
+
+    assert result.content_type == "text/plain; charset=utf-8"
+
+
+@pytest.mark.anyio
+async def test_uploadfile_validate_skips_unset_constraints() -> None:
+    file = upload_file(b"any-size", content_type="application/octet-stream")
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 8
+    assert result.content_type == "application/octet-stream"
+
+
+def test_uploadfile_rejects_negative_max_size() -> None:
+    with pytest.raises(ValueError, match="max_size"):
+        upload_file(max_size=-1)
+
+
+def test_existing_uploadfile_route_usage_still_works() -> None:
+    app = FastAPI()
+
+    @app.post("/upload")
+    async def upload(file: UploadFile = File()):
+        return {"filename": file.filename, "content": (await file.read()).decode()}
+
+    response = TestClient(app).post(
+        "/upload",
+        files={"file": ("hello.txt", b"hello", "text/plain")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"filename": "hello.txt", "content": "hello"}


### PR DESCRIPTION
## Issue
Closes #761

## Summary
Extend `UploadFile` with optional `max_size` and `allowed_content_types` constraints plus an async `validate()` method returning file metadata.

## Acceptance criteria
- [x] Files exceeding max_size raise 413 Payload Too Large
- [x] Files with disallowed content types raise 415 Unsupported Media Type
- [x] When max_size is None, no size check is performed
- [x] When allowed_content_types is None, no type check is performed
- [x] The validate method returns accurate file metadata
- [x] Existing UploadFile usage without the new parameters works unchanged
- [x] PR title includes agent name and [ FastAPI ]
- [x] Included `contributor_meta.json` with the changes

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_uploadfile_validation.py tests/test_datastructures.py -q` -> 13 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/datastructures.py tests/test_uploadfile_validation.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/datastructures.py tests/test_uploadfile_validation.py` -> passed
- `git diff --check` -> passed

/claim #761
