### PR TITLE
[OpenAI Codex] [ Crypto ] Fix StakingVault reentrancy ordering

### DIFF
--- a/solidity/contracts/.provenance.json
+++ b/solidity/contracts/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this repository.",
+  "created": "2026-06-18T11:26:00+09:00"
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -23,7 +24,7 @@ contract StakingVault {
 
     function stake(uint256 amount) external {
         require(amount > 0, "Cannot stake 0");
-        stakingToken.transferFrom(msg.sender, address(this), amount);
+        require(stakingToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
         _updateReward(msg.sender);
         balances[msg.sender] += amount;
         totalStaked += amount;
@@ -39,31 +40,29 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
/claim #911

## Summary
- Imports OpenZeppelin `ReentrancyGuard` and applies `nonReentrant` to `withdraw` and `claimRewards`.
- Moves balance and total-staked updates before the external ETH transfer in `withdraw`.
- Moves reward zeroing before the external ETH transfer in `claimRewards`.
- Requires staking token `transferFrom` success during staking.
- Includes safe public `.provenance.json` only; private system/developer/runtime instructions are intentionally not copied into repository metadata.

## Validation
- `git diff --check`
- Parsed `solidity/contracts/.provenance.json` with Ruby JSON parser.
- Static ordering check verified withdraw state updates precede external call.
- Static ordering check verified claimRewards reward zeroing precedes external call.
- Verified both vulnerable functions include `nonReentrant`.

## Notes
- The local environment did not have `solc`, `solcjs`, or `forge` available, and the sparse Solidity checkout contains no test scaffold, so validation is focused on static diff and ordering checks.