### PR TITLE
[OpenAI Codex] [ Crypto ] Fix TokenVesting overflow and revoke accounting

### DIFF
--- a/solidity/contracts/.audit.json
+++ b/solidity/contracts/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this repository.",
+  "completed_at": "2026-06-18T11:01:00+09:00"
+}

--- a/solidity/contracts/TokenVesting.sol
+++ b/solidity/contracts/TokenVesting.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract TokenVesting {
     IERC20 public token;
@@ -26,6 +27,7 @@ contract TokenVesting {
         uint256 _cliffDuration,
         uint256 _vestingDuration
     ) {
+        require(_vestingDuration > 0, "Duration must be > 0");
         token = IERC20(_token);
         beneficiary = _beneficiary;
         owner = msg.sender;
@@ -35,18 +37,24 @@ contract TokenVesting {
         duration = _vestingDuration;
     }
 
-    // BUG: Overflow risk for large allocations — totalAllocation * elapsed can exceed uint256
     function vestedAmount() public view returns (uint256) {
+        if (block.timestamp < start) return 0;
         if (block.timestamp < cliff) return 0;
-        if (block.timestamp >= start + duration) return totalAllocation;
 
         uint256 elapsed = block.timestamp - start;
-        // This multiplication can overflow for large totalAllocation values
-        return totalAllocation * elapsed / duration;
+        if (elapsed >= duration) return totalAllocation;
+
+        uint256 vestedWholeUnits = (totalAllocation / duration) * elapsed;
+        uint256 vestedRemainder = Math.mulDiv(totalAllocation % duration, elapsed, duration);
+        return vestedWholeUnits + vestedRemainder;
     }
 
     function claimable() public view returns (uint256) {
-        return vestedAmount() - claimed;
+        if (revoked) return 0;
+
+        uint256 vested = vestedAmount();
+        if (vested <= claimed) return 0;
+        return vested - claimed;
     }
 
     function claim() external {
@@ -54,25 +62,28 @@ contract TokenVesting {
         uint256 amount = claimable();
         require(amount > 0, "Nothing to claim");
         claimed += amount;
-        token.transfer(beneficiary, amount);
+        require(token.transfer(beneficiary, amount), "Transfer failed");
         emit TokensClaimed(beneficiary, amount);
     }
 
-    // BUG: Incorrect unvested calculation during cliff period
     function revoke() external {
         require(msg.sender == owner, "Not owner");
         require(!revoked, "Already revoked");
         revoked = true;
 
+        uint256 claimableAmount = 0;
         uint256 vested = vestedAmount();
-        // BUG: Should be totalAllocation - claimed, not totalAllocation - vested
-        // during cliff, vested is 0 but user may have claimed nothing
-        uint256 unvested = totalAllocation - vested;
-
         if (vested > claimed) {
-            token.transfer(beneficiary, vested - claimed);
+            claimableAmount = vested - claimed;
         }
-        token.transfer(owner, unvested);
+
+        uint256 unvested = totalAllocation - claimed - claimableAmount;
+
+        if (claimableAmount > 0) {
+            claimed += claimableAmount;
+            require(token.transfer(beneficiary, claimableAmount), "Transfer failed");
+        }
+        require(token.transfer(owner, unvested), "Transfer failed");
         emit VestingRevoked(beneficiary, unvested);
     }
 }


### PR DESCRIPTION
/claim #917

## Summary
- Replaces overflow-prone `totalAllocation * elapsed / duration` vesting math with quotient/remainder arithmetic.
- Uses `Math.mulDiv` only for the bounded remainder term, preserving final vesting accuracy without multiplying the full allocation by elapsed time.
- Avoids `start + duration` overflow by comparing elapsed duration directly.
- Fixes revocation accounting so unclaimed vested tokens go to the beneficiary and only truly unvested allocation returns to the owner.
- Checks ERC20 transfer return values and rejects zero vesting duration.
- Includes safe public `.audit.json` only; private system/developer/runtime instructions are intentionally not copied into repository metadata.

## Validation
- `git diff --check`
- Parsed `solidity/contracts/.audit.json` with Ruby JSON parser.
- Deterministic arithmetic sanity check for 1B tokens with 18 decimals across start, midpoint, final second, and full completion.
- Revocation math sanity checks for cliff and partial-vesting cases.

## Notes
- The local environment did not have `solc`, `solcjs`, or `forge` available, so validation is focused on static diff checks and deterministic arithmetic checks.