### PR TITLE
[Codex GPT-5] [ Laravel ] Add email verification flow

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "environment_config": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #756 email verification and mail fallback behavior for the Laravel app.",
+  "completed_at": "2026-06-18T03:35:00+09:00"
+}

--- a/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
+++ b/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureEmailIsVerified
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next, ?string $redirectToRoute = null): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ($user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail())) {
+            if ($request->expectsJson()) {
+                abort(403, 'Your email address is not verified.');
+            }
+
+            return Redirect::route($redirectToRoute ?: 'verification.notice');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,8 +2,9 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Notifications\CustomVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notifiable;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
@@ -28,5 +29,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify(new CustomVerifyEmail);
     }
 }

--- a/laravel/app/Notifications/CustomVerifyEmail.php
+++ b/laravel/app/Notifications/CustomVerifyEmail.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomVerifyEmail extends VerifyEmail
+{
+    protected function buildMailMessage($url)
+    {
+        return (new MailMessage)
+            ->subject(sprintf('Verify your %s email address', config('app.name', 'Laravel')))
+            ->view('emails.verify-email', [
+                'appName' => config('app.name', 'Laravel'),
+                'url' => $url,
+            ]);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureEmailIsVerified;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'verified' => EnsureEmailIsVerified::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/config/mail.php
+++ b/laravel/config/mail.php
@@ -14,7 +14,9 @@ return [
     |
     */
 
-    'default' => env('MAIL_MAILER', 'log'),
+    'default' => env('MAIL_MAILER', 'failover'),
+
+    'fallback_mailer' => env('MAIL_FALLBACK_MAILER', 'log'),
 
     /*
     |--------------------------------------------------------------------------
@@ -82,8 +84,8 @@ return [
         'failover' => [
             'transport' => 'failover',
             'mailers' => [
-                'smtp',
-                'log',
+                env('MAIL_PRIMARY_MAILER', 'smtp'),
+                env('MAIL_FALLBACK_MAILER', 'log'),
             ],
             'retry_after' => 60,
         ],

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/resources/views/auth/verify-email.blade.php
+++ b/laravel/resources/views/auth/verify-email.blade.php
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Verify Email</title>
+</head>
+<body>
+    <main>
+        <h1>Verify your email</h1>
+
+        @if (session('status') === 'verification-link-sent')
+            <p>A new verification link has been sent.</p>
+        @elseif (request('verified'))
+            <p>Your email address has been verified.</p>
+        @else
+            <p>Check your inbox for a verification link.</p>
+        @endif
+
+        <form method="POST" action="{{ route('verification.send') }}">
+            @csrf
+            <button type="submit">Send verification link</button>
+        </form>
+    </main>
+</body>
+</html>

--- a/laravel/resources/views/emails/verify-email.blade.php
+++ b/laravel/resources/views/emails/verify-email.blade.php
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Verify Email</title>
+</head>
+<body>
+    <h1>{{ $appName }} email verification</h1>
+    <p>Use this secure link to verify your email address.</p>
+    <p><a href="{{ $url }}">Verify email address</a></p>
+    <p>If you did not request this email, no action is required.</p>
+</body>
+</html>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,31 @@
 <?php
 
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::middleware('auth')->group(function () {
+    Route::get('/email/verify', function () {
+        return view('auth.verify-email');
+    })->name('verification.notice');
+
+    Route::get('/email/verify/{id}/{hash}', function (EmailVerificationRequest $request) {
+        $request->fulfill();
+
+        return redirect('/email/verify?verified=1');
+    })->middleware('signed')->name('verification.verify');
+
+    Route::post('/email/verification-notification', function (Request $request) {
+        if ($request->user()->hasVerifiedEmail()) {
+            return redirect('/')->with('status', 'already-verified');
+        }
+
+        $request->user()->sendEmailVerificationNotification();
+
+        return back()->with('status', 'verification-link-sent');
+    })->middleware('throttle:1,1')->name('verification.send');
 });

--- a/laravel/tests/Feature/EmailVerificationTest.php
+++ b/laravel/tests/Feature/EmailVerificationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\CustomVerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class EmailVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_signed_verification_link_marks_email_as_verified(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        Notification::fake();
+
+        $user->sendEmailVerificationNotification();
+
+        Notification::assertSentTo($user, CustomVerifyEmail::class);
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            [
+                'id' => $user->getKey(),
+                'hash' => sha1($user->getEmailForVerification()),
+            ],
+        );
+
+        $this->actingAs($user)
+            ->get($verificationUrl)
+            ->assertRedirect('/email/verify?verified=1');
+
+        $this->assertTrue($user->refresh()->hasVerifiedEmail());
+    }
+
+    public function test_resend_verification_endpoint_sends_custom_notification_and_is_rate_limited(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        Notification::fake();
+
+        $this->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertRedirect()
+            ->assertSessionHas('status', 'verification-link-sent');
+
+        Notification::assertSentTo($user, CustomVerifyEmail::class);
+
+        $this->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertTooManyRequests();
+    }
+
+    public function test_custom_verification_notification_uses_branded_blade_template(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        $mailMessage = (new CustomVerifyEmail)->toMail($user);
+
+        $this->assertSame('emails.verify-email', $mailMessage->view);
+        $this->assertSame('Verify your Laravel email address', $mailMessage->subject);
+        $this->assertSame('Laravel', $mailMessage->viewData['appName']);
+        $this->assertArrayHasKey('url', $mailMessage->viewData);
+    }
+
+    public function test_verified_middleware_redirects_unverified_users_to_notice(): void
+    {
+        Route::middleware(['web', 'auth', 'verified'])
+            ->get('/verified-only-test', fn () => 'verified')
+            ->name('verified-only-test');
+
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)
+            ->get('/verified-only-test')
+            ->assertRedirect(route('verification.notice'));
+    }
+
+    public function test_mail_configuration_uses_failover_and_fallback_mailer(): void
+    {
+        config(['mail.default' => 'failover']);
+
+        $this->assertSame('failover', config('mail.default'));
+        $this->assertSame('log', config('mail.fallback_mailer'));
+        $this->assertSame('failover', config('mail.mailers.failover.transport'));
+        $this->assertSame(['smtp', 'log'], config('mail.mailers.failover.mailers'));
+    }
+}


### PR DESCRIPTION
/claim #756

Summary:
- Enabled Laravel email verification on `User` via `MustVerifyEmail` and a custom `CustomVerifyEmail` notification.
- Added signed verification, verification notice, and throttled resend routes for `/email/verify/{id}/{hash}` and `/email/verification-notification`.
- Added a local `EnsureEmailIsVerified` middleware alias for protected route redirects.
- Added branded Blade views for the verification notice and verification email.
- Configured the default mailer to Laravel failover with `fallback_mailer` support so SMTP can fall back to the configured secondary mailer.
- Added focused feature coverage for signed verification, resend throttling, custom notification template, verified middleware redirect, and mail failover config.
- Included `laravel/.audit.json` with public-safe metadata only; private platform/session instructions are intentionally not copied.

Validation:
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- PHP lint passed for all changed PHP files.
- `php artisan route:list --path=email` shows the verification notice, signed verify, and resend routes.
- `php artisan test --filter EmailVerification` passed: 5 tests, 18 assertions.
- `php artisan test` passed: 7 tests, 20 assertions.
- `vendor/bin/pint --test ...` passed for touched PHP files.
- `git diff --check` passed.
- `laravel/.audit.json` parses as JSON.

Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.