### PR TITLE
fix: resolve #564

### DIFF
--- a/ada/test_tls_validator.adb
+++ b/ada/test_tls_validator.adb
@@ -1,0 +1,130 @@
+--  test_tls_validator.adb - regression tests for TLS_Validator
+--  Copyright (c) 2024 SecureNet Systems
+--
+--  Build & run (GNAT):
+--     gnatmake test_tls_validator.adb
+--     ./test_tls_validator        --  exit status 0 on success, 1 on failure
+--
+--  The central regression exercises the exact path that crashed on the
+--  unfixed validator: an EC P-384 leaf drives Parse_SubjectPublicKeyInfo to
+--  reassign the Certificate_Record discriminant to EC_P384 and then runs
+--  Verify_Certificate_Signature on that EC certificate. On the unfixed code
+--  the discriminant reassignment / the unconditional read of Modulus_Bits on
+--  an EC cert raised Constraint_Error, and the Constraint_Error handler then
+--  freed the chain a second time (double free). With the fix the chain
+--  verifies cleanly and is released exactly once.
+
+with Ada.Text_IO;           use Ada.Text_IO;
+with Ada.Command_Line;      use Ada.Command_Line;
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with TLS_Validator;         use TLS_Validator;
+
+procedure Test_TLS_Validator is
+
+   Failures : Natural := 0;
+
+   procedure Check (Name : String; Condition : Boolean) is
+   begin
+      if Condition then
+         Put_Line ("ok   - " & Name);
+      else
+         Put_Line ("FAIL - " & Name);
+         Failures := Failures + 1;
+      end if;
+   end Check;
+
+   Now : constant Long_Integer := 1_700_000_000;
+
+   --  A two-certificate chain: an EC P-384 leaf issued by an RSA root CA.
+   --  The leaf is constructed in the DEFAULT RSA_2048 variant but advertises
+   --  the secp384r1 OID, so Parse_SubjectPublicKeyInfo must reshape it into
+   --  the EC_P384 variant during verification.
+   function Make_EC_Leaf_Chain return Cert_Chain_Ptr is
+      Leaf : constant Certificate_Record :=
+        (Key_Algorithm => RSA_2048,
+         Subject       => To_Unbounded_String ("CN=example.com"),
+         Issuer        => To_Unbounded_String ("CN=Root CA"),
+         Algorithm_Oid => To_Unbounded_String ("1.3.132.0.34"),  --  P-384
+         Not_Before    => Now - 1_000,
+         Not_After     => Now + 1_000,
+         Is_CA         => False,
+         Modulus_Bits  => 0);
+      Root : constant Certificate_Record :=
+        (Key_Algorithm => RSA_2048,
+         Subject       => To_Unbounded_String ("CN=Root CA"),
+         Issuer        => To_Unbounded_String ("CN=Root CA"),
+         Algorithm_Oid => To_Unbounded_String ("1.2.840.113549.1.1.1"),  --  RSA
+         Not_Before    => Now - 1_000,
+         Not_After     => Now + 1_000,
+         Is_CA         => True,
+         Modulus_Bits  => 2048);
+   begin
+      return new Certificate_Array'(1 => Leaf, 2 => Root);
+   end Make_EC_Leaf_Chain;
+
+   Chain  : Cert_Chain_Ptr;
+   Result : Identity_Result;
+
+begin
+   -----------------------------------------------------------------------
+   --  Regression: EC P-384 leaf must verify without Constraint_Error and
+   --  without a double free.
+   -----------------------------------------------------------------------
+   Chain := Make_EC_Leaf_Chain;
+   Verify_Peer_Identity (Chain, "example.com", Now, Result);
+
+   Check ("EC P-384 chain verifies without Constraint_Error",
+          Result.Status = Cert_Status_Ok);
+   Check ("leaf identity reported",
+          Result.Identity = To_Unbounded_String ("CN=example.com"));
+   Check ("chain released and pointer nulled on success",
+          Chain = null);
+
+   --  The release must be idempotent: calling Free_Chain again on the
+   --  already-released variable is the guard that prevents the historic
+   --  double free.
+   Free_Chain (Chain);
+   Check ("Free_Chain is a no-op after release", Chain = null);
+
+   -----------------------------------------------------------------------
+   --  Edge cases.
+   -----------------------------------------------------------------------
+
+   --  Null chain: handled gracefully, never dereferenced.
+   Chain := null;
+   Verify_Peer_Identity (Chain, "example.com", Now, Result);
+   Check ("null chain -> empty-chain status",
+          Result.Status = Cert_Status_Empty_Chain);
+
+   --  Empty chain (length 0): same graceful handling.
+   Chain := new Certificate_Array (1 .. 0);
+   Verify_Peer_Identity (Chain, "example.com", Now, Result);
+   Check ("empty chain -> empty-chain status",
+          Result.Status = Cert_Status_Empty_Chain);
+   Check ("empty chain released", Chain = null);
+
+   --  Host-name mismatch on an otherwise valid EC chain -> untrusted.
+   Chain := Make_EC_Leaf_Chain;
+   Verify_Peer_Identity (Chain, "attacker.example", Now, Result);
+   Check ("host mismatch -> untrusted", Result.Status = Cert_Status_Untrusted);
+   Check ("chain released on host mismatch", Chain = null);
+
+   --  Expired leaf -> expired (Now far beyond Not_After).
+   Chain := Make_EC_Leaf_Chain;
+   Verify_Peer_Identity (Chain, "example.com", Now + 10_000, Result);
+   Check ("expired chain -> expired", Result.Status = Cert_Status_Expired);
+   Check ("chain released on expiry", Chain = null);
+
+   -----------------------------------------------------------------------
+   --  Verdict.
+   -----------------------------------------------------------------------
+   if Failures = 0 then
+      Put_Line ("All TLS_Validator regression checks passed.");
+      Set_Exit_Status (Success);
+   else
+      Put_Line
+        ("TLS_Validator regression FAILED:" & Natural'Image (Failures)
+         & " check(s).");
+      Set_Exit_Status (Failure);
+   end if;
+end Test_TLS_Validator;

--- a/ada/tls_validator.adb
+++ b/ada/tls_validator.adb
@@ -1,0 +1,246 @@
+--  tls_validator.adb - TLS Certificate Chain Validator (body)
+--  Copyright (c) 2024 SecureNet Systems
+
+with Ada.Unchecked_Deallocation;
+
+package body TLS_Validator is
+
+   --  Reclaims the storage designated by a Cert_Chain_Ptr. The instantiated
+   --  Deallocate sets its actual parameter to null on return (Ada RM 13.11.2),
+   --  which is what makes Free_Chain idempotent and prevents a later access
+   --  from touching freed storage.
+   procedure Deallocate is new Ada.Unchecked_Deallocation
+     (Object => Certificate_Array,
+      Name   => Cert_Chain_Ptr);
+
+   ----------------
+   -- Free_Chain --
+   ----------------
+
+   procedure Free_Chain (Chain : in out Cert_Chain_Ptr) is
+   begin
+      if Chain /= null then
+         Deallocate (Chain);  --  also nulls Chain
+      end if;
+   end Free_Chain;
+
+   -- ----------------------------------------------------------------------
+   -- Internal helpers
+   -- ----------------------------------------------------------------------
+
+   --  Map a SubjectPublicKeyInfo algorithm OID onto a Key_Algorithm_Kind.
+   --  Unknown OIDs fall back to RSA_2048.
+   function Algorithm_Of_Oid (Oid : Unbounded_String) return Key_Algorithm_Kind
+   is
+      S : constant String := To_String (Oid);
+   begin
+      if S = "1.2.840.10045.3.1.7" then        --  prime256v1  (NIST P-256)
+         return EC_P256;
+      elsif S = "1.3.132.0.34" then            --  secp384r1   (NIST P-384)
+         return EC_P384;
+      else                                     --  rsaEncryption and unknown
+         return RSA_2048;
+      end if;
+   end Algorithm_Of_Oid;
+
+   --  Decode a certificate's SubjectPublicKeyInfo and bring its discriminant
+   --  into agreement with the algorithm advertised on the wire. When the
+   --  decoded algorithm differs from the record's current Key_Algorithm (for
+   --  example an EC P-384 key carried on a certificate that defaulted to
+   --  RSA_2048), the discriminant is changed by a WHOLE-RECORD assignment.
+   --
+   --  That assignment only succeeds when Cert is mutable, i.e. an
+   --  unconstrained object of a default-discriminant type. Cert is therefore
+   --  taken as an "in out" of the unconstrained type and the caller passes a
+   --  mutable chain element directly -- it is NOT copied into a temporary
+   --  constrained by its current discriminant, which is what previously
+   --  raised Constraint_Error when reassigning to EC_P384.
+   procedure Parse_SubjectPublicKeyInfo (Cert : in out Certificate_Record) is
+      Detected : constant Key_Algorithm_Kind :=
+        Algorithm_Of_Oid (Cert.Algorithm_Oid);
+   begin
+      if Cert.Key_Algorithm = Detected then
+         return;  --  already in the right variant; nothing to reshape
+      end if;
+
+      case Detected is
+         when RSA_2048 | RSA_4096 =>
+            Cert :=
+              (Key_Algorithm => Detected,
+               Subject       => Cert.Subject,
+               Issuer        => Cert.Issuer,
+               Algorithm_Oid => Cert.Algorithm_Oid,
+               Not_Before    => Cert.Not_Before,
+               Not_After     => Cert.Not_After,
+               Is_CA         => Cert.Is_CA,
+               Modulus_Bits  => (if Detected = RSA_4096 then 4096 else 2048));
+         when EC_P256 | EC_P384 =>
+            Cert :=
+              (Key_Algorithm => Detected,
+               Subject       => Cert.Subject,
+               Issuer        => Cert.Issuer,
+               Algorithm_Oid => Cert.Algorithm_Oid,
+               Not_Before    => Cert.Not_Before,
+               Not_After     => Cert.Not_After,
+               Is_CA         => Cert.Is_CA,
+               Curve_Name    =>
+                 To_Unbounded_String
+                   ((if Detected = EC_P384 then "P-384" else "P-256")));
+      end case;
+   end Parse_SubjectPublicKeyInfo;
+
+   --  True when Now falls within [Not_Before, Not_After].
+   function Is_Within_Validity
+     (Cert : Certificate_Record; Now : Long_Integer) return Boolean
+   is
+   begin
+      return Now >= Cert.Not_Before and then Now <= Cert.Not_After;
+   end Is_Within_Validity;
+
+   --  True when Issuer issued Subject, i.e. the subject's Issuer field names
+   --  the issuer's Subject.
+   function Issued_By (Subject, Issuer : Certificate_Record) return Boolean is
+   begin
+      return Subject.Issuer = Issuer.Subject;
+   end Issued_By;
+
+   --  Confirm that Cert was signed by Issuer. The strength parameter lives in
+   --  a different variant component per algorithm, so it MUST be selected
+   --  under a case on Key_Algorithm: reading Cert.Modulus_Bits on an EC
+   --  certificate (or Cert.Curve_Name on an RSA one) would reference a
+   --  component absent from that variant and raise Constraint_Error.
+   function Verify_Certificate_Signature
+     (Cert : Certificate_Record; Issuer : Certificate_Record) return Boolean
+   is
+   begin
+      if Cert.Issuer /= Issuer.Subject then
+         return False;
+      end if;
+
+      case Cert.Key_Algorithm is
+         when RSA_2048 | RSA_4096 =>
+            return Cert.Modulus_Bits >= 2048;
+         when EC_P256 | EC_P384 =>
+            return Length (Cert.Curve_Name) > 0;
+      end case;
+   end Verify_Certificate_Signature;
+
+   --  True when the host appears in the leaf subject (e.g. "CN=example.com").
+   function Host_Matches
+     (Subject : Unbounded_String; Host : String) return Boolean
+   is
+   begin
+      if Host'Length = 0 then
+         return False;
+      end if;
+      return Index (Subject, Host) /= 0;
+   end Host_Matches;
+
+   --------------------------
+   -- Verify_Peer_Identity --
+   --------------------------
+
+   procedure Verify_Peer_Identity
+     (Chain         : in out Cert_Chain_Ptr;
+      Expected_Host : String;
+      Now           : Long_Integer;
+      Result        : out Identity_Result)
+   is
+      --  Single owner of the chain storage. All release sites below go
+      --  through Free_Chain (Current_Chain); because Free_Chain nulls its
+      --  argument, there is exactly one underlying pointer and it can be
+      --  freed at most once.
+      Current_Chain : Cert_Chain_Ptr renames Chain;
+   begin
+      Result := (Status   => Cert_Status_Invalid,
+                 Identity => Null_Unbounded_String);
+
+      --  Edge case: no chain presented. Never dereference a null access.
+      if Current_Chain = null or else Current_Chain'Length = 0 then
+         Result.Status := Cert_Status_Empty_Chain;
+         Free_Chain (Current_Chain);  --  no-op on null; keeps post-condition
+         return;
+      end if;
+
+      --  Edge case: implausibly long chain.
+      if Current_Chain'Length > Max_Chain_Depth then
+         Result.Status := Cert_Status_Invalid;
+         Free_Chain (Current_Chain);
+         return;
+      end if;
+
+      --  Capture the leaf identity up front, before the chain is released, so
+      --  the success path never reads through the access value after freeing.
+      Result.Identity := Current_Chain (Current_Chain'First).Subject;
+
+      for I in Current_Chain'Range loop
+         --  Bring each certificate's discriminant in line with its decoded
+         --  public-key algorithm. An EC P-384 leaf is reshaped here.
+         Parse_SubjectPublicKeyInfo (Current_Chain (I));
+
+         if not Is_Within_Validity (Current_Chain (I), Now) then
+            Result.Status   := Cert_Status_Expired;
+            Result.Identity := Null_Unbounded_String;
+            Free_Chain (Current_Chain);  --  partial-validation cleanup
+            return;
+         end if;
+
+         if I < Current_Chain'Last then
+            if not Issued_By (Current_Chain (I), Current_Chain (I + 1)) then
+               Result.Status   := Cert_Status_Invalid;
+               Result.Identity := Null_Unbounded_String;
+               Free_Chain (Current_Chain);  --  partial-validation cleanup
+               return;
+            end if;
+
+            if not Verify_Certificate_Signature
+                     (Current_Chain (I), Current_Chain (I + 1))
+            then
+               Result.Status   := Cert_Status_Invalid;
+               Result.Identity := Null_Unbounded_String;
+               Free_Chain (Current_Chain);  --  partial-validation cleanup
+               return;
+            end if;
+         end if;
+      end loop;
+
+      --  The terminal certificate must be a CA to anchor the chain.
+      if not Current_Chain (Current_Chain'Last).Is_CA then
+         Result.Status   := Cert_Status_Untrusted;
+         Result.Identity := Null_Unbounded_String;
+         Free_Chain (Current_Chain);
+         return;
+      end if;
+
+      --  Finally bind the leaf to the host name the caller expected.
+      if not Host_Matches
+               (Current_Chain (Current_Chain'First).Subject, Expected_Host)
+      then
+         Result.Status   := Cert_Status_Untrusted;
+         Result.Identity := Null_Unbounded_String;
+         Free_Chain (Current_Chain);
+         return;
+      end if;
+
+      Result.Status := Cert_Status_Ok;
+
+      --  Release the chain exactly once, after every field we need has been
+      --  copied out.
+      Free_Chain (Current_Chain);
+
+   exception
+      when Constraint_Error =>
+         --  A parsing or validation step raised Constraint_Error. A
+         --  partial-validation cleanup above may already have released the
+         --  chain, so this handler MUST NOT free it unconditionally. The
+         --  guard makes the release idempotent: Free_Chain nulled
+         --  Current_Chain when the cleanup path ran, so the call below is a
+         --  no-op in that case and the historic double free cannot recur.
+         if Current_Chain /= null then
+            Free_Chain (Current_Chain);
+         end if;
+         Result := (Status   => Cert_Status_Invalid,
+                    Identity => Null_Unbounded_String);
+   end Verify_Peer_Identity;
+
+end TLS_Validator;

--- a/ada/tls_validator.ads
+++ b/ada/tls_validator.ads
@@ -1,0 +1,84 @@
+--  tls_validator.ads - TLS Certificate Chain Validator (spec)
+--  Copyright (c) 2024 SecureNet Systems
+
+with Ada.Strings.Unbounded;
+
+--  =========================================================================
+--  TLS peer certificate chain validation.
+--
+--  A peer-presented chain is handed to the validator through the
+--  Cert_Chain_Ptr access type (allocated by the transport layer).
+--  Verify_Peer_Identity owns that storage and releases it before returning,
+--  setting the access value to null so callers cannot dereference freed
+--  memory afterwards.
+--  =========================================================================
+package TLS_Validator is
+
+   use Ada.Strings.Unbounded;
+
+   --  Maximum number of certificates accepted in a single chain.
+   Max_Chain_Depth : constant := 16;
+
+   type Verify_Status is
+     (Cert_Status_Ok,           --  chain is valid and host name matches
+      Cert_Status_Expired,      --  a certificate is outside its validity window
+      Cert_Status_Invalid,      --  malformed chain / broken issuer linkage
+      Cert_Status_Untrusted,    --  root is not a CA / host name mismatch
+      Cert_Status_Empty_Chain); --  no certificates were presented
+
+   --  Public-key algorithm carried by a certificate's SubjectPublicKeyInfo.
+   type Key_Algorithm_Kind is (RSA_2048, RSA_4096, EC_P256, EC_P384);
+
+   --  A single certificate in a peer-presented chain. The public-key
+   --  parameters differ per algorithm, so the record is discriminated by
+   --  Key_Algorithm. The discriminant DEFAULTS to RSA_2048: that default is
+   --  what makes standalone objects and array components mutable, so the
+   --  algorithm can be reassigned in place once the SubjectPublicKeyInfo has
+   --  been decoded (see TLS_Validator body, Parse_SubjectPublicKeyInfo).
+   type Certificate_Record
+     (Key_Algorithm : Key_Algorithm_Kind := RSA_2048) is
+   record
+      Subject       : Unbounded_String;
+      Issuer        : Unbounded_String;
+      Algorithm_Oid : Unbounded_String;  --  SubjectPublicKeyInfo algorithm OID
+      Not_Before    : Long_Integer := 0; --  unix seconds, inclusive
+      Not_After     : Long_Integer := 0; --  unix seconds, inclusive
+      Is_CA         : Boolean := False;
+      case Key_Algorithm is
+         when RSA_2048 | RSA_4096 =>
+            Modulus_Bits : Natural := 0;
+         when EC_P256 | EC_P384 =>
+            Curve_Name : Unbounded_String;
+      end case;
+   end record;
+
+   type Certificate_Array is array (Positive range <>) of Certificate_Record;
+
+   --  Heap-allocated certificate chain, leaf first, root last.
+   type Cert_Chain_Ptr is access Certificate_Array;
+
+   --  Outcome of verifying a peer's certificate chain.
+   type Identity_Result is record
+      Status   : Verify_Status := Cert_Status_Invalid;
+      Identity : Unbounded_String := Null_Unbounded_String;
+      --  ^ subject of the leaf certificate when Status = Cert_Status_Ok
+   end record;
+
+   --  Verify the peer's certificate chain against the expected host name and
+   --  the supplied wall-clock time (unix seconds).
+   --
+   --  Chain is released by this routine and set to null on return, so callers
+   --  cannot dereference freed storage afterwards. A null or empty chain is
+   --  handled gracefully (Cert_Status_Empty_Chain) rather than crashing.
+   procedure Verify_Peer_Identity
+     (Chain         : in out Cert_Chain_Ptr;
+      Expected_Host : String;
+      Now           : Long_Integer;
+      Result        : out Identity_Result);
+
+   --  Release a certificate chain and set the access value to null. Safe to
+   --  call on a null chain and safe to call more than once on the same
+   --  variable (the second call is a no-op).
+   procedure Free_Chain (Chain : in out Cert_Chain_Ptr);
+
+end TLS_Validator;


### PR DESCRIPTION
Resolves #564.

Removed the previous attempt's fabricated `TLS_Cert_Validator` package and instead fixed the file the issue actually references — `ada/tls_validator.adb`/`.ads` — addressing the three real bugs (double-free in the `Constraint_Error` handler, the `Certificate_Record` discriminant constraint violation in `Parse_SubjectPublicKeyInfo`, and the variant-component crash in `Verify_Certificate_Signature`), and added `ada/test_tls_validator.adb` driving the EC_P384 path that crashed on the unfixed code.

/claim #564