### PR TITLE
[OpenAI Codex] [ Crypto ] Fix MultiSigWallet confirmation race

### DIFF
--- a/_provenance.json
+++ b/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this public repository.",
+  "timestamp": "2026-06-18T11:24:17+09:00"
+}

--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -15,7 +15,12 @@ contract MultiSigWallet {
 
     mapping(uint256 => Transaction) public transactions;
     mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => uint256)) public confirmationTimestamp;
+    mapping(uint256 => mapping(address => uint256)) public confirmationBlock;
+    mapping(uint256 => mapping(address => uint256)) public revocationBlock;
     mapping(address => bool) public isOwner;
+
+    bool private executing;
 
     event Submitted(uint256 indexed txId);
     event Confirmed(uint256 indexed txId, address indexed owner);
@@ -31,14 +36,18 @@ contract MultiSigWallet {
         require(_owners.length > 0, "No owners");
         require(_required > 0 && _required <= _owners.length, "Invalid required");
         for (uint256 i = 0; i < _owners.length; i++) {
+            require(_owners[i] != address(0), "Invalid owner");
+            require(!isOwner[_owners[i]], "Duplicate owner");
             isOwner[_owners[i]] = true;
         }
         owners = _owners;
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid target");
+        require(data.length == 0 || to.code.length > 0, "Target not contract");
+
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
@@ -51,16 +60,24 @@ contract MultiSigWallet {
     }
 
     function confirmTransaction(uint256 txId) external onlyOwner {
+        require(!executing, "Execution in progress");
+        require(txId < transactionCount, "Transaction does not exist");
         require(!transactions[txId].executed, "Already executed");
         require(!confirmations[txId][msg.sender], "Already confirmed");
         confirmations[txId][msg.sender] = true;
+        confirmationTimestamp[txId][msg.sender] = block.timestamp;
+        confirmationBlock[txId][msg.sender] = block.number;
+        revocationBlock[txId][msg.sender] = 0;
         emit Confirmed(txId, msg.sender);
     }
 
     function revokeConfirmation(uint256 txId) external onlyOwner {
+        require(!executing, "Execution in progress");
+        require(txId < transactionCount, "Transaction does not exist");
         require(!transactions[txId].executed, "Already executed");
         require(confirmations[txId][msg.sender], "Not confirmed");
         confirmations[txId][msg.sender] = false;
+        revocationBlock[txId][msg.sender] = block.number;
         emit Revoked(txId, msg.sender);
     }
 
@@ -70,18 +87,41 @@ contract MultiSigWallet {
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
+    function isConfirmedAtBlock(uint256 txId, address owner, uint256 blockNumber) public view returns (bool) {
+        uint256 confirmedAt = confirmationBlock[txId][owner];
+        if (confirmedAt == 0 || confirmedAt > blockNumber) {
+            return false;
+        }
+
+        uint256 revokedAt = revocationBlock[txId][owner];
+        if (revokedAt == 0 || revokedAt > blockNumber) {
+            return true;
+        }
+
+        return false;
+    }
+
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
+        for (uint256 i = 0; i < owners.length; i++) {
+            if (isConfirmedAtBlock(txId, owners[i], blockNumber)) count++;
+        }
+    }
+
     function executeTransaction(uint256 txId) external onlyOwner {
+        require(!executing, "Execution in progress");
+        require(txId < transactionCount, "Transaction does not exist");
         require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
+        require(getConfirmationCountAtBlock(txId, block.number) >= required, "Not enough confirmations");
 
         Transaction storage txn = transactions[txId];
+        executing = true;
         txn.executed = true;
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
         require(success, "Execution failed");
+        require(getConfirmationCount(txId) >= required, "Confirmations revoked");
 
+        executing = false;
         emit Executed(txId);
     }
 

--- a/solidity/tests/test_multisig_wallet.py
+++ b/solidity/tests/test_multisig_wallet.py
@@ -1,0 +1,170 @@
+from pathlib import Path
+
+import pytest
+from eth_tester.exceptions import TransactionFailed
+from solcx import compile_standard, install_solc
+from web3 import EthereumTesterProvider, Web3
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "solidity" / "contracts" / "MultiSigWallet.sol"
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+CALLBACK_OWNER_SOURCE = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IMultiSigWallet {
+    function confirmTransaction(uint256 txId) external;
+    function revokeConfirmation(uint256 txId) external;
+}
+
+contract CallbackOwner {
+    IMultiSigWallet public wallet;
+    uint256 public txToRevoke;
+    bool public revokeOnReceive;
+
+    function configure(address wallet_) external {
+        wallet = IMultiSigWallet(wallet_);
+    }
+
+    function setRevocation(uint256 txId, bool enabled) external {
+        txToRevoke = txId;
+        revokeOnReceive = enabled;
+    }
+
+    function confirm(uint256 txId) external {
+        wallet.confirmTransaction(txId);
+    }
+
+    receive() external payable {
+        if (revokeOnReceive) {
+            wallet.revokeConfirmation(txToRevoke);
+        }
+    }
+}
+"""
+
+
+@pytest.fixture(scope="session")
+def compiled_contracts():
+    install_solc("0.8.20")
+    compiled = compile_standard(
+        {
+            "language": "Solidity",
+            "sources": {
+                "MultiSigWallet.sol": {"content": CONTRACT.read_text(encoding="utf-8")},
+                "CallbackOwner.sol": {"content": CALLBACK_OWNER_SOURCE},
+            },
+            "settings": {
+                "outputSelection": {"*": {"*": ["abi", "evm.bytecode.object"]}},
+            },
+        },
+        solc_version="0.8.20",
+    )
+    return compiled["contracts"]
+
+
+@pytest.fixture()
+def w3():
+    return Web3(EthereumTesterProvider())
+
+
+def deploy(w3, contract_def, args=(), sender=None):
+    sender = sender or w3.eth.accounts[0]
+    contract = w3.eth.contract(
+        abi=contract_def["abi"],
+        bytecode=contract_def["evm"]["bytecode"]["object"],
+    )
+    tx_hash = contract.constructor(*args).transact({"from": sender})
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+    return w3.eth.contract(address=receipt.contractAddress, abi=contract_def["abi"])
+
+
+def deploy_wallet(w3, compiled_contracts, owners=None, required=2):
+    owners = owners or [w3.eth.accounts[0], w3.eth.accounts[1]]
+    wallet_def = compiled_contracts["MultiSigWallet.sol"]["MultiSigWallet"]
+    wallet = deploy(w3, wallet_def, (owners, required))
+    w3.eth.send_transaction(
+        {
+            "from": w3.eth.accounts[0],
+            "to": wallet.address,
+            "value": w3.to_wei(1, "ether"),
+        }
+    )
+    return wallet
+
+
+def next_tx_id(wallet):
+    return wallet.functions.transactionCount().call()
+
+
+def submit(wallet, sender, to, value=0, data=b""):
+    tx_id = next_tx_id(wallet)
+    wallet.functions.submitTransaction(to, value, data).transact({"from": sender})
+    return tx_id
+
+
+def test_normal_submit_confirm_revoke_execute_flow_and_simple_transfer_gas(w3, compiled_contracts):
+    wallet = deploy_wallet(w3, compiled_contracts)
+    tx_id = submit(wallet, w3.eth.accounts[0], w3.eth.accounts[2], value=1)
+
+    wallet.functions.confirmTransaction(tx_id).transact({"from": w3.eth.accounts[0]})
+    wallet.functions.confirmTransaction(tx_id).transact({"from": w3.eth.accounts[1]})
+    wallet.functions.revokeConfirmation(tx_id).transact({"from": w3.eth.accounts[1]})
+    assert wallet.functions.getConfirmationCount(tx_id).call() == 1
+
+    wallet.functions.confirmTransaction(tx_id).transact({"from": w3.eth.accounts[1]})
+    tx_hash = wallet.functions.executeTransaction(tx_id).transact({"from": w3.eth.accounts[0]})
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+
+    assert receipt.gasUsed <= 100_000
+    assert wallet.functions.transactions(tx_id).call()[3] is True
+
+
+def test_zero_address_and_eoa_calldata_targets_are_rejected(w3, compiled_contracts):
+    wallet = deploy_wallet(w3, compiled_contracts)
+
+    with pytest.raises(TransactionFailed):
+        wallet.functions.submitTransaction(ZERO_ADDRESS, 0, b"").transact({"from": w3.eth.accounts[0]})
+
+    with pytest.raises(TransactionFailed):
+        wallet.functions.submitTransaction(w3.eth.accounts[2], 0, b"\x12\x34").transact(
+            {"from": w3.eth.accounts[0]}
+        )
+
+
+def test_revocation_before_execution_blocks_front_running_attempt(w3, compiled_contracts):
+    wallet = deploy_wallet(w3, compiled_contracts)
+    tx_id = submit(wallet, w3.eth.accounts[0], w3.eth.accounts[2], value=1)
+
+    wallet.functions.confirmTransaction(tx_id).transact({"from": w3.eth.accounts[0]})
+    wallet.functions.confirmTransaction(tx_id).transact({"from": w3.eth.accounts[1]})
+    confirmed_block = wallet.functions.confirmationBlock(tx_id, w3.eth.accounts[1]).call()
+    assert wallet.functions.isConfirmedAtBlock(tx_id, w3.eth.accounts[1], confirmed_block).call()
+
+    wallet.functions.revokeConfirmation(tx_id).transact({"from": w3.eth.accounts[1]})
+    with pytest.raises(TransactionFailed):
+        wallet.functions.executeTransaction(tx_id).transact({"from": w3.eth.accounts[0]})
+
+    wallet.functions.confirmTransaction(tx_id).transact({"from": w3.eth.accounts[1]})
+    wallet.functions.executeTransaction(tx_id).transact({"from": w3.eth.accounts[0]})
+    assert wallet.functions.transactions(tx_id).call()[3] is True
+
+
+def test_callback_time_revocation_reverts_execution(w3, compiled_contracts):
+    callback_def = compiled_contracts["CallbackOwner.sol"]["CallbackOwner"]
+    callback_owner = deploy(w3, callback_def)
+    wallet = deploy_wallet(w3, compiled_contracts, owners=[w3.eth.accounts[0], callback_owner.address])
+    callback_owner.functions.configure(wallet.address).transact({"from": w3.eth.accounts[0]})
+
+    tx_id = submit(wallet, w3.eth.accounts[0], callback_owner.address, value=1)
+    callback_owner.functions.setRevocation(tx_id, True).transact({"from": w3.eth.accounts[0]})
+    wallet.functions.confirmTransaction(tx_id).transact({"from": w3.eth.accounts[0]})
+    callback_owner.functions.confirm(tx_id).transact({"from": w3.eth.accounts[0]})
+
+    with pytest.raises(TransactionFailed):
+        wallet.functions.executeTransaction(tx_id).transact({"from": w3.eth.accounts[0]})
+
+    assert wallet.functions.transactions(tx_id).call()[3] is False
+    assert wallet.functions.confirmations(tx_id, callback_owner.address).call() is True


### PR DESCRIPTION
/claim #916

## Summary
- Preserve the public `confirmations` mapping while adding timestamp/block metadata for confirmation and revocation history.
- Reject zero-address transaction targets and calldata sent to non-contract targets.
- Add an execution lock around `executeTransaction`, use block-aware confirmation counting before the external call, and re-check live confirmations after the call.
- Add focused pytest coverage for normal submit/confirm/revoke/execute flow, simple-transfer gas, zero-address rejection, EOA calldata rejection, pre-execution revocation, and callback-time revocation.
- Include safe public `_provenance.json` metadata without publishing private runtime instructions, hidden configuration, secrets, or credentials.

## Local validation
- `git diff --check` passed.
- `_provenance.json` parses as JSON.
- `solidity/tests/test_multisig_wallet.py` parses with Python AST.
- Dependency-free static checks verified the target guards, block snapshot helpers, post-call revocation check, and execute-order invariant.
- Dependency-free confirmation/revocation block model passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider solidity/tests/test_multisig_wallet.py` was attempted, but this bare checkout does not include the required Solidity test dependencies (`eth_tester`, `web3`, `py-solc-x`), so collection stopped with `ModuleNotFoundError: No module named eth_tester`.
