### PR TITLE
[Codex GPT-5] [ Laravel ] Fix DatabaseSeeder idempotency

### DIFF
--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    protected $model = Role::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->slug(2),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_06_18_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_06_18_000000_create_roles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/.provenance.json
+++ b/laravel/database/seeders/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Codex GPT-5",
+  "config_snapshot": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #746 idempotent Laravel seeders and default roles.",
+  "created": "2026-06-18T05:05:00+09:00"
+}

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => Hash::make('password'),
+            ],
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default roles.
+     */
+    public function run(): void
+    {
+        collect([
+            'admin' => 'Full application administration access.',
+            'editor' => 'Content creation and editing access.',
+            'viewer' => 'Read-only application access.',
+        ])->each(function (string $description, string $name): void {
+            Role::firstOrCreate(
+                ['name' => $name],
+                ['description' => $description],
+            );
+        });
+    }
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_can_run_multiple_times_without_duplicate_users_or_roles(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertSame(
+            ['admin', 'editor', 'viewer'],
+            Role::orderBy('name')->pluck('name')->all(),
+        );
+        $this->assertSame(3, Role::count());
+    }
+
+    public function test_role_seeder_is_idempotent(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $this->seed(RoleSeeder::class);
+
+        $this->assertSame(3, Role::count());
+        $this->assertSame(
+            ['admin', 'editor', 'viewer'],
+            Role::orderBy('name')->pluck('name')->all(),
+        );
+    }
+
+    public function test_role_factory_generates_valid_roles(): void
+    {
+        $role = Role::factory()->create();
+
+        $this->assertNotNull($role->id);
+        $this->assertNotEmpty($role->name);
+        $this->assertNotEmpty($role->description);
+        $this->assertDatabaseHas('roles', [
+            'id' => $role->id,
+            'name' => $role->name,
+        ]);
+    }
+}


### PR DESCRIPTION
/claim #746

Summary:
- Make `DatabaseSeeder` idempotent by using `User::firstOrCreate()` for the test user.
- Add a `Role` model, factory, migration, and dedicated `RoleSeeder` with three default roles.
- Add feature coverage proving `DatabaseSeeder` and `RoleSeeder` can run repeatedly without duplicate rows.
- Add safe public provenance metadata for this task; private platform/system/developer/user-session instructions are intentionally redacted.

Validation:
- `php -l app/Models/Role.php`
- `php -l database/factories/RoleFactory.php`
- `php -l database/migrations/2026_06_18_000000_create_roles_table.php`
- `php -l database/seeders/RoleSeeder.php`
- `php -l database/seeders/DatabaseSeeder.php`
- `php -l tests/Feature/DatabaseSeederTest.php`
- `ruby -rjson -e 'JSON.parse(File.read("database/seeders/.provenance.json")); puts "valid json"'`
- `php artisan test --filter DatabaseSeeder` - passed, 3 tests / 9 assertions
- `php artisan test` - passed, 5 tests / 11 assertions
- `vendor/bin/pint --test app/Models/Role.php database/factories/RoleFactory.php database/migrations/2026_06_18_000000_create_roles_table.php database/seeders/DatabaseSeeder.php database/seeders/RoleSeeder.php tests/Feature/DatabaseSeederTest.php`
- `git diff --check`