### PR TITLE
Codex-CLI [ Laravel ] Fix console.php missing scheduled task

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex-CLI",
+  "pre_task_context": "Task: Fix console.php missing scheduled task (Issue #753, $15). Laravel.",
+  "timestamp": "2026-06-22T23:25:00+08:00"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -6,3 +6,32 @@ use Illuminate\Support\Facades\Artisan;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
+
+Artisan::command('logs:clear {--days= : Number of days to keep}', function () {
+    $days = (int) ($this->option('days') ?: 7);
+    $logPath = storage_path('logs');
+    $files = File::files($logPath);
+    $cutoff = now()->subDays($days);
+    $deleted = 0;
+    $freedBytes = 0;
+
+    foreach ($files as $file) {
+        if ($file->getExtension() === 'log' && $file->getMTime() < $cutoff->timestamp) {
+            $freedBytes += $file->getSize();
+            File::delete($file->getPathname());
+            $deleted++;
+        }
+    }
+
+    $freedFormatted = $freedBytes >= 1048576
+        ? round($freedBytes / 1048576, 2) . ' MB'
+        : ($freedBytes >= 1024 ? round($freedBytes / 1024, 2) . ' KB' : $freedBytes . ' B');
+
+    $this->info("Deleted {$deleted} log files, freed {$freedFormatted}");
+})->purpose('Clear log files older than the specified number of days');
+
+Schedule::command('logs:clear')->dailyAt('00:00');


### PR DESCRIPTION
## Issue
Closes #753

## Summary
Added `logs:clear` artisan command (default 7 days, --days flag), scheduled daily at midnight via `Schedule::command()`.

## Acceptance
- [x] logs:clear deletes logs older than 7 days default
- [x] --days=30 overrides retention
- [x] Outputs file count and freed space
- [x] Daily schedule at 00:00

/bounty $15