### PR TITLE
Wulansari [ Crypto ] Fix cross-chain replay attack in CrossChainBridge EIP-712

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -6,9 +6,17 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract CrossChainBridge {
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public senderNonces;
+
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "Transfer(address recipient,uint256 amount,uint256 nonce)"
+    );
+    bytes32 private immutable _domainSeparator;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -16,30 +24,28 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+        _domainSeparator = keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid,
+            address(this)
+        ));
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
         bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        emit TransferInitiated(msg.sender, amount, targetChain, senderNonces[msg.sender]++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        bytes32 transferHash = hashTransfer(recipient, amount, transferNonce);
 
         require(!processedTransfers[transferHash], "Already processed");
         require(verifySignature(transferHash, signature), "Invalid signature");
@@ -50,7 +56,20 @@ contract CrossChainBridge {
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    function hashTransfer(
+        address recipient,
+        uint256 amount,
+        uint256 transferNonce
+    ) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            transferNonce
+        ));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator, structHash));
+    }
+
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -66,13 +85,14 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature");
         return recovered == validator;
+    }
+
+    function domainSeparator() external view returns (bytes32) {
+        return _domainSeparator;
     }
 
     function getPoolBalance() external view returns (uint256) {

--- a/solidity/test/CrossChainBridge.t.sol
+++ b/solidity/test/CrossChainBridge.t.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../contracts/CrossChainBridge.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock", "MCK") {
+        _mint(msg.sender, 1_000_000 * 10 ** 18);
+    }
+}
+
+contract CrossChainBridgeTest {
+    CrossChainBridge internal bridge;
+    MockToken internal token;
+    uint256 internal validatorPk = 0xA1;
+    address internal validator;
+
+    function setUp() public {
+        validator = vm.addr(validatorPk);
+        token = new MockToken();
+        bridge = new CrossChainBridge(address(token), validator);
+        token.approve(address(bridge), type(uint256).max);
+        token.transfer(address(this), 0);
+    }
+
+    function _sign(bytes32 hash) internal view returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(validatorPk, hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function test_EIP712DomainSeparator() public view {
+        bytes32 expected = keccak256(abi.encode(
+            bridge.EIP712_DOMAIN_TYPEHASH(),
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid,
+            address(bridge)
+        ));
+        assertEq(bridge.domainSeparator(), expected);
+    }
+
+    function test_PerSenderNonce() public {
+        address sender1 = address(0xBEEF);
+        address sender2 = address(0xCAFE);
+
+        assertEq(bridge.senderNonces(sender1), 0);
+        assertEq(bridge.senderNonces(sender2), 0);
+
+        // Fund senders
+        token.transfer(sender1, 1000);
+        token.transfer(sender2, 1000);
+
+        // Prank as sender1
+        vm.startPrank(sender1);
+        token.approve(address(bridge), type(uint256).max);
+        bridge.initiateTransfer(100, 2);
+        assertEq(bridge.senderNonces(sender1), 1);
+        bridge.initiateTransfer(200, 2);
+        assertEq(bridge.senderNonces(sender1), 2);
+        vm.stopPrank();
+
+        // Prank as sender2
+        vm.startPrank(sender2);
+        token.approve(address(bridge), type(uint256).max);
+        bridge.initiateTransfer(50, 2);
+        assertEq(bridge.senderNonces(sender2), 1);
+        vm.stopPrank();
+    }
+
+    function test_ValidSignature_ProcessTransfer() public {
+        address recipient = address(0x1234);
+        uint256 amount = 500;
+        uint256 nonce = 42;
+
+        bytes32 hash = bridge.hashTransfer(recipient, amount, nonce);
+        bytes memory sig = _sign(hash);
+
+        uint256 balBefore = token.balanceOf(recipient);
+        bridge.processTransfer(recipient, amount, nonce, sig);
+        assertEq(token.balanceOf(recipient), balBefore + amount);
+    }
+
+    function testRevert_SameChainReplay() public {
+        address recipient = address(0x1234);
+        uint256 amount = 500;
+        uint256 nonce = 42;
+
+        bytes32 hash = bridge.hashTransfer(recipient, amount, nonce);
+        bytes memory sig = _sign(hash);
+
+        bridge.processTransfer(recipient, amount, nonce, sig);
+
+        // Replay same transfer
+        vm.expectRevert("Already processed");
+        bridge.processTransfer(recipient, amount, nonce, sig);
+    }
+
+    function testRevert_InvalidSignature() public {
+        address recipient = address(0x1234);
+        uint256 amount = 500;
+        uint256 nonce = 42;
+
+        // Sign with wrong key
+        uint256 wrongPk = 0xB2;
+        bytes32 hash = bridge.hashTransfer(recipient, amount, nonce);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongPk, hash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        vm.expectRevert("Invalid signature");
+        bridge.processTransfer(recipient, amount, nonce, sig);
+    }
+
+    function testRevert_EcrecoverZeroAddress() public {
+        address recipient = address(0x1234);
+        uint256 amount = 500;
+        uint256 nonce = 42;
+
+        // Craft signature that makes ecrecover return address(0)
+        // v=0, r=0, s=0 causes ecrecover to return address(0)
+        bytes memory sig = abi.encodePacked(bytes32(0), bytes32(0), uint8(0));
+
+        vm.expectRevert("Invalid signature");
+        bridge.processTransfer(recipient, amount, nonce, sig);
+    }
+
+    function test_CrossChainReplay_Prevented() public {
+        // Simulate different chain by forking at different chainId
+        address recipient = address(0x1234);
+        uint256 amount = 500;
+        uint256 nonce = 42;
+
+        // Hash on chain 1
+        bytes32 hash1 = bridge.hashTransfer(recipient, amount, nonce);
+        bytes memory sig1 = _sign(hash1);
+        bridge.processTransfer(recipient, amount, nonce, sig1);
+
+        // Now simulate chain 2 — deploy new bridge
+        vm.chainId(999);
+        CrossChainBridge bridge2 = new CrossChainBridge(address(token), validator);
+
+        // Same signature should not work on different chain
+        bytes32 hash2 = bridge2.hashTransfer(recipient, amount, nonce);
+        assertNotEq(hash1, hash2);
+
+        // sig1 was for hash1 (chain 1), not hash2 (chain 2)
+        vm.expectRevert("Invalid signature");
+        bridge2.processTransfer(recipient, amount, nonce, sig1);
+    }
+
+    function test_PostUpgradeReplay_Prevented() public {
+        address recipient = address(0x1234);
+        uint256 amount = 500;
+        uint256 nonce = 42;
+
+        bytes32 hash1 = bridge.hashTransfer(recipient, amount, nonce);
+        bytes memory sig1 = _sign(hash1);
+        bridge.processTransfer(recipient, amount, nonce, sig1);
+
+        // Deploy new bridge at different address (simulating upgrade)
+        CrossChainBridge bridge2 = new CrossChainBridge(address(token), validator);
+
+        // Hash includes contract address via domain separator
+        bytes32 hash2 = bridge2.hashTransfer(recipient, amount, nonce);
+        assertNotEq(hash1, hash2);
+
+        // Same signature should not work on new contract
+        vm.expectRevert("Invalid signature");
+        bridge2.processTransfer(recipient, amount, nonce, sig1);
+    }
+
+    function test_NonceQueryable() public {
+        address sender = address(0xBEEF);
+        token.transfer(sender, 10000);
+        vm.startPrank(sender);
+        token.approve(address(bridge), type(uint256).max);
+        bridge.initiateTransfer(100, 2);
+        assertEq(bridge.senderNonces(sender), 1);
+        bridge.initiateTransfer(200, 2);
+        assertEq(bridge.senderNonces(sender), 2);
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #920

## Summary
Added EIP-712 typed data signing with domain separator (chainId + verifyingContract), per-sender nonce mapping, and ecrecover zero-address rejection to prevent cross-chain replay, same-chain replay, and post-upgrade replay attacks.

## Acceptance Criteria Checklist
- [x] Signed messages include chain ID, nonce, and contract address (via EIP-712 domain separator)
- [x] Same message cannot be replayed on a different chain (chainId in domain separator)
- [x] Same message cannot be replayed on the same chain (processedTransfers + nonce)
- [x] Contract upgrade does not allow old message replay (verifyingContract in domain separator)
- [x] ecrecover zero-address result is rejected as invalid signature
- [x] EIP-712 domain separator correctly constructed with name, version, chainId, verifyingContract
- [x] Nonce is queryable per sender for frontend integration (senderNonces mapping)
- [x] Tests cover: cross-chain replay, same-chain replay, post-upgrade replay, invalid signature, EIP-712 verification