### PR TITLE
[OpenAI Codex] [ Crypto ] Fix YieldVault reward period accounting

### DIFF
--- a/solidity/contracts/YieldVault.sol
+++ b/solidity/contracts/YieldVault.sol
@@ -4,10 +4,12 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract YieldVault {
+    uint256 private constant PRECISION = 1e18;
+
     IERC20 public rewardToken;
     IERC20 public stakingToken;
 
-    uint256 public rewardRate;
+    uint256 public rewardRate; // reward tokens per second, scaled by 1e18
     uint256 public periodFinish;
     uint256 public lastUpdateTime;
     uint256 public rewardPerTokenStored;
@@ -29,22 +31,27 @@ contract YieldVault {
         rewardDistributor = msg.sender;
     }
 
-    // BUG: Does not cap at periodFinish — accrues phantom rewards after period ends
+    function lastTimeRewardApplicable() public view returns (uint256) {
+        return block.timestamp < periodFinish ? block.timestamp : periodFinish;
+    }
+
     function rewardPerToken() public view returns (uint256) {
         if (totalSupply == 0) return rewardPerTokenStored;
+        uint256 applicableTime = lastTimeRewardApplicable();
+        if (applicableTime <= lastUpdateTime) return rewardPerTokenStored;
+
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / totalSupply
+            (applicableTime - lastUpdateTime) * rewardRate / totalSupply
         );
     }
 
-    // BUG: Uses uncapped rewardPerToken
     function earned(address account) public view returns (uint256) {
-        return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / 1e18 + rewards[account];
+        return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / PRECISION + rewards[account];
     }
 
     modifier updateReward(address account) {
         rewardPerTokenStored = rewardPerToken();
-        lastUpdateTime = block.timestamp;
+        lastUpdateTime = lastTimeRewardApplicable();
         if (account != address(0)) {
             rewards[account] = earned(account);
             userRewardPerTokenPaid[account] = rewardPerTokenStored;
@@ -56,15 +63,16 @@ contract YieldVault {
         require(amount > 0, "Cannot deposit 0");
         totalSupply += amount;
         balanceOf[msg.sender] += amount;
-        stakingToken.transferFrom(msg.sender, address(this), amount);
+        require(stakingToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
         emit Deposited(msg.sender, amount);
     }
 
     function withdraw(uint256 amount) external updateReward(msg.sender) {
         require(amount > 0, "Cannot withdraw 0");
+        require(balanceOf[msg.sender] >= amount, "Insufficient balance");
         totalSupply -= amount;
         balanceOf[msg.sender] -= amount;
-        stakingToken.transfer(msg.sender, amount);
+        require(stakingToken.transfer(msg.sender, amount), "Transfer failed");
         emit Withdrawn(msg.sender, amount);
     }
 
@@ -72,15 +80,22 @@ contract YieldVault {
         uint256 reward = rewards[msg.sender];
         if (reward > 0) {
             rewards[msg.sender] = 0;
-            rewardToken.transfer(msg.sender, reward);
+            require(rewardToken.transfer(msg.sender, reward), "Transfer failed");
             emit RewardPaid(msg.sender, reward);
         }
     }
 
-    // BUG: No access control — anyone can call
-    // BUG: Precision loss in rewardRate calculation
     function notifyRewardAmount(uint256 reward, uint256 duration) external updateReward(address(0)) {
-        rewardRate = reward / duration;
+        require(msg.sender == rewardDistributor, "Not distributor");
+        require(duration > 0, "Invalid duration");
+
+        if (block.timestamp < periodFinish) {
+            uint256 remaining = periodFinish - block.timestamp;
+            uint256 leftover = remaining * rewardRate / PRECISION;
+            reward += leftover;
+        }
+
+        rewardRate = reward * PRECISION / duration;
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + duration;
     }

--- a/solidity/contracts/_contributor.json
+++ b/solidity/contracts/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this repository.",
+  "timestamp": "2026-06-18T11:31:00+09:00"
+}


### PR DESCRIPTION
/claim #914

## Summary
- Adds `lastTimeRewardApplicable()` and caps reward accrual at `periodFinish`.
- Makes `rewardPerToken()` and `earned()` use the capped timestamp so rewards freeze after expiry.
- Restricts `notifyRewardAmount()` to the configured `rewardDistributor`.
- Stores `rewardRate` with 1e18 fixed-point precision to reduce truncation loss.
- Preserves deposit, withdrawal, and claim flows with checked ERC20 transfer results.
- Includes safe public `_contributor.json` only; private system/developer/runtime instructions are intentionally not copied into repository metadata.

## Validation
- `git diff --check`
- Parsed `solidity/contracts/_contributor.json` with Ruby JSON parser.
- Deterministic reward math sanity check for capped accrual after period end and fixed-point precision behavior.

## Notes
- The local environment did not have `solc`, `solcjs`, or `forge` available, and the sparse Solidity checkout contains no test scaffold, so validation is focused on static diff checks and reward accounting checks.