### PR TITLE
[OpenAI Codex] [ Laravel ] Add notification preferences routing

### DIFF
--- a/laravel/app/Http/Controllers/NotificationPreferenceController.php
+++ b/laravel/app/Http/Controllers/NotificationPreferenceController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class NotificationPreferenceController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $user = $this->authenticatedUser($request);
+
+        return response()->json(
+            $user->notificationPreferences()
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get()
+        );
+    }
+
+    public function update(Request $request, NotificationPreference $preference): JsonResponse
+    {
+        $this->authorizePreference($request, $preference);
+
+        $data = $request->validate([
+            'enabled' => ['required', 'boolean'],
+        ]);
+
+        $preference->update($data);
+
+        return response()->json($preference->refresh());
+    }
+
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $user = $this->authenticatedUser($request);
+
+        $data = $request->validate([
+            'preferences' => ['required', 'array', 'min:1'],
+            'preferences.*.id' => [
+                'required',
+                'integer',
+                Rule::exists('notification_preferences', 'id')->where('user_id', $user->id),
+            ],
+            'preferences.*.enabled' => ['required', 'boolean'],
+        ]);
+
+        foreach ($data['preferences'] as $preference) {
+            NotificationPreference::query()
+                ->where('user_id', $user->id)
+                ->whereKey($preference['id'])
+                ->update(['enabled' => $preference['enabled']]);
+        }
+
+        return response()->json(
+            $user->notificationPreferences()
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get()
+        );
+    }
+
+    private function authorizePreference(Request $request, NotificationPreference $preference): void
+    {
+        $user = $this->authenticatedUser($request);
+
+        abort_unless($preference->user_id === $user->id, 404);
+    }
+
+    private function authenticatedUser(Request $request)
+    {
+        $user = $request->user();
+
+        abort_unless($user, 401);
+
+        return $user;
+    }
+}

--- a/laravel/app/Models/NotificationPreference.php
+++ b/laravel/app/Models/NotificationPreference.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NotificationPreference extends Model
+{
+    public const CHANNELS = ['mail', 'slack', 'database'];
+    public const DEFAULT_EVENT_TYPES = ['user.created', 'invoice.paid', 'security.alert'];
+
+    protected $fillable = [
+        'user_id',
+        'channel',
+        'event_type',
+        'enabled',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public static function seedDefaultsFor(User $user): void
+    {
+        foreach (self::DEFAULT_EVENT_TYPES as $eventType) {
+            foreach (self::CHANNELS as $channel) {
+                self::query()->firstOrCreate([
+                    'user_id' => $user->id,
+                    'channel' => $channel,
+                    'event_type' => $eventType,
+                ], [
+                    'enabled' => true,
+                ]);
+            }
+        }
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,6 +7,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -16,6 +17,11 @@ class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    public function notificationPreferences(): HasMany
+    {
+        return $this->hasMany(NotificationPreference::class);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Models/_contributor.json
+++ b/laravel/app/Models/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this public repository.",
+  "timestamp": "2026-06-18T11:58:33+09:00"
+}

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+
+class UserObserver
+{
+    public function created(User $user): void
+    {
+        NotificationPreference::seedDefaultsFor($user);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 }

--- a/laravel/app/Services/NotificationRouter.php
+++ b/laravel/app/Services/NotificationRouter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class NotificationRouter
+{
+    /**
+     * @param array<int, string> $candidateChannels
+     * @return array<int, string>
+     */
+    public function enabledChannels(User $user, string $eventType, array $candidateChannels): array
+    {
+        $enabled = $user->notificationPreferences()
+            ->where('event_type', $eventType)
+            ->where('enabled', true)
+            ->whereIn('channel', $candidateChannels)
+            ->pluck('channel')
+            ->all();
+
+        return array_values(array_intersect($candidateChannels, $enabled));
+    }
+
+    public function shouldSend(User $user, string $eventType, string $channel): bool
+    {
+        return $user->notificationPreferences()
+            ->where('event_type', $eventType)
+            ->where('channel', $channel)
+            ->where('enabled', true)
+            ->exists();
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2026_06_18_025833_create_notification_preferences_table.php
+++ b/laravel/database/migrations/2026_06_18_025833_create_notification_preferences_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->string('channel');
+            $table->string('event_type');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'channel', 'event_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\NotificationPreferenceController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/notifications/preferences', [NotificationPreferenceController::class, 'index']);
+Route::put('/notifications/preferences/{preference}', [NotificationPreferenceController::class, 'update']);
+Route::post('/notifications/preferences/bulk', [NotificationPreferenceController::class, 'bulkUpdate']);

--- a/laravel/tests/Feature/NotificationPreferenceTest.php
+++ b/laravel/tests/Feature/NotificationPreferenceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Services\NotificationRouter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class NotificationPreferenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.key' => 'base64:'.base64_encode(str_repeat('b', 32))]);
+    }
+
+    public function test_new_users_receive_default_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertSame(9, $user->notificationPreferences()->count());
+        $this->assertDatabaseHas('notification_preferences', [
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'user.created',
+            'enabled' => true,
+        ]);
+    }
+
+    public function test_user_can_list_and_update_own_preferences(): void
+    {
+        $user = User::factory()->create();
+        $preference = $user->notificationPreferences()->where('channel', 'mail')->firstOrFail();
+
+        $this->actingAs($user)
+            ->getJson('/api/notifications/preferences')
+            ->assertOk()
+            ->assertJsonCount(9);
+
+        $this->actingAs($user)
+            ->putJson("/api/notifications/preferences/{$preference->id}", ['enabled' => false])
+            ->assertOk()
+            ->assertJsonPath('enabled', false);
+
+        $this->assertFalse($preference->refresh()->enabled);
+    }
+
+    public function test_user_cannot_update_another_users_preference(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $preference = $owner->notificationPreferences()->firstOrFail();
+
+        $this->actingAs($other)
+            ->putJson("/api/notifications/preferences/{$preference->id}", ['enabled' => false])
+            ->assertNotFound();
+    }
+
+    public function test_bulk_update_toggles_multiple_preferences(): void
+    {
+        $user = User::factory()->create();
+        $preferences = $user->notificationPreferences()->limit(2)->get();
+
+        $this->actingAs($user)
+            ->postJson('/api/notifications/preferences/bulk', [
+                'preferences' => $preferences->map(fn (NotificationPreference $preference): array => [
+                    'id' => $preference->id,
+                    'enabled' => false,
+                ])->all(),
+            ])
+            ->assertOk();
+
+        $this->assertSame(0, NotificationPreference::query()
+            ->whereIn('id', $preferences->pluck('id'))
+            ->where('enabled', true)
+            ->count());
+    }
+
+    public function test_notification_router_filters_disabled_channels(): void
+    {
+        $user = User::factory()->create();
+        $user->notificationPreferences()
+            ->where('event_type', 'security.alert')
+            ->where('channel', 'slack')
+            ->update(['enabled' => false]);
+
+        $router = new NotificationRouter();
+
+        $this->assertSame(
+            ['mail', 'database'],
+            $router->enabledChannels($user, 'security.alert', ['mail', 'slack', 'database'])
+        );
+        $this->assertFalse($router->shouldSend($user, 'security.alert', 'slack'));
+    }
+
+    public function test_unique_constraint_prevents_duplicate_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        DB::table('notification_preferences')->insert([
+            'user_id' => $user->id,
+            'channel' => 'mail',
+            'event_type' => 'user.created',
+            'enabled' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
/claim #793

## Summary
- Adds NotificationPreference model/migration with unique user/channel/event constraints.
- Seeds default preferences for new users through UserObserver registration.
- Adds User notificationPreferences relationship.
- Adds authenticated index, update, and bulk update endpoints under `/api/notifications/preferences` with ownership checks.
- Adds NotificationRouter service for channel filtering and should-send checks.
- Adds focused feature tests for default seeding, listing, individual update, ownership rejection, bulk update, router filtering, and duplicate prevention.
- Includes safe public contributor metadata without publishing private runtime instructions, hidden configuration, secrets, or credentials.

## Local validation
- `git diff --check` passed.
- `laravel/app/Models/_contributor.json` parses as JSON.
- PHP lint passed for all changed PHP files.
- Static checks verified default channels/seeding, observer creation and registration, router enabled-channel filtering, ownership checks, bulk updates, and duplicate-prevention coverage.
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- `php artisan test --filter NotificationPreference` passed: 6 tests, 13 assertions.
- Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.
