### PR TITLE
Fix Laravel web rate limiting and session fallback

### DIFF
--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +14,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $configuredDriver = config('session.driver');
+        $fallbackDriver = config('session.fallback', 'file');
+
+        if (! in_array($configuredDriver, $this->supportedSessionDrivers(), true)) {
+            config(['session.driver' => $fallbackDriver]);
+        }
     }
 
     /**
@@ -19,6 +27,18 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('web', function (Request $request) {
+            return Limit::perMinute(60)->by(
+                $request->user()?->getAuthIdentifier() ?: $request->ip()
+            );
+        });
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function supportedSessionDrivers(): array
+    {
+        return ['file', 'cookie', 'database', 'apc', 'memcached', 'redis', 'dynamodb', 'array'];
     }
 }

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -22,6 +22,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fallback Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | When the configured session backend is unavailable or intentionally
+    | disabled in an environment, application code can use this value to fall
+    | back to the local file session driver instead of failing hard.
+    |
+    */
+
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Lifetime
     |--------------------------------------------------------------------------
     |

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,21 @@
 <?php
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('throttle:web')->group(function (): void {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/rate-limit-headers', function (Request $request) {
+        return response()->json([
+            'limit' => 60,
+            'window_seconds' => 60,
+            'key_type' => $request->user() ? 'user' : 'ip',
+            'key' => $request->user()?->getAuthIdentifier() ?? $request->ip(),
+            'attempts' => RateLimiter::attempts(($request->user()?->getAuthIdentifier() ?? $request->ip()).'|web'),
+        ]);
+    })->name('rate-limit.headers');
 });

--- a/laravel/tests/Feature/RateLimitHeadersTest.php
+++ b/laravel/tests/Feature/RateLimitHeadersTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Providers\AppServiceProvider;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class RateLimitHeadersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function test_web_routes_include_rate_limit_headers(): void
+    {
+        $response = $this->get('/rate-limit-headers');
+
+        $response->assertOk()
+            ->assertHeader('X-RateLimit-Limit', '60')
+            ->assertHeader('X-RateLimit-Remaining', '59')
+            ->assertJson([
+                'limit' => 60,
+                'window_seconds' => 60,
+                'key_type' => 'ip',
+            ]);
+    }
+
+    public function test_web_routes_return_too_many_requests_after_sixty_requests(): void
+    {
+        for ($i = 0; $i < 60; $i++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')->assertTooManyRequests();
+    }
+
+    public function test_authenticated_users_are_limited_separately_from_guests(): void
+    {
+        for ($i = 0; $i < 60; $i++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->actingAs(User::factory()->make(['id' => 123]))
+            ->get('/')
+            ->assertOk();
+    }
+
+    public function test_session_fallback_defaults_to_file(): void
+    {
+        $this->assertSame('file', config('session.fallback'));
+    }
+
+    public function test_unsupported_session_driver_falls_back_to_configured_fallback(): void
+    {
+        config([
+            'session.driver' => 'missing-backend',
+            'session.fallback' => 'file',
+        ]);
+
+        (new AppServiceProvider($this->app))->register();
+
+        $this->assertSame('file', config('session.driver'));
+    }
+}


### PR DESCRIPTION
Fixes #749.

This reworks the Laravel rate-limit/session fallback fix after the previous PR was closed as incomplete.

Summary:
- Registers an explicit `web` rate limiter using Laravel's `RateLimiter` API.
- Applies `throttle:web` to the web route group so normal browser/web traffic receives deterministic 429 responses instead of bypassing throttling.
- Adds a configurable `session.fallback` driver and uses `SESSION_DRIVER=array` in PHPUnit for deterministic test runs.
- Adds focused feature coverage for successful requests, rate-limit headers, 429 behavior after the configured limit, and session fallback config.

Validation run locally:
- `git diff --check -- laravel/app/Providers/AppServiceProvider.php laravel/config/session.php laravel/phpunit.xml laravel/routes/web.php laravel/tests/Feature/RateLimitHeadersTest.php`
- `php -l laravel/app/Providers/AppServiceProvider.php`
- `php -l laravel/config/session.php`
- `php -l laravel/routes/web.php`
- `php -l laravel/tests/Feature/RateLimitHeadersTest.php`
- `COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --prefer-dist`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test --filter=RateLimitHeadersTest`

Note: I intentionally did not include any prompt/session-initialization metadata in this PR. The patch is limited to source/test changes needed to resolve the Laravel issue.
