### PR TITLE
[Codex GPT-5] [ Laravel ] Implement file upload system with checksums

### DIFF
--- a/laravel/.generation_meta.json
+++ b/laravel/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initial_directives": "REDACTED: private system, developer, and user instructions are not included.",
+  "date": "2026-06-13T09:55:00+08:00"
+}

--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File as FileSystem;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class FileController extends Controller
+{
+    public function upload(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'file' => ['required', 'file', 'max:51200'],
+        ]);
+
+        /** @var UploadedFile $upload */
+        $upload = $validated['file'];
+        $contents = file_get_contents($upload->getRealPath());
+
+        if ($contents === false) {
+            return response()->json(['message' => 'Unable to read uploaded file.'], 422);
+        }
+
+        if ($this->containsBlockedSignature($contents)) {
+            return response()->json(['message' => 'Uploaded file failed virus scan.'], 422);
+        }
+
+        $checksum = hash('sha256', $contents);
+
+        if (File::where('checksum_sha256', $checksum)->exists()) {
+            return response()->json(['message' => 'Duplicate file checksum.'], 409);
+        }
+
+        $dateFolder = now()->format('Y/m/d');
+        $extension = $upload->getClientOriginalExtension();
+        $filename = Str::uuid()->toString().($extension ? '.'.$extension : '');
+        $storedPath = 'uploads/'.$dateFolder.'/'.$filename;
+
+        $absolutePath = $this->absoluteStoragePath($storedPath);
+        FileSystem::ensureDirectoryExists(dirname($absolutePath));
+        file_put_contents($absolutePath, $contents);
+
+        $thumbnailPath = null;
+        $mimeType = $upload->getMimeType() ?: 'application/octet-stream';
+
+        if (str_starts_with($mimeType, 'image/')) {
+            $thumbnailPath = $this->generateThumbnail($contents, $dateFolder);
+        }
+
+        $file = File::create([
+            'original_name' => $upload->getClientOriginalName(),
+            'stored_path' => $storedPath,
+            'mime_type' => $mimeType,
+            'size_bytes' => $upload->getSize() ?: strlen($contents),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => $request->user()?->getAuthIdentifier(),
+            'thumbnail_path' => $thumbnailPath,
+        ]);
+
+        return response()->json(['data' => $file], 201);
+    }
+
+    public function download(File $file): BinaryFileResponse|JsonResponse
+    {
+        if (! FileSystem::exists($this->absoluteStoragePath($file->stored_path))) {
+            return response()->json(['message' => 'File not found on disk.'], 404);
+        }
+
+        return response()->download(
+            $this->absoluteStoragePath($file->stored_path),
+            $file->original_name,
+            ['Content-Type' => $file->mime_type]
+        );
+    }
+
+    public function delete(File $file): JsonResponse
+    {
+        FileSystem::delete($this->absoluteStoragePath($file->stored_path));
+
+        if ($file->thumbnail_path !== null) {
+            FileSystem::delete($this->absoluteStoragePath($file->thumbnail_path));
+        }
+
+        $file->delete();
+
+        return response()->json(['message' => 'File deleted.']);
+    }
+
+    public function list(): JsonResponse
+    {
+        return response()->json(
+            File::query()
+                ->latest()
+                ->paginate(20)
+        );
+    }
+
+    private function containsBlockedSignature(string $contents): bool
+    {
+        return str_contains($contents, 'EICAR-STANDARD-ANTIVIRUS-TEST-FILE');
+    }
+
+    private function generateThumbnail(string $contents, string $dateFolder): ?string
+    {
+        if (! function_exists('imagecreatefromstring') || ! function_exists('imagecreatetruecolor')) {
+            return null;
+        }
+
+        $source = @imagecreatefromstring($contents);
+
+        if ($source === false) {
+            return null;
+        }
+
+        $sourceWidth = imagesx($source);
+        $sourceHeight = imagesy($source);
+        $canvas = imagecreatetruecolor(200, 200);
+
+        if ($canvas === false || $sourceWidth <= 0 || $sourceHeight <= 0) {
+            imagedestroy($source);
+
+            return null;
+        }
+
+        imagealphablending($canvas, false);
+        imagesavealpha($canvas, true);
+
+        $transparent = imagecolorallocatealpha($canvas, 0, 0, 0, 127);
+        imagefilledrectangle($canvas, 0, 0, 200, 200, $transparent);
+
+        $scale = min(200 / $sourceWidth, 200 / $sourceHeight);
+        $targetWidth = max(1, (int) round($sourceWidth * $scale));
+        $targetHeight = max(1, (int) round($sourceHeight * $scale));
+        $targetX = (int) floor((200 - $targetWidth) / 2);
+        $targetY = (int) floor((200 - $targetHeight) / 2);
+
+        imagecopyresampled(
+            $canvas,
+            $source,
+            $targetX,
+            $targetY,
+            0,
+            0,
+            $targetWidth,
+            $targetHeight,
+            $sourceWidth,
+            $sourceHeight
+        );
+
+        $thumbnailPath = 'thumbnails/'.$dateFolder.'/'.Str::uuid()->toString().'.png';
+        $absolutePath = $this->absoluteStoragePath($thumbnailPath);
+
+        FileSystem::ensureDirectoryExists(dirname($absolutePath));
+
+        imagepng($canvas, $absolutePath);
+        imagedestroy($source);
+        imagedestroy($canvas);
+
+        return $thumbnailPath;
+    }
+
+    private function absoluteStoragePath(string $relativePath): string
+    {
+        return storage_path('app/'.$relativePath);
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class File extends Model
+{
+    protected $fillable = [
+        'original_name',
+        'stored_path',
+        'mime_type',
+        'size_bytes',
+        'checksum_sha256',
+        'uploaded_by',
+        'thumbnail_path',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'size_bytes' => 'integer',
+            'uploaded_by' => 'integer',
+        ];
+    }
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by');
+    }
+}

--- a/laravel/database/migrations/2026_06_13_000006_create_files_table.php
+++ b/laravel/database/migrations/2026_06_13_000006_create_files_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size_bytes');
+            $table->string('checksum_sha256', 64)->unique();
+            $table->foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+
+            $table->index('created_at');
+            $table->index('uploaded_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Http\Controllers\FileController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::post('/files/upload', [FileController::class, 'upload']);
+Route::get('/files/{file}/download', [FileController::class, 'download']);
+Route::delete('/files/{file}', [FileController::class, 'delete']);
+Route::get('/files', [FileController::class, 'list']);

--- a/laravel/tests/Feature/FileUploadTest.php
+++ b/laravel/tests/Feature/FileUploadTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File as FileSystem;
+use Tests\TestCase;
+
+class FileUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        FileSystem::deleteDirectory(storage_path('app/uploads'));
+        FileSystem::deleteDirectory(storage_path('app/thumbnails'));
+
+        parent::tearDown();
+    }
+
+    public function test_upload_stores_metadata_and_rejects_duplicate_checksum(): void
+    {
+        $upload = UploadedFile::fake()->createWithContent('report.txt', 'quarterly results');
+
+        $response = $this->post('/files/upload', ['file' => $upload]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.original_name', 'report.txt')
+            ->assertJsonPath('data.mime_type', 'text/plain')
+            ->assertJsonPath('data.thumbnail_path', null);
+
+        $file = File::query()->firstOrFail();
+
+        $this->assertSame(hash('sha256', 'quarterly results'), $file->checksum_sha256);
+        $this->assertFileExists(storage_path('app/'.$file->stored_path));
+
+        $duplicate = UploadedFile::fake()->createWithContent('copy.txt', 'quarterly results');
+
+        $this->post('/files/upload', ['file' => $duplicate])
+            ->assertConflict()
+            ->assertJsonPath('message', 'Duplicate file checksum.');
+    }
+
+    public function test_image_upload_generates_thumbnail(): void
+    {
+        if (! function_exists('imagecreatetruecolor')) {
+            $this->markTestSkipped('GD extension is required for thumbnail generation.');
+        }
+
+        $response = $this->post('/files/upload', [
+            'file' => UploadedFile::fake()->image('avatar.png', 640, 360),
+        ]);
+
+        $response->assertCreated();
+
+        $file = File::query()->firstOrFail();
+
+        $this->assertNotNull($file->thumbnail_path);
+        $this->assertFileExists(storage_path('app/'.$file->thumbnail_path));
+
+        [$width, $height] = getimagesize(storage_path('app/'.$file->thumbnail_path));
+
+        $this->assertSame([200, 200], [$width, $height]);
+    }
+
+    public function test_download_delete_and_paginated_listing(): void
+    {
+        $storedPath = 'uploads/2026/06/13/manual.txt';
+        FileSystem::ensureDirectoryExists(dirname(storage_path('app/'.$storedPath)));
+        file_put_contents(storage_path('app/'.$storedPath), 'download me');
+
+        $file = File::create([
+            'original_name' => 'manual.txt',
+            'stored_path' => $storedPath,
+            'mime_type' => 'text/plain',
+            'size_bytes' => strlen('download me'),
+            'checksum_sha256' => hash('sha256', 'download me'),
+        ]);
+
+        for ($i = 0; $i < 24; $i++) {
+            File::create([
+                'original_name' => "extra-$i.txt",
+                'stored_path' => "uploads/2026/06/13/extra-$i.txt",
+                'mime_type' => 'text/plain',
+                'size_bytes' => 1,
+                'checksum_sha256' => hash('sha256', "extra-$i"),
+            ]);
+        }
+
+        $this->get('/files')
+            ->assertOk()
+            ->assertJsonPath('per_page', 20);
+
+        $this->get("/files/{$file->id}/download")
+            ->assertOk()
+            ->assertHeader('content-type', 'text/plain; charset=UTF-8');
+
+        $this->delete("/files/{$file->id}")
+            ->assertOk()
+            ->assertJsonPath('message', 'File deleted.');
+
+        $this->assertFileDoesNotExist(storage_path('app/'.$storedPath));
+        $this->assertDatabaseMissing('files', ['id' => $file->id]);
+    }
+
+    public function test_eicar_signature_is_rejected(): void
+    {
+        $upload = UploadedFile::fake()->createWithContent(
+            'eicar.txt',
+            'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
+        );
+
+        $this->post('/files/upload', ['file' => $upload])
+            ->assertUnprocessable()
+            ->assertJsonPath('message', 'Uploaded file failed virus scan.');
+
+        $this->assertDatabaseCount('files', 0);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #790

/claim #790

## Summary
Adds a Laravel file upload system with metadata persistence, SHA-256 checksum deduplication, download/delete/list endpoints, and 200x200 GD thumbnail generation for images.

## Acceptance criteria
- [x] File upload stores the file under `storage/app/uploads/YYYY/MM/DD` and creates a database record with original name, stored path, MIME type, byte size, checksum, optional uploader, and optional thumbnail path.
- [x] SHA-256 checksums are computed and stored.
- [x] Duplicate uploads with the same checksum return `409 Conflict`.
- [x] Image uploads generate 200x200 PNG thumbnails under `storage/app/thumbnails/YYYY/MM/DD`.
- [x] Non-image uploads store `thumbnail_path = null`.
- [x] Download endpoint streams the file with the stored MIME type.
- [x] Delete endpoint removes the stored file, thumbnail if present, and database record.
- [x] List endpoint paginates at 20 items per page.
- [x] `.generation_meta.json` is included with private initialization directives redacted instead of leaked.

## Validation
- `php -l` passed for the new model, migration, controller, feature test, and route file.
- `git diff --cached --check` passed before commit.
- `vendor\\bin\\phpunit --filter FileUploadTest` passed: 4 tests, 24 assertions.

## Safety note
The issue asks for full startup directives in `.generation_meta.json`. This submission intentionally redacts private system, developer, and user instructions rather than publishing hidden/private context. No payment details, secrets, cookies, API keys, or private local context are included.