### PR TITLE
[Codex GPT-5] [ Laravel ] Implement API authentication controller

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initial_directives": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #752 Laravel API authentication with Sanctum tokens.",
+  "date": "2026-06-18T03:50:00+09:00"
+}

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class AuthController extends Controller
+{
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => $validated['password'],
+        ]);
+
+        return response()->json([
+            'message' => 'Registered successfully.',
+            'user' => $this->userPayload($user),
+            'token' => $user->createToken('api-token')->plainTextToken,
+        ], 201);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::where('email', $credentials['email'])->first();
+
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            return response()->json([
+                'message' => 'Invalid credentials.',
+            ], 401);
+        }
+
+        return response()->json([
+            'message' => 'Logged in successfully.',
+            'user' => $this->userPayload($user),
+            'token' => $user->createToken('api-token')->plainTextToken,
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()?->currentAccessToken()?->delete();
+
+        return response()->json([
+            'message' => 'Logged out successfully.',
+        ]);
+    }
+
+    /**
+     * @return array{id: int, name: string, email: string}
+     */
+    private function userPayload(User $user): array
+    {
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,13 +9,14 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.3",
         "laravel/framework": "^13.8",
+        "laravel/sanctum": "^4.3",
         "laravel/tinker": "^3.0"
     },
     "require-dev": {

--- a/laravel/database/migrations/2026_06_18_000000_create_personal_access_tokens_table.php
+++ b/laravel/database/migrations/2026_06_18_000000_create_personal_access_tokens_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');

--- a/laravel/tests/Feature/ApiAuthenticationTest.php
+++ b/laravel/tests/Feature/ApiAuthenticationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\PersonalAccessToken;
+use Tests\TestCase;
+
+class ApiAuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_validates_input_creates_user_and_returns_token(): void
+    {
+        $response = $this->postJson('/api/register', [
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonStructure([
+                'message',
+                'user' => ['id', 'name', 'email'],
+                'token',
+            ])
+            ->assertJsonPath('user.email', 'ada@example.com');
+
+        $user = User::where('email', 'ada@example.com')->firstOrFail();
+
+        $this->assertTrue(Hash::check('password123', $user->password));
+        $this->assertDatabaseCount('personal_access_tokens', 1);
+        $this->assertNotEmpty($response->json('token'));
+    }
+
+    public function test_registration_rejects_duplicate_email_and_short_password(): void
+    {
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        $this->postJson('/api/register', [
+            'name' => 'Ada Lovelace',
+            'email' => 'taken@example.com',
+            'password' => 'short',
+            'password_confirmation' => 'short',
+        ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['email', 'password']);
+    }
+
+    public function test_login_returns_token_for_valid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+        ]);
+
+        $this->postJson('/api/login', [
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+        ])
+            ->assertOk()
+            ->assertJsonStructure([
+                'message',
+                'user' => ['id', 'name', 'email'],
+                'token',
+            ])
+            ->assertJsonPath('user.email', 'ada@example.com');
+
+        $this->assertDatabaseCount('personal_access_tokens', 1);
+    }
+
+    public function test_login_returns_unauthorized_for_invalid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+        ]);
+
+        $this->postJson('/api/login', [
+            'email' => 'ada@example.com',
+            'password' => 'wrong-password',
+        ])
+            ->assertUnauthorized()
+            ->assertJson([
+                'message' => 'Invalid credentials.',
+            ]);
+
+        $this->assertDatabaseCount('personal_access_tokens', 0);
+    }
+
+    public function test_logout_revokes_the_current_access_token(): void
+    {
+        $user = User::factory()->create();
+        $plainTextToken = $user->createToken('test-token')->plainTextToken;
+
+        $this->postJson('/api/logout', [], [
+            'Authorization' => 'Bearer '.$plainTextToken,
+        ])
+            ->assertOk()
+            ->assertJson([
+                'message' => 'Logged out successfully.',
+            ]);
+
+        $this->assertSame(0, PersonalAccessToken::query()->count());
+    }
+
+    public function test_logout_requires_authentication(): void
+    {
+        $this->postJson('/api/logout')
+            ->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
/claim #752

Summary:
- Added Laravel Sanctum as the API token backend and enabled `HasApiTokens` on `User`.
- Added API route loading plus `POST /api/register`, `POST /api/login`, and protected `POST /api/logout` routes.
- Implemented `AuthController` register/login/logout JSON endpoints with validation, duplicate email checks, password minimum checks, 201/200/401 responses, token issuance, and current-token revocation.
- Added the personal access token migration needed for Sanctum tokens.
- Added focused feature coverage for successful registration, validation failures, successful login, invalid login, logout token revocation, and unauthenticated logout.
- Included `laravel/app/Http/Controllers/.generation_meta.json` with public-safe metadata only; private platform/session instructions are intentionally not copied.

Validation:
- `composer install --no-interaction --no-progress` completed locally and installed `laravel/sanctum v4.3.2` for verification.
- PHP lint passed for all changed PHP files.
- `php artisan route:list --path=api` shows `POST api/register`, `POST api/login`, and `POST api/logout`.
- `php artisan test --filter ApiAuthentication` passed: 6 tests, 31 assertions.
- `php artisan test` passed: 8 tests, 33 assertions.
- `vendor/bin/pint --test ...` passed for touched PHP files.
- `git diff --check` passed.
- `laravel/app/Http/Controllers/.generation_meta.json` parses as JSON.

Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.