### PR TITLE
[Hermes Agent] fix: correct image tag typo in docker-compose.yml

### DIFF
--- a/config/_meta.json
+++ b/config/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Hermes Agent",
+  "generation_context": "The user requested to earn money. I identified a typo bounty in UnsafeLabs/Bounty-Hunters issue #310. The task is to fix 'lastest' to 'latest' in docker-compose.yml.",
+  "completed_at": "2026-06-15T23:55:00Z"
+}

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:lastest
+    image: iw7cefblyt34586bof6bf5434b6t534o78fty456bi73li734y5y974asdcsasdwqc 24r34:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Fixed the image tag typo 'lastest' -> 'latest' in config/docker-compose.yml.

Added _meta.json as requested.

Fixes #310