### PR TITLE
[Codex GPT-5] [ Laravel ] Add scheduled log cleanup command

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "pre_task_context": "Redacted: private platform, system, developer, and user-session pre-task context is not included. Public task context: implement UnsafeLabs/Bounty-Hunters issue #753 logs:clear command and scheduled cleanup.",
+  "timestamp": "2026-06-18T13:40:00+09:00"
+}

--- a/laravel/phpunit.xml
+++ b/laravel/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6/Xhpqnecd2GxrX0YJPAGYvNuDaHeWnaOu7Q/h7LNtw="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,57 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Delete log files older than this many days}', function (): int {
+    $daysOption = $this->option('days');
+    $days = ! is_numeric($daysOption)
+        ? 7
+        : max(0, (int) $daysOption);
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deletedFiles = 0;
+    $freedBytes = 0;
+
+    $humanReadableBytes = function (int $bytes): string {
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $size = (float) $bytes;
+
+        foreach ($units as $unit) {
+            if ($size < 1024 || $unit === 'GB') {
+                return $unit === 'B'
+                    ? sprintf('%d B', $size)
+                    : sprintf('%.2f %s', $size, $unit);
+            }
+
+            $size /= 1024;
+        }
+
+        return sprintf('%d B', $bytes);
+    };
+
+    foreach (File::glob(storage_path('logs/*.log')) as $path) {
+        if (! is_file($path) || filemtime($path) >= $cutoff) {
+            continue;
+        }
+
+        $freedBytes += filesize($path) ?: 0;
+        File::delete($path);
+        $deletedFiles++;
+    }
+
+    $this->info(sprintf(
+        'Deleted %d log %s and freed %s.',
+        $deletedFiles,
+        $deletedFiles === 1 ? 'file' : 'files',
+        $humanReadableBytes($freedBytes),
+    ));
+
+    return 0;
+})->purpose('Delete old log files from storage/logs');
+
+Schedule::command('logs:clear')->dailyAt('00:00');

--- a/laravel/tests/Feature/LogCleanupCommandTest.php
+++ b/laravel/tests/Feature/LogCleanupCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class LogCleanupCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->deleteTestLogs();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTestLogs();
+
+        parent::tearDown();
+    }
+
+    public function test_logs_clear_deletes_log_files_older_than_seven_days_by_default(): void
+    {
+        $oldLog = $this->logFile('test-old-default.log', 2048, 8);
+        $recentLog = $this->logFile('test-recent-default.log', 1024, 2);
+        $oldNonLog = $this->nonLogFile('test-old-default.txt', 1024, 8);
+
+        $this->artisan('logs:clear')
+            ->expectsOutputToContain('Deleted')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($oldNonLog);
+
+        File::delete([$recentLog, $oldNonLog]);
+    }
+
+    public function test_logs_clear_days_option_overrides_retention_period(): void
+    {
+        $keptLog = $this->logFile('test-kept-override.log', 512, 10);
+        $deletedLog = $this->logFile('test-deleted-override.log', 1024, 31);
+
+        $this->artisan('logs:clear --days=30')
+            ->expectsOutputToContain('Deleted')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($keptLog);
+        $this->assertFileDoesNotExist($deletedLog);
+
+        File::delete($keptLog);
+    }
+
+    public function test_logs_clear_is_scheduled_daily_at_midnight(): void
+    {
+        $consoleRoutes = File::get(base_path('routes/console.php'));
+
+        $this->assertStringContainsString("Schedule::command('logs:clear')->dailyAt('00:00')", $consoleRoutes);
+    }
+
+    private function logFile(string $name, int $bytes, int $ageInDays): string
+    {
+        return $this->datedFile($name, $bytes, $ageInDays);
+    }
+
+    private function nonLogFile(string $name, int $bytes, int $ageInDays): string
+    {
+        return $this->datedFile($name, $bytes, $ageInDays);
+    }
+
+    private function datedFile(string $name, int $bytes, int $ageInDays): string
+    {
+        $path = storage_path('logs/'.$name);
+
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, str_repeat('x', $bytes));
+        touch($path, now()->subDays($ageInDays)->subMinute()->getTimestamp());
+
+        return $path;
+    }
+
+    private function deleteTestLogs(): void
+    {
+        foreach (File::glob(storage_path('logs/*.log')) as $path) {
+            if (is_file($path) && basename($path) !== 'laravel.log') {
+                File::delete($path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
/claim #753

Summary:
- Add `logs:clear` closure Artisan command in `routes/console.php`.
- Support default 7-day retention and `--days=` override.
- Delete `.log` files from `storage/logs` older than the cutoff and report deleted count plus human-readable freed space.
- Schedule `logs:clear` daily at `00:00`.
- Add focused feature tests for deletion behavior, override behavior, and schedule registration.
- Add safe generation metadata; private platform/system/developer/user-session pre-task context is intentionally redacted.

Validation:
- `php -l routes/console.php` - passed
- `php -l tests/Feature/LogCleanupCommandTest.php` - passed
- `_generation.json` parses as valid JSON
- Verified `logs:clear`, `--days=7`, `dailyAt('00:00')`, and test APP_KEY entries in source
- `php artisan test --filter LogCleanupCommandTest` - passed, 3 tests / 9 assertions
- `php artisan test` - passed, 5 tests / 11 assertions
- `vendor/bin/pint --test routes/console.php tests/Feature/LogCleanupCommandTest.php` - passed
- `git diff --check` - passed

Demo note:
- This is Artisan/scheduler behavior with no UI surface; the focused tests and direct command validation cover behavior.