### PR TITLE
[Codex GPT-5] [ Laravel ] Add failed job monitoring and summary command

### DIFF
--- a/laravel/app/Console/Commands/FailedJobSummary.php
+++ b/laravel/app/Console/Commands/FailedJobSummary.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class FailedJobSummary extends Command
+{
+    protected $signature = 'queue:failed-summary';
+
+    protected $description = 'Display failed jobs grouped by exception class';
+
+    public function handle(): int
+    {
+        $rows = DB::table(config('queue.failed.table', 'failed_jobs'))
+            ->select('exception')
+            ->get();
+
+        if ($rows->isEmpty()) {
+            $this->info('No failed jobs found.');
+
+            return self::SUCCESS;
+        }
+
+        $summary = $rows
+            ->map(fn (object $row): string => $this->exceptionClass($row->exception))
+            ->countBy()
+            ->sortKeys()
+            ->map(fn (int $count, string $exception): array => [$exception, $count])
+            ->values()
+            ->all();
+
+        $this->table(['Exception', 'Count'], $summary);
+
+        return self::SUCCESS;
+    }
+
+    private function exceptionClass(?string $exception): string
+    {
+        if (! $exception) {
+            return 'Unknown';
+        }
+
+        preg_match('/^([A-Za-z_\\\\][A-Za-z0-9_\\\\]*)(?::|$)/', trim($exception), $matches);
+
+        return $matches[1] ?? 'Unknown';
+    }
+}

--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class LogFailedJob
+{
+    public function handle(JobFailed $event): void
+    {
+        Log::error('Queue job failed', [
+            'connection' => $event->connectionName,
+            'queue' => $event->job->getQueue(),
+            'job' => $event->job->resolveName(),
+            'payload' => $this->payload($event->job),
+            'exception' => [
+                'class' => get_class($event->exception),
+                'message' => $event->exception->getMessage(),
+                'file' => $event->exception->getFile(),
+                'line' => $event->exception->getLine(),
+                'trace' => $event->exception->getTraceAsString(),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(Job $job): array
+    {
+        try {
+            return $job->payload();
+        } catch (Throwable $exception) {
+            return [
+                'payload_error' => $exception->getMessage(),
+            ];
+        }
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Console\Commands\FailedJobSummary;
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +23,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, LogFailedJob::class);
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                FailedJobSummary::class,
+            ]);
+        }
     }
 }

--- a/laravel/config/queue.php
+++ b/laravel/config/queue.php
@@ -41,6 +41,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'max_tries' => (int) env('DB_QUEUE_MAX_TRIES', 3),
             'after_commit' => false,
         ],
 

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex GPT-5",
+  "session_init": "Redacted: private platform, system, developer, and user-session initialization text is not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #789 failed job monitoring listener, queue failed summary command, and queue retry configuration.",
+  "ts": "2026-06-18T13:19:30+09:00"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/FailedJobMonitoringTest.php
+++ b/laravel/tests/Feature/FailedJobMonitoringTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Listeners\LogFailedJob;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Mockery;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Tests\TestCase;
+
+class FailedJobMonitoringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_failed_job_listener_is_registered(): void
+    {
+        Event::fake();
+
+        Event::assertListening(JobFailed::class, LogFailedJob::class);
+    }
+
+    public function test_failed_job_listener_logs_queue_payload_and_exception_metadata(): void
+    {
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('getQueue')->once()->andReturn('emails');
+        $job->shouldReceive('resolveName')->once()->andReturn('App\\Jobs\\SendEmail');
+        $job->shouldReceive('payload')->once()->andReturn([
+            'uuid' => 'job-uuid',
+            'displayName' => 'App\\Jobs\\SendEmail',
+        ]);
+
+        $exception = new RuntimeException('SMTP gateway failed');
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Queue job failed', Mockery::on(function (array $context) use ($exception): bool {
+                return $context['connection'] === 'database'
+                    && $context['queue'] === 'emails'
+                    && $context['job'] === 'App\\Jobs\\SendEmail'
+                    && $context['payload']['uuid'] === 'job-uuid'
+                    && $context['exception']['class'] === RuntimeException::class
+                    && $context['exception']['message'] === 'SMTP gateway failed'
+                    && $context['exception']['file'] === $exception->getFile()
+                    && $context['exception']['line'] === $exception->getLine()
+                    && is_string($context['exception']['trace']);
+            }));
+
+        (new LogFailedJob)->handle(new JobFailed('database', $job, $exception));
+    }
+
+    public function test_failed_summary_command_groups_failed_jobs_by_exception_class(): void
+    {
+        $this->insertFailedJob(RuntimeException::class.': first failure');
+        $this->insertFailedJob(RuntimeException::class.': second failure');
+        $this->insertFailedJob(InvalidArgumentException::class.': bad argument');
+
+        $this->artisan('queue:failed-summary')
+            ->expectsTable(
+                ['Exception', 'Count'],
+                [
+                    [InvalidArgumentException::class, 1],
+                    [RuntimeException::class, 2],
+                ],
+            )
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_database_queue_retry_settings_are_configured(): void
+    {
+        $this->assertSame(90, config('queue.connections.database.retry_after'));
+        $this->assertSame(3, config('queue.connections.database.max_tries'));
+    }
+
+    private function insertFailedJob(string $exception): void
+    {
+        DB::table('failed_jobs')->insert([
+            'uuid' => (string) Str::uuid(),
+            'connection' => 'database',
+            'queue' => 'default',
+            'payload' => '{}',
+            'exception' => $exception,
+            'failed_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
/claim #789

Summary:
- Add `LogFailedJob` listener for `JobFailed` events that logs connection, queue, job name, payload, and full exception metadata.
- Register the listener in `AppServiceProvider` and register the `queue:failed-summary` command for console usage.
- Add `queue:failed-summary`, grouped by exception class from `failed_jobs` rows.
- Add database queue `max_tries` default of 3 while keeping `retry_after` at 90 seconds.
- Add focused feature coverage for listener registration, logged metadata, summary grouping, and queue config values.
- Add safe contributor metadata; private platform/system/developer/user-session initialization text is intentionally redacted.

Validation:
- `php -l app/Providers/AppServiceProvider.php` - passed
- `php -l app/Listeners/LogFailedJob.php` - passed
- `php -l app/Console/Commands/FailedJobSummary.php` - passed
- `php -l tests/Feature/FailedJobMonitoringTest.php` - passed
- `contributor_meta.json` parses as valid JSON
- `php artisan test --filter FailedJobMonitoringTest` - passed, 4 tests / 14 assertions
- `php artisan test` - passed, 6 tests / 16 assertions
- `vendor/bin/pint --test app/Providers/AppServiceProvider.php app/Listeners/LogFailedJob.php app/Console/Commands/FailedJobSummary.php tests/Feature/FailedJobMonitoringTest.php` - passed
- `git diff --check` - passed

Demo note:
- This is queue monitoring/Artisan behavior with no UI surface; the command and listener behavior are covered by the focused feature tests.