### PR TITLE
[Codex GPT-5] [ Laravel ] Fix Slack notification service retry handling

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "pre_task_context": "Redacted: private platform, system, developer, and user-session pre-task context is not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #791 Slack notification service with retry and timeout handling.",
+  "timestamp": "2026-06-18T13:24:00+09:00"
+}

--- a/laravel/app/Services/SlackNotifier.php
+++ b/laravel/app/Services/SlackNotifier.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+
+class SlackNotifier
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     */
+    public static function send(string $message, ?string $channel = null, array $blocks = []): void
+    {
+        (new self)->sendMessage($message, $channel, $blocks);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     */
+    public function sendMessage(string $message, ?string $channel = null, array $blocks = []): void
+    {
+        $webhookUrl = config('services.slack.webhook_url');
+
+        if (! is_string($webhookUrl) || $webhookUrl === '') {
+            throw new InvalidArgumentException('Slack webhook URL is not configured.');
+        }
+
+        $payload = $this->payload($message, $channel, $blocks);
+        $response = Http::timeout(5)->post($webhookUrl, $payload);
+
+        if ($response->serverError()) {
+            $response = Http::timeout(5)->post($webhookUrl, $payload);
+        }
+
+        if ($response->failed()) {
+            throw new RequestException($response);
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $blocks
+     * @return array<string, mixed>
+     */
+    private function payload(string $message, ?string $channel, array $blocks): array
+    {
+        $payload = [
+            'text' => $message,
+            'channel' => $channel ?? config('services.slack.default_channel'),
+        ];
+
+        if ($blocks !== []) {
+            $payload['blocks'] = $blocks;
+        }
+
+        return array_filter($payload, fn (mixed $value): bool => $value !== null && $value !== '');
+    }
+}

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -29,6 +29,9 @@ return [
     ],
 
     'slack' => [
+        'webhook_url' => env('SLACK_WEBHOOK_URL'),
+        'default_channel' => env('SLACK_DEFAULT_CHANNEL', env('SLACK_BOT_USER_DEFAULT_CHANNEL')),
+
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/SlackNotifierTest.php
+++ b/laravel/tests/Feature/SlackNotifierTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SlackNotifier;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SlackNotifierTest extends TestCase
+{
+    public function test_slack_notifier_sends_default_channel_payload(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/default',
+            'services.slack.default_channel' => '#ops',
+        ]);
+
+        Http::fake([
+            'https://hooks.slack.test/*' => Http::response('ok', 200),
+        ]);
+
+        SlackNotifier::send('Deploy complete');
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://hooks.slack.test/services/default'
+                && $request['text'] === 'Deploy complete'
+                && $request['channel'] === '#ops';
+        });
+    }
+
+    public function test_slack_notifier_accepts_channel_override_and_blocks(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/override',
+            'services.slack.default_channel' => '#ops',
+        ]);
+
+        Http::fake([
+            'https://hooks.slack.test/*' => Http::response('ok', 200),
+        ]);
+
+        $blocks = [
+            [
+                'type' => 'section',
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => '*Build passed*',
+                ],
+            ],
+        ];
+
+        SlackNotifier::send('Build passed', '#deploys', $blocks);
+
+        Http::assertSent(function (Request $request) use ($blocks): bool {
+            return $request['text'] === 'Build passed'
+                && $request['channel'] === '#deploys'
+                && $request['blocks'] === $blocks;
+        });
+    }
+
+    public function test_slack_notifier_retries_once_on_server_errors(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/retry',
+        ]);
+
+        Http::fake([
+            'https://hooks.slack.test/*' => Http::sequence()
+                ->push('server error', 500)
+                ->push('ok', 200),
+        ]);
+
+        SlackNotifier::send('Retry once');
+
+        Http::assertSentCount(2);
+    }
+
+    public function test_slack_notifier_throws_immediately_on_client_errors(): void
+    {
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.test/services/client-error',
+        ]);
+
+        Http::fake([
+            'https://hooks.slack.test/*' => Http::response('bad request', 400),
+        ]);
+
+        try {
+            SlackNotifier::send('Do not retry');
+            $this->fail('Expected SlackNotifier to throw for a client error.');
+        } catch (RequestException) {
+            Http::assertSentCount(1);
+        }
+    }
+}


### PR DESCRIPTION
/claim #791

Summary:
- Add `AppServicesSlackNotifier` with `SlackNotifier::send()` convenience API.
- Read `services.slack.webhook_url` and `services.slack.default_channel` from config.
- Send Slack webhook payloads with message text, default or overridden channel, and optional blocks.
- Use Laravel HTTP client with `timeout(5)`.
- Retry once on 5xx responses and throw immediately on 4xx responses.
- Add HTTP fake tests for payload structure, channel override/blocks, 5xx retry count, and 4xx fail-fast behavior.
- Add safe generation metadata; private platform/system/developer/user-session pre-task context is intentionally redacted.

Validation:
- `php -l app/Services/SlackNotifier.php` - passed
- `php -l tests/Feature/SlackNotifierTest.php` - passed
- `_generation.json` parses as valid JSON
- Verified `services.slack.webhook_url` and `services.slack.default_channel` config entries
- Verified `Http::timeout(5)` and 5xx retry source paths in `SlackNotifier`
- `php artisan test --filter SlackNotifierTest` - passed, 4 tests / 4 assertions
- `php artisan test` - passed, 6 tests / 6 assertions
- `vendor/bin/pint --test app/Services/SlackNotifier.php tests/Feature/SlackNotifierTest.php` - passed
- `git diff --check` - passed

Demo note:
- This is an HTTP service with no UI surface; behavior is demonstrated by the HTTP fake tests and source checks above.