### PR TITLE
[Codex GPT-5] [ Laravel ] Add web rate limiting and session fallback

### DIFF
--- a/laravel/.contributor.json
+++ b/laravel/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #749 web rate limiting and session fallback.",
+  "timestamp": "2026-06-18T04:50:00+09:00"
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Support\WebRateLimit;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('web', function (Request $request) {
+            return Limit::perMinute(WebRateLimit::MAX_ATTEMPTS)->by(WebRateLimit::key($request));
+        });
     }
 }

--- a/laravel/app/Support/SessionDriverFallback.php
+++ b/laravel/app/Support/SessionDriverFallback.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Support;
+
+class SessionDriverFallback
+{
+    public static function fallbackDriver(): string
+    {
+        return (string) config('session.fallback', 'file');
+    }
+
+    public static function resolveDriver(?string $driver = null): string
+    {
+        $driver = $driver ?? (string) config('session.driver', 'file');
+
+        return $driver !== '' ? $driver : self::fallbackDriver();
+    }
+}

--- a/laravel/app/Support/WebRateLimit.php
+++ b/laravel/app/Support/WebRateLimit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+
+class WebRateLimit
+{
+    public const MAX_ATTEMPTS = 60;
+
+    public static function key(Request $request): string
+    {
+        $user = $request->user();
+
+        if ($user !== null) {
+            return 'web:user:'.$user->getAuthIdentifier();
+        }
+
+        return 'web:ip:'.$request->ip();
+    }
+}

--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -20,6 +20,8 @@ return [
 
     'driver' => env('SESSION_DRIVER', 'database'),
 
+    'fallback' => env('SESSION_FALLBACK_DRIVER', 'file'),
+
     /*
     |--------------------------------------------------------------------------
     | Session Lifetime

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,29 @@
 <?php
 
+use App\Support\WebRateLimit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('throttle:web')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
+
+    Route::get('/rate-limit/debug', function (Request $request) {
+        $key = WebRateLimit::key($request);
+        $remaining = RateLimiter::remaining($key, WebRateLimit::MAX_ATTEMPTS);
+
+        return response()
+            ->json([
+                'key' => $key,
+                'limit' => WebRateLimit::MAX_ATTEMPTS,
+                'remaining' => $remaining,
+                'retry_after' => RateLimiter::availableIn($key),
+            ])
+            ->withHeaders([
+                'X-RateLimit-Limit' => WebRateLimit::MAX_ATTEMPTS,
+                'X-RateLimit-Remaining' => $remaining,
+            ]);
+    });
 });

--- a/laravel/tests/Feature/WebRateLimitTest.php
+++ b/laravel/tests/Feature/WebRateLimitTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\SessionDriverFallback;
+use App\Support\WebRateLimit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+class WebRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        RateLimiter::clear('web:ip:127.0.0.1');
+    }
+
+    public function test_guest_web_requests_are_limited_after_sixty_attempts_per_minute(): void
+    {
+        for ($attempt = 0; $attempt < WebRateLimit::MAX_ATTEMPTS; $attempt++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')->assertTooManyRequests();
+    }
+
+    public function test_authenticated_users_have_a_separate_rate_limit_key_from_guest_ip(): void
+    {
+        for ($attempt = 0; $attempt < WebRateLimit::MAX_ATTEMPTS; $attempt++) {
+            $this->get('/')->assertOk();
+        }
+
+        $this->get('/')->assertTooManyRequests();
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk();
+    }
+
+    public function test_debug_route_returns_current_rate_limit_headers(): void
+    {
+        $this->getJson('/rate-limit/debug')
+            ->assertOk()
+            ->assertHeader('X-RateLimit-Limit', (string) WebRateLimit::MAX_ATTEMPTS)
+            ->assertJsonStructure([
+                'key',
+                'limit',
+                'remaining',
+                'retry_after',
+            ])
+            ->assertJson([
+                'key' => 'web:ip:127.0.0.1',
+                'limit' => WebRateLimit::MAX_ATTEMPTS,
+            ]);
+    }
+
+    public function test_session_fallback_configuration_defaults_to_file(): void
+    {
+        $this->assertSame('file', config('session.fallback'));
+        $this->assertSame('file', SessionDriverFallback::resolveDriver(''));
+
+        config(['session.fallback' => 'array']);
+
+        $this->assertSame('array', SessionDriverFallback::fallbackDriver());
+        $this->assertSame('array', SessionDriverFallback::resolveDriver(''));
+    }
+}


### PR DESCRIPTION
/claim #749

Summary:
- Added a named `web` rate limiter equivalent to 60 requests per minute, keyed by authenticated user id or guest IP.
- Applied `throttle:web` to the web route group.
- Added `/rate-limit/debug` to expose current limiter key, limit, remaining count, retry-after value, and rate-limit headers.
- Added `session.fallback` config defaulting to `file` plus a small `SessionDriverFallback` helper.
- Added focused tests for 429 behavior after 60 requests, authenticated-user vs guest-IP limiter isolation, debug headers/body, and session fallback configuration.
- Included `laravel/.contributor.json` with public-safe metadata only; private platform/session instructions are intentionally not copied.

Validation:
- `composer install --no-interaction --no-progress` completed locally to install ignored vendor dependencies for verification.
- PHP lint passed for all changed PHP files.
- `php artisan route:list --path=rate-limit/debug` shows `GET rate-limit/debug`.
- `php artisan test --filter WebRateLimit` passed: 4 tests, 135 assertions.
- `php artisan test` passed: 6 tests, 137 assertions.
- `vendor/bin/pint --test ...` passed for touched PHP files.
- `git diff --check` passed.
- `laravel/.contributor.json` parses as JSON.

Generated local dependency artifacts (`vendor/`, `composer.lock`, PHPUnit cache) were removed from the worktree before committing because this repository does not track a Laravel lock file.