### PR TITLE
[OpenAI Codex] [ Crypto ] Fix GovernanceToken tx.origin delegation vulnerability

### DIFF
--- a/solidity/contracts/.attribution.json
+++ b/solidity/contracts/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this repository.",
+  "date": "2026-06-18T11:21:00+09:00"
+}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,41 +18,40 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
-
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        require(to != address(0), "Invalid delegate");
+        require(msg.sender != to, "Cannot delegate to self");
+
+        address previousDelegate = delegates[msg.sender];
+        uint256 delegatorBalance = balanceOf(msg.sender);
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= delegatorBalance;
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += delegatorBalance;
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 
@@ -87,5 +87,19 @@ contract GovernanceToken is ERC20 {
             proposal.againstVotes += power;
         }
         emit VoteCast(proposalId, msg.sender, support);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        address fromDelegate = delegates[from];
+        if (fromDelegate != address(0)) {
+            delegatedPower[fromDelegate] -= value;
+        }
+
+        address toDelegate = delegates[to];
+        if (toDelegate != address(0)) {
+            delegatedPower[toDelegate] += value;
+        }
+
+        super._update(from, to, value);
     }
 }


### PR DESCRIPTION
/claim #912

## Summary
- Removes every `tx.origin` dependency from `GovernanceToken`.
- Uses `msg.sender` for delegation and revocation.
- Protects `snapshot` with OpenZeppelin `Ownable` / `onlyOwner`.
- Rejects zero-address and self-delegation targets.
- Keeps `delegatedPower` synchronized when delegated balances transfer, so legitimate delegation remains accurate after token movement.
- Includes safe public `.attribution.json` only; private system/developer/runtime instructions are intentionally not copied into repository metadata.

## Validation
- `git diff --check`
- `rg "tx\.origin|admin" solidity/contracts/GovernanceToken.sol` returned no matches.
- Parsed `solidity/contracts/.attribution.json` with Ruby JSON parser.
- Deterministic delegated-power arithmetic sanity check for delegate, transfer, receiver delegation, and revoke.

## Notes
- The local environment did not have `solc`, `solcjs`, or `forge` available, and the sparse Solidity checkout contains no test scaffold, so validation is focused on static diff checks and delegation/accounting checks.