### PR TITLE
[OpenAI Codex] [ Laravel ] Implement file upload system

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Safe public metadata only. Private system, developer, runtime, and user instructions were intentionally not copied into this public repository.",
+  "date": "2026-06-18T12:05:32+09:00"
+}

--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File as StoredFile;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class FileController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(StoredFile::query()->latest()->paginate(20));
+    }
+
+    public function upload(Request $request): JsonResponse
+    {
+        $request->validate([
+            'file' => ['required', 'file', 'max:10240'],
+        ]);
+
+        $upload = $request->file('file');
+        $checksum = hash_file('sha256', $upload->getRealPath());
+
+        if (StoredFile::query()->where('checksum_sha256', $checksum)->exists()) {
+            return response()->json(['message' => 'Duplicate file checksum'], 409);
+        }
+
+        if ($this->containsVirusSignature($upload->getRealPath())) {
+            return response()->json(['message' => 'File failed virus scan'], 422);
+        }
+
+        $storedPath = $upload->storeAs(
+            'uploads/'.now()->format('Y/m/d'),
+            (string) Str::uuid().'.'.$upload->getClientOriginalExtension(),
+            'local'
+        );
+
+        $file = StoredFile::query()->create([
+            'original_name' => $upload->getClientOriginalName(),
+            'stored_path' => $storedPath,
+            'mime_type' => $upload->getMimeType() ?: 'application/octet-stream',
+            'size_bytes' => $upload->getSize(),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => $request->user()?->id,
+            'thumbnail_path' => null,
+        ]);
+
+        if (str_starts_with($file->mime_type, 'image/')) {
+            $file->forceFill([
+                'thumbnail_path' => $this->generateThumbnail($file),
+            ])->save();
+        }
+
+        return response()->json($file->refresh(), 201);
+    }
+
+    public function download(StoredFile $file): BinaryFileResponse
+    {
+        abort_unless(Storage::disk('local')->exists($file->stored_path), 404);
+
+        return response()->download(
+            Storage::disk('local')->path($file->stored_path),
+            $file->original_name,
+            ['Content-Type' => $file->mime_type]
+        );
+    }
+
+    public function destroy(StoredFile $file): Response
+    {
+        Storage::disk('local')->delete(array_filter([
+            $file->stored_path,
+            $file->thumbnail_path,
+        ]));
+
+        $file->delete();
+
+        return response()->noContent();
+    }
+
+    private function containsVirusSignature(string $path): bool
+    {
+        $contents = file_get_contents($path);
+
+        return $contents !== false && str_contains($contents, 'EICAR-STANDARD-ANTIVIRUS-TEST-FILE');
+    }
+
+    private function generateThumbnail(StoredFile $file): string
+    {
+        $source = imagecreatefromstring(Storage::disk('local')->get($file->stored_path));
+        abort_unless($source !== false, 422, 'Image thumbnail generation failed');
+
+        $thumbnail = imagecreatetruecolor(200, 200);
+        imagealphablending($thumbnail, false);
+        imagesavealpha($thumbnail, true);
+
+        $width = imagesx($source);
+        $height = imagesy($source);
+        imagecopyresampled($thumbnail, $source, 0, 0, 0, 0, 200, 200, $width, $height);
+
+        $thumbnailPath = 'thumbnails/'.now()->format('Y/m/d').'/'.Str::uuid().'.png';
+        $absolutePath = Storage::disk('local')->path($thumbnailPath);
+
+        if (! is_dir(dirname($absolutePath))) {
+            mkdir(dirname($absolutePath), 0755, true);
+        }
+
+        imagepng($thumbnail, $absolutePath);
+        imagedestroy($source);
+        imagedestroy($thumbnail);
+
+        return $thumbnailPath;
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class File extends Model
+{
+    protected $fillable = [
+        'original_name',
+        'stored_path',
+        'mime_type',
+        'size_bytes',
+        'checksum_sha256',
+        'uploaded_by',
+        'thumbnail_path',
+    ];
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by');
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,8 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
+        apiPrefix: '',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2026_06_18_030532_create_files_table.php
+++ b/laravel/database/migrations/2026_06_18_030532_create_files_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size_bytes');
+            $table->string('checksum_sha256', 64)->unique();
+            $table->foreignIdFor(User::class, 'uploaded_by')->nullable()->constrained()->nullOnDelete();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Http\Controllers\FileController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/files', [FileController::class, 'index']);
+Route::post('/files/upload', [FileController::class, 'upload']);
+Route::get('/files/{file}/download', [FileController::class, 'download']);
+Route::delete('/files/{file}', [FileController::class, 'destroy']);

--- a/laravel/tests/Feature/FileUploadTest.php
+++ b/laravel/tests/Feature/FileUploadTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File as StoredFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FileUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+    }
+
+    public function test_image_upload_stores_metadata_checksum_and_thumbnail(): void
+    {
+        $upload = $this->imageUpload('photo.png');
+        $checksum = hash_file('sha256', $upload->getRealPath());
+
+        $response = $this->post('/files/upload', ['file' => $upload])
+            ->assertCreated();
+
+        $file = StoredFile::query()->firstOrFail();
+
+        $response->assertJsonPath('id', $file->id);
+        $this->assertSame('photo.png', $file->original_name);
+        $this->assertSame('image/png', $file->mime_type);
+        $this->assertSame($checksum, $file->checksum_sha256);
+        $this->assertNotNull($file->thumbnail_path);
+        Storage::disk('local')->assertExists($file->stored_path);
+        Storage::disk('local')->assertExists($file->thumbnail_path);
+
+        [$width, $height] = getimagesize(Storage::disk('local')->path($file->thumbnail_path));
+        $this->assertSame([200, 200], [$width, $height]);
+    }
+
+    public function test_duplicate_checksum_is_rejected_and_non_image_has_no_thumbnail(): void
+    {
+        $this->post('/files/upload', ['file' => $this->textUpload('note.txt', 'same-content')])
+            ->assertCreated()
+            ->assertJsonPath('thumbnail_path', null);
+
+        $this->post('/files/upload', ['file' => $this->textUpload('copy.txt', 'same-content')])
+            ->assertConflict()
+            ->assertJsonPath('message', 'Duplicate file checksum');
+
+        $this->assertSame(1, StoredFile::query()->count());
+    }
+
+    public function test_virus_signature_is_rejected(): void
+    {
+        $this->post('/files/upload', [
+            'file' => $this->textUpload('eicar.txt', 'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'),
+        ])->assertUnprocessable()
+            ->assertJsonPath('message', 'File failed virus scan');
+    }
+
+    public function test_download_streams_file_with_content_type(): void
+    {
+        $this->post('/files/upload', ['file' => $this->textUpload('note.txt', 'download me')])
+            ->assertCreated();
+        $file = StoredFile::query()->firstOrFail();
+
+        $response = $this->get("/files/{$file->id}/download")
+            ->assertOk()
+            ->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+
+        $this->assertSame('download me', $response->streamedContent());
+    }
+
+    public function test_delete_removes_file_thumbnail_and_database_record(): void
+    {
+        $this->post('/files/upload', ['file' => $this->imageUpload('delete.png')])
+            ->assertCreated();
+        $file = StoredFile::query()->firstOrFail();
+
+        $this->delete("/files/{$file->id}")->assertNoContent();
+
+        Storage::disk('local')->assertMissing($file->stored_path);
+        Storage::disk('local')->assertMissing($file->thumbnail_path);
+        $this->assertDatabaseMissing('files', ['id' => $file->id]);
+    }
+
+    public function test_list_endpoint_paginates_twenty_files_per_page(): void
+    {
+        for ($i = 0; $i < 25; $i++) {
+            StoredFile::query()->create([
+                'original_name' => "file-{$i}.txt",
+                'stored_path' => "uploads/test/file-{$i}.txt",
+                'mime_type' => 'text/plain',
+                'size_bytes' => 10,
+                'checksum_sha256' => hash('sha256', "file-{$i}"),
+            ]);
+        }
+
+        $this->get('/files')
+            ->assertOk()
+            ->assertJsonCount(20, 'data')
+            ->assertJsonPath('per_page', 20)
+            ->assertJsonPath('total', 25);
+    }
+
+    private function textUpload(string $name, string $content): UploadedFile
+    {
+        $path = tempnam(sys_get_temp_dir(), 'upload-');
+        file_put_contents($path, $content);
+
+        return new UploadedFile($path, $name, 'text/plain', null, true);
+    }
+
+    private function imageUpload(string $name): UploadedFile
+    {
+        $path = tempnam(sys_get_temp_dir(), 'upload-').'.png';
+        $image = imagecreatetruecolor(300, 300);
+        imagefilledrectangle($image, 0, 0, 300, 300, imagecolorallocate($image, 20, 120, 180));
+        imagepng($image, $path);
+        imagedestroy($image);
+
+        return new UploadedFile($path, $name, 'image/png', null, true);
+    }
+}


### PR DESCRIPTION
/claim #790

## Summary
- Adds File model and migration with original filename, stored path, MIME type, byte size, SHA-256 checksum, nullable uploader, nullable thumbnail, and timestamps.
- Adds FileController upload, list, download, and delete actions.
- Stores uploads under date-organized `uploads/YYYY/MM/DD` paths on the local disk.
- Computes SHA-256 checksums and rejects duplicate uploads with 409 Conflict.
- Adds a lightweight EICAR signature check for upload scanning.
- Generates 200x200 PNG thumbnails with GD for image uploads under `thumbnails/YYYY/MM/DD`.
- Streams downloads with the stored Content-Type header and removes stored files/thumbnails on delete.
- Adds literal `/files`, `/files/upload`, `/files/{id}/download`, and `/files/{id}` routes by enabling API routes with an empty API prefix.
- Adds focused feature tests for image metadata/thumbnails, duplicate rejection, virus signature rejection, download headers/content, delete cleanup, and 20-item pagination.
- Includes safe public generation metadata without publishing private runtime instructions, hidden configuration, secrets, or credentials.

## Local validation
- `git diff --check` passed.
- `laravel/app/Http/Controllers/.generation_meta.json` parses as JSON.
- PHP lint passed for all changed PHP files.
- Static checks verified upload/download routes, checksum generation, duplicate conflict handling, virus signature check, GD thumbnail generation, pagination, storage delete cleanup, and thumbnail dimension coverage.
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- `php artisan test --filter FileUpload` passed: 6 tests, 31 assertions.
- Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.
