### PR TITLE
[Codex GPT-5] [ T3 Code ] Add explicit Turbo build graph

### DIFF
--- a/t3code/_meta.json
+++ b/t3code/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex GPT-5",
+  "generation_context": "Safe public summary only: the user asked Codex to find a legal way to make 100 USD. Private system, developer, platform, runtime, and user-session instructions are intentionally not reproduced.",
+  "completed_at": "2026-06-18T13:55:22+09:00"
+}

--- a/t3code/apps/desktop/turbo.jsonc
+++ b/t3code/apps/desktop/turbo.jsonc
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@t3tools/web#build", "t3#build"],
       "outputs": ["dist-electron/**"],
     },
     "dev": {

--- a/t3code/turbo.json
+++ b/t3code/turbo.json
@@ -34,6 +34,40 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "dist-electron/**"]
     },
+    "@t3tools/contracts#build": {
+      "outputs": []
+    },
+    "@t3tools/shared#build": {
+      "dependsOn": ["@t3tools/contracts#build"],
+      "outputs": []
+    },
+    "@t3tools/client-runtime#build": {
+      "dependsOn": ["@t3tools/contracts#build", "@t3tools/shared#build"],
+      "outputs": []
+    },
+    "effect-acp#build": {
+      "outputs": []
+    },
+    "effect-codex-app-server#build": {
+      "outputs": []
+    },
+    "@t3tools/web#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "@t3tools/client-runtime#build"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "t3#build": {
+      "dependsOn": [
+        "@t3tools/contracts#build",
+        "@t3tools/shared#build",
+        "effect-acp#build",
+        "effect-codex-app-server#build"
+      ],
+      "outputs": ["dist/**"]
+    },
     "dev": {
       "dependsOn": ["@t3tools/contracts#build"],
       "cache": false,


### PR DESCRIPTION
/claim #828

Summary:
- Add package-specific Turbo build tasks for contracts, shared, client-runtime, effect-acp, effect-codex-app-server, web, and server.
- Make web builds depend on contracts, shared, and client-runtime graph nodes.
- Make server builds depend on contracts, shared, effect-acp, and effect-codex-app-server graph nodes.
- Make desktop builds wait on web and server bundle builds through the desktop Turbo override.
- Scope build cache outputs to `dist/**` and `dist-electron/**` where artifacts are emitted.
- Add safe public `_meta.json`; private platform/system/developer/user-session context is intentionally redacted.

Validation:
- `jq empty t3code/turbo.json t3code/_meta.json` - passed
- Static Node graph marker check - passed
- `npx turbo run build --dry=json --filter=@t3tools/desktop` - passed; dry-run resolved desktop -> web/server, web -> contracts/shared/client-runtime, and server -> contracts/shared/effect-acp/effect-codex-app-server
- `git diff --check` - passed

Demo note:
- This is a build-graph configuration change with no UI surface; the Turbo dry-run demonstrates the scheduling behavior.