### PR TITLE
[Codex GPT-5] [ FastAPI ] Add concurrent task runner with timeout

### DIFF
--- a/fastapi/_contributor.json
+++ b/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "Codex GPT-5",
+  "runtime_instructions": "Safe public summary only: the user asked Codex to find a legal way to make 100 USD. Private system, developer, platform, runtime, and user-session instructions are intentionally not reproduced.",
+  "timestamp": "2026-06-18T14:13:52+09:00"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,8 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +13,86 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+_UNSET: object = object()
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more concurrent tasks fail."""
+
+    def __init__(
+        self,
+        failures: list[BaseException],
+        *,
+        partial_results: list[_T] | None = None,
+    ) -> None:
+        super().__init__(self._message(failures))
+        self.failures = failures
+        self.partial_results = partial_results
+
+    @staticmethod
+    def _message(failures: list[BaseException]) -> str:
+        messages = [f"  - {exc}" for exc in failures]
+        return "Concurrent run failed:\n" + "\n".join(messages)
+
+
+async def _run_in_slot(
+    index: int,
+    coroutine: Awaitable[_T],
+    limiter: asyncio.Semaphore,
+) -> tuple[int, _T]:
+    async with limiter:
+        return index, await coroutine
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    *,
+    max_concurrency: int,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be >= 1")
+
+    if not coroutines:
+        return []
+
+    limiter = asyncio.Semaphore(max_concurrency)
+    tasks: list[asyncio.Task[tuple[int, _T]]] = [
+        asyncio.create_task(_run_in_slot(index, coroutine, limiter))
+        for index, coroutine in enumerate(coroutines)
+    ]
+    completed: list[_T | object] = [_UNSET] * len(coroutines)
+    failures: list[BaseException] = []
+
+    try:
+        if timeout is None:
+            raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+        else:
+            raw_results = await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=True),
+                timeout=timeout,
+            )
+    except asyncio.TimeoutError as exc:
+        failures.append(exc)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for result in raw_results:
+        if isinstance(result, asyncio.CancelledError):
+            continue
+        if isinstance(result, BaseException):
+            failures.append(result)
+            continue
+        index, value = result
+        completed[index] = value
+
+    if failures:
+        partial_results = [cast(_T, value) for value in completed if value is not _UNSET]
+        raise ConcurrencyError(failures=failures, partial_results=partial_results)
+
+    return cast(list[_T], completed)
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,112 @@
+import asyncio
+
+import pytest
+
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_preserves_input_order() -> None:
+    async def worker(index: int) -> int:
+        await asyncio.sleep(0.02 - index * 0.003)
+        return index
+
+    result = await run_concurrently(
+        [worker(0), worker(1), worker(2), worker(3)],
+        max_concurrency=2,
+    )
+
+    assert result == [0, 1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_obeys_max_concurrency_of_one() -> None:
+    active = 0
+    max_active = 0
+
+    async def worker() -> int:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return 1
+
+    await run_concurrently(
+        [worker(), worker(), worker(), worker()],
+        max_concurrency=1,
+    )
+
+    assert max_active == 1
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_runs_all_when_pool_large() -> None:
+    active = 0
+    max_active = 0
+
+    async def worker() -> int:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return 1
+
+    await run_concurrently(
+        [worker(), worker(), worker()],
+        max_concurrency=10,
+    )
+
+    assert max_active == 3
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_raises_with_collected_failures() -> None:
+    async def success(value: int) -> int:
+        await asyncio.sleep(0.01)
+        return value
+
+    async def fail(value: int) -> int:
+        await asyncio.sleep(0.005)
+        raise RuntimeError(f"fail-{value}")
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [success(1), fail(2), success(3)],
+            max_concurrency=2,
+        )
+
+    assert len(exc_info.value.failures) == 1
+    assert isinstance(exc_info.value.failures[0], RuntimeError)
+    assert exc_info.value.partial_results == [1, 3]
+
+
+@pytest.mark.anyio
+async def test_run_concurrently_cancels_and_reports_timeout() -> None:
+    cancelled = 0
+
+    async def slow_task() -> int:
+        nonlocal cancelled
+        try:
+            await asyncio.sleep(0.2)
+        except asyncio.CancelledError:
+            cancelled += 1
+            raise
+        return 1
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [slow_task(), slow_task()],
+            max_concurrency=2,
+            timeout=0.01,
+        )
+
+    assert any(isinstance(exc, asyncio.TimeoutError) for exc in exc_info.value.failures)
+    assert cancelled == 2
+    assert exc_info.value.partial_results == []


### PR DESCRIPTION
/claim #803

Summary:
- Add `run_concurrently()` to `fastapi.concurrency`.
- Enforce `max_concurrency` with `asyncio.Semaphore`.
- Preserve result order by input position.
- Add `ConcurrencyError` carrying collected failures and `partial_results`.
- Support total timeout cancellation and report timeout through `ConcurrencyError`.
- Add focused async tests for ordering, max concurrency 1, large pools, failure aggregation, and timeout cancellation.
- Add safe public `_contributor.json`; private platform/system/developer/user-session context is intentionally redacted.

Validation:
- `python3 -m py_compile fastapi/concurrency.py tests/test_concurrency.py` - passed
- `jq empty fastapi/_contributor.json` - passed
- `git diff --check` - passed
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD uv run --no-project --python 3.12 --with pytest --with pytest-timeout --with anyio[trio]>=3.2.1,<5.0.0 --with pydantic>=2.9.0 --with starlette>=0.46.0 --with typing-extensions>=4.8.0 --with typing-inspection>=0.4.2 --with annotated-doc>=0.0.2 python -m pytest tests/test_concurrency.py -q` - passed, 5 tests

Test note:
- The helper is intentionally asyncio-based per the issue requirement; the test module pins the AnyIO backend to `asyncio`.