### PR TITLE
[OpenAI Codex] [ Crypto ] Fix CrossChainBridge replay protection

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this public repository.",
+  "ts": "2026-06-18T11:31:34+09:00"
+}

--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -4,10 +4,21 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract CrossChainBridge {
+    string public constant NAME = "CrossChainBridge";
+    string public constant VERSION = "1";
+
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "BridgeTransfer(address sender,address recipient,uint256 amount,uint256 nonce,uint256 chainId,address bridge)"
+    );
+
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
+    bytes32 public immutable DOMAIN_SEPARATOR;
 
+    mapping(address => uint256) public nonces;
     mapping(bytes32 => bool) public processedTransfers;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
@@ -16,42 +27,78 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes(NAME)),
+            keccak256(bytes(VERSION)),
+            block.chainid,
+            address(this)
+        ));
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
-        bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        uint256 transferNonce = nonces[msg.sender]++;
+        require(bridgeToken.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+        emit TransferInitiated(msg.sender, amount, targetChain, transferNonce);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
+        address sender,
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        require(transferNonce == nonces[sender], "Invalid nonce");
+
+        bytes32 transferHash = getTransferHash(sender, recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
 
         processedTransfers[transferHash] = true;
-        bridgeToken.transfer(recipient, amount);
+        nonces[sender] = transferNonce + 1;
+        require(bridgeToken.transfer(recipient, amount), "Transfer failed");
 
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
-    function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
+    function getNonce(address sender) external view returns (uint256) {
+        return nonces[sender];
+    }
+
+    function hashTransfer(
+        address sender,
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        return keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            sender,
+            recipient,
+            amount,
+            transferNonce,
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    function getTransferHash(
+        address sender,
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        return toTypedDataHash(hashTransfer(sender, recipient, amount, transferNonce));
+    }
+
+    function toTypedDataHash(bytes32 structHash) public view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+    }
+
+    function verifySignature(bytes32 digest, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
         bytes32 r;
@@ -65,13 +112,11 @@ contract CrossChainBridge {
         }
 
         if (v < 27) v += 27;
+        if (v != 27 && v != 28) return false;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(digest, v, r, s);
+        if (recovered == address(0)) return false;
 
-        // BUG: Missing require(recovered != address(0))
         return recovered == validator;
     }
 

--- a/solidity/tests/test_cross_chain_bridge.py
+++ b/solidity/tests/test_cross_chain_bridge.py
@@ -1,0 +1,215 @@
+from pathlib import Path
+
+import pytest
+from eth_account import Account
+from eth_keys import keys
+from eth_tester.exceptions import TransactionFailed
+from eth_utils import to_bytes
+from hexbytes import HexBytes
+from solcx import compile_standard, install_solc
+from web3 import EthereumTesterProvider, Web3
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "solidity" / "contracts" / "CrossChainBridge.sol"
+
+TOKEN_SOURCE = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract TestToken {
+    string public name = "Bridge Token";
+    string public symbol = "BRG";
+    uint8 public decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(uint256 supply) {
+        balanceOf[msg.sender] = supply;
+        totalSupply = supply;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+"""
+
+IERC20_SOURCE = """
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+"""
+
+
+@pytest.fixture(scope="session")
+def compiled_contracts():
+    install_solc("0.8.20")
+    compiled = compile_standard(
+        {
+            "language": "Solidity",
+            "sources": {
+                "CrossChainBridge.sol": {"content": CONTRACT.read_text(encoding="utf-8")},
+                "@openzeppelin/contracts/token/ERC20/IERC20.sol": {"content": IERC20_SOURCE},
+                "TestToken.sol": {"content": TOKEN_SOURCE},
+            },
+            "settings": {
+                "outputSelection": {"*": {"*": ["abi", "evm.bytecode.object"]}},
+            },
+        },
+        solc_version="0.8.20",
+    )
+    return compiled["contracts"]
+
+
+@pytest.fixture()
+def w3():
+    return Web3(EthereumTesterProvider())
+
+
+def deploy(w3, contract_def, args=(), sender=None):
+    sender = sender or w3.eth.accounts[0]
+    contract = w3.eth.contract(
+        abi=contract_def["abi"],
+        bytecode=contract_def["evm"]["bytecode"]["object"],
+    )
+    tx_hash = contract.constructor(*args).transact({"from": sender})
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+    return w3.eth.contract(address=receipt.contractAddress, abi=contract_def["abi"])
+
+
+@pytest.fixture()
+def bridge_setup(w3, compiled_contracts):
+    validator_key = Account.create().key
+    validator = Account.from_key(validator_key).address
+
+    token_def = compiled_contracts["TestToken.sol"]["TestToken"]
+    bridge_def = compiled_contracts["CrossChainBridge.sol"]["CrossChainBridge"]
+    token = deploy(w3, token_def, (10**24,))
+    bridge = deploy(w3, bridge_def, (token.address, validator))
+    token.functions.transfer(bridge.address, 1_000_000).transact({"from": w3.eth.accounts[0]})
+
+    return {
+        "w3": w3,
+        "token": token,
+        "bridge": bridge,
+        "validator_key": validator_key,
+        "validator": validator,
+    }
+
+
+def sign_digest(private_key, digest):
+    signature = keys.PrivateKey(to_bytes(private_key)).sign_msg_hash(HexBytes(digest))
+    return signature.r.to_bytes(32, "big") + signature.s.to_bytes(32, "big") + bytes([signature.v + 27])
+
+
+def sign_transfer(setup, sender, recipient, amount, nonce):
+    digest = setup["bridge"].functions.getTransferHash(sender, recipient, amount, nonce).call()
+    return sign_digest(setup["validator_key"], digest)
+
+
+def test_eip712_domain_separator_matches_contract_context(bridge_setup):
+    bridge = bridge_setup["bridge"]
+    assert bridge.functions.NAME().call() == "CrossChainBridge"
+    assert bridge.functions.VERSION().call() == "1"
+    assert bridge.functions.DOMAIN_SEPARATOR().call() != b"\x00" * 32
+
+
+def test_process_transfer_consumes_sender_nonce_and_blocks_same_chain_replay(bridge_setup):
+    bridge = bridge_setup["bridge"]
+    token = bridge_setup["token"]
+    sender = bridge_setup["w3"].eth.accounts[1]
+    recipient = bridge_setup["w3"].eth.accounts[2]
+    amount = 1234
+    nonce = bridge.functions.getNonce(sender).call()
+    signature = sign_transfer(bridge_setup, sender, recipient, amount, nonce)
+
+    bridge.functions.processTransfer(sender, recipient, amount, nonce, signature).transact(
+        {"from": bridge_setup["w3"].eth.accounts[0]}
+    )
+
+    assert bridge.functions.getNonce(sender).call() == nonce + 1
+    assert token.functions.balanceOf(recipient).call() == amount
+
+    with pytest.raises(TransactionFailed):
+        bridge.functions.processTransfer(sender, recipient, amount, nonce, signature).transact(
+            {"from": bridge_setup["w3"].eth.accounts[0]}
+        )
+
+
+def test_signature_is_bound_to_recipient_amount_chain_and_bridge(bridge_setup, compiled_contracts):
+    bridge = bridge_setup["bridge"]
+    sender = bridge_setup["w3"].eth.accounts[1]
+    recipient = bridge_setup["w3"].eth.accounts[2]
+    amount = 500
+    nonce = bridge.functions.getNonce(sender).call()
+    signature = sign_transfer(bridge_setup, sender, recipient, amount, nonce)
+
+    with pytest.raises(TransactionFailed):
+        bridge.functions.processTransfer(sender, bridge_setup["w3"].eth.accounts[3], amount, nonce, signature).transact(
+            {"from": bridge_setup["w3"].eth.accounts[0]}
+        )
+
+    with pytest.raises(TransactionFailed):
+        bridge.functions.processTransfer(sender, recipient, amount + 1, nonce, signature).transact(
+            {"from": bridge_setup["w3"].eth.accounts[0]}
+        )
+
+    bridge_def = compiled_contracts["CrossChainBridge.sol"]["CrossChainBridge"]
+    replacement = deploy(bridge_setup["w3"], bridge_def, (bridge_setup["token"].address, bridge_setup["validator"]))
+    with pytest.raises(TransactionFailed):
+        replacement.functions.processTransfer(sender, recipient, amount, nonce, signature).transact(
+            {"from": bridge_setup["w3"].eth.accounts[0]}
+        )
+
+
+def test_invalid_signature_and_zero_address_recovery_are_rejected(bridge_setup):
+    bridge = bridge_setup["bridge"]
+    sender = bridge_setup["w3"].eth.accounts[1]
+    recipient = bridge_setup["w3"].eth.accounts[2]
+    amount = 100
+    nonce = bridge.functions.getNonce(sender).call()
+    digest = bridge.functions.getTransferHash(sender, recipient, amount, nonce).call()
+
+    invalid_signature = b"\x00" * 65
+    assert bridge.functions.verifySignature(digest, invalid_signature).call() is False
+
+    with pytest.raises(TransactionFailed):
+        bridge.functions.processTransfer(sender, recipient, amount, nonce, invalid_signature).transact(
+            {"from": bridge_setup["w3"].eth.accounts[0]}
+        )
+
+
+def test_initiate_transfer_uses_queryable_sender_nonce(bridge_setup):
+    bridge = bridge_setup["bridge"]
+    token = bridge_setup["token"]
+    sender = bridge_setup["w3"].eth.accounts[0]
+
+    start_nonce = bridge.functions.getNonce(sender).call()
+    token.functions.approve(bridge.address, 100).transact({"from": sender})
+    bridge.functions.initiateTransfer(100, 8453).transact({"from": sender})
+
+    assert bridge.functions.getNonce(sender).call() == start_nonce + 1


### PR DESCRIPTION
/claim #920

## Summary
- Replaces the ad hoc signed message with an EIP-712 typed transfer digest bound to chain ID and the bridge contract address.
- Adds sender, recipient, amount, and per-sender nonce to the signed transfer struct.
- Adds queryable sender nonces and consumes the sender nonce during `processTransfer` to stop same-chain replay.
- Rejects invalid `v` values and zero-address `ecrecover` results.
- Checks ERC20 transfer return values.
- Adds focused Python regression tests for domain construction, same-chain replay, replacement-contract replay, invalid signatures, and queryable sender nonce behavior.
- Includes safe public `contributor_meta.json` metadata without publishing private runtime instructions, hidden configuration, secrets, or credentials.

## Local validation
- `git diff --check` passed.
- `contributor_meta.json` parses as JSON.
- `solidity/tests/test_cross_chain_bridge.py` parses with Python AST.
- Dependency-free static checks verified EIP-712 domain/type hash markers, sender nonce enforcement, typed-data hashing, invalid-v rejection, zero-address recovery rejection, and process-order invariants.
- Dependency-free replay model passed for same-chain nonce replay, cross-chain binding, replacement-contract binding, and new-nonce digest separation.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider solidity/tests/test_cross_chain_bridge.py` was attempted, but this bare checkout does not include the required Solidity test dependencies (`eth_account`, `eth_keys`, `eth_tester`, `web3`, `py-solc-x`), so collection stopped with `ModuleNotFoundError: No module named eth_account`.
