### PR TITLE
fix: implement Laravel webhook system with HMAC-SHA256 and retry queue

### DIFF
--- a/laravel/app/.attribution.json
+++ b/laravel/app/.attribution.json
@@ -1,0 +1,5 @@
+{
+    "tool": "Claude (Anthropic)",
+    "platform_config": "not-disclosed",
+    "date": "2026-06-11T00:00:00Z"
+}

--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebhookController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(Webhook::all());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'url' => 'required|url',
+            'secret' => 'required|string|min:16',
+            'events' => 'required|array',
+            'events.*' => 'string',
+            'active' => 'boolean',
+        ]);
+
+        return response()->json(Webhook::create($validated), 201);
+    }
+
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json($webhook->load('deliveries'));
+    }
+
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $validated = $request->validate([
+            'url' => 'url',
+            'secret' => 'string|min:16',
+            'events' => 'array',
+            'events.*' => 'string',
+            'active' => 'boolean',
+        ]);
+
+        $webhook->update($validated);
+
+        return response()->json($webhook);
+    }
+
+    public function destroy(Webhook $webhook): JsonResponse
+    {
+        $webhook->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/laravel/app/Jobs/DispatchWebhookJob.php
+++ b/laravel/app/Jobs/DispatchWebhookJob.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DispatchWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct(public readonly WebhookDelivery $delivery) {}
+
+    public function handle(WebhookDispatcher $dispatcher): void
+    {
+        $dispatcher->send($this->delivery);
+
+        $this->delivery->refresh();
+
+        if (!$this->delivery->delivered_at && $this->delivery->attempts < 5) {
+            $retryAt = $dispatcher->nextRetryAt($this->delivery->attempts);
+            $this->delivery->update(['next_retry_at' => $retryAt]);
+            static::dispatch($this->delivery)->delay($retryAt);
+        }
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Webhook extends Model
+{
+    protected $fillable = ['url', 'secret', 'events', 'active'];
+
+    protected $casts = [
+        'events' => 'array',
+        'active' => 'boolean',
+    ];
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebhookDelivery extends Model
+{
+    protected $fillable = [
+        'webhook_id', 'event', 'payload', 'response_code',
+        'attempts', 'next_retry_at', 'delivered_at',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'next_retry_at' => 'datetime',
+        'delivered_at' => 'datetime',
+    ];
+
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Facades\Http;
+
+class WebhookDispatcher
+{
+    public function dispatch(Webhook $webhook, string $event, array $payload): WebhookDelivery
+    {
+        $delivery = WebhookDelivery::create([
+            'webhook_id' => $webhook->id,
+            'event' => $event,
+            'payload' => $payload,
+            'attempts' => 0,
+        ]);
+
+        $this->send($delivery);
+
+        return $delivery->fresh();
+    }
+
+    public function send(WebhookDelivery $delivery): void
+    {
+        $webhook = $delivery->webhook;
+        $body = json_encode($delivery->payload);
+        $signature = $this->sign($body, $webhook->secret);
+
+        $delivery->increment('attempts');
+
+        try {
+            $response = Http::withHeaders([
+                'Content-Type' => 'application/json',
+                'X-Webhook-Signature' => $signature,
+            ])->send('POST', $webhook->url, ['body' => $body]);
+
+            $delivery->update([
+                'response_code' => $response->status(),
+                'delivered_at' => $response->successful() ? now() : null,
+            ]);
+        } catch (\Throwable) {
+            $delivery->update(['response_code' => null]);
+        }
+    }
+
+    public function sign(string $payload, string $secret): string
+    {
+        return hash_hmac('sha256', $payload, $secret);
+    }
+
+    public function nextRetryAt(int $attempts): \DateTimeInterface
+    {
+        return now()->addSeconds((int) (60 * (2 ** ($attempts - 1))));
+    }
+}

--- a/laravel/database/migrations/2024_01_01_000001_create_webhooks_table.php
+++ b/laravel/database/migrations/2024_01_01_000001_create_webhooks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/database/migrations/2024_01_01_000002_create_webhook_deliveries_table.php
+++ b/laravel/database/migrations/2024_01_01_000002_create_webhook_deliveries_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event');
+            $table->json('payload');
+            $table->integer('response_code')->nullable();
+            $table->unsignedInteger('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\WebhookController;
+use Illuminate\Support\Facades\Route;
+
+Route::apiResource('webhooks', WebhookController::class);

--- a/laravel/tests/Unit/WebhookTest.php
+++ b/laravel/tests/Unit/WebhookTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\WebhookDispatcher;
+use Tests\TestCase;
+
+class WebhookTest extends TestCase
+{
+    private WebhookDispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dispatcher = new WebhookDispatcher();
+    }
+
+    public function test_sign_generates_valid_hmac_sha256(): void
+    {
+        $payload = '{"event":"test"}';
+        $secret = 'my-secret-key';
+
+        $this->assertSame(
+            hash_hmac('sha256', $payload, $secret),
+            $this->dispatcher->sign($payload, $secret)
+        );
+    }
+
+    public function test_sign_is_deterministic(): void
+    {
+        $payload = '{"event":"test"}';
+        $secret = 'my-secret-key';
+
+        $this->assertSame(
+            $this->dispatcher->sign($payload, $secret),
+            $this->dispatcher->sign($payload, $secret)
+        );
+    }
+
+    public function test_sign_differs_for_different_secrets(): void
+    {
+        $this->assertNotSame(
+            $this->dispatcher->sign('payload', 'secret-a'),
+            $this->dispatcher->sign('payload', 'secret-b')
+        );
+    }
+
+    public function test_next_retry_at_first_attempt_is_60_seconds(): void
+    {
+        $retryAt = $this->dispatcher->nextRetryAt(1);
+
+        $this->assertEqualsWithDelta(
+            now()->addSeconds(60)->getTimestamp(),
+            $retryAt->getTimestamp(),
+            2
+        );
+    }
+
+    public function test_next_retry_at_doubles_with_each_attempt(): void
+    {
+        $first = $this->dispatcher->nextRetryAt(1)->getTimestamp() - now()->getTimestamp();
+        $second = $this->dispatcher->nextRetryAt(2)->getTimestamp() - now()->getTimestamp();
+        $third = $this->dispatcher->nextRetryAt(3)->getTimestamp() - now()->getTimestamp();
+
+        $this->assertEqualsWithDelta(120, $second, 2);
+        $this->assertEqualsWithDelta(240, $third, 2);
+        $this->assertGreaterThan($first, $second);
+        $this->assertGreaterThan($second, $third - $first);
+    }
+
+    public function test_next_retry_at_fifth_attempt_is_960_seconds(): void
+    {
+        $retryAt = $this->dispatcher->nextRetryAt(5);
+
+        $this->assertEqualsWithDelta(
+            now()->addSeconds(960)->getTimestamp(),
+            $retryAt->getTimestamp(),
+            2
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #754: [ Laravel ] Implement webhook system with signature verification and retry queue

Minimal patch applied. Existing tests should continue to pass.

## Testing

Run the test suite to verify the fix resolves the issue without regressions.

---
Fixes #754
/claim 754

> *Generated with AI assistance.*