### PR TITLE
[Codex GPT-5] [ Laravel ] Add PHPUnit coverage config and grouped tests

### DIFF
--- a/laravel/.audit.json
+++ b/laravel/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "environment_config": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #794 PHPUnit coverage config, grouped route tests, and User model tests.",
+  "completed_at": "2026-06-18T13:08:30+09:00"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -16,9 +16,14 @@
         <include>
             <directory>app</directory>
         </include>
+        <exclude>
+            <directory>app/Providers</directory>
+            <directory>app/Console</directory>
+        </exclude>
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/RouteTest.php
+++ b/laravel/tests/Feature/RouteTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('feature')]
+class RouteTest extends TestCase
+{
+    public function test_all_registered_get_routes_return_non_server_error_responses(): void
+    {
+        $routes = collect(Route::getRoutes())->filter(function ($route): bool {
+            return in_array('GET', $route->methods(), true)
+                && ! str_contains($route->uri(), '{');
+        });
+
+        $this->assertNotEmpty($routes);
+
+        $routes->each(function ($route): void {
+            $uri = '/'.ltrim($route->uri(), '/');
+            $response = $this->get($uri === '/' ? '/' : $uri);
+
+            $this->assertLessThan(
+                500,
+                $response->getStatusCode(),
+                sprintf('GET %s returned a server error.', $uri),
+            );
+        });
+    }
+}

--- a/laravel/tests/Unit/UserModelTest.php
+++ b/laravel/tests/Unit/UserModelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('unit')]
+class UserModelTest extends TestCase
+{
+    public function test_user_model_has_expected_fillable_attributes(): void
+    {
+        $this->assertSame(
+            ['name', 'email', 'password'],
+            (new User)->getFillable(),
+        );
+    }
+
+    public function test_user_model_has_expected_hidden_attributes(): void
+    {
+        $this->assertSame(
+            ['password', 'remember_token'],
+            (new User)->getHidden(),
+        );
+    }
+
+    public function test_user_model_has_expected_casts(): void
+    {
+        $casts = (new User)->getCasts();
+
+        $this->assertSame('datetime', $casts['email_verified_at']);
+        $this->assertSame('hashed', $casts['password']);
+    }
+}


### PR DESCRIPTION
/claim #794

Summary:
- Add PHPUnit coverage source exclusions for `app/Providers` and `app/Console` while keeping `app/` as the covered source tree.
- Add a feature route smoke test tagged `feature` that exercises registered GET routes and asserts they do not return 500+ responses.
- Add a unit `UserModelTest` tagged `unit` that verifies fillable, hidden, and casts configuration.
- Add a test `APP_KEY` so the feature suite boots consistently.
- Add safe audit metadata; private platform/system/developer/user-session initialization payloads are intentionally redacted.

Validation:
- `php -l tests/Feature/RouteTest.php` - passed
- `php -l tests/Unit/UserModelTest.php` - passed
- `.audit.json` parses as valid JSON
- `php artisan test` - passed, 6 tests / 9 assertions
- `php artisan test --group=unit` - passed, 3 tests / 4 assertions
- `php artisan test --group=feature` - passed, 1 test / 3 assertions
- `vendor/bin/pint --test tests/Feature/RouteTest.php tests/Unit/UserModelTest.php` - passed
- `git diff --check` - passed

Demo note:
- This is a PHPUnit/test-configuration change with no UI surface; the separate full/unit/feature test runs demonstrate the behavior.