### PR TITLE
[Codex GPT-5] [ Laravel ] Implement RBAC with roles and permissions

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+    "agent": "Codex GPT-5",
+    "initialized_with": "REDACTED: private system, developer, and user instructions are not included.",
+    "timestamp": "2026-06-13T00:23:07Z"
+}

--- a/laravel/app/Http/Middleware/CheckRole.php
+++ b/laravel/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        $user = $request->user();
+
+        if ($user === null || ! method_exists($user, 'hasRole') || ! $user->hasRole($role)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'guard_name',
+    ];
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'guard_name',
+    ];
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_has_permissions')
+            ->withTimestamps();
+    }
+
+    public function users(): MorphToMany
+    {
+        return $this->morphedByMany(User::class, 'model', 'model_has_roles')
+            ->withTimestamps();
+    }
+
+    public function givePermissionTo(Permission|string $permission): static
+    {
+        $permission = $permission instanceof Permission
+            ? $permission
+            : Permission::query()->where('name', $permission)->firstOrFail();
+
+        $this->permissions()->syncWithoutDetaching([$permission->getKey()]);
+
+        return $this;
+    }
+
+    public function revokePermissionTo(Permission|string $permission): static
+    {
+        $permission = $permission instanceof Permission
+            ? $permission
+            : Permission::query()->where('name', $permission)->first();
+
+        if ($permission !== null) {
+            $this->permissions()->detach($permission->getKey());
+        }
+
+        return $this;
+    }
+
+    public function hasPermission(Permission|string $permission): bool
+    {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
+        return $this->permissions()
+            ->where('name', $permissionName)
+            ->exists();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\HasRoles;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Collection;
+
+trait HasRoles
+{
+    public function roles(): MorphToMany
+    {
+        return $this->morphToMany(Role::class, 'model', 'model_has_roles')
+            ->withTimestamps();
+    }
+
+    public function permissions(): MorphToMany
+    {
+        return $this->morphToMany(Permission::class, 'model', 'model_has_permissions')
+            ->withTimestamps();
+    }
+
+    public function assignRole(Role|string $role): static
+    {
+        $role = $this->resolveRole($role);
+
+        $this->roles()->syncWithoutDetaching([$role->getKey()]);
+
+        return $this;
+    }
+
+    public function removeRole(Role|string $role): static
+    {
+        $role = $this->resolveRole($role, failIfMissing: false);
+
+        if ($role !== null) {
+            $this->roles()->detach($role->getKey());
+        }
+
+        return $this;
+    }
+
+    public function givePermissionTo(Permission|string $permission): static
+    {
+        $permission = $this->resolvePermission($permission);
+
+        $this->permissions()->syncWithoutDetaching([$permission->getKey()]);
+
+        return $this;
+    }
+
+    public function revokePermissionTo(Permission|string $permission): static
+    {
+        $permission = $this->resolvePermission($permission, failIfMissing: false);
+
+        if ($permission !== null) {
+            $this->permissions()->detach($permission->getKey());
+        }
+
+        return $this;
+    }
+
+    public function hasRole(Role|string $role): bool
+    {
+        $roleName = $role instanceof Role ? $role->name : $role;
+
+        return $this->roles()
+            ->where('name', $roleName)
+            ->exists();
+    }
+
+    public function hasPermission(Permission|string $permission): bool
+    {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
+        if ($this->permissions()->where('name', $permissionName)->exists()) {
+            return true;
+        }
+
+        return $this->roles()
+            ->whereHas('permissions', fn ($query) => $query->where('name', $permissionName))
+            ->exists();
+    }
+
+    public function getAllPermissions(): Collection
+    {
+        $direct = $this->permissions()->get();
+        $roleIds = $this->roles()->pluck('roles.id');
+        $viaRoles = Permission::query()
+            ->whereHas('roles', fn ($query) => $query->whereIn('roles.id', $roleIds))
+            ->get();
+
+        return $direct
+            ->merge($viaRoles)
+            ->unique('id')
+            ->values();
+    }
+
+    protected function resolveRole(Role|string $role, bool $failIfMissing = true): ?Role
+    {
+        if ($role instanceof Role) {
+            return $role;
+        }
+
+        $query = Role::query()->where('name', $role);
+
+        return $failIfMissing ? $query->firstOrFail() : $query->first();
+    }
+
+    protected function resolvePermission(Permission|string $permission, bool $failIfMissing = true): ?Permission
+    {
+        if ($permission instanceof Permission) {
+            return $permission;
+        }
+
+        $query = Permission::query()->where('name', $permission);
+
+        return $failIfMissing ? $query->firstOrFail() : $query->first();
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Http\Middleware\CheckRole;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/database/migrations/2026_06_13_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_06_13_000000_create_roles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/migrations/2026_06_13_000001_create_permissions_table.php
+++ b/laravel/database/migrations/2026_06_13_000001_create_permissions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/laravel/database/migrations/2026_06_13_000002_create_role_permission_tables.php
+++ b/laravel/database/migrations/2026_06_13_000002_create_role_permission_tables.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['role_id', 'permission_id']);
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+            $table->timestamps();
+
+            $table->primary(['permission_id', 'model_id', 'model_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
+    }
+};

--- a/laravel/tests/Feature/RolePermissionTest.php
+++ b/laravel/tests/Feature/RolePermissionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RolePermissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_users_can_be_assigned_and_removed_from_roles(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::create(['name' => 'admin']);
+
+        $user->assignRole($role);
+
+        $this->assertTrue($user->hasRole('admin'));
+
+        $user->removeRole('admin');
+
+        $this->assertFalse($user->hasRole('admin'));
+    }
+
+    public function test_roles_can_have_permissions_and_users_inherit_them(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::create(['name' => 'editor']);
+        $permission = Permission::create(['name' => 'publish-posts']);
+
+        $role->givePermissionTo($permission);
+        $user->assignRole($role);
+
+        $this->assertTrue($role->hasPermission('publish-posts'));
+        $this->assertTrue($user->hasPermission('publish-posts'));
+        $this->assertTrue($user->getAllPermissions()->contains('name', 'publish-posts'));
+    }
+
+    public function test_users_can_hold_direct_permissions(): void
+    {
+        $user = User::factory()->create();
+        Permission::create(['name' => 'view-reports']);
+
+        $user->givePermissionTo('view-reports');
+
+        $this->assertTrue($user->hasPermission('view-reports'));
+        $this->assertTrue($user->getAllPermissions()->contains('name', 'view-reports'));
+    }
+
+    public function test_role_middleware_allows_matching_role_only(): void
+    {
+        Route::get('/role-gated', fn () => 'ok')->middleware('role:admin');
+
+        $admin = User::factory()->create();
+        $viewer = User::factory()->create();
+        $admin->assignRole(Role::create(['name' => 'admin']));
+
+        $this->actingAs($admin)->get('/role-gated')->assertOk();
+        $this->actingAs($viewer)->get('/role-gated')->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #788

/claim #788

## Summary
Adds a lightweight Laravel RBAC implementation without pulling in Spatie or another authorization package. The change introduces Role and Permission models, RBAC pivot migrations, a reusable HasRoles trait on User, and a role middleware alias.

## Acceptance criteria
- [x] Users can be assigned and removed from roles
- [x] Roles can have permissions attached
- [x] hasRole checks if user has a specific role
- [x] hasPermission checks direct permissions and permissions inherited through roles
- [x] CheckRole middleware returns 403 when user lacks the required role
- [x] getAllPermissions returns merged permissions from all assigned roles plus direct permissions
- [x] Tests cover role assignment, permission checking, and middleware rejection

## Validation / evidence
- Added `laravel/tests/Feature/RolePermissionTest.php` covering role assignment/removal, role permissions, direct permissions, merged permissions, and middleware rejection.
- `laravel/.contributor.json` is valid JSON and intentionally omits private system/developer/user initialization text.
- Static file checks passed locally. Follow-up validation on 2026-06-13: PHP 8.3 `php -l` checked 35 Laravel PHP files with 0 syntax errors; evidence comment: https://github.com/UnsafeLabs/Bounty-Hunters/pull/6718#issuecomment-4696901557. Full `php artisan test` was not executed because the Laravel dependency install did not complete in this Windows environment.