### PR TITLE
[Codex GPT-5] [ Laravel ] Fix Slack notification service with retry handling

### DIFF
--- a/laravel/app/Services/SlackNotifier.php
+++ b/laravel/app/Services/SlackNotifier.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class SlackNotifier
+{
+    public function __construct(
+        private readonly ?string $webhookUrl = null,
+        private readonly ?string $defaultChannel = null,
+    ) {
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     */
+    public static function send(string $message, ?string $channel = null, array $blocks = []): Response
+    {
+        return app(static::class)->notify($message, $channel, $blocks);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     */
+    public function notify(string $message, ?string $channel = null, array $blocks = []): Response
+    {
+        $webhookUrl = $this->webhookUrl ?? config('services.slack.webhook_url');
+
+        if (blank($webhookUrl)) {
+            throw new RuntimeException('Slack webhook URL is not configured.');
+        }
+
+        $payload = [
+            'text' => $message,
+        ];
+
+        $channel = $channel ?? $this->defaultChannel ?? config('services.slack.default_channel');
+        if (! blank($channel)) {
+            $payload['channel'] = $channel;
+        }
+
+        if ($blocks !== []) {
+            $payload['blocks'] = $blocks;
+        }
+
+        $response = $this->post($webhookUrl, $payload);
+
+        if ($response->serverError()) {
+            $response = $this->post($webhookUrl, $payload);
+        }
+
+        if ($response->failed()) {
+            $response->throw();
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function post(string $webhookUrl, array $payload): Response
+    {
+        return Http::timeout(5)->post($webhookUrl, $payload);
+    }
+}

--- a/laravel/app/Services/_generation.json
+++ b/laravel/app/Services/_generation.json
@@ -1,0 +1,5 @@
+{
+    "agent": "Codex GPT-5",
+    "pre_task_context": "REDACTED: private system, developer, and user instructions are not included.",
+    "timestamp": "2026-06-13T00:42:00Z"
+}

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -29,6 +29,8 @@ return [
     ],
 
     'slack' => [
+        'webhook_url' => env('SLACK_WEBHOOK_URL'),
+        'default_channel' => env('SLACK_DEFAULT_CHANNEL'),
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/laravel/tests/Feature/SlackNotifierTest.php
+++ b/laravel/tests/Feature/SlackNotifierTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SlackNotifier;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SlackNotifierTest extends TestCase
+{
+    public function test_sends_slack_payload_with_configured_default_channel(): void
+    {
+        Config::set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+        Config::set('services.slack.default_channel', '#alerts');
+        Http::fake([
+            'hooks.slack.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        SlackNotifier::send('Build finished');
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://hooks.slack.test/services/default'
+                && $request['text'] === 'Build finished'
+                && $request['channel'] === '#alerts';
+        });
+    }
+
+    public function test_channel_override_and_blocks_are_included(): void
+    {
+        Config::set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+        Config::set('services.slack.default_channel', '#alerts');
+        Http::fake([
+            'hooks.slack.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        SlackNotifier::send(
+            'Deployment failed',
+            '#deployments',
+            [['type' => 'section', 'text' => ['type' => 'mrkdwn', 'text' => '*Failed*']]],
+        );
+
+        Http::assertSent(function (Request $request): bool {
+            return $request['channel'] === '#deployments'
+                && $request['blocks'][0]['type'] === 'section';
+        });
+    }
+
+    public function test_retries_once_on_server_error(): void
+    {
+        Config::set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+        Http::fakeSequence()
+            ->push(['ok' => false], 500)
+            ->push(['ok' => true], 200);
+
+        SlackNotifier::send('Retry me');
+
+        Http::assertSentCount(2);
+    }
+
+    public function test_client_error_throws_without_retry(): void
+    {
+        Config::set('services.slack.webhook_url', 'https://hooks.slack.test/services/default');
+        Http::fakeSequence()->push(['ok' => false], 400);
+
+        $this->expectException(RequestException::class);
+
+        try {
+            SlackNotifier::send('Do not retry');
+        } finally {
+            Http::assertSentCount(1);
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Closes #791

/claim #791

## Summary
Adds a config-driven Laravel SlackNotifier service with optional channel override, optional Slack blocks, 5 second HTTP timeout, one retry for 5xx responses, and immediate failure for 4xx responses.

## Acceptance criteria
- [x] SlackNotifier sends POST request with correct Slack webhook payload format
- [x] Channel override works when provided
- [x] Timeout is set to 5 seconds on the HTTP client
- [x] 5xx errors trigger one retry before throwing
- [x] 4xx errors throw immediately without retry
- [x] Config values are read from services.slack
- [x] Tests use HTTP fake to verify payload structure and retry behavior

## Validation / evidence
- Added `laravel/tests/Feature/SlackNotifierTest.php` covering payload structure, channel override, blocks, one 5xx retry, and 4xx no-retry behavior.
- `laravel/app/Services/_generation.json` is valid JSON and intentionally omits private system/developer/user initialization text.
- Static scans found no payment details or hidden prompt/config text beyond the explicit redaction notice. Follow-up validation on 2026-06-13: PHP 8.3 `php -l` checked 29 Laravel PHP files with 0 syntax errors; evidence comment: https://github.com/UnsafeLabs/Bounty-Hunters/pull/6720#issuecomment-4696901687. Full `php artisan test` was not executed because the Laravel dependency install did not complete in this Windows environment.