### PR TITLE
[OpenAI Codex] [ Crypto ] Fix FlashLoan fee floor and pool accounting

### DIFF
--- a/solidity/contracts/.contributor.json
+++ b/solidity/contracts/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this repository.",
+  "timestamp": "2026-06-18T11:13:00+09:00"
+}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -8,58 +8,88 @@ interface IFlashLoanReceiver {
 }
 
 contract FlashLoan {
+    uint256 private constant BPS_DENOMINATOR = 10_000;
+
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
+    uint256 public poolLiquidity;
     address public owner;
     bool public paused;
+    bool private activeLoan;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event PoolDeposit(address indexed depositor, uint256 amount);
+    event FeesWithdrawn(address indexed owner, uint256 amount);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
 
     constructor(address _loanToken, uint256 _feeBPS) {
+        require(_feeBPS < BPS_DENOMINATOR, "Invalid fee");
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
     function flashLoan(uint256 amount, bytes calldata data) external {
         require(!paused, "Paused");
+        require(!activeLoan, "Flash loan active");
         require(amount > 0, "Amount must be > 0");
+        require(amount <= poolLiquidity / 2, "Loan exceeds 50% cap");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        uint256 fee = _calculateFee(amount);
+        uint256 repayment = amount + fee;
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
-
-        loanToken.transfer(msg.sender, amount);
+        activeLoan = true;
+        poolLiquidity -= amount;
+        require(loanToken.transfer(msg.sender, amount), "Transfer failed");
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(loanToken.transferFrom(msg.sender, address(this), repayment), "Loan not repaid");
 
         totalFees += fee;
+        poolLiquidity += repayment;
+        activeLoan = false;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(amount > 0, "Amount must be > 0");
+        require(loanToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+        poolLiquidity += amount;
+        emit PoolDeposit(msg.sender, amount);
     }
 
     function withdrawFees() external {
         require(msg.sender == owner, "Not owner");
         uint256 fees = totalFees;
+        require(fees > 0, "No fees");
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        poolLiquidity -= fees;
+        require(loanToken.transfer(owner, fees), "Transfer failed");
+        emit FeesWithdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external {
+        require(msg.sender == owner, "Not owner");
+        paused = true;
+        emit Paused(owner);
+    }
+
+    function unpause() external {
+        require(msg.sender == owner, "Not owner");
+        paused = false;
+        emit Unpaused(owner);
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolLiquidity;
+    }
+
+    function _calculateFee(uint256 amount) internal view returns (uint256) {
+        uint256 fee = amount * feeBPS / BPS_DENOMINATOR;
+        if (fee == 0) return 1;
+        return fee;
     }
 }


### PR DESCRIPTION
/claim #919

## Summary
- Adds a one-unit minimum fee so small nonzero flash loans cannot become free through integer truncation.
- Caps loans at 50% of internally tracked pool liquidity.
- Replaces callback-time `balanceOf` repayment validation with explicit `transferFrom(amount + fee)` repayment.
- Tracks pool liquidity internally so rebasing/direct balance changes do not satisfy repayment by accident.
- Adds owner-only pause/unpause controls and a nested-loan guard.
- Tracks fee accrual and deducts withdrawn fees from internal liquidity.
- Includes safe public `.contributor.json` only; private system/developer/runtime instructions are intentionally not copied into repository metadata.

## Validation
- `git diff --check`
- Parsed `solidity/contracts/.contributor.json` with Ruby JSON parser.
- Deterministic fee/accounting sanity check for fee floor, 50% cap, fee accrual, and fee withdrawal.

## Notes
- The local environment did not have `solc`, `solcjs`, or `forge` available, and the sparse Solidity checkout contains no test scaffold, so validation is focused on static diff checks and accounting checks.