### PR TITLE
[Codex GPT-5] [ Laravel ] Implement lightweight RBAC

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #788 lightweight Laravel RBAC.",
+  "timestamp": "2026-06-18T04:05:00+09:00"
+}

--- a/laravel/app/Http/Middleware/CheckRole.php
+++ b/laravel/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! method_exists($user, 'hasRole') || ! $user->hasRole($role)) {
+            abort(403, 'This action requires the '.$role.' role.');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Permission extends Model
+{
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_has_permissions')->withTimestamps();
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+#[Fillable(['name', 'guard_name'])]
+class Role extends Model
+{
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_has_permissions')->withTimestamps();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\HasRoles;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+
+trait HasRoles
+{
+    public function roles(): MorphToMany
+    {
+        return $this->morphToMany(Role::class, 'model', 'model_has_roles')->withTimestamps();
+    }
+
+    public function permissions(): MorphToMany
+    {
+        return $this->morphToMany(Permission::class, 'model', 'model_has_permissions')->withTimestamps();
+    }
+
+    public function assignRole(Role|string $role): static
+    {
+        $this->roles()->syncWithoutDetaching([$this->resolveRole($role)->getKey()]);
+
+        return $this;
+    }
+
+    public function removeRole(Role|string $role): static
+    {
+        $this->roles()->detach($this->resolveRole($role)->getKey());
+
+        return $this;
+    }
+
+    public function hasRole(Role|string $role): bool
+    {
+        $role = $role instanceof Role ? $role->name : $role;
+
+        return $this->roles()->where('name', $role)->exists();
+    }
+
+    public function hasPermission(Permission|string $permission): bool
+    {
+        $permissionName = $permission instanceof Permission ? $permission->name : $permission;
+
+        if ($this->permissions()->where('name', $permissionName)->exists()) {
+            return true;
+        }
+
+        return $this->roles()
+            ->whereHas('permissions', fn ($query) => $query->where('name', $permissionName))
+            ->exists();
+    }
+
+    /**
+     * @return Collection<int, Permission>
+     */
+    public function getAllPermissions(): Collection
+    {
+        $directPermissions = $this->permissions()->get();
+        $rolePermissions = $this->roles()
+            ->with('permissions')
+            ->get()
+            ->flatMap(fn (Role $role) => $role->permissions);
+
+        return $directPermissions
+            ->merge($rolePermissions)
+            ->unique('id')
+            ->values();
+    }
+
+    private function resolveRole(Role|string $role): Role
+    {
+        if ($role instanceof Role) {
+            return $role;
+        }
+
+        $resolvedRole = Role::where('name', $role)->first();
+
+        if (! $resolvedRole) {
+            throw new InvalidArgumentException("Role [{$role}] does not exist.");
+        }
+
+        return $resolvedRole;
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\CheckRole;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/database/migrations/2026_06_18_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_06_18_000000_create_roles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/migrations/2026_06_18_000001_create_permissions_table.php
+++ b/laravel/database/migrations/2026_06_18_000001_create_permissions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/laravel/database/migrations/2026_06_18_000002_create_rbac_pivot_tables.php
+++ b/laravel/database/migrations/2026_06_18_000002_create_rbac_pivot_tables.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('role_has_permissions', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['role_id', 'permission_id']);
+        });
+
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+            $table->timestamps();
+
+            $table->primary(['role_id', 'model_id', 'model_type']);
+            $table->index(['model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+            $table->timestamps();
+
+            $table->primary(['permission_id', 'model_id', 'model_type']);
+            $table->index(['model_id', 'model_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
+    }
+};

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/RbacTest.php
+++ b/laravel/tests/Feature/RbacTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RbacTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_users_can_be_assigned_and_removed_from_roles(): void
+    {
+        $user = User::factory()->create();
+        Role::create(['name' => 'admin']);
+
+        $user->assignRole('admin');
+
+        $this->assertTrue($user->hasRole('admin'));
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => Role::where('name', 'admin')->value('id'),
+            'model_type' => User::class,
+            'model_id' => $user->id,
+        ]);
+
+        $user->removeRole('admin');
+
+        $this->assertFalse($user->hasRole('admin'));
+    }
+
+    public function test_permissions_include_direct_and_role_inherited_permissions(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::create(['name' => 'editor']);
+        $publish = Permission::create(['name' => 'publish articles']);
+        $delete = Permission::create(['name' => 'delete articles']);
+
+        $role->permissions()->attach($publish);
+        $user->permissions()->attach($delete);
+        $user->assignRole($role);
+
+        $this->assertTrue($user->hasPermission('publish articles'));
+        $this->assertTrue($user->hasPermission('delete articles'));
+        $this->assertFalse($user->hasPermission('archive articles'));
+
+        $this->assertSame(
+            ['delete articles', 'publish articles'],
+            $user->getAllPermissions()->pluck('name')->sort()->values()->all(),
+        );
+    }
+
+    public function test_role_middleware_rejects_users_without_required_role(): void
+    {
+        Route::middleware(['web', 'auth', 'role:admin'])
+            ->get('/admin-only-test', fn () => 'ok')
+            ->name('admin-only-test');
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get('/admin-only-test')
+            ->assertForbidden();
+
+        Role::create(['name' => 'admin']);
+        $user->assignRole('admin');
+
+        $this->actingAs($user->fresh())
+            ->get('/admin-only-test')
+            ->assertOk()
+            ->assertSee('ok');
+    }
+}


### PR DESCRIPTION
/claim #788

Summary:
- Added lightweight `Role` and `Permission` models with unique names and guard support.
- Added role, permission, and polymorphic pivot migrations for role permissions, model roles, and direct model permissions.
- Added a `HasRoles` trait with `assignRole`, `removeRole`, `hasRole`, `hasPermission`, and `getAllPermissions` helpers.
- Applied `HasRoles` to `User`.
- Added `CheckRole` middleware and registered the `role` middleware alias.
- Added feature tests for role assignment/removal, direct and inherited permissions, merged permissions, and middleware rejection/allowance.
- Included `laravel/.contributor.json` with public-safe metadata only; private platform/session instructions are intentionally not copied.

Validation:
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- PHP lint passed for all changed PHP files.
- `php artisan test --filter Rbac` passed: 3 tests, 10 assertions.
- `php artisan test` passed: 5 tests, 12 assertions.
- `vendor/bin/pint --test ...` passed for touched PHP files.
- `git diff --check` passed.
- `laravel/.contributor.json` parses as JSON.

Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.