### PR TITLE
[Codex GPT-5] [ Laravel ] Implement audit logging for model changes

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class AuditLog extends Model
+{
+    protected $fillable = [
+        'auditable_type',
+        'auditable_id',
+        'event',
+        'old_values',
+        'new_values',
+        'user_id',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+            'user_id' => 'integer',
+        ];
+    }
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/.provenance.json
+++ b/laravel/app/Traits/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex GPT-5",
+  "config_snapshot": "REDACTED: private system, developer, and user instructions are not included.",
+  "created": "2026-06-13T10:45:00+08:00"
+}

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Arr;
+
+trait Auditable
+{
+    public static function bootAuditable(): void
+    {
+        static::created(function ($model): void {
+            $model->writeAuditLog('created', null, $model->auditValuesFromAttributes($model->getAttributes()));
+        });
+
+        static::updated(function ($model): void {
+            $newValues = $model->auditValuesFromAttributes($model->getChanges());
+            $oldValues = Arr::only(
+                $model->auditValuesFromAttributes($model->getOriginal()),
+                array_keys($newValues)
+            );
+
+            $model->writeAuditLog(
+                'updated',
+                $oldValues,
+                $newValues
+            );
+        });
+
+        static::deleted(function ($model): void {
+            $model->writeAuditLog('deleted', $model->auditValuesFromAttributes($model->getOriginal()), null);
+        });
+    }
+
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    public function getAuditHistory()
+    {
+        return $this->auditLogs()
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    protected function auditValuesFromAttributes(array $attributes): array
+    {
+        return collect($attributes)
+            ->except($this->auditHiddenFields())
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function auditHiddenFields(): array
+    {
+        return array_values(array_unique(array_merge(
+            property_exists($this, 'hidden') ? $this->hidden : [],
+            ['password', 'remember_token']
+        )));
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $oldValues
+     * @param  array<string, mixed>|null  $newValues
+     */
+    protected function writeAuditLog(string $event, ?array $oldValues, ?array $newValues): void
+    {
+        AuditLog::create([
+            'auditable_type' => $this->getMorphClass(),
+            'auditable_id' => $this->getKey(),
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => auth()->id(),
+            'ip_address' => request()?->ip(),
+            'user_agent' => request()?->userAgent(),
+        ]);
+    }
+}

--- a/laravel/database/migrations/2026_06_13_000008_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_06_13_000008_create_audit_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->unsignedBigInteger('auditable_id');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id']);
+            $table->index(['event', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditLoggingTest.php
+++ b/laravel/tests/Feature/AuditLoggingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AuditLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_user_writes_audit_log_without_sensitive_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.test',
+            'password' => Hash::make('secret-password'),
+        ]);
+
+        $log = AuditLog::query()->where('event', 'created')->firstOrFail();
+
+        $this->assertSame(User::class, $log->auditable_type);
+        $this->assertSame($user->id, $log->auditable_id);
+        $this->assertNull($log->old_values);
+        $this->assertSame('Ada Lovelace', $log->new_values['name']);
+        $this->assertSame('ada@example.test', $log->new_values['email']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+        $this->assertArrayNotHasKey('remember_token', $log->new_values);
+    }
+
+    public function test_updating_user_writes_old_and_new_values_with_actor_and_request_metadata(): void
+    {
+        $actor = User::factory()->create();
+        $user = User::factory()->create([
+            'name' => 'Audit Target',
+            'email' => 'audit-target@example.test',
+        ]);
+        AuditLog::query()->delete();
+
+        $request = Request::create('/audit-test/users/'.$user->id, 'PUT', [], [], [], [
+            'REMOTE_ADDR' => '203.0.113.10',
+            'HTTP_USER_AGENT' => 'AuditTest/1.0',
+        ]);
+        $this->app->instance('request', $request);
+
+        $this->actingAs($actor);
+
+        $user->update(['name' => 'Grace Hopper']);
+
+        $log = AuditLog::query()->where('event', 'updated')->firstOrFail();
+
+        $this->assertSame($actor->id, $log->user_id);
+        $this->assertSame('203.0.113.10', $log->ip_address);
+        $this->assertSame('AuditTest/1.0', $log->user_agent);
+        $this->assertSame('Audit Target', $log->old_values['name']);
+        $this->assertSame('Grace Hopper', $log->new_values['name']);
+        $this->assertArrayNotHasKey('email', $log->old_values);
+        $this->assertArrayNotHasKey('password', $log->old_values);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+    }
+
+    public function test_deleting_user_writes_old_values_and_history_is_reverse_chronological(): void
+    {
+        $user = User::factory()->create(['name' => 'Delete Me']);
+        AuditLog::query()->delete();
+
+        $user->update(['name' => 'Delete Me Later']);
+        $user->delete();
+
+        $deletedLog = AuditLog::query()->where('event', 'deleted')->firstOrFail();
+
+        $this->assertSame('Delete Me Later', $deletedLog->old_values['name']);
+        $this->assertNull($deletedLog->new_values);
+        $this->assertArrayNotHasKey('password', $deletedLog->old_values);
+
+        $history = $user->getAuditHistory();
+
+        $this->assertSame(['deleted', 'updated'], $history->pluck('event')->all());
+    }
+}


### PR DESCRIPTION
## Issue
Closes #786

/claim #786

## Summary
Adds an Eloquent audit logging system with an `Auditable` trait, `AuditLog` model/migration, sensitive-field filtering, auth/request metadata capture, and reverse chronological audit history lookup. The `User` model uses the trait as the example implementation.

## Acceptance criteria
- [x] Creating a User generates an audit log with `event=created` and `new_values` containing non-sensitive attributes.
- [x] Updating a User generates an audit log with changed `old_values` and `new_values`.
- [x] Deleting a User generates an audit log with `event=deleted` and `old_values`.
- [x] Sensitive fields such as `password` and `remember_token` are excluded.
- [x] `getAuditHistory` returns logs in reverse chronological order.
- [x] Audit logs include `user_id`, `ip_address`, and `user_agent` when available from auth/request context.
- [x] Tests cover created, updated, deleted, sensitive filtering, actor/request metadata, and history ordering.
- [x] `.provenance.json` is included with private runtime instructions redacted instead of leaked.

## Validation
- `php -l` passed for the changed PHP files.
- `git diff --cached --check` passed before commit.
- `vendor\\bin\\phpunit --filter AuditLoggingTest` passed: 3 tests, 19 assertions.

## Safety note
The issue asks for verbatim runtime instructions in `.provenance.json`. This submission intentionally redacts private system, developer, and user instructions rather than publishing hidden/private context. No payment details, secrets, cookies, API keys, or private local context are included.