### PR TITLE
Codex [ FastAPI ] Fix duplicate operation IDs across routers

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex",
+  "platform_config": "AI-assisted implementation; private runtime, system, developer, and user instructions were intentionally not disclosed.",
+  "date": "2026-06-12T14:20:00Z"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -250,6 +250,11 @@ def get_openapi_operation_metadata(
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        base_operation_id = operation_id
+        suffix = 2
+        while operation_id in operation_ids:
+            operation_id = f"{base_operation_id}_{suffix}"
+            suffix += 1
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -93,10 +93,12 @@ def generate_operation_id_for_path(
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    method = sorted(route.methods)[0].lower()
+    path_part = re.sub(r"\W", "_", route.path_format).strip("_").lower()
+    name_part = re.sub(r"\W", "_", route.name).strip("_").lower()
+    operation_id = "_".join(part for part in (method, path_part, name_part) if part)
+    operation_id = re.sub(r"_+", "_", operation_id)
     return operation_id
 
 

--- a/fastapi/tests/test_operation_id_generation_bounty.py
+++ b/fastapi/tests/test_operation_id_generation_bounty.py
@@ -1,0 +1,61 @@
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_default_operation_ids_include_method_prefix_and_endpoint_name():
+    app = FastAPI()
+    users_router = APIRouter(prefix="/users")
+    teams_router = APIRouter(prefix="/teams")
+
+    def users_list_items():
+        return []
+
+    def teams_list_items():
+        return []
+
+    users_list_items.__name__ = "list_items"
+    teams_list_items.__name__ = "list_items"
+    users_router.add_api_route("/", users_list_items, methods=["GET"])
+    teams_router.add_api_route("/", teams_list_items, methods=["GET"])
+
+    app.include_router(users_router)
+    app.include_router(teams_router)
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert schema["paths"]["/users/"]["get"]["operationId"] == "get_users_list_items"
+    assert schema["paths"]["/teams/"]["get"]["operationId"] == "get_teams_list_items"
+
+
+def test_default_operation_ids_are_lowercase_alphanumeric_and_underscores():
+    app = FastAPI()
+
+    @app.post("/API-v1/items/")
+    def create_item():
+        return {}
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert (
+        schema["paths"]["/API-v1/items/"]["post"]["operationId"]
+        == "post_api_v1_items_create_item"
+    )
+
+
+def test_duplicate_operation_ids_get_numeric_suffixes():
+    app = FastAPI()
+
+    @app.get("/first", operation_id="duplicate")
+    def first():
+        return {}
+
+    @app.get("/second", operation_id="duplicate")
+    def second():
+        return {}
+
+    with pytest.warns(UserWarning, match="Duplicate Operation ID duplicate"):
+        schema = TestClient(app).get("/openapi.json").json()
+
+    assert schema["paths"]["/first"]["get"]["operationId"] == "duplicate"
+    assert schema["paths"]["/second"]["get"]["operationId"] == "duplicate_2"


### PR DESCRIPTION
## Summary
/claim #764

- Generate default FastAPI operation IDs from HTTP method, sanitized route path, and endpoint name.
- Normalize generated IDs to lowercase alphanumeric/underscore format.
- Append deterministic numeric suffixes when duplicate operation IDs still occur during OpenAPI generation.
- Add focused tests for duplicate endpoint names across routers, sanitization, and custom operation ID collisions.
- Include safe public attribution metadata only; private runtime/system/developer instructions are not disclosed.

## Validation
- `python3 -m py_compile fastapi/fastapi/utils.py fastapi/fastapi/openapi/utils.py fastapi/tests/test_operation_id_generation_bounty.py`
- `.venv-fastapi-test/bin/python -m ruff check fastapi/fastapi/utils.py fastapi/fastapi/openapi/utils.py fastapi/tests/test_operation_id_generation_bounty.py`
- `.venv-fastapi-test/bin/python -m ruff format --check fastapi/fastapi/utils.py fastapi/fastapi/openapi/utils.py fastapi/tests/test_operation_id_generation_bounty.py`
- `.venv-fastapi-test/bin/python -m pytest fastapi/tests/test_operation_id_generation_bounty.py fastapi/tests/test_generate_unique_id_function.py -q` -> 11 passed
- `git diff --check`
