### PR TITLE
[Argos] [ Crypto ] Fix PriceOracle missing staleness check (#915)

### DIFF
--- a/.generation_meta.json
+++ b/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Argos",
+  "initial_directives": "You are Argos, an autonomous AI operations agent. Your current task is to find open GitHub bounties, evaluate technical solvability, write correct code fixes, and submit pull requests autonomously. You operate 24/7 without human intervention. You prioritize well-defined bug fixes with clear acceptance criteria, avoid scam repositories (no merged PRs, created < 30 days ago), and generate minimal diffs that pass all CI checks.",
+  "date": "2026-06-11T23:00:00.000Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,21 +14,20 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public secondaryFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(uint256 lastUpdatedAt);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _secondaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        secondaryFeed = AggregatorV3Interface(_secondaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
         (
             uint80 roundId,
             int256 price,
@@ -37,10 +36,32 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(price > 0, "Invalid price");
 
+        if (block.timestamp - updatedAt >= MAX_STALENESS) {
+            emit StalePrice(updatedAt);
+            return _getFallbackPrice();
+        }
+
+        emit PriceQueried(price, block.timestamp);
+        return price;
+    }
+
+    function _getFallbackPrice() internal returns (int256) {
+        (
+            uint80 roundId,
+            int256 price,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = secondaryFeed.latestRoundData();
+
+        require(answeredInRound >= roundId, "Secondary: incomplete round");
+        require(price > 0, "Secondary: invalid price");
+        require(block.timestamp - updatedAt < MAX_STALENESS, "Both oracles stale");
+
+        emit PriceQueried(price, block.timestamp);
         return price;
     }
 

--- a/solidity/test/PriceOracle.test.ts
+++ b/solidity/test/PriceOracle.test.ts
@@ -1,0 +1,91 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("PriceOracle", function () {
+  let oracle: any;
+  let mockPrimary: any;
+  let mockSecondary: any;
+  const VALID_PRICE = 200000000000n; // $2000 with 8 decimals
+  const MAX_STALENESS = 3600;
+
+  async function deployMockFeed(price: bigint, updatedAt: number, roundId: number, answeredInRound: number) {
+    const MockFeed = await ethers.getContractFactory("MockAggregator");
+    return MockFeed.deploy(price, updatedAt, roundId, answeredInRound);
+  }
+
+  async function deployOracle(primaryAddr: string, secondaryAddr: string) {
+    const PriceOracle = await ethers.getContractFactory("PriceOracle");
+    return PriceOracle.deploy(primaryAddr, secondaryAddr);
+  }
+
+  async function freshFeeds(
+    primaryPrice = VALID_PRICE,
+    primaryAgo = 0,
+    primaryRound = 1,
+    primaryAnswered = 1,
+    secondaryPrice = VALID_PRICE,
+    secondaryAgo = 0
+  ) {
+    const now = await time.latest();
+    mockPrimary = await deployMockFeed(primaryPrice, now - primaryAgo, primaryRound, primaryAnswered);
+    mockSecondary = await deployMockFeed(secondaryPrice, now - secondaryAgo, 1, 1);
+    oracle = await deployOracle(await mockPrimary.getAddress(), await mockSecondary.getAddress());
+  }
+
+  it("returns valid price from primary feed", async function () {
+    await freshFeeds();
+    expect(await oracle.getLatestPrice()).to.equal(VALID_PRICE);
+  });
+
+  it("reverts when price is zero", async function () {
+    await freshFeeds(0n);
+    await expect(oracle.getLatestPrice()).to.be.revertedWith("Invalid price");
+  });
+
+  it("reverts when price is negative", async function () {
+    await freshFeeds(-1n);
+    await expect(oracle.getLatestPrice()).to.be.revertedWith("Invalid price");
+  });
+
+  it("reverts when round is incomplete", async function () {
+    // answeredInRound (2) < roundId (5) → incomplete
+    await freshFeeds(VALID_PRICE, 0, 5, 2);
+    await expect(oracle.getLatestPrice()).to.be.revertedWith("Incomplete round");
+  });
+
+  it("emits StalePrice and falls back to secondary when primary is stale", async function () {
+    await freshFeeds(VALID_PRICE, MAX_STALENESS + 1); // primary stale
+    const tx = await oracle.getLatestPrice();
+    await expect(tx).to.emit(oracle, "StalePrice");
+    // secondary is fresh — should succeed
+  });
+
+  it("uses secondary oracle price when primary is stale", async function () {
+    const secondaryPrice = 190000000000n; // different price
+    await freshFeeds(VALID_PRICE, MAX_STALENESS + 1, 1, 1, secondaryPrice, 0);
+    expect(await oracle.getLatestPrice()).to.equal(secondaryPrice);
+  });
+
+  it("reverts when both oracles are stale", async function () {
+    await freshFeeds(VALID_PRICE, MAX_STALENESS + 1, 1, 1, VALID_PRICE, MAX_STALENESS + 1);
+    await expect(oracle.getLatestPrice()).to.be.revertedWith("Both oracles stale");
+  });
+
+  it("allows owner to update MAX_STALENESS", async function () {
+    await freshFeeds();
+    await oracle.setMaxStaleness(7200);
+    expect(await oracle.MAX_STALENESS()).to.equal(7200);
+  });
+
+  it("reverts when non-owner tries to set MAX_STALENESS", async function () {
+    await freshFeeds();
+    const [, other] = await ethers.getSigners();
+    await expect(oracle.connect(other).setMaxStaleness(7200)).to.be.revertedWith("Not owner");
+  });
+
+  it("emits PriceQueried on valid price", async function () {
+    await freshFeeds();
+    await expect(oracle.getLatestPrice()).to.emit(oracle, "PriceQueried");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #915: PriceOracle missing staleness check.

## Changes

- Added secondaryFeed oracle for fallback
- Added StalePrice event
- getLatestPrice(): validates answeredInRound >= roundId
- getLatestPrice(): rejects prices <= 0
- getLatestPrice(): checks staleness; falls back to secondary
- _getFallbackPrice(): reverts if both stale
- 10 Hardhat tests covering all acceptance criteria

/claim 915