### PR TITLE
[OpenAI Codex] [ Crypto ] Fix PriceOracle stale feed fallback validation

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this repository.",
+  "date": "2026-06-18T11:09:00+09:00"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,33 +14,35 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(uint256 updatedAt);
+    event FallbackFeedUpdated(address indexed fallbackFeed);
+    event MaxStalenessUpdated(uint256 maxStaleness);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function getLatestPrice() external returns (int256) {
         (
-            uint80 roundId,
             int256 price,
-            ,
             uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+            bool stale
+        ) = _readAndValidate(primaryFeed, true);
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        if (stale) {
+            emit StalePrice(updatedAt);
+            require(address(fallbackFeed) != address(0), "Stale price");
+            (price, updatedAt, stale) = _readAndValidate(fallbackFeed, false);
+            require(!stale, "Stale price");
+        }
 
+        emit PriceQueried(price, updatedAt);
         return price;
     }
 
@@ -50,6 +52,40 @@ contract PriceOracle {
 
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
+        require(_maxStaleness > 0, "Invalid staleness");
         MAX_STALENESS = _maxStaleness;
+        emit MaxStalenessUpdated(_maxStaleness);
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        require(_fallbackFeed != address(0), "Invalid fallback");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        emit FallbackFeedUpdated(_fallbackFeed);
+    }
+
+    function _readAndValidate(
+        AggregatorV3Interface feed,
+        bool allowStale
+    ) internal view returns (int256 price, uint256 updatedAt, bool stale) {
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 feedUpdatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        require(answer > 0, "Invalid price");
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(feedUpdatedAt > 0 && feedUpdatedAt <= block.timestamp, "Invalid timestamp");
+
+        uint256 age = block.timestamp - feedUpdatedAt;
+        if (age > MAX_STALENESS) {
+            require(allowStale, "Stale price");
+            return (answer, feedUpdatedAt, true);
+        }
+
+        return (answer, feedUpdatedAt, false);
     }
 }


### PR DESCRIPTION
/claim #915

## Summary
- Validates Chainlink round completeness with `answeredInRound >= roundId`.
- Rejects zero and negative prices with `Invalid price`.
- Rejects zero/future timestamps and stale fallback data.
- Falls back to an owner-configured secondary feed only when the primary feed is stale.
- Emits `StalePrice(updatedAt)` before using the fallback feed.
- Keeps `MAX_STALENESS` owner-configurable and adds owner-only fallback feed configuration.
- Includes safe public `.generation_meta.json` only; private system/developer/runtime instructions are intentionally not copied into repository metadata.

## Validation
- `git diff --check`
- Parsed `solidity/contracts/.generation_meta.json` with Ruby JSON parser.
- Static review against required cases: valid primary, stale primary with valid fallback, invalid price, incomplete round, and both feeds stale.

## Notes
- The local environment did not have `solc`, `solcjs`, or `forge` available, and the sparse Solidity checkout contains no test scaffold, so validation is focused on static diff checks and contract-level reasoning.