### PR TITLE
Wulansari [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/.generation_meta.json
+++ b/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Wulansari (wulansari999)",
+  "initial_directives": "You are Wulansari, a freelance security researcher and software engineer. You work on open source bounties to earn income. Key constraints: be efficient, ship working code, minimize tool calls. Use gh CLI and git. Fix the PriceOracle contract to add staleness checking, price validation, round completeness, and fallback oracle support. Requirements: add require(price > 0), add require(answeredInRound >= roundId), add staleness check with MAX_STALENESS, add fallback oracle, emit StalePrice event, write tests.",
+  "date": "2026-06-22T08:15:00Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,34 +14,45 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(uint256 primaryUpdatedAt, uint256 fallbackUpdatedAt);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+    function getLatestPrice() external returns (int256) {
+        (uint80 roundId, int256 price, , uint256 updatedAt, uint80 answeredInRound) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        require(price > 0, "Invalid price");
+        require(answeredInRound >= roundId, "Round incomplete");
 
-        return price;
+        if (block.timestamp - updatedAt < MAX_STALENESS) {
+            emit PriceQueried(price, updatedAt);
+            return price;
+        }
+
+        // Primary is stale — try fallback
+        if (address(fallbackFeed) == address(0)) {
+            revert("Stale price");
+        }
+
+        (uint80 fbRoundId, int256 fbPrice, , uint256 fbUpdatedAt, uint80 fbAnsweredInRound) = fallbackFeed.latestRoundData();
+        require(fbPrice > 0, "Fallback invalid price");
+        require(fbAnsweredInRound >= fbRoundId, "Fallback round incomplete");
+
+        if (block.timestamp - fbUpdatedAt < MAX_STALENESS) {
+            emit StalePrice(updatedAt, fbUpdatedAt);
+            emit PriceQueried(fbPrice, fbUpdatedAt);
+            return fbPrice;
+        }
+
+        revert("Stale price");
     }
 
     function getDecimals() external view returns (uint8) {
@@ -51,5 +62,10 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
     }
 }

--- a/solidity/contracts/test/MockAggregator.sol
+++ b/solidity/contracts/test/MockAggregator.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockAggregator {
+    int256 private _answer;
+    uint256 private _updatedAt;
+    uint80 private _roundId;
+    uint80 private _answeredInRound;
+
+    constructor(int256 answer, uint256 updatedAt, uint80 roundId, uint80 answeredInRound) {
+        _answer = answer;
+        _updatedAt = updatedAt;
+        _roundId = roundId;
+        _answeredInRound = answeredInRound;
+    }
+
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return 8;
+    }
+}

--- a/solidity/test/PriceOracle.test.js
+++ b/solidity/test/PriceOracle.test.js
@@ -1,0 +1,142 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PriceOracle", function () {
+  let oracle, mockFeed, mockFallback, owner;
+  const ONE_HOUR = 3600;
+  const VALID_PRICE = 2000n * 10n ** 8n;
+
+  async function deployMockFeed(price, updatedAt, roundId, answeredInRound) {
+    const Mock = await ethers.getContractFactory("AggregatorV3Interface");
+    // Use a simple contract via hardhat's approach
+    const MockFeed = await ethers.getContractFactory(
+      "contracts/test/MockAggregator.sol:MockAggregator"
+    );
+    const feed = await MockFeed.deploy(price, updatedAt, roundId, answeredInRound);
+    await feed.waitForDeployment();
+    return feed;
+  }
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    const now = Math.floor(Date.now() / 1000);
+    const MockFeed = await ethers.getContractFactory("MockAggregator");
+    mockFeed = await MockFeed.deploy(VALID_PRICE, now, 1, 1);
+    await mockFeed.waitForDeployment();
+
+    const PriceOracle = await ethers.getContractFactory("PriceOracle");
+    oracle = await PriceOracle.deploy(await mockFeed.getAddress());
+    await oracle.waitForDeployment();
+  });
+
+  describe("Valid price", function () {
+    it("should return price when data is fresh and valid", async function () {
+      const price = await oracle.getLatestPrice.staticCall();
+      expect(price).to.equal(VALID_PRICE);
+    });
+  });
+
+  describe("Price validation", function () {
+    it("should reject zero price", async function () {
+      const now = Math.floor(Date.now() / 1000);
+      const zeroFeed = await ethers.getContractFactory("MockAggregator");
+      const zf = await zeroFeed.deploy(0, now, 1, 1);
+      await zf.waitForDeployment();
+      const Oracle = await ethers.getContractFactory("PriceOracle");
+      const o = await Oracle.deploy(await zf.getAddress());
+      await o.waitForDeployment();
+      await expect(o.getLatestPrice()).to.be.revertedWith("Invalid price");
+    });
+
+    it("should reject negative price", async function () {
+      const now = Math.floor(Date.now() / 1000);
+      const negFeed = await ethers.getContractFactory("MockAggregator");
+      const nf = await negFeed.deploy(-100, now, 1, 1);
+      await nf.waitForDeployment();
+      const Oracle = await ethers.getContractFactory("PriceOracle");
+      const o = await Oracle.deploy(await nf.getAddress());
+      await o.waitForDeployment();
+      await expect(o.getLatestPrice()).to.be.revertedWith("Invalid price");
+    });
+  });
+
+  describe("Round completeness", function () {
+    it("should reject incomplete round (answeredInRound < roundId)", async function () {
+      const now = Math.floor(Date.now() / 1000);
+      const badFeed = await ethers.getContractFactory("MockAggregator");
+      const bf = await badFeed.deploy(VALID_PRICE, now, 5, 3);
+      await bf.waitForDeployment();
+      const Oracle = await ethers.getContractFactory("PriceOracle");
+      const o = await Oracle.deploy(await bf.getAddress());
+      await o.waitForDeployment();
+      await expect(o.getLatestPrice()).to.be.revertedWith("Round incomplete");
+    });
+  });
+
+  describe("Staleness check", function () {
+    it("should reject stale data (older than MAX_STALENESS)", async function () {
+      const staleTime = Math.floor(Date.now() / 1000) - 7200; // 2 hours old
+      const staleFeed = await ethers.getContractFactory("MockAggregator");
+      const sf = await staleFeed.deploy(VALID_PRICE, staleTime, 1, 1);
+      await sf.waitForDeployment();
+      const Oracle = await ethers.getContractFactory("PriceOracle");
+      const o = await Oracle.deploy(await sf.getAddress());
+      await o.waitForDeployment();
+      await expect(o.getLatestPrice()).to.be.revertedWith("Stale price");
+    });
+  });
+
+  describe("Fallback oracle", function () {
+    it("should use fallback when primary is stale and fallback is fresh", async function () {
+      const now = Math.floor(Date.now() / 1000);
+      const staleTime = now - 7200;
+
+      const MockFeed = await ethers.getContractFactory("MockAggregator");
+      const primary = await MockFeed.deploy(VALID_PRICE, staleTime, 1, 1);
+      await primary.waitForDeployment();
+      const fallback = await MockFeed.deploy(VALID_PRICE, now, 1, 1);
+      await fallback.waitForDeployment();
+
+      const Oracle = await ethers.getContractFactory("PriceOracle");
+      const o = await Oracle.deploy(await primary.getAddress());
+      await o.waitForDeployment();
+      await o.setFallbackFeed(await fallback.getAddress());
+
+      const price = await o.getLatestPrice.staticCall();
+      expect(price).to.equal(VALID_PRICE);
+    });
+
+    it("should revert if both oracles are stale", async function () {
+      const staleTime = Math.floor(Date.now() / 1000) - 7200;
+
+      const MockFeed = await ethers.getContractFactory("MockAggregator");
+      const primary = await MockFeed.deploy(VALID_PRICE, staleTime, 1, 1);
+      await primary.waitForDeployment();
+      const fallback = await MockFeed.deploy(VALID_PRICE, staleTime, 1, 1);
+      await fallback.waitForDeployment();
+
+      const Oracle = await ethers.getContractFactory("PriceOracle");
+      const o = await Oracle.deploy(await primary.getAddress());
+      await o.waitForDeployment();
+      await o.setFallbackFeed(await fallback.getAddress());
+
+      await expect(o.getLatestPrice()).to.be.revertedWith("Stale price");
+    });
+  });
+
+  describe("Ownership", function () {
+    it("should allow owner to set MAX_STALENESS", async function () {
+      await oracle.setMaxStaleness(1800);
+      expect(await oracle.MAX_STALENESS()).to.equal(1800);
+    });
+
+    it("should allow owner to set fallback feed", async function () {
+      const now = Math.floor(Date.now() / 1000);
+      const MockFeed = await ethers.getContractFactory("MockAggregator");
+      const fb = await MockFeed.deploy(VALID_PRICE, now, 1, 1);
+      await fb.waitForDeployment();
+      await oracle.setFallbackFeed(await fb.getAddress());
+      expect(await oracle.fallbackFeed()).to.equal(await fb.getAddress());
+    });
+  });
+});


### PR DESCRIPTION
/claim #915

## Issue
Closes #915

## Summary
Fix PriceOracle to validate price freshness, completeness, and add fallback oracle support.

## Acceptance criteria
- [x] Stale prices (older than 1 hour) trigger fallback to secondary oracle
- [x] Zero or negative prices revert with clear error
- [x] Incomplete rounds are rejected
- [x] StalePrice event is emitted with the primary oracle's last update timestamp
- [x] If both oracles return stale data, the function reverts instead of returning bad data
- [x] MAX_STALENESS is configurable by the contract owner
- [x] Tests mock Chainlink responses for: valid price, stale price, negative price, incomplete round, both oracles stale

## Changes
- solidity/contracts/PriceOracle.sol — added price validation, staleness check, fallback oracle
- solidity/contracts/test/MockAggregator.sol — mock for testing
- solidity/test/PriceOracle.test.js — 9 tests covering all acceptance criteria
- .generation_meta.json