### PR TITLE
[OpenAI Codex] [ Laravel ] Add structured logging channels

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, runtime, and platform instructions are intentionally omitted. This submission was produced by OpenAI Codex for GitHub issue #787 and does not disclose hidden instructions, credentials, secrets, or private session context.",
+  "timestamp": "2026-06-12T12:47:35+02:00"
+}

--- a/laravel/app/Logging/StructuredJsonFormatter.php
+++ b/laravel/app/Logging/StructuredJsonFormatter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\LogRecord;
+
+class StructuredJsonFormatter extends NormalizerFormatter
+{
+    public function format(LogRecord $record): string
+    {
+        $payload = [
+            'timestamp' => $record->datetime->format('c'),
+            'level' => $record->level->getName(),
+            'message' => $record->message,
+            'context' => $record->context,
+            'channel' => $record->channel,
+            'extra' => $record->extra,
+        ];
+
+        return $this->toJson($this->normalize($payload), true)."\n";
+    }
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -4,6 +4,7 @@ use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
+use App\Logging\StructuredJsonFormatter;
 
 return [
 
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,25 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/error.log'),
+            'level' => env('LOG_ERROR_LEVEL', 'error'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/json.log'),
+            ],
+            'formatter' => StructuredJsonFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [

--- a/laravel/tests/Feature/LoggingConfigTest.php
+++ b/laravel/tests/Feature/LoggingConfigTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Logging\StructuredJsonFormatter;
+use DateTimeImmutable;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Tests\TestCase;
+
+class LoggingConfigTest extends TestCase
+{
+    public function test_default_stack_writes_to_daily_and_error_logs(): void
+    {
+        $this->assertSame(['daily', 'error'], config('logging.channels.stack.channels'));
+    }
+
+    public function test_daily_log_retention_keeps_fourteen_days(): void
+    {
+        $this->assertSame(14, config('logging.channels.daily.days'));
+    }
+
+    public function test_error_channel_writes_only_error_and_above_to_error_log(): void
+    {
+        $channel = config('logging.channels.error');
+
+        $this->assertSame('daily', $channel['driver']);
+        $this->assertSame(storage_path('logs/error.log'), $channel['path']);
+        $this->assertSame('error', $channel['level']);
+        $this->assertSame(14, $channel['days']);
+    }
+
+    public function test_json_channel_uses_structured_formatter(): void
+    {
+        $channel = config('logging.channels.json');
+
+        $this->assertSame('monolog', $channel['driver']);
+        $this->assertSame(StreamHandler::class, $channel['handler']);
+        $this->assertSame(storage_path('logs/json.log'), $channel['handler_with']['stream']);
+        $this->assertSame(StructuredJsonFormatter::class, $channel['formatter']);
+    }
+
+    public function test_structured_json_formatter_outputs_required_fields(): void
+    {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-06-12T12:00:00+00:00'),
+            channel: 'testing',
+            level: Level::Error,
+            message: 'Something failed',
+            context: ['job_id' => 123],
+            extra: [],
+        );
+
+        $payload = json_decode($formatter->format($record), true);
+
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('timestamp', $payload);
+        $this->assertSame('ERROR', $payload['level']);
+        $this->assertSame('Something failed', $payload['message']);
+        $this->assertSame(['job_id' => 123], $payload['context']);
+    }
+}


### PR DESCRIPTION
/claim #787

## Summary
- updates the Laravel default log stack to write to both `daily` and a new error-only channel
- adds an `error` channel writing ERROR+ entries to `storage/logs/error.log`
- adds a `json` Monolog channel using `App\Logging\StructuredJsonFormatter`
- adds focused tests for stack membership, retention, error channel config, JSON channel config, and formatter output
- includes safe provenance metadata without disclosing hidden system/developer/runtime/session instructions

## Validation
- `git diff --check`
- `jq . laravel/_provenance.json`

PHP and Composer are not installed in this environment, so I could not run `php -l` or `php artisan test` locally.
