### PR TITLE
Ola Pagination Agent [ FastAPI ] Rework standardized pagination utility

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Ola Pagination Agent",
+  "platform_config": "Public task context only: GitHub issue UnsafeLabs/Bounty-Hunters#802 requests a FastAPI pagination utility with offset and cursor support, a generic PaginatedResponse model, a paginate dependency, query parameter defaults, boundary tests, and a PR title containing [ FastAPI ]. Private system, developer, runtime, user, account, credential, and hidden session instructions are not safe to publish in a repository and are intentionally not disclosed.",
+  "date": "2026-06-12T10:20:00Z"
+}

--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -9,6 +9,12 @@ from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
+from .pagination import PaginatedResponse as PaginatedResponse
+from .pagination import PaginationParams as PaginationParams
+from .pagination import Paginator as Paginator
+from .pagination import decode_cursor as decode_cursor
+from .pagination import encode_cursor as encode_cursor
+from .pagination import paginate as paginate
 from .param_functions import Body as Body
 from .param_functions import Cookie as Cookie
 from .param_functions import Depends as Depends

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import base64
+import json
+import math
+from collections.abc import Callable, Iterable, Sequence
+from typing import Annotated, Any, Generic, TypeVar
+
+from pydantic import BaseModel, Field
+
+from .param_functions import Query
+
+ItemT = TypeVar("ItemT")
+QueryT = TypeVar("QueryT")
+CursorKey = str | Callable[[Any], Any] | None
+
+DEFAULT_PAGE = 1
+DEFAULT_PAGE_SIZE = 20
+DEFAULT_MAX_PAGE_SIZE = 100
+
+
+class PaginationParams(BaseModel):
+    page: int = DEFAULT_PAGE
+    page_size: int = DEFAULT_PAGE_SIZE
+    cursor: str | None = None
+
+    def to_paginator(self) -> Paginator[Any]:
+        return Paginator(
+            page=self.page,
+            page_size=self.page_size,
+            cursor=self.cursor,
+        )
+
+
+class PaginatedResponse(BaseModel, Generic[ItemT]):
+    items: list[ItemT]
+    total: int = Field(ge=0)
+    page: int = Field(ge=1)
+    page_size: int = Field(ge=1)
+    total_pages: int = Field(ge=0)
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+class Paginator(Generic[ItemT]):
+    def __init__(
+        self,
+        page: int = DEFAULT_PAGE,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        *,
+        max_page_size: int = DEFAULT_MAX_PAGE_SIZE,
+        cursor: str | None = None,
+    ) -> None:
+        self.max_page_size = _normalize_max_page_size(max_page_size)
+        self.page = _normalize_page(page)
+        self.page_size = _normalize_page_size(page_size, self.max_page_size)
+        self.cursor = cursor
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def skip(self) -> int:
+        return self.offset
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    def total_pages(self, total: int) -> int:
+        total_items = max(0, int(total))
+        if total_items == 0:
+            return 0
+        return math.ceil(total_items / self.page_size)
+
+    def create_response(
+        self,
+        items: Iterable[ItemT],
+        *,
+        total: int,
+        page: int | None = None,
+        next_cursor: str | None = None,
+        previous_cursor: str | None = None,
+    ) -> PaginatedResponse[ItemT]:
+        total_items = max(0, int(total))
+        current_page = self.page if page is None else _normalize_page(page)
+        total_pages = self.total_pages(total_items)
+        return PaginatedResponse[ItemT](
+            items=list(items),
+            total=total_items,
+            page=current_page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=current_page < total_pages,
+            has_previous=current_page > 1 and total_pages > 0,
+            next_cursor=next_cursor,
+            previous_cursor=previous_cursor,
+        )
+
+    def paginate(
+        self,
+        items: Sequence[ItemT],
+        *,
+        total: int | None = None,
+        already_sliced: bool = False,
+    ) -> PaginatedResponse[ItemT]:
+        total_items = len(items) if total is None else max(0, int(total))
+        page_items = (
+            list(items)
+            if already_sliced
+            else list(items[self.offset : self.offset + self.page_size])
+        )
+        return self.create_response(page_items, total=total_items)
+
+    def paginate_sequence(self, items: Sequence[ItemT]) -> PaginatedResponse[ItemT]:
+        return self.paginate(items)
+
+    def apply_to_query(self, query: QueryT) -> QueryT:
+        return query.offset(self.offset).limit(self.limit)
+
+    def apply(self, query: QueryT) -> QueryT:
+        return self.apply_to_query(query)
+
+    def paginate_cursor(
+        self,
+        items: Sequence[ItemT],
+        *,
+        total: int | None = None,
+        cursor: str | None = None,
+        after: str | None = None,
+        before: str | None = None,
+        cursor_key: CursorKey = None,
+    ) -> PaginatedResponse[ItemT]:
+        if cursor_key is None:
+            return self._paginate_offset_cursor(
+                items,
+                total=total,
+                cursor=cursor,
+            )
+        return self._paginate_key_cursor(
+            items,
+            after=after if after is not None else cursor,
+            before=before,
+            cursor_key=cursor_key,
+        )
+
+    def cursor_page(
+        self,
+        items: Sequence[ItemT],
+        *,
+        total: int | None = None,
+        cursor: str | None = None,
+        after: str | None = None,
+        before: str | None = None,
+        cursor_key: CursorKey = None,
+    ) -> PaginatedResponse[ItemT]:
+        return self.paginate_cursor(
+            items,
+            total=total,
+            cursor=cursor,
+            after=after,
+            before=before,
+            cursor_key=cursor_key,
+        )
+
+    def _paginate_offset_cursor(
+        self,
+        items: Sequence[ItemT],
+        *,
+        total: int | None,
+        cursor: str | None,
+    ) -> PaginatedResponse[ItemT]:
+        total_items = len(items) if total is None else max(0, int(total))
+        active_cursor = cursor or self.cursor
+        page_start = (
+            _decode_offset_cursor(active_cursor)
+            if active_cursor is not None
+            else 0
+        )
+        page_start = min(max(0, page_start), total_items)
+        page_end = page_start + self.page_size
+        page_items = list(items[page_start:page_end])
+        total_pages = self.total_pages(total_items)
+        current_page = (page_start // self.page_size) + 1
+        has_next = page_end < total_items
+        has_previous = page_start > 0 and total_items > 0
+        return PaginatedResponse[ItemT](
+            items=page_items,
+            total=total_items,
+            page=current_page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=has_next,
+            has_previous=has_previous,
+            next_cursor=encode_cursor(page_end) if has_next else None,
+            previous_cursor=(
+                encode_cursor(max(0, page_start - self.page_size))
+                if has_previous
+                else None
+            ),
+        )
+
+    def _paginate_key_cursor(
+        self,
+        items: Sequence[ItemT],
+        *,
+        after: str | None,
+        before: str | None,
+        cursor_key: CursorKey,
+    ) -> PaginatedResponse[ItemT]:
+        if after is not None and before is not None:
+            raise ValueError("Use either after or before cursor, not both")
+
+        total_items = len(items)
+        page_start = self._key_cursor_start(items, after, before, cursor_key)
+        page_end = page_start + self.page_size
+        page_items = list(items[page_start:page_end])
+        has_next = page_end < total_items
+        has_previous = page_start > 0 and total_items > 0
+        current_page = (page_start // self.page_size) + 1
+        next_cursor = (
+            encode_cursor(self._cursor_value(page_items[-1], page_end - 1, cursor_key))
+            if has_next and page_items
+            else None
+        )
+        previous_cursor = self._previous_key_cursor(
+            items,
+            page_items,
+            page_start,
+            cursor_key,
+        )
+        return PaginatedResponse[ItemT](
+            items=page_items,
+            total=total_items,
+            page=current_page,
+            page_size=self.page_size,
+            total_pages=self.total_pages(total_items),
+            has_next=has_next,
+            has_previous=has_previous,
+            next_cursor=next_cursor,
+            previous_cursor=previous_cursor,
+        )
+
+    def _key_cursor_start(
+        self,
+        items: Sequence[ItemT],
+        after: str | None,
+        before: str | None,
+        cursor_key: CursorKey,
+    ) -> int:
+        if before is not None:
+            before_index = self._find_cursor_index(items, before, cursor_key)
+            return max(0, before_index - self.page_size)
+        if after is not None:
+            after_index = self._find_cursor_index(items, after, cursor_key)
+            return min(after_index + 1, len(items))
+        return 0
+
+    def _find_cursor_index(
+        self,
+        items: Sequence[ItemT],
+        cursor: str,
+        cursor_key: CursorKey,
+    ) -> int:
+        cursor_value = decode_cursor(cursor)
+        for index, item in enumerate(items):
+            if self._cursor_value(item, index, cursor_key) == cursor_value:
+                return index
+        raise ValueError("Cursor does not match any item")
+
+    def _previous_key_cursor(
+        self,
+        items: Sequence[ItemT],
+        page_items: list[ItemT],
+        page_start: int,
+        cursor_key: CursorKey,
+    ) -> str | None:
+        if page_start <= 0 or not items:
+            return None
+        if page_items:
+            return encode_cursor(
+                self._cursor_value(page_items[0], page_start, cursor_key)
+            )
+        return encode_cursor(
+            self._cursor_value(items[-1], len(items) - 1, cursor_key),
+        )
+
+    def _cursor_value(self, item: ItemT, index: int, cursor_key: CursorKey) -> Any:
+        if cursor_key is None:
+            return index
+        if callable(cursor_key):
+            return cursor_key(item)
+        if isinstance(item, dict):
+            return item[cursor_key]
+        return getattr(item, cursor_key)
+
+
+def paginate(
+    page: Annotated[
+        int,
+        Query(description="One-based page number for offset pagination."),
+    ] = DEFAULT_PAGE,
+    page_size: Annotated[
+        int,
+        Query(description="Number of items per page."),
+    ] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[
+        str | None,
+        Query(description="Opaque cursor for cursor-based pagination."),
+    ] = None,
+) -> Paginator[Any]:
+    return Paginator(page=page, page_size=page_size, cursor=cursor)
+
+
+def encode_cursor(value: Any) -> str:
+    payload = json.dumps({"value": value}, default=str, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+
+def decode_cursor(cursor: str) -> Any:
+    try:
+        padding = "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(f"{cursor}{padding}".encode()).decode()
+        if raw.startswith("offset:"):
+            return int(raw.split(":", 1)[1])
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError
+        if "value" in data:
+            return data["value"]
+        if "offset" in data:
+            return data["offset"]
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("Invalid pagination cursor") from exc
+    raise ValueError("Invalid pagination cursor")
+
+
+def _decode_offset_cursor(cursor: str | None) -> int:
+    if cursor is None:
+        return 0
+    value = decode_cursor(cursor)
+    if not isinstance(value, int) or value < 0:
+        raise ValueError("Invalid pagination cursor")
+    return value
+
+
+def _normalize_page(page: int) -> int:
+    try:
+        normalized = int(page)
+    except (TypeError, ValueError):
+        normalized = DEFAULT_PAGE
+    return max(1, normalized)
+
+
+def _normalize_page_size(page_size: int, max_page_size: int) -> int:
+    try:
+        normalized = int(page_size)
+    except (TypeError, ValueError):
+        normalized = DEFAULT_PAGE_SIZE
+    if normalized < 1:
+        normalized = DEFAULT_PAGE_SIZE
+    return min(normalized, max_page_size)
+
+
+def _normalize_max_page_size(max_page_size: int) -> int:
+    try:
+        normalized = int(max_page_size)
+    except (TypeError, ValueError):
+        normalized = DEFAULT_MAX_PAGE_SIZE
+    return max(1, normalized)

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,249 @@
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.pagination import (
+    PaginatedResponse,
+    PaginationParams,
+    Paginator,
+    decode_cursor,
+    encode_cursor,
+    paginate,
+)
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+ITEMS = [Item(id=number, name=f"item-{number}") for number in range(1, 11)]
+
+
+def test_offset_pagination_calculates_skip_limit_and_boundaries() -> None:
+    paginator = Paginator[Item](page=2, page_size=3)
+    response = paginator.paginate(ITEMS)
+
+    assert paginator.offset == 3
+    assert paginator.skip == 3
+    assert paginator.limit == 3
+    assert [item.id for item in response.items] == [4, 5, 6]
+    assert response.total == 10
+    assert response.page == 2
+    assert response.page_size == 3
+    assert response.total_pages == 4
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_offset_pagination_handles_first_last_and_empty_boundaries() -> None:
+    first_page = Paginator[Item](page=1, page_size=5).paginate(ITEMS)
+    last_page = Paginator[Item](page=2, page_size=5).paginate(ITEMS)
+    empty_page = Paginator[Item](page=1, page_size=5).paginate([])
+
+    assert first_page.has_next is True
+    assert first_page.has_previous is False
+    assert last_page.has_next is False
+    assert last_page.has_previous is True
+    assert empty_page.items == []
+    assert empty_page.total == 0
+    assert empty_page.total_pages == 0
+    assert empty_page.has_next is False
+    assert empty_page.has_previous is False
+
+
+def test_edge_case_page_and_page_size_values_are_normalized() -> None:
+    negative_page = Paginator[Item](page=-5, page_size=2).paginate(ITEMS)
+    zero_page = Paginator[Item](page=0, page_size=2).paginate(ITEMS)
+    zero_size = Paginator[Item](page=1, page_size=0).paginate(ITEMS)
+    capped_size = Paginator[Item](page=1, page_size=500, max_page_size=30).paginate(ITEMS)
+
+    assert negative_page.page == 1
+    assert zero_page.page == 1
+    assert zero_size.page_size == 20
+    assert capped_size.page_size == 30
+
+
+def test_already_sliced_results_can_be_wrapped_with_total_metadata() -> None:
+    response = Paginator[Item](page=3, page_size=2).paginate(
+        ITEMS[4:6],
+        total=len(ITEMS),
+        already_sliced=True,
+    )
+
+    assert [item.id for item in response.items] == [5, 6]
+    assert response.total == 10
+    assert response.total_pages == 5
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_sqlalchemy_style_queries_receive_offset_and_limit() -> None:
+    class QuerySpy:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int]] = []
+
+        def offset(self, value: int) -> "QuerySpy":
+            self.calls.append(("offset", value))
+            return self
+
+        def limit(self, value: int) -> "QuerySpy":
+            self.calls.append(("limit", value))
+            return self
+
+    query = QuerySpy()
+    returned = Paginator[Item](page=4, page_size=25).apply_to_query(query)
+
+    assert returned is query
+    assert query.calls == [("offset", 75), ("limit", 25)]
+
+
+def test_offset_cursor_pagination_returns_encoded_next_and_previous_cursors() -> None:
+    first_page = Paginator[Item](page_size=4).paginate_cursor(ITEMS)
+
+    assert [item.id for item in first_page.items] == [1, 2, 3, 4]
+    assert first_page.page == 1
+    assert first_page.has_next is True
+    assert first_page.has_previous is False
+    assert first_page.next_cursor is not None
+    assert first_page.previous_cursor is None
+    assert decode_cursor(first_page.next_cursor) == 4
+
+    second_page = Paginator[Item](
+        page_size=4,
+        cursor=first_page.next_cursor,
+    ).paginate_cursor(ITEMS)
+
+    assert [item.id for item in second_page.items] == [5, 6, 7, 8]
+    assert second_page.page == 2
+    assert second_page.has_next is True
+    assert second_page.has_previous is True
+    assert second_page.previous_cursor == encode_cursor(0)
+
+
+def test_offset_cursor_pagination_handles_out_of_range_and_invalid_cursors() -> None:
+    response = Paginator[Item](
+        page_size=3,
+        cursor=encode_cursor(999),
+    ).paginate_cursor(ITEMS)
+
+    assert response.items == []
+    assert response.page == 4
+    assert response.has_next is False
+    assert response.has_previous is True
+
+    with pytest.raises(ValueError, match="Invalid pagination cursor"):
+        Paginator[Item](cursor="not-a-cursor").paginate_cursor(ITEMS)
+
+
+def test_key_cursor_pagination_can_move_forward_and_backward() -> None:
+    first_page = Paginator[Item](page_size=3).paginate_cursor(
+        ITEMS,
+        cursor_key="id",
+    )
+    second_page = Paginator[Item](page_size=3).paginate_cursor(
+        ITEMS,
+        after=first_page.next_cursor,
+        cursor_key="id",
+    )
+    previous_page = Paginator[Item](page_size=3).paginate_cursor(
+        ITEMS,
+        before=second_page.previous_cursor,
+        cursor_key="id",
+    )
+
+    assert [item.id for item in first_page.items] == [1, 2, 3]
+    assert first_page.next_cursor is not None
+    assert first_page.next_cursor != "3"
+    assert first_page.previous_cursor is None
+    assert [item.id for item in second_page.items] == [4, 5, 6]
+    assert second_page.has_next is True
+    assert second_page.has_previous is True
+    assert [item.id for item in previous_page.items] == [1, 2, 3]
+
+
+def test_cursor_helpers_validate_payloads() -> None:
+    assert decode_cursor(encode_cursor(6)) == 6
+
+    with pytest.raises(ValueError, match="Invalid pagination cursor"):
+        decode_cursor("not-a-cursor")
+
+
+def test_paginated_response_is_generic_over_pydantic_models() -> None:
+    response = PaginatedResponse[Item](
+        items=[Item(id=1, name="item-1")],
+        total=1,
+        page=1,
+        page_size=20,
+        total_pages=1,
+        has_next=False,
+        has_previous=False,
+    )
+
+    assert response.model_dump()["items"] == [{"id": 1, "name": "item-1"}]
+
+
+def test_paginate_dependency_reads_query_parameters_and_normalizes_edges() -> None:
+    app = FastAPI()
+
+    @app.get("/items", response_model=PaginatedResponse[Item])
+    def read_items(
+        paginator: Annotated[Paginator[Item], Depends(paginate)],
+    ) -> PaginatedResponse[Item]:
+        return paginator.paginate(ITEMS)
+
+    client = TestClient(app)
+    response = client.get("/items?page=2&page_size=4")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {"id": 5, "name": "item-5"},
+            {"id": 6, "name": "item-6"},
+            {"id": 7, "name": "item-7"},
+            {"id": 8, "name": "item-8"},
+        ],
+        "total": 10,
+        "page": 2,
+        "page_size": 4,
+        "total_pages": 3,
+        "has_next": True,
+        "has_previous": True,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+    edge_response = client.get("/items?page=0&page_size=0")
+
+    assert edge_response.status_code == 200
+    assert edge_response.json()["page"] == 1
+    assert edge_response.json()["page_size"] == 20
+
+
+def test_paginate_dependency_can_pass_cursor_query_parameter() -> None:
+    app = FastAPI()
+
+    @app.get("/items", response_model=PaginatedResponse[Item])
+    def read_items(
+        paginator: Annotated[Paginator[Item], Depends(paginate)],
+    ) -> PaginatedResponse[Item]:
+        return paginator.paginate_cursor(ITEMS)
+
+    client = TestClient(app)
+    response = client.get(f"/items?page_size=3&cursor={encode_cursor(3)}")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["items"]] == [4, 5, 6]
+    assert response.json()["has_next"] is True
+    assert response.json()["has_previous"] is True
+
+
+def test_pagination_params_can_create_paginator() -> None:
+    params = PaginationParams(page=2, page_size=2, cursor=encode_cursor(4))
+    paginator = params.to_paginator()
+
+    assert paginator.page == 2
+    assert paginator.page_size == 2
+    assert paginator.cursor == encode_cursor(4)


### PR DESCRIPTION
## Summary
- Add `fastapi.pagination` with `Paginator`, `PaginationParams`, generic `PaginatedResponse[T]`, and an injectable `paginate` dependency.
- Normalize `page` and `page_size` edge cases consistently for direct use and FastAPI query-parameter dependency use.
- Support offset pagination, already-sliced result wrapping, SQLAlchemy-style `offset()`/`limit()` application, and URL-safe cursor pagination with next/previous cursors.
- Export the pagination helpers from top-level `fastapi` and include safe public attribution metadata.

## Demo
- https://github.com/Ola-Yeenca/Bounty-Hunters/releases/download/bounty-802-demo-r2-20260612/pagination-802-r2-demo.mp4

## Validation
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest fastapi/tests/test_pagination.py -q` -> 13 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest fastapi/tests/test_query.py -q` -> 29 passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile fastapi/fastapi/pagination.py fastapi/tests/test_pagination.py` -> passed
- `/Users/olayinka/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check fastapi/fastapi/pagination.py fastapi/fastapi/__init__.py fastapi/tests/test_pagination.py` -> passed
- `git diff --check` -> passed

/claim #802
Closes #802
