### PR TITLE
Wulansari [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Wulansari",
+  "initial_directives": "You are Wulansari, a security researcher and freelance professional. Modal $4, provider OpenRouter, payment USDC Base. Sumber revenue: GitHub Bug Bounty, Fiverr freelance, pentest lokal. Hanya target authorized. Task: cari tiket bounty open source yang membayar crypto, perbaiki kode, buat PR.",
+  "date": "2026-06-22T00:00:00Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,33 +14,80 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event StalePrice(address indexed oracle, uint256 lastUpdateTimestamp);
 
-    constructor(address _primaryFeed) {
+    error InvalidPrice();
+    error IncompleteRound();
+    error StalePriceBothOracles();
+
+    constructor(address _primaryFeed, address _fallbackFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function _validateRound(
+        uint80 roundId,
+        int256 price,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) internal view {
+        if (price <= 0) revert InvalidPrice();
+        if (answeredInRound < roundId) revert IncompleteRound();
+        if (block.timestamp - updatedAt >= MAX_STALENESS) revert StalePriceBothOracles();
+    }
+
+    function _fetchFromFeed(AggregatorV3Interface feed)
+        internal
+        returns (int256 price, uint256 updatedAt, bool stale)
+    {
         (
             uint80 roundId,
-            int256 price,
+            int256 answer,
             ,
-            uint256 updatedAt,
+            uint256 _updatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) = feed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        // Check for invalid price or incomplete round first
+        if (answer <= 0) revert InvalidPrice();
+        if (answeredInRound < roundId) revert IncompleteRound();
 
+        // Check staleness
+        if (block.timestamp - _updatedAt >= MAX_STALENESS) {
+            return (0, _updatedAt, true);
+        }
+
+        return (answer, _updatedAt, false);
+    }
+
+    function getLatestPrice() external returns (int256) {
+        (int256 price, uint256 primaryUpdatedAt, bool stale) = _fetchFromFeed(primaryFeed);
+
+        if (stale) {
+            // Emit StalePrice for primary oracle before trying fallback
+            emit StalePrice(address(primaryFeed), primaryUpdatedAt);
+
+            // Try fallback oracle
+            (int256 fallbackPrice, uint256 fallbackUpdatedAt, bool fallbackStale)
+                = _fetchFromFeed(fallbackFeed);
+
+            if (fallbackStale) {
+                // Both oracles stale — emit for fallback too, then revert
+                emit StalePrice(address(fallbackFeed), fallbackUpdatedAt);
+                revert StalePriceBothOracles();
+            }
+
+            emit PriceQueried(fallbackPrice, block.timestamp);
+            return fallbackPrice;
+        }
+
+        emit PriceQueried(price, block.timestamp);
         return price;
     }
 
@@ -51,5 +98,10 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
     }
 }

--- a/solidity/contracts/mocks/MockAggregatorV3.sol
+++ b/solidity/contracts/mocks/MockAggregatorV3.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockAggregatorV3 {
+    uint80 private s_roundId;
+    int256 private s_answer;
+    uint256 private s_startedAt;
+    uint256 private s_updatedAt;
+    uint80 private s_answeredInRound;
+    uint8 private s_decimals;
+
+    constructor(uint8 _decimals) {
+        s_decimals = _decimals;
+    }
+
+    function setLatestRoundData(
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) external {
+        s_roundId = roundId;
+        s_answer = answer;
+        s_startedAt = startedAt;
+        s_updatedAt = updatedAt;
+        s_answeredInRound = answeredInRound;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (s_roundId, s_answer, s_startedAt, s_updatedAt, s_answeredInRound);
+    }
+
+    function decimals() external view returns (uint8) {
+        return s_decimals;
+    }
+}

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,0 +1,17 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: {
+    version: "0.8.24",
+    settings: {
+      optimizer: { enabled: true, runs: 200 },
+      evmVersion: "cancun",
+    },
+  },
+  paths: {
+    sources: "./contracts",
+    tests: "./test",
+    cache: "./cache",
+    artifacts: "./artifacts",
+  },
+};

--- a/solidity/test/PriceOracle.test.js
+++ b/solidity/test/PriceOracle.test.js
@@ -1,0 +1,67 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Mock Chainlink aggregator for testing
+async function deployMockAggregator(decimals = 8) {
+  const MockAggregator = await ethers.getContractFactory("MockAggregatorV3");
+  const agg = await MockAggregator.deploy(decimals);
+  await agg.waitForDeployment();
+  return agg;
+}
+
+describe("PriceOracle", function () {
+  let primaryAgg, fallbackAgg, oracle;
+
+  beforeEach(async function () {
+    primaryAgg = await deployMockAggregator(8);
+    fallbackAgg = await deployMockAggregator(8);
+    const PriceOracle = await ethers.getContractFactory("PriceOracle");
+    oracle = await PriceOracle.deploy(await primaryAgg.getAddress(), await fallbackAgg.getAddress());
+    await oracle.waitForDeployment();
+  });
+
+  it("returns valid price from primary oracle", async function () {
+    await primaryAgg.setLatestRoundData(1, 300000000000, 1000, Math.floor(Date.now() / 1000), 1);
+    const price = await oracle.getLatestPrice.staticCall();
+    expect(price).to.equal(300000000000);
+  });
+
+  it("reverts on zero or negative price", async function () {
+    await primaryAgg.setLatestRoundData(1, 0, 1000, Math.floor(Date.now() / 1000), 1);
+    await expect(oracle.getLatestPrice()).to.be.revertedWithCustomError(oracle, "InvalidPrice");
+  });
+
+  it("reverts on incomplete round", async function () {
+    await primaryAgg.setLatestRoundData(5, 300000000000, 1000, Math.floor(Date.now() / 1000), 3);
+    await expect(oracle.getLatestPrice()).to.be.revertedWithCustomError(oracle, "IncompleteRound");
+  });
+
+  it("falls back to secondary oracle when primary is stale", async function () {
+    const staleTs = Math.floor(Date.now() / 1000) - 7200; // 2 hours ago
+    await primaryAgg.setLatestRoundData(1, 300000000000, 1000, staleTs, 1);
+    await fallbackAgg.setLatestRoundData(1, 310000000000, 1000, Math.floor(Date.now() / 1000), 1);
+    const price = await oracle.getLatestPrice.staticCall();
+    expect(price).to.equal(310000000000);
+  });
+
+  it("reverts when both oracles are stale", async function () {
+    const staleTs = Math.floor(Date.now() / 1000) - 7200;
+    await primaryAgg.setLatestRoundData(1, 300000000000, 1000, staleTs, 1);
+    await fallbackAgg.setLatestRoundData(1, 310000000000, 1000, staleTs, 1);
+    await expect(oracle.getLatestPrice()).to.be.revertedWithCustomError(oracle, "StalePriceBothOracles");
+  });
+
+  it("emits StalePrice event when falling back", async function () {
+    const staleTs = Math.floor(Date.now() / 1000) - 7200;
+    await primaryAgg.setLatestRoundData(1, 300000000000, 1000, staleTs, 1);
+    await fallbackAgg.setLatestRoundData(1, 310000000000, 1000, Math.floor(Date.now() / 1000), 1);
+    await expect(oracle.getLatestPrice())
+      .to.emit(oracle, "StalePrice")
+      .withArgs(await primaryAgg.getAddress(), staleTs);
+  });
+
+  it("owner can update MAX_STALENESS", async function () {
+    await oracle.setMaxStaleness(7200);
+    expect(await oracle.MAX_STALENESS()).to.equal(7200);
+  });
+});


### PR DESCRIPTION
## Wulansari [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### Summary
Fixes the PriceOracle vulnerability where `latestRoundData` responses were not validated for stale data, negative prices, or round completeness. Adds a fallback oracle mechanism.

### Changes
- **Round completeness**: `answeredInRound >= roundId` validation (reverts with `IncompleteRound`)
- **Price validation**: `price > 0` check (reverts with `InvalidPrice`)
- **Staleness check**: `block.timestamp - updatedAt < MAX_STALENESS` (3600s default, owner-configurable)
- **Fallback oracle**: Secondary Chainlink feed queried when primary returns stale data
- **StalePrice event**: Emitted with primary oracle's last update timestamp when falling back
- **Both stale revert**: If both oracles return stale data, function reverts (`StalePriceBothOracles`)
- **Owner functions**: `setMaxStaleness` (existing) + `setFallbackFeed` (new)

### Files
- `solidity/contracts/PriceOracle.sol` — fixed contract
- `solidity/contracts/mocks/MockAggregatorV3.sol` — test mock
- `solidity/test/PriceOracle.test.js` — test suite
- `solidity/hardhat.config.js` — Hardhat config (Solidity 0.8.24, Cancun EVM)
- `solidity/contracts/.generation_meta.json` — agent metadata

### Test Coverage
- Valid price from primary oracle
- Zero/negative price reverts
- Incomplete round reverts
- Stale primary → fallback to secondary
- Both stale → revert
- StalePrice event emission
- Owner can update MAX_STALENESS

/bounty $200

Closes #915