### PR TITLE
[Codex GPT-5] [ Laravel ] Add cache health checks and status command

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "[REDACTED: private system, developer, and user instructions are not safe to publish in a public repository.]",
+  "timestamp": "2026-06-13T02:39:30Z"
+}

--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status
+        {--store= : Cache store to check instead of the configured default}
+        {--force : Ignore the memoized health-check interval}
+        {--json : Output the raw status payload as JSON}';
+
+    protected $description = 'Display the configured cache store health status';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $store = $this->option('store') ?: null;
+        $status = $healthCheck->check($store, (bool) $this->option('force'));
+
+        if ($this->option('json')) {
+            $this->line(json_encode($status, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('Driver: '.$status['driver']);
+            $this->line('Store: '.$status['store']);
+            $this->line('Available: '.($status['available'] ? 'yes' : 'no'));
+            $this->line('Latency: '.$status['latency_ms'].' ms');
+
+            if (isset($status['error'])) {
+                $this->line('Error: '.$status['error']);
+            }
+
+            if (($status['checked'] ?? true) === false) {
+                $this->line($status['message']);
+            }
+        }
+
+        return $status['available'] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+class CacheHealthCheck
+{
+    /**
+     * @var array<string, array{checked_at_epoch: float, status: array<string, mixed>}>
+     */
+    private static array $memoized = [];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function check(?string $storeName = null, bool $force = false): array
+    {
+        $storeName ??= (string) config('cache.default', 'array');
+        $driver = (string) config("cache.stores.{$storeName}.driver", $storeName);
+
+        if (! (bool) config('cache.health_check_enabled', true)) {
+            return [
+                'available' => true,
+                'driver' => $driver,
+                'store' => $storeName,
+                'latency_ms' => 0.0,
+                'cached' => false,
+                'checked' => false,
+                'message' => 'Cache health checks are disabled.',
+            ];
+        }
+
+        $interval = max(0, (int) config('cache.health_check_interval', 300));
+        $memoKey = "{$storeName}:{$driver}";
+        $now = microtime(true);
+
+        if (! $force && $interval > 0 && isset(self::$memoized[$memoKey])) {
+            $cached = self::$memoized[$memoKey];
+
+            if (($now - $cached['checked_at_epoch']) < $interval) {
+                return array_merge($cached['status'], ['cached' => true]);
+            }
+        }
+
+        $started = microtime(true);
+        $status = [
+            'available' => false,
+            'driver' => $driver,
+            'store' => $storeName,
+            'latency_ms' => null,
+            'cached' => false,
+            'checked' => true,
+        ];
+
+        try {
+            $repository = Cache::store($storeName);
+            $probeKey = 'cache-health-check:'.(string) Str::uuid();
+            $probeValue = Str::random(32);
+
+            $repository->put($probeKey, $probeValue, now()->addSeconds(30));
+
+            if ($repository->get($probeKey) !== $probeValue) {
+                throw new RuntimeException('Cache probe value could not be read back.');
+            }
+
+            $repository->forget($probeKey);
+
+            $status['available'] = true;
+        } catch (Throwable $exception) {
+            $status['error'] = $exception->getMessage();
+        } finally {
+            $status['latency_ms'] = round((microtime(true) - $started) * 1000, 2);
+        }
+
+        self::$memoized[$memoKey] = [
+            'checked_at_epoch' => $now,
+            'status' => $status,
+        ];
+
+        return $status;
+    }
+
+    public static function clearMemoizedResults(): void
+    {
+        self::$memoized = [];
+    }
+}

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -19,6 +19,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Health Checks
+    |--------------------------------------------------------------------------
+    |
+    | These options control the lightweight cache store health check exposed by
+    | the cache:status command and /health/cache endpoint.
+    |
+    */
+
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => (int) env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Stores
     |--------------------------------------------------------------------------
     |

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    $status = $healthCheck->check();
+
+    return response()->json($status, $status['available'] ? 200 : 503);
 });

--- a/laravel/tests/Feature/CacheStatusTest.php
+++ b/laravel/tests/Feature/CacheStatusTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\CacheHealthCheck;
+use Tests\TestCase;
+
+class CacheStatusTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CacheHealthCheck::clearMemoizedResults();
+    }
+
+    public function test_cache_status_command_outputs_driver_availability_and_latency(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $this->artisan('cache:status --force')
+            ->expectsOutput('Driver: array')
+            ->expectsOutput('Store: array')
+            ->expectsOutput('Available: yes')
+            ->assertExitCode(0);
+    }
+
+    public function test_cache_status_command_fails_when_store_is_unavailable(): void
+    {
+        config([
+            'cache.default' => 'missing',
+            'cache.stores.missing' => [
+                'driver' => 'not-a-real-cache-driver',
+            ],
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $this->artisan('cache:status --force')
+            ->expectsOutput('Driver: not-a-real-cache-driver')
+            ->expectsOutput('Store: missing')
+            ->expectsOutput('Available: no')
+            ->assertExitCode(1);
+    }
+
+    public function test_cache_health_endpoint_returns_healthy_json(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertOk()
+            ->assertJson([
+                'available' => true,
+                'driver' => 'array',
+                'store' => 'array',
+            ])
+            ->assertJsonStructure([
+                'available',
+                'driver',
+                'store',
+                'latency_ms',
+                'checked',
+            ]);
+    }
+
+    public function test_cache_health_endpoint_returns_503_for_unavailable_cache(): void
+    {
+        config([
+            'cache.default' => 'missing',
+            'cache.stores.missing' => [
+                'driver' => 'not-a-real-cache-driver',
+            ],
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertStatus(503)
+            ->assertJson([
+                'available' => false,
+                'driver' => 'not-a-real-cache-driver',
+                'store' => 'missing',
+            ])
+            ->assertJsonStructure(['error']);
+    }
+}

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CacheHealthCheck::clearMemoizedResults();
+    }
+
+    public function test_it_reports_the_configured_cache_store_as_available(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('array', $status['driver']);
+        $this->assertSame('array', $status['store']);
+        $this->assertIsFloat($status['latency_ms']);
+        $this->assertFalse($status['cached']);
+    }
+
+    public function test_it_reports_unavailable_cache_stores(): void
+    {
+        config([
+            'cache.default' => 'missing',
+            'cache.stores.missing' => [
+                'driver' => 'not-a-real-cache-driver',
+            ],
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertFalse($status['available']);
+        $this->assertSame('not-a-real-cache-driver', $status['driver']);
+        $this->assertSame('missing', $status['store']);
+        $this->assertArrayHasKey('error', $status);
+    }
+
+    public function test_it_respects_disabled_health_checks(): void
+    {
+        config([
+            'cache.default' => 'missing',
+            'cache.stores.missing' => [
+                'driver' => 'not-a-real-cache-driver',
+            ],
+            'cache.health_check_enabled' => false,
+        ]);
+
+        $status = app(CacheHealthCheck::class)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertFalse($status['checked']);
+        $this->assertSame(0.0, $status['latency_ms']);
+    }
+
+    public function test_it_memoizes_results_within_the_configured_interval(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 300,
+        ]);
+
+        $healthCheck = app(CacheHealthCheck::class);
+
+        $this->assertFalse($healthCheck->check()['cached']);
+        $this->assertTrue($healthCheck->check()['cached']);
+        $this->assertFalse($healthCheck->check(force: true)['cached']);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #747

/claim #747

## Summary
Adds a Laravel cache health check implementation for the configured cache store, including a `CacheHealthCheck` service, `cache:status` Artisan command, `/health/cache` JSON endpoint, health-check config defaults, and interval-based memoization.

## Acceptance criteria
- [x] `CacheHealthCheck` reports availability, driver, store, latency, cached/checked state, and error details when a store is unavailable.
- [x] `cache:status` outputs driver name, store, availability, latency, and exits non-zero for unavailable stores.
- [x] `/health/cache` returns 200 for healthy stores and 503 for unavailable stores.
- [x] `cache.health_check_enabled` and `cache.health_check_interval` are respected.
- [x] Tests cover service behavior, disabled health checks, memoization, command output, and endpoint status codes.
- [x] `_provenance.json` is included with private runtime instructions redacted instead of leaked.

## Validation
- GitHub checks passed on head `627d960`: `track` success and `check` success.
- `php -l` passed for changed PHP files.
- `git diff --cached --check` passed before commit.
- `vendor\bin\phpunit --filter Cache` passed: 8 tests, 33 assertions.
- Full Laravel `vendor\bin\phpunit` passed: 10 tests, 35 assertions.

## Safety note
The issue asks for verbatim boot context in `_provenance.json`. This submission intentionally redacts private system, developer, and user instructions rather than publishing hidden/private context. No payment details, secrets, cookies, API keys, OTPs, or private local context are included.