### PR TITLE
[Codex GPT-5] [ Laravel ] Add global scope and User observer

### DIFF
--- a/laravel/app/Observers/.attribution.json
+++ b/laravel/app/Observers/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #792 ActiveScope, UserObserver UUID/logging, and lazy-loading prevention.",
+  "date": "2026-06-18T04:20:00+09:00"
+}

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class UserObserver
+{
+    public function creating(User $user): void
+    {
+        if (empty($user->uuid)) {
+            $user->uuid = (string) Str::uuid();
+        }
+    }
+
+    public function created(User $user): void
+    {
+        Log::info('User created', [
+            'user_id' => $user->id,
+            'uuid' => $user->uuid,
+        ]);
+    }
+
+    public function deleted(User $user): void
+    {
+        Log::info('User deleted', [
+            'user_id' => $user->id,
+            'uuid' => $user->uuid,
+        ]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
+
+        Model::preventLazyLoading(! $this->app->environment('production'));
     }
 }

--- a/laravel/app/Scopes/ActiveScope.php
+++ b/laravel/app/Scopes/ActiveScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ActiveScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where($model->qualifyColumn('active'), true);
+    }
+}

--- a/laravel/database/migrations/2026_06_18_000000_add_uuid_to_users_table.php
+++ b/laravel/database/migrations/2026_06_18_000000_add_uuid_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable()->unique()->after('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/ModelLifecycleTest.php
+++ b/laravel/tests/Feature/ModelLifecycleTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Scopes\ActiveScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ModelLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_scope_filters_active_records_and_can_be_removed(): void
+    {
+        Schema::create('active_scope_test_models', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('active')->default(true);
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        ActiveScopeTestModel::create(['name' => 'visible', 'active' => true]);
+        ActiveScopeTestModel::create(['name' => 'hidden', 'active' => false]);
+
+        $this->assertSame(['visible'], ActiveScopeTestModel::pluck('name')->all());
+        $this->assertSame(
+            ['hidden', 'visible'],
+            ActiveScopeTestModel::withoutGlobalScope(ActiveScope::class)
+                ->orderBy('name')
+                ->pluck('name')
+                ->all(),
+        );
+    }
+
+    public function test_user_observer_assigns_uuid_and_logs_lifecycle_events(): void
+    {
+        Log::spy();
+
+        $user = User::factory()->create();
+
+        $this->assertNotEmpty($user->uuid);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $user->uuid,
+        );
+
+        Log::shouldHaveReceived('info')->with('User created', [
+            'user_id' => $user->id,
+            'uuid' => $user->uuid,
+        ]);
+
+        $user->delete();
+
+        Log::shouldHaveReceived('info')->with('User deleted', [
+            'user_id' => $user->id,
+            'uuid' => $user->uuid,
+        ]);
+    }
+
+    public function test_lazy_loading_prevention_is_enabled_outside_production(): void
+    {
+        $this->assertTrue(Model::preventsLazyLoading());
+    }
+}
+
+class ActiveScopeTestModel extends Model
+{
+    protected $table = 'active_scope_test_models';
+
+    protected $guarded = [];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new ActiveScope);
+    }
+}


### PR DESCRIPTION
/claim #792

Summary:
- Added opt-in `ActiveScope` that filters scoped models to `active = 1` and supports `withoutGlobalScope` opt-out.
- Added `UserObserver` that assigns UUIDs before creation and logs user creation/deletion lifecycle events.
- Added a migration for a nullable unique `users.uuid` column.
- Registered the user observer in `AppServiceProvider`.
- Enabled `Model::preventLazyLoading` outside production environments.
- Added focused tests for ActiveScope filtering/opt-out, observer UUID/logging behavior, and lazy-loading prevention.
- Included `laravel/app/Observers/.attribution.json` with public-safe metadata only; private platform/session instructions are intentionally not copied.

Validation:
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- PHP lint passed for all changed PHP files.
- `php artisan test --filter ModelLifecycle` passed: 3 tests, 7 assertions.
- `php artisan test` passed: 5 tests, 9 assertions.
- `vendor/bin/pint --test ...` passed for touched PHP files.
- `git diff --check` passed.
- `laravel/app/Observers/.attribution.json` parses as JSON.

Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.