### PR TITLE
[OpenAI Codex] [ Laravel ] Implement webhook delivery system

### DIFF
--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class WebhookController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(Webhook::query()->latest()->get());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validated($request);
+        $data['secret'] ??= Str::random(40);
+        $data['active'] ??= true;
+
+        $webhook = Webhook::query()->create($data);
+
+        return response()->json($webhook, 201);
+    }
+
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json($webhook->load('deliveries'));
+    }
+
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $webhook->update($this->validated($request, true));
+
+        return response()->json($webhook->refresh());
+    }
+
+    public function destroy(Webhook $webhook): JsonResponse
+    {
+        $webhook->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validated(Request $request, bool $partial = false): array
+    {
+        $required = $partial ? 'sometimes' : 'required';
+
+        return $request->validate([
+            'url' => [$required, 'url'],
+            'secret' => ['sometimes', 'nullable', 'string', 'min:8'],
+            'events' => [$required, 'array', 'min:1'],
+            'events.*' => ['string', 'max:120'],
+            'active' => ['sometimes', 'boolean'],
+        ]);
+    }
+}

--- a/laravel/app/Jobs/DispatchWebhookJob.php
+++ b/laravel/app/Jobs/DispatchWebhookJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class DispatchWebhookJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 5;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        public int $webhookId,
+        public string $event,
+        public array $payload,
+        public ?int $deliveryId = null,
+    ) {
+        //
+    }
+
+    public function handle(WebhookDispatcher $dispatcher): void
+    {
+        $webhook = Webhook::query()->findOrFail($this->webhookId);
+        $delivery = $this->deliveryId ? WebhookDelivery::query()->find($this->deliveryId) : null;
+
+        $delivery = $dispatcher->send($webhook, $this->event, $this->payload, $delivery);
+        $this->deliveryId = $delivery->id;
+
+        if ($delivery->shouldRetry($this->tries)) {
+            $this->release($dispatcher->retryDelaySeconds($delivery->attempts));
+        }
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [60, 120, 240, 480, 960];
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Webhook extends Model
+{
+    /** @use HasFactory<\Database\Factories\WebhookFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'url',
+        'secret',
+        'events',
+        'active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'events' => 'array',
+            'active' => 'boolean',
+        ];
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebhookDelivery extends Model
+{
+    /** @use HasFactory<\Database\Factories\WebhookDeliveryFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'webhook_id',
+        'event',
+        'payload',
+        'response_code',
+        'attempts',
+        'next_retry_at',
+        'delivered_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'next_retry_at' => 'datetime',
+            'delivered_at' => 'datetime',
+        ];
+    }
+
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+
+    public function shouldRetry(int $maxAttempts = 5): bool
+    {
+        return $this->delivered_at === null && $this->attempts < $maxAttempts;
+    }
+}

--- a/laravel/app/Services/.attribution.json
+++ b/laravel/app/Services/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this public repository.",
+  "date": "2026-06-18T11:42:48+09:00"
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+class WebhookDispatcher
+{
+    public function dispatch(string $event, array $payload): void
+    {
+        Webhook::query()
+            ->where('active', true)
+            ->get()
+            ->filter(fn (Webhook $webhook): bool => in_array($event, $webhook->events ?? [], true))
+            ->each(fn (Webhook $webhook) => DispatchWebhookJob::dispatch($webhook->id, $event, $payload));
+    }
+
+    public function send(Webhook $webhook, string $event, array $payload, ?WebhookDelivery $delivery = null): WebhookDelivery
+    {
+        $delivery ??= WebhookDelivery::query()->create([
+            'webhook_id' => $webhook->id,
+            'event' => $event,
+            'payload' => $payload,
+            'attempts' => 0,
+        ]);
+
+        $body = $this->canonicalPayload($payload);
+        $signature = $this->signature($webhook->secret, $body);
+        $attempt = $delivery->attempts + 1;
+
+        try {
+            $response = Http::withHeaders([
+                'Content-Type' => 'application/json',
+                'X-Webhook-Event' => $event,
+                'X-Webhook-Signature' => $signature,
+            ])->withBody($body, 'application/json')->post($webhook->url);
+
+            $delivery->fill([
+                'response_code' => $response->status(),
+                'attempts' => $attempt,
+                'next_retry_at' => $response->successful() ? null : $this->nextRetryAt($attempt),
+                'delivered_at' => $response->successful() ? now() : null,
+            ])->save();
+        } catch (Throwable) {
+            $delivery->fill([
+                'response_code' => null,
+                'attempts' => $attempt,
+                'next_retry_at' => $this->nextRetryAt($attempt),
+            ])->save();
+        }
+
+        return $delivery->refresh();
+    }
+
+    public function canonicalPayload(array $payload): string
+    {
+        return json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+    }
+
+    public function signature(string $secret, string $body): string
+    {
+        return 'sha256='.hash_hmac('sha256', $body, $secret);
+    }
+
+    public function retryDelaySeconds(int $attempt): int
+    {
+        return min(3600, 60 * (2 ** max(0, $attempt - 1)));
+    }
+
+    public function nextRetryAt(int $attempt): Carbon
+    {
+        return now()->addSeconds($this->retryDelaySeconds($attempt));
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2026_06_18_024248_create_webhooks_table.php
+++ b/laravel/database/migrations/2026_06_18_024248_create_webhooks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/database/migrations/2026_06_18_024249_create_webhook_deliveries_table.php
+++ b/laravel/database/migrations/2026_06_18_024249_create_webhook_deliveries_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event');
+            $table->json('payload');
+            $table->unsignedSmallInteger('response_code')->nullable();
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable()->index();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\WebhookController;
+use Illuminate\Support\Facades\Route;
+
+Route::apiResource('webhooks', WebhookController::class);

--- a/laravel/tests/Feature/WebhookControllerTest.php
+++ b/laravel/tests/Feature/WebhookControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Webhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebhookControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_webhook_crud_endpoints(): void
+    {
+        $create = $this->postJson('/api/webhooks', [
+            'url' => 'https://example.test/hooks',
+            'secret' => 'top-secret',
+            'events' => ['user.created'],
+            'active' => true,
+        ])->assertCreated();
+
+        $id = $create->json('id');
+
+        $this->assertDatabaseHas('webhooks', [
+            'id' => $id,
+            'url' => 'https://example.test/hooks',
+            'active' => true,
+        ]);
+
+        $this->getJson('/api/webhooks')
+            ->assertOk()
+            ->assertJsonFragment(['url' => 'https://example.test/hooks']);
+
+        $this->patchJson("/api/webhooks/{$id}", [
+            'url' => 'https://example.test/updated',
+            'events' => ['invoice.paid'],
+            'active' => false,
+        ])->assertOk()
+            ->assertJsonPath('url', 'https://example.test/updated')
+            ->assertJsonPath('active', false);
+
+        $this->deleteJson("/api/webhooks/{$id}")->assertNoContent();
+
+        $this->assertDatabaseMissing('webhooks', ['id' => $id]);
+    }
+
+    public function test_show_endpoint_includes_delivery_history(): void
+    {
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.test/hooks',
+            'secret' => 'top-secret',
+            'events' => ['user.created'],
+            'active' => true,
+        ]);
+
+        $webhook->deliveries()->create([
+            'event' => 'user.created',
+            'payload' => ['id' => 123],
+            'attempts' => 1,
+            'response_code' => 204,
+            'delivered_at' => now(),
+        ]);
+
+        $this->getJson("/api/webhooks/{$webhook->id}")
+            ->assertOk()
+            ->assertJsonPath('deliveries.0.event', 'user.created')
+            ->assertJsonPath('deliveries.0.response_code', 204);
+    }
+}

--- a/laravel/tests/Unit/WebhookDispatcherTest.php
+++ b/laravel/tests/Unit/WebhookDispatcherTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Webhook;
+use App\Services\WebhookDispatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_signature_generation_uses_hmac_sha256(): void
+    {
+        $dispatcher = new WebhookDispatcher();
+        $body = '{"event":"user.created"}';
+
+        $this->assertSame(
+            'sha256='.hash_hmac('sha256', $body, 'top-secret'),
+            $dispatcher->signature('top-secret', $body),
+        );
+    }
+
+    public function test_retry_delay_uses_exponential_backoff(): void
+    {
+        $dispatcher = new WebhookDispatcher();
+
+        $this->assertSame(60, $dispatcher->retryDelaySeconds(1));
+        $this->assertSame(120, $dispatcher->retryDelaySeconds(2));
+        $this->assertSame(240, $dispatcher->retryDelaySeconds(3));
+        $this->assertSame(960, $dispatcher->retryDelaySeconds(5));
+    }
+
+    public function test_successful_delivery_is_signed_and_recorded(): void
+    {
+        Http::fake([
+            'example.test/*' => Http::response(['ok' => true], 204),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.test/hooks',
+            'secret' => 'top-secret',
+            'events' => ['user.created'],
+            'active' => true,
+        ]);
+
+        $dispatcher = new WebhookDispatcher();
+        $delivery = $dispatcher->send($webhook, 'user.created', ['id' => 123]);
+
+        Http::assertSent(function ($request): bool {
+            return $request->hasHeader('X-Webhook-Event', 'user.created')
+                && $request->hasHeader('X-Webhook-Signature', 'sha256='.hash_hmac('sha256', '{"id":123}', 'top-secret'))
+                && $request->body() === '{"id":123}';
+        });
+
+        $this->assertSame(204, $delivery->response_code);
+        $this->assertSame(1, $delivery->attempts);
+        $this->assertNotNull($delivery->delivered_at);
+        $this->assertNull($delivery->next_retry_at);
+    }
+
+    public function test_failed_delivery_records_next_retry(): void
+    {
+        Http::fake([
+            'example.test/*' => Http::response(['error' => true], 500),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.test/hooks',
+            'secret' => 'top-secret',
+            'events' => ['user.created'],
+            'active' => true,
+        ]);
+
+        $delivery = (new WebhookDispatcher())->send($webhook, 'user.created', ['id' => 123]);
+
+        $this->assertSame(500, $delivery->response_code);
+        $this->assertSame(1, $delivery->attempts);
+        $this->assertNull($delivery->delivered_at);
+        $this->assertNotNull($delivery->next_retry_at);
+        $this->assertTrue($delivery->shouldRetry());
+    }
+}


### PR DESCRIPTION
/claim #754

## Summary
- Adds Webhook and WebhookDelivery models, relationships, and migrations.
- Adds WebhookDispatcher with canonical JSON payloads, HMAC-SHA256 `X-Webhook-Signature`, delivery history, response codes, attempt counts, and exponential retry timing.
- Adds DispatchWebhookJob with max 5 attempts and retry release scheduling.
- Adds WebhookController CRUD endpoints through `/api/webhooks` and enables `routes/api.php` in the Laravel bootstrap routing config.
- Adds focused tests for signature generation, retry backoff, successful and failed delivery persistence, CRUD endpoints, and delivery-history loading.
- Includes safe public attribution metadata without publishing private runtime instructions, hidden configuration, secrets, or credentials.

## Local validation
- `git diff --check` passed.
- `laravel/app/Services/.attribution.json` parses as JSON.
- PHP lint passed for all changed PHP files.
- Static source checks verified HMAC header generation, SHA-256 signing, delivery attempts, retry delay logic, five job tries, API resource routing, API route bootstrap, and event validation.
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- `php artisan test --filter Webhook` passed: 6 tests, 28 assertions.
- Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.
