### PR TITLE
[Codex GPT-5] [ Laravel ] Fix User model password cast rounds

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "generation_context": "Redacted: private platform, system, developer, and user-session instructions are not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #745 bcrypt rounds-aware User password hashing and factory coverage.",
+  "completed_at": "2026-06-18T13:13:00+09:00"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,19 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value === null || Hash::isHashed($value)) {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value, [
+            'rounds' => config('hashing.bcrypt.rounds'),
+        ]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
+        'limit' => env('BCRYPT_LIMIT', null),
+    ],
+
+    'argon' => [
+        'memory' => env('ARGON_MEMORY', 65536),
+        'threads' => env('ARGON_THREADS', 1),
+        'time' => env('ARGON_TIME', 4),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,9 +13,11 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
+     * The current passwords being used by configured bcrypt rounds.
+     *
+     * @var array<int, string>
      */
-    protected static ?string $password;
+    protected static array $passwords = [];
 
     /**
      * Define the model's default state.
@@ -24,11 +26,15 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $rounds = (int) config('hashing.bcrypt.rounds');
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$passwords[$rounds] ??= Hash::make('password', [
+                'rounds' => $rounds,
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_password_mutator_uses_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User;
+        $user->password = 'secret-password';
+
+        $this->assertSame(6, password_get_info($user->password)['options']['cost']);
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+    }
+
+    public function test_user_factory_generates_passwords_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 7]);
+
+        $user = User::factory()->make();
+
+        $this->assertSame(7, password_get_info($user->password)['options']['cost']);
+        $this->assertTrue(Hash::check('password', $user->password));
+    }
+
+    public function test_existing_default_bcrypt_hashes_still_verify_without_rehashing(): void
+    {
+        $legacyHash = Hash::make('legacy-password', ['rounds' => 10]);
+
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User;
+        $user->password = $legacyHash;
+
+        $this->assertSame($legacyHash, $user->password);
+        $this->assertSame(10, password_get_info($user->password)['options']['cost']);
+        $this->assertTrue(Hash::check('legacy-password', $user->password));
+    }
+}


### PR DESCRIPTION
/claim #745

Summary:
- Add Laravel hashing config so `config("hashing.bcrypt.rounds")` is available.
- Replace the generic User password `hashed` cast with an explicit mutator using configured bcrypt rounds.
- Preserve already-hashed password values so legacy/default-round bcrypt hashes still verify and are not rehashed accidentally.
- Update `UserFactory` to hash generated passwords with the configured rounds and cache per cost value.
- Add focused unit coverage for model hashing rounds, factory hashing rounds, and legacy hash verification.
- Add safe metadata; private platform/system/developer/user-session generation context is intentionally redacted.

Validation:
- `php -l app/Models/User.php` - passed
- `php -l database/factories/UserFactory.php` - passed
- `php -l config/hashing.php` - passed
- `php -l tests/Unit/UserPasswordHashingTest.php` - passed
- `_meta.json` parses as valid JSON
- `php artisan test --filter UserPasswordHashingTest` - passed, 3 tests / 7 assertions
- `php artisan test` - passed, 5 tests / 9 assertions
- `vendor/bin/pint --test app/Models/User.php database/factories/UserFactory.php config/hashing.php tests/Unit/UserPasswordHashingTest.php` - passed
- `git diff --check` - passed

Demo note:
- This is password hashing behavior with no UI surface; the focused tests assert configured bcrypt costs and backward-compatible `Hash::check()` behavior.