### PR TITLE
[Codex GPT-5] [ Laravel ] Add ActiveScope, User observer, and UUID migration

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-#[Fillable(['name', 'email', 'password'])]
+#[Fillable(['name', 'email', 'password', 'uuid'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class UserObserver
+{
+    public function creating(User $user): void
+    {
+        if (blank($user->uuid)) {
+            $user->uuid = (string) Str::uuid();
+        }
+    }
+
+    public function created(User $user): void
+    {
+        Log::info('User created', ['user_id' => $user->getKey(), 'uuid' => $user->uuid]);
+    }
+
+    public function deleted(User $user): void
+    {
+        Log::info('User deleted', ['user_id' => $user->getKey(), 'uuid' => $user->uuid]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
+
+        if (! $this->app->isProduction()) {
+            Model::preventLazyLoading();
+        }
     }
 }

--- a/laravel/app/Scopes/ActiveScope.php
+++ b/laravel/app/Scopes/ActiveScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ActiveScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where($model->qualifyColumn('active'), 1);
+    }
+}

--- a/laravel/database/migrations/2026_06_13_000003_add_uuid_to_users_table.php
+++ b/laravel/database/migrations/2026_06_13_000003_add_uuid_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable()->unique()->after('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/laravel/tests/Feature/ActiveScopeAndUserObserverTest.php
+++ b/laravel/tests/Feature/ActiveScopeAndUserObserverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Scopes\ActiveScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class ActiveScopeAndUserObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('active_scope_test_models');
+        Schema::create('active_scope_test_models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function test_active_scope_filters_inactive_records(): void
+    {
+        ActiveScopeTestModel::create(['name' => 'visible', 'active' => true]);
+        ActiveScopeTestModel::create(['name' => 'hidden', 'active' => false]);
+
+        $this->assertSame(['visible'], ActiveScopeTestModel::query()->pluck('name')->all());
+    }
+
+    public function test_active_scope_can_be_removed(): void
+    {
+        ActiveScopeTestModel::create(['name' => 'visible', 'active' => true]);
+        ActiveScopeTestModel::create(['name' => 'hidden', 'active' => false]);
+
+        $names = ActiveScopeTestModel::withoutGlobalScope(ActiveScope::class)
+            ->orderBy('name')
+            ->pluck('name')
+            ->all();
+
+        $this->assertSame(['hidden', 'visible'], $names);
+    }
+
+    public function test_user_observer_generates_uuid_and_logs_lifecycle_events(): void
+    {
+        Log::spy();
+
+        $user = User::factory()->create(['uuid' => null]);
+
+        $this->assertNotEmpty($user->uuid);
+        Log::shouldHaveReceived('info')->with('User created', \Mockery::type('array'))->once();
+
+        $user->delete();
+
+        Log::shouldHaveReceived('info')->with('User deleted', \Mockery::type('array'))->once();
+    }
+
+    public function test_lazy_loading_prevention_is_enabled_outside_production(): void
+    {
+        $this->assertTrue(Model::preventsLazyLoading());
+    }
+}
+
+class ActiveScopeTestModel extends Model
+{
+    protected $table = 'active_scope_test_models';
+
+    protected $fillable = [
+        'name',
+        'active',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new ActiveScope());
+    }
+}


### PR DESCRIPTION
## Issue
Closes #792

/claim #792

## Summary
Adds the Laravel ActiveScope and UserObserver requested by the issue. The change also adds a users.uuid migration, registers observer/lazy-loading behavior in AppServiceProvider, and covers the behavior with feature tests.

## Acceptance criteria
- [x] ActiveScope filters records where active = 1 when applied to a model
- [x] Models can opt out using withoutGlobalScope
- [x] UserObserver fires on creating and deleting events
- [x] UUID is automatically generated for new users
- [x] User model has a UUID column via migration
- [x] Observer is registered in AppServiceProvider
- [x] Model::preventLazyLoading is enabled in non-production environments
- [x] Tests cover scope filtering, opt-out, UUID generation, observer logging, and lazy-loading prevention

## Validation / evidence
- Added `laravel/tests/Feature/ActiveScopeAndUserObserverTest.php` for the requested behavior.
- Static scans found no payment details or hidden prompt/config text in the Laravel changes.
- Basic PHP file shape checks passed locally. Follow-up validation on 2026-06-13: PHP 8.3 `php -l` checked 31 Laravel PHP files with 0 syntax errors; evidence comment: https://github.com/UnsafeLabs/Bounty-Hunters/pull/6719#issuecomment-4696901635. Full `php artisan test` was not executed because the Laravel dependency install did not complete in this Windows environment.