### PR TITLE
[OpenAI Codex] [ Laravel ] Add audit logging trait

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class AuditLog extends Model
+{
+    protected $fillable = [
+        'auditable_type',
+        'auditable_id',
+        'event',
+        'old_values',
+        'new_values',
+        'user_id',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/.provenance.json
+++ b/laravel/app/Traits/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this public repository.",
+  "created": "2026-06-18T11:52:34+09:00"
+}

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Arr;
+
+trait Auditable
+{
+    public static function bootAuditable(): void
+    {
+        static::created(function (Model $model): void {
+            $model->writeAuditLog('created', [], $model->auditableValues($model->getAttributes()));
+        });
+
+        static::updated(function (Model $model): void {
+            $changedKeys = array_keys($model->getChanges());
+            $oldValues = $model->auditableValues(Arr::only($model->getOriginal(), $changedKeys));
+            $newValues = $model->auditableValues(Arr::only($model->getAttributes(), $changedKeys));
+
+            if ($oldValues !== [] || $newValues !== []) {
+                $model->writeAuditLog('updated', $oldValues, $newValues);
+            }
+        });
+
+        static::deleted(function (Model $model): void {
+            $model->writeAuditLog('deleted', $model->auditableValues($model->getOriginal()), []);
+        });
+    }
+
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    public function getAuditHistory()
+    {
+        return $this->auditLogs()
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    /**
+     * @param array<string, mixed> $oldValues
+     * @param array<string, mixed> $newValues
+     */
+    protected function writeAuditLog(string $event, array $oldValues, array $newValues): void
+    {
+        AuditLog::query()->create([
+            'auditable_type' => $this->getMorphClass(),
+            'auditable_id' => $this->getKey(),
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => auth()->id(),
+            'ip_address' => request()?->ip(),
+            'user_agent' => request()?->userAgent(),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     * @return array<string, mixed>
+     */
+    protected function auditableValues(array $values): array
+    {
+        return Arr::except($values, $this->auditExcludedFields());
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function auditExcludedFields(): array
+    {
+        return array_values(array_unique(array_merge([
+            'password',
+            'remember_token',
+        ], property_exists($this, 'hidden') ? $this->hidden : [])));
+    }
+}

--- a/laravel/database/migrations/2026_06_18_025234_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_06_18_025234_create_audit_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->unsignedBigInteger('auditable_id');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->foreignIdFor(User::class)->nullable()->constrained()->nullOnDelete();
+            $table->string('ip_address')->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditLoggingTest.php
+++ b/laravel/tests/Feature/AuditLoggingTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AuditLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_user_generates_audit_log_without_sensitive_fields(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.test',
+            'password' => Hash::make('secret-password'),
+        ]);
+
+        $log = AuditLog::query()->where('event', 'created')->firstOrFail();
+
+        $this->assertSame(User::class, $log->auditable_type);
+        $this->assertSame($user->id, $log->auditable_id);
+        $this->assertSame('Ada Lovelace', $log->new_values['name']);
+        $this->assertSame('ada@example.test', $log->new_values['email']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+        $this->assertSame([], $log->old_values);
+    }
+
+    public function test_updating_user_records_old_and_new_changed_values(): void
+    {
+        $user = User::factory()->create(['name' => 'Before']);
+        AuditLog::query()->delete();
+
+        $user->update(['name' => 'After']);
+
+        $log = AuditLog::query()->where('event', 'updated')->firstOrFail();
+
+        $this->assertSame('Before', $log->old_values['name']);
+        $this->assertSame('After', $log->new_values['name']);
+        $this->assertArrayNotHasKey('password', $log->old_values);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+    }
+
+    public function test_deleting_user_records_old_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Delete Me',
+            'email' => 'delete@example.test',
+        ]);
+        AuditLog::query()->delete();
+
+        $user->delete();
+
+        $log = AuditLog::query()->where('event', 'deleted')->firstOrFail();
+
+        $this->assertSame('Delete Me', $log->old_values['name']);
+        $this->assertSame('delete@example.test', $log->old_values['email']);
+        $this->assertSame([], $log->new_values);
+        $this->assertArrayNotHasKey('password', $log->old_values);
+    }
+
+    public function test_audit_logs_include_authenticated_user_and_request_metadata(): void
+    {
+        config(['app.key' => 'base64:'.base64_encode(str_repeat('a', 32))]);
+
+        $actor = User::factory()->create();
+        AuditLog::query()->delete();
+
+        $this->actingAs($actor)
+            ->withHeader('User-Agent', 'AuditTest/1.0')
+            ->get('/');
+
+        User::factory()->create();
+
+        $log = AuditLog::query()->where('event', 'created')->firstOrFail();
+
+        $this->assertSame($actor->id, $log->user_id);
+        $this->assertSame('127.0.0.1', $log->ip_address);
+        $this->assertSame('AuditTest/1.0', $log->user_agent);
+    }
+
+    public function test_get_audit_history_returns_reverse_chronological_logs(): void
+    {
+        $user = User::factory()->create(['name' => 'One']);
+        $user->update(['name' => 'Two']);
+        $user->update(['name' => 'Three']);
+
+        $history = $user->getAuditHistory();
+
+        $this->assertGreaterThanOrEqual(3, $history->count());
+        $this->assertSame(['updated', 'updated', 'created'], $history->take(3)->pluck('event')->all());
+    }
+}


### PR DESCRIPTION
/claim #786

## Summary
- Adds an AuditLog model and migration for created/updated/deleted model-change records.
- Adds an Auditable trait that hooks Eloquent created, updated, and deleted events.
- Filters sensitive fields such as `password` and `remember_token` from audit values.
- Captures authenticated user ID, request IP, and user-agent metadata when available.
- Adds reverse-chronological `getAuditHistory()` and `auditLogs()` relationship helpers.
- Applies the trait to the User model as the example implementation.
- Adds focused feature tests for create/update/delete logs, sensitive-field exclusion, authenticated user/request metadata, and audit history ordering.
- Includes safe public provenance metadata without publishing private runtime instructions, hidden configuration, secrets, or credentials.

## Local validation
- `git diff --check` passed.
- `laravel/app/Traits/.provenance.json` parses as JSON.
- PHP lint passed for all changed PHP files.
- Static checks verified created/updated/deleted hooks, sensitive-field exclusion, auth/request metadata capture, reverse history ordering, User trait wiring, and delete coverage.
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- `php artisan test --filter AuditLogging` passed: 5 tests, 20 assertions.
- Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.
