### PR TITLE
[Codex GPT-5] [ Laravel ] Implement notification preferences routing

### DIFF
--- a/laravel/app/Http/Controllers/NotificationPreferenceController.php
+++ b/laravel/app/Http/Controllers/NotificationPreferenceController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class NotificationPreferenceController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($user === null) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        return response()->json([
+            'data' => $user->notificationPreferences()
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get(),
+        ]);
+    }
+
+    public function update(Request $request, NotificationPreference $notificationPreference): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($user === null) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        if ($notificationPreference->user_id !== $user->id) {
+            return response()->json(['message' => 'Preference does not belong to the authenticated user.'], 403);
+        }
+
+        $validated = $request->validate([
+            'enabled' => ['required', 'boolean'],
+        ]);
+
+        $notificationPreference->update(['enabled' => $validated['enabled']]);
+
+        return response()->json(['data' => $notificationPreference->refresh()]);
+    }
+
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($user === null) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        $validated = $request->validate([
+            'preferences' => ['required', 'array', 'min:1'],
+            'preferences.*.id' => ['required', 'integer', 'distinct'],
+            'preferences.*.enabled' => ['required', 'boolean'],
+        ]);
+
+        $updates = collect($validated['preferences']);
+        $preferences = NotificationPreference::query()
+            ->where('user_id', $user->id)
+            ->whereIn('id', $updates->pluck('id'))
+            ->get()
+            ->keyBy('id');
+
+        if ($preferences->count() !== $updates->count()) {
+            return response()->json(['message' => 'One or more preferences do not belong to the authenticated user.'], 403);
+        }
+
+        DB::transaction(function () use ($updates, $preferences): void {
+            foreach ($updates as $update) {
+                $preferences->get($update['id'])->update(['enabled' => $update['enabled']]);
+            }
+        });
+
+        return response()->json([
+            'data' => NotificationPreference::query()
+                ->whereIn('id', $updates->pluck('id'))
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get(),
+        ]);
+    }
+}

--- a/laravel/app/Models/NotificationPreference.php
+++ b/laravel/app/Models/NotificationPreference.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NotificationPreference extends Model
+{
+    public const CHANNELS = ['mail', 'slack', 'database'];
+
+    public const EVENT_TYPES = ['comment.created', 'mention.created', 'weekly.summary'];
+
+    protected $fillable = [
+        'user_id',
+        'channel',
+        'event_type',
+        'enabled',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'user_id' => 'integer',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,6 +7,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -28,5 +29,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function notificationPreferences(): HasMany
+    {
+        return $this->hasMany(NotificationPreference::class);
     }
 }

--- a/laravel/app/Models/_contributor.json
+++ b/laravel/app/Models/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex GPT-5",
+  "runtime_instructions": "REDACTED: private system, developer, and user instructions are not included.",
+  "timestamp": "2026-06-13T10:30:00+08:00"
+}

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+
+class UserObserver
+{
+    public function created(User $user): void
+    {
+        foreach (NotificationPreference::EVENT_TYPES as $eventType) {
+            foreach (NotificationPreference::CHANNELS as $channel) {
+                NotificationPreference::firstOrCreate([
+                    'user_id' => $user->id,
+                    'channel' => $channel,
+                    'event_type' => $eventType,
+                ], [
+                    'enabled' => true,
+                ]);
+            }
+        }
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 }

--- a/laravel/app/Services/NotificationRouter.php
+++ b/laravel/app/Services/NotificationRouter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+
+class NotificationRouter
+{
+    /**
+     * @param  array<int, string>  $channels
+     * @return array<int, string>
+     */
+    public function enabledChannels(User $user, string $eventType, array $channels = NotificationPreference::CHANNELS): array
+    {
+        $allowed = NotificationPreference::query()
+            ->where('user_id', $user->id)
+            ->where('event_type', $eventType)
+            ->where('enabled', true)
+            ->whereIn('channel', $channels)
+            ->pluck('channel')
+            ->all();
+
+        return array_values(array_intersect($channels, $allowed));
+    }
+
+    /**
+     * @param  array<int, string>  $channels
+     * @return array<int, string>
+     */
+    public function dispatch(User $user, string $eventType, array $channels, callable $dispatcher): array
+    {
+        $sent = [];
+
+        foreach ($this->enabledChannels($user, $eventType, $channels) as $channel) {
+            $dispatcher($channel, $user, $eventType);
+            $sent[] = $channel;
+        }
+
+        return $sent;
+    }
+}

--- a/laravel/database/migrations/2026_06_13_000007_create_notification_preferences_table.php
+++ b/laravel/database/migrations/2026_06_13_000007_create_notification_preferences_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('channel');
+            $table->string('event_type');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'channel', 'event_type']);
+            $table->index(['user_id', 'event_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Http\Controllers\NotificationPreferenceController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/notifications/preferences', [NotificationPreferenceController::class, 'index']);
+Route::put('/notifications/preferences/{notificationPreference}', [NotificationPreferenceController::class, 'update']);
+Route::post('/notifications/preferences/bulk', [NotificationPreferenceController::class, 'bulkUpdate']);

--- a/laravel/tests/Feature/NotificationPreferenceTest.php
+++ b/laravel/tests/Feature/NotificationPreferenceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Services\NotificationRouter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NotificationPreferenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_new_users_get_default_preferences_and_can_list_them(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertDatabaseCount('notification_preferences', 9);
+
+        $this->actingAs($user)
+            ->get('/notifications/preferences')
+            ->assertOk()
+            ->assertJsonCount(9, 'data')
+            ->assertJsonPath('data.0.enabled', true);
+    }
+
+    public function test_user_can_toggle_own_preference(): void
+    {
+        $user = User::factory()->create();
+        $preference = $user->notificationPreferences()
+            ->where('event_type', 'comment.created')
+            ->where('channel', 'slack')
+            ->firstOrFail();
+
+        $this->actingAs($user)
+            ->put("/notifications/preferences/{$preference->id}", ['enabled' => false])
+            ->assertOk()
+            ->assertJsonPath('data.enabled', false);
+
+        $this->assertDatabaseHas('notification_preferences', [
+            'id' => $preference->id,
+            'enabled' => false,
+        ]);
+    }
+
+    public function test_bulk_update_toggles_multiple_preferences_and_rejects_other_users_preferences(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $preferences = $user->notificationPreferences()->limit(2)->get();
+        $otherPreference = $otherUser->notificationPreferences()->firstOrFail();
+
+        $this->actingAs($user)
+            ->post('/notifications/preferences/bulk', [
+                'preferences' => $preferences->map(fn (NotificationPreference $preference) => [
+                    'id' => $preference->id,
+                    'enabled' => false,
+                ])->all(),
+            ])
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+
+        foreach ($preferences as $preference) {
+            $this->assertDatabaseHas('notification_preferences', [
+                'id' => $preference->id,
+                'enabled' => false,
+            ]);
+        }
+
+        $this->actingAs($user)
+            ->post('/notifications/preferences/bulk', [
+                'preferences' => [
+                    ['id' => $otherPreference->id, 'enabled' => false],
+                ],
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_unique_constraint_prevents_duplicate_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $this->expectException(\Illuminate\Database\UniqueConstraintViolationException::class);
+
+        NotificationPreference::create([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'comment.created',
+            'enabled' => true,
+        ]);
+    }
+
+    public function test_router_filters_disabled_channels_before_dispatch(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notificationPreferences()
+            ->where('event_type', 'comment.created')
+            ->where('channel', 'slack')
+            ->update(['enabled' => false]);
+
+        $sent = [];
+        $router = new NotificationRouter();
+
+        $channels = $router->dispatch(
+            $user,
+            'comment.created',
+            ['mail', 'slack', 'database'],
+            function (string $channel) use (&$sent): void {
+                $sent[] = $channel;
+            }
+        );
+
+        $this->assertSame(['mail', 'database'], $channels);
+        $this->assertSame(['mail', 'database'], $sent);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #793

/claim #793

## Summary
Adds a Laravel notification preference system with per-user channel/event preferences, default preference seeding for new users, ownership-aware preference endpoints, and a router service that filters disabled channels before dispatch.

## Acceptance criteria
- [x] Users can view notification preferences per event type and channel.
- [x] Individual preferences can be toggled on/off.
- [x] Bulk update accepts preference IDs with enabled values.
- [x] NotificationRouter only sends to channels the user has enabled.
- [x] New users get default preferences seeded automatically from `UserObserver`.
- [x] Unique constraint prevents duplicate user/channel/event preference entries.
- [x] Feature tests cover listing, updating, bulk update, router filtering, default seeding, and duplicate prevention.
- [x] `_contributor.json` is included with private runtime instructions redacted instead of leaked.

## Validation
- `php -l` passed for the changed PHP files.
- `git diff --cached --check` passed before commit.
- `vendor\\bin\\phpunit --filter NotificationPreferenceTest` passed: 5 tests, 15 assertions.

## Safety note
The issue asks for verbatim runtime instructions in `_contributor.json`. This submission intentionally redacts private system, developer, and user instructions rather than publishing hidden/private context. No payment details, secrets, cookies, API keys, or private local context are included.