### PR TITLE
[Codex GPT-5] [ Laravel ] Fix welcome CSRF meta and security headers

### DIFF
--- a/laravel/app/Http/Middleware/SecurityHeaders.php
+++ b/laravel/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        return $response;
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(SecurityHeaders::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex GPT-5",
+  "session_init": "Redacted: private platform, system, developer, and user-session initialization text is not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #751 CSRF meta tag and global security headers.",
+  "ts": "2026-06-18T13:31:00+09:00"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 

--- a/laravel/tests/Feature/SecurityHeadersTest.php
+++ b/laravel/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    public function test_welcome_response_includes_csrf_meta_tag_and_security_headers(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="csrf-token"', false);
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('X-Frame-Options', 'DENY');
+        $response->assertHeader('X-XSS-Protection', '1; mode=block');
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
+}


### PR DESCRIPTION
/claim #751

Summary:
- Add `<meta name="csrf-token" content="{{ csrf_token() }}">` to the welcome view head.
- Add global `SecurityHeaders` middleware for `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy`.
- Register the middleware through `bootstrap/app.php` so it applies to web responses.
- Add feature coverage for the welcome page CSRF meta tag and all required response headers.
- Add safe contributor metadata; private platform/system/developer/user-session initialization text is intentionally redacted.

Validation:
- `php -l app/Http/Middleware/SecurityHeaders.php` - passed
- `php -l tests/Feature/SecurityHeadersTest.php` - passed
- `php -l bootstrap/app.php` - passed
- `contributor_meta.json` parses as valid JSON
- Verified CSRF meta tag, middleware registration, and all four headers in source
- `php artisan test --filter SecurityHeadersTest` - passed, 1 test / 10 assertions
- `php artisan test` - passed, 3 tests / 12 assertions
- `vendor/bin/pint --test app/Http/Middleware/SecurityHeaders.php tests/Feature/SecurityHeadersTest.php bootstrap/app.php` - passed
- `git diff --check` - passed

Demo note:
- This is response-header/view behavior with no separate UI workflow; the focused feature test verifies the rendered response.