### PR TITLE
[Codex GPT-5] [ T3 Code ] Add CLI version command

### DIFF
--- a/t3code/apps/server/src/.contributor.json
+++ b/t3code/apps/server/src/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex GPT-5",
+  "initialized_with": "Safe public summary only: the user asked Codex to find a legal way to make 100 USD. Private system, developer, platform, runtime, and user-session instructions are intentionally not reproduced.",
+  "timestamp": "2026-06-18T13:59:42+09:00"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -16,6 +16,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
+import packageJson from "../package.json" with { type: "json" };
 import { cli } from "./bin.ts";
 import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "./config.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
@@ -156,6 +157,17 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
 
   it.effect("accepts canonical --no-<flag> boolean negation", () =>
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),
+  );
+
+  it.effect("prints detailed package and runtime information for the version subcommand", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["version"]));
+
+      assert.match(output, new RegExp(`^t3code v${packageJson.version.replaceAll(".", "\\.")} `));
+      assert.match(output, /\((bun|node) [^,]+, [a-z0-9]+ [a-z0-9_]+(?:-[a-z0-9_]+)?\)$/);
+      assert.include(output, process.platform);
+      assert.include(output, process.arch);
+    }),
   );
 
   it.effect("rejects invalid log-level casing before launching the server", () =>

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -10,13 +10,20 @@ import { authCommand } from "./cli/auth.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { versionCommand } from "./cli/version.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([
+    startCommand,
+    serveCommand,
+    authCommand,
+    projectCommand,
+    versionCommand,
+  ]),
 );
 
 if (import.meta.main) {

--- a/t3code/apps/server/src/cli/version.ts
+++ b/t3code/apps/server/src/cli/version.ts
@@ -1,0 +1,32 @@
+import * as Console from "effect/Console";
+import { Command } from "effect/unstable/cli";
+
+import packageJson from "../../package.json" with { type: "json" };
+
+export function getRuntimeLabel(): string {
+  const bunVersion = process.versions.bun;
+  return bunVersion !== undefined ? `bun ${bunVersion}` : `node ${process.versions.node}`;
+}
+
+export function formatVersionInfo(input: {
+  readonly version: string;
+  readonly runtime: string;
+  readonly platform: NodeJS.Platform;
+  readonly arch: NodeJS.Architecture;
+}): string {
+  return `t3code v${input.version} (${input.runtime}, ${input.platform} ${input.arch})`;
+}
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print T3 Code version and runtime details."),
+  Command.withHandler(() =>
+    Console.log(
+      formatVersionInfo({
+        version: packageJson.version,
+        runtime: getRuntimeLabel(),
+        platform: process.platform,
+        arch: process.arch,
+      }),
+    ),
+  ),
+);


### PR DESCRIPTION
/claim #821

Summary:
- Add a `version` subcommand to the existing T3 CLI.
- Preserve the existing built-in root `--version` support that reads `apps/server/package.json` through `Command.run`.
- Print detailed version info in the requested format: `t3code v<version> (<runtime>, <platform> <arch>)`.
- Add focused CLI parsing coverage for the new subcommand.
- Add safe public `.contributor.json`; private platform/system/developer/user-session context is intentionally redacted.

Validation:
- `jq empty t3code/apps/server/src/.contributor.json` - passed
- `node --check t3code/apps/server/src/cli/version.ts` - passed
- `node --check t3code/apps/server/src/bin.ts` - passed
- Static source marker check for package version, runtime label, platform, arch, and command registration - passed
- `git diff --check` - passed

Dependency note:
- This sparse checkout does not include the installed T3Code workspace dependencies, so I could not run the focused Vitest test locally without installing the full workspace.