### PR TITLE
[Codex GPT-5] [ Laravel ] Add cache health checks

### DIFF
--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status {--force : Bypass the cached health result}';
+
+    protected $description = 'Report availability for the configured cache store.';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $result = $healthCheck->check((bool) $this->option('force'));
+
+        $this->line(sprintf('Driver: %s', $result['driver']));
+        $this->line(sprintf('Store: %s', $result['store']));
+        $this->line(sprintf('Available: %s', $result['available'] ? 'yes' : 'no'));
+        $this->line(sprintf('Latency: %.2f ms', $result['latency_ms']));
+
+        if (($result['skipped'] ?? false) === true) {
+            $this->warn($result['message'] ?? 'Cache health checks are disabled.');
+        } elseif (! $result['available'] && isset($result['message'])) {
+            $this->error($result['message']);
+        }
+
+        return $result['available'] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +12,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(CacheHealthCheck::class);
     }
 
     /**

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Throwable;
+
+class CacheHealthCheck
+{
+    private ?array $lastResult = null;
+
+    private ?float $lastCheckedAt = null;
+
+    public function __construct(private readonly CacheFactory $cache) {}
+
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float, store: string, checked_at: string, skipped?: bool, message?: string}
+     */
+    public function check(bool $force = false): array
+    {
+        $store = $this->storeName();
+        $driver = $this->driverFor($store);
+
+        if (! (bool) config('cache.health_check_enabled', true)) {
+            return $this->remember([
+                'available' => true,
+                'driver' => $driver,
+                'latency_ms' => 0.0,
+                'store' => $store,
+                'checked_at' => now()->toIso8601String(),
+                'skipped' => true,
+                'message' => 'Cache health checks are disabled.',
+            ]);
+        }
+
+        $now = microtime(true);
+        $interval = max(0, (int) config('cache.health_check_interval', 300));
+
+        if (! $force && $interval > 0 && $this->lastResult !== null && $this->lastCheckedAt !== null) {
+            if (($now - $this->lastCheckedAt) < $interval) {
+                return $this->lastResult;
+            }
+        }
+
+        $startedAt = hrtime(true);
+
+        try {
+            $repository = $this->cache->store($store);
+            $key = sprintf('cache-health:%s:%s', $store, bin2hex(random_bytes(8)));
+            $value = bin2hex(random_bytes(16));
+
+            $repository->put($key, $value, 30);
+            $storedValue = $repository->get($key);
+            $repository->forget($key);
+
+            if ($storedValue !== $value) {
+                return $this->remember($this->result(
+                    false,
+                    $driver,
+                    $store,
+                    $startedAt,
+                    'Cache round-trip validation failed.'
+                ));
+            }
+
+            return $this->remember($this->result(true, $driver, $store, $startedAt));
+        } catch (Throwable $throwable) {
+            return $this->remember($this->result(
+                false,
+                $driver,
+                $store,
+                $startedAt,
+                $throwable->getMessage()
+            ));
+        }
+    }
+
+    private function remember(array $result): array
+    {
+        $this->lastResult = $result;
+        $this->lastCheckedAt = microtime(true);
+
+        return $result;
+    }
+
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float, store: string, checked_at: string, message?: string}
+     */
+    private function result(bool $available, string $driver, string $store, int $startedAt, ?string $message = null): array
+    {
+        $result = [
+            'available' => $available,
+            'driver' => $driver,
+            'latency_ms' => round((hrtime(true) - $startedAt) / 1_000_000, 2),
+            'store' => $store,
+            'checked_at' => now()->toIso8601String(),
+        ];
+
+        if ($message !== null) {
+            $result['message'] = $message;
+        }
+
+        return $result;
+    }
+
+    private function storeName(): string
+    {
+        return (string) config('cache.default', 'array');
+    }
+
+    private function driverFor(string $store): string
+    {
+        $driver = config("cache.stores.{$store}.driver");
+
+        return is_string($driver) && $driver !== '' ? $driver : 'unknown';
+    }
+}

--- a/laravel/app/Services/_provenance.json
+++ b/laravel/app/Services/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #747 cache health checks for the Laravel app.",
+  "timestamp": "2026-06-18T03:20:00+09:00"
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\CacheStatusCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -10,6 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        CacheStatusCommand::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -19,6 +19,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Health Checks
+    |--------------------------------------------------------------------------
+    |
+    | These values control the lightweight cache round-trip probe used by the
+    | cache:status command and the /health/cache endpoint.
+    |
+    */
+
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Stores
     |--------------------------------------------------------------------------
     |

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Services\CacheHealthCheck;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    $result = $healthCheck->check();
+
+    return response()->json($result, $result['available'] ? 200 : 503);
 });

--- a/laravel/tests/Feature/CacheHealthEndpointTest.php
+++ b/laravel/tests/Feature/CacheHealthEndpointTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class CacheHealthEndpointTest extends TestCase
+{
+    public function test_cache_health_endpoint_returns_ok_when_cache_is_available(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertOk()
+            ->assertJson([
+                'available' => true,
+                'driver' => 'array',
+                'store' => 'array',
+            ])
+            ->assertJsonStructure([
+                'available',
+                'driver',
+                'latency_ms',
+                'store',
+                'checked_at',
+            ]);
+    }
+
+    public function test_cache_health_endpoint_returns_service_unavailable_when_cache_is_unavailable(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertServiceUnavailable()
+            ->assertJson([
+                'available' => false,
+                'driver' => 'unknown',
+                'store' => 'missing-store',
+            ]);
+    }
+}

--- a/laravel/tests/Feature/CacheStatusCommandTest.php
+++ b/laravel/tests/Feature/CacheStatusCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class CacheStatusCommandTest extends TestCase
+{
+    public function test_cache_status_command_outputs_driver_availability_and_latency(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $exitCode = Artisan::call('cache:status', ['--force' => true]);
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Driver: array', $output);
+        $this->assertStringContainsString('Available: yes', $output);
+        $this->assertStringContainsString('Latency:', $output);
+    }
+
+    public function test_cache_status_command_fails_when_store_is_unavailable(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $exitCode = Artisan::call('cache:status', ['--force' => true]);
+        $output = Artisan::output();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Driver: unknown', $output);
+        $this->assertStringContainsString('Available: no', $output);
+    }
+}

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    public function test_it_reports_the_active_cache_store_as_available(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 300,
+        ]);
+
+        $result = app(CacheHealthCheck::class)->check(force: true);
+
+        $this->assertTrue($result['available']);
+        $this->assertSame('array', $result['driver']);
+        $this->assertSame('array', $result['store']);
+        $this->assertArrayHasKey('latency_ms', $result);
+        $this->assertGreaterThanOrEqual(0, $result['latency_ms']);
+    }
+
+    public function test_it_reports_an_unavailable_store_without_throwing(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 0,
+        ]);
+
+        $result = app(CacheHealthCheck::class)->check(force: true);
+
+        $this->assertFalse($result['available']);
+        $this->assertSame('unknown', $result['driver']);
+        $this->assertSame('missing-store', $result['store']);
+        $this->assertArrayHasKey('message', $result);
+    }
+
+    public function test_it_reuses_the_last_result_inside_the_configured_interval(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 300,
+        ]);
+
+        $healthCheck = app(CacheHealthCheck::class);
+        $firstResult = $healthCheck->check(force: true);
+
+        config(['cache.default' => 'missing-store']);
+
+        $cachedResult = $healthCheck->check();
+        $forcedResult = $healthCheck->check(force: true);
+
+        $this->assertTrue($cachedResult['available']);
+        $this->assertSame($firstResult['store'], $cachedResult['store']);
+        $this->assertFalse($forcedResult['available']);
+    }
+
+    public function test_it_marks_health_check_as_skipped_when_disabled(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_enabled' => false,
+        ]);
+
+        $result = app(CacheHealthCheck::class)->check(force: true);
+
+        $this->assertTrue($result['available']);
+        $this->assertTrue($result['skipped']);
+        $this->assertSame('missing-store', $result['store']);
+    }
+}


### PR DESCRIPTION
/claim #747

Summary:
- Added `App\Services\CacheHealthCheck` to validate the active cache store with a lightweight write/read/delete round trip and return `available`, `driver`, `latency_ms`, `store`, and timestamp details.
- Registered a `cache:status` Artisan command that prints driver, store, availability, and latency and exits non-zero when the active store is unavailable.
- Added `GET /health/cache` JSON health endpoint with HTTP 200 for available stores and HTTP 503 for unavailable stores.
- Added `cache.health_check_enabled` and `cache.health_check_interval` config values with in-process interval reuse.
- Added focused service, command, and endpoint tests.
- Included `laravel/app/Services/_provenance.json` with public-safe metadata only; private platform/session instructions are intentionally not copied.

Validation:
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- PHP lint passed for all changed PHP files.
- `php artisan test --filter Cache` passed: 8 tests, 32 assertions.
- `php artisan test` passed: 10 tests, 34 assertions.
- `vendor/bin/pint --test ...` passed for touched PHP files.
- `git diff --check` passed.
- `laravel/app/Services/_provenance.json` parses as JSON.
- `CACHE_STORE=array php artisan cache:status --force` reports available with driver/store `array`.
- With the repository default `database` cache store and no sqlite database file, `php artisan cache:status --force` reports unavailable and exits non-zero as expected.

Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.