### PR TITLE
[Codex GPT-5] [ Laravel ] Add database health check endpoint

### DIFF
--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    public function database(): JsonResponse
+    {
+        $connectionName = (string) config('database.default');
+        $driver = (string) config("database.connections.{$connectionName}.driver", 'unknown');
+        $startedAt = hrtime(true);
+        $lastError = null;
+
+        for ($attempt = 1; $attempt <= 3; $attempt++) {
+            try {
+                DB::connection($connectionName)->getPdo();
+
+                return response()->json([
+                    'status' => 'ok',
+                    'driver' => $driver,
+                    'latency_ms' => $this->latencySince($startedAt),
+                    'connection_name' => $connectionName,
+                    'attempts' => $attempt,
+                ]);
+            } catch (Throwable $throwable) {
+                $lastError = $throwable;
+
+                if ($attempt < 3) {
+                    usleep(500_000);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'error',
+            'driver' => $driver,
+            'latency_ms' => $this->latencySince($startedAt),
+            'connection_name' => $connectionName,
+            'attempts' => 3,
+            'error' => $lastError?->getMessage(),
+        ], 503);
+    }
+
+    private function latencySince(int $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000, 2);
+    }
+}

--- a/laravel/app/Http/Controllers/_meta.json
+++ b/laravel/app/Http/Controllers/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "generation_context": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #785 database health check endpoint with retry logic.",
+  "completed_at": "2026-06-18T04:35:00+09:00"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);

--- a/laravel/tests/Feature/DatabaseHealthTest.php
+++ b/laravel/tests/Feature/DatabaseHealthTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Tests\TestCase;
+
+class DatabaseHealthTest extends TestCase
+{
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        config(['database.default' => 'sqlite']);
+
+        $this->getJson('/health/database')
+            ->assertOk()
+            ->assertJson([
+                'status' => 'ok',
+                'driver' => 'sqlite',
+                'connection_name' => 'sqlite',
+                'attempts' => 1,
+            ])
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+                'attempts',
+            ]);
+    }
+
+    public function test_database_health_endpoint_retries_three_times_before_failure(): void
+    {
+        config([
+            'database.default' => 'broken',
+            'database.connections.broken.driver' => 'sqlite',
+        ]);
+
+        DB::shouldReceive('connection')
+            ->times(3)
+            ->with('broken')
+            ->andThrow(new RuntimeException('database unavailable'));
+
+        $this->getJson('/health/database')
+            ->assertServiceUnavailable()
+            ->assertJson([
+                'status' => 'error',
+                'driver' => 'sqlite',
+                'connection_name' => 'broken',
+                'attempts' => 3,
+                'error' => 'database unavailable',
+            ]);
+    }
+}


### PR DESCRIPTION
/claim #785

Summary:
- Added `HealthController::database` for `GET /health/database`.
- Reports `status`, `driver`, `latency_ms`, `connection_name`, and attempt count for the active DB connection.
- Retries the active connection up to 3 times with 500ms delay before returning JSON 503 with the final error.
- Added focused feature coverage for successful connection metadata and three-attempt failure behavior.
- Included `laravel/app/Http/Controllers/_meta.json` with public-safe metadata only; private platform/session instructions are intentionally not copied.

Validation:
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- PHP lint passed for all changed PHP files.
- `php artisan route:list --path=health/database` shows `GET health/database` mapped to `HealthController@database`.
- `php artisan test --filter DatabaseHealth` passed: 2 tests, 10 assertions.
- `php artisan test` passed: 4 tests, 12 assertions.
- `vendor/bin/pint --test ...` passed for touched PHP files.
- `git diff --check` passed.
- `laravel/app/Http/Controllers/_meta.json` parses as JSON.

Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.