### PR TITLE
[Codex GPT-5] [ Laravel ] Fix logging config for error and JSON logs

### DIFF
--- a/laravel/_provenance.json
+++ b/laravel/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "Redacted: private platform, system, developer, and user-session boot context is not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #787 separated error logs and JSON structured logging.",
+  "timestamp": "2026-06-18T13:35:00+09:00"
+}

--- a/laravel/app/Logging/JsonLogFormatter.php
+++ b/laravel/app/Logging/JsonLogFormatter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+class JsonLogFormatter implements FormatterInterface
+{
+    public function format(LogRecord $record): string
+    {
+        return json_encode([
+            'timestamp' => $record->datetime->format(DATE_ATOM),
+            'level' => $record->level->getName(),
+            'message' => $record->message,
+            'context' => $record->context,
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL;
+    }
+
+    /**
+     * @param  array<int, LogRecord>  $records
+     */
+    public function formatBatch(array $records): string
+    {
+        return implode('', array_map(fn (LogRecord $record): string => $this->format($record), $records));
+    }
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\JsonLogFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,24 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/structured.log'),
+            ],
+            'formatter' => JsonLogFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/tests/Feature/LoggingConfigurationTest.php
+++ b/laravel/tests/Feature/LoggingConfigurationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Logging\JsonLogFormatter;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Tests\TestCase;
+
+class LoggingConfigurationTest extends TestCase
+{
+    public function test_logging_stack_and_channels_are_configured(): void
+    {
+        $this->assertSame(['daily', 'error'], config('logging.channels.stack.channels'));
+        $this->assertSame(14, (int) config('logging.channels.daily.days'));
+        $this->assertSame(storage_path('logs/error.log'), config('logging.channels.error.path'));
+        $this->assertSame('error', config('logging.channels.error.level'));
+        $this->assertSame(JsonLogFormatter::class, config('logging.channels.json.formatter'));
+    }
+
+    public function test_error_messages_are_duplicated_to_error_log_but_info_messages_are_not(): void
+    {
+        $dailyPath = storage_path('logs/test-laravel.log');
+        $datedDailyPath = storage_path('logs/test-laravel-'.now()->format('Y-m-d').'.log');
+        $errorPath = storage_path('logs/test-error.log');
+
+        File::delete([$dailyPath, $datedDailyPath, $errorPath]);
+
+        config([
+            'logging.channels.daily.path' => $dailyPath,
+            'logging.channels.error.path' => $errorPath,
+        ]);
+
+        Log::forgetChannel('stack');
+        Log::channel('stack')->info('general log entry');
+        Log::channel('stack')->error('error log entry');
+
+        $dailyContents = File::get($datedDailyPath);
+        $errorContents = File::get($errorPath);
+
+        $this->assertStringContainsString('general log entry', $dailyContents);
+        $this->assertStringContainsString('error log entry', $dailyContents);
+        $this->assertStringNotContainsString('general log entry', $errorContents);
+        $this->assertStringContainsString('error log entry', $errorContents);
+
+        File::delete([$dailyPath, $datedDailyPath, $errorPath]);
+    }
+
+    public function test_json_formatter_outputs_required_structured_fields(): void
+    {
+        $formatter = new JsonLogFormatter;
+        $line = $formatter->format(new LogRecord(
+            datetime: new DateTimeImmutable('2026-06-18T00:00:00+00:00'),
+            channel: 'testing',
+            level: Level::Info,
+            message: 'Structured message',
+            context: ['request_id' => 'abc123'],
+            extra: [],
+        ));
+
+        $data = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('2026-06-18T00:00:00+00:00', $data['timestamp']);
+        $this->assertSame('INFO', $data['level']);
+        $this->assertSame('Structured message', $data['message']);
+        $this->assertSame(['request_id' => 'abc123'], $data['context']);
+    }
+}


### PR DESCRIPTION
/claim #787

Summary:
- Change the default log stack to write to both `daily` and the new `error` channel.
- Add an error-only channel writing to `storage/logs/error.log` at ERROR level and above.
- Keep daily retention at 14 days.
- Add a `json` monolog channel using `JsonLogFormatter` for `timestamp`, `level`, `message`, and `context` fields.
- Add tests for channel config, actual daily/error file routing, and JSON formatter output.
- Add safe provenance metadata; private platform/system/developer/user-session boot context is intentionally redacted.

Validation:
- `php -l app/Logging/JsonLogFormatter.php` - passed
- `php -l tests/Feature/LoggingConfigurationTest.php` - passed
- `php -l config/logging.php` - passed
- `_provenance.json` parses as valid JSON
- Verified stack, error path, structured path, formatter, and APP_KEY entries in source
- `php artisan test --filter LoggingConfigurationTest` - passed, 3 tests / 13 assertions
- `php artisan test` - passed, 5 tests / 15 assertions
- `vendor/bin/pint --test config/logging.php app/Logging/JsonLogFormatter.php tests/Feature/LoggingConfigurationTest.php` - passed
- `git diff --check` - passed

Demo note:
- This is logging configuration behavior with no UI surface; the focused tests verify file routing and JSON formatter output.