### PR TITLE
Codex-CLI [ FastAPI ] Fix validation error handler missing request context and body

### DIFF
--- a/fastapi/_meta.json
+++ b/fastapi/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Codex-CLI",
+  "generation_context": "Task: Fix validation error handler missing request context (Issue #757, $40). FastAPI.",
+  "completed_at": "2026-06-23T00:10:00+08:00"
+}

--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -8,6 +8,22 @@ from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
 
 
+SENSITIVE_FIELDS = {"password", "secret", "token", "api_key", "api_secret"}
+
+
+def _redact_sensitive(data: object) -> object:
+    """Replace sensitive field values with ***REDACTED*** recursively."""
+    if isinstance(data, dict):
+        return {
+            k: "***REDACTED***" if isinstance(k, str) and k.lower() in SENSITIVE_FIELDS
+            else _redact_sensitive(v)
+            for k, v in data.items()
+        }
+    if isinstance(data, list):
+        return [_redact_sensitive(item) for item in data]
+    return data
+
+
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
     headers = getattr(exc, "headers", None)
     if not is_body_allowed_for_status_code(exc.status_code):
@@ -20,10 +36,29 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    return JSONResponse(
-        status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
-    )
+    content: dict[str, object] = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+
+    # In debug mode, include the request body with sensitive fields redacted
+    app = request.app
+    debug = getattr(app.state, "debug", getattr(app, "debug", False))
+    if debug:
+        try:
+            body_bytes = await request.body()
+            if body_bytes:
+                import json as _json
+                try:
+                    body_data = _json.loads(body_bytes)
+                    content["body"] = _redact_sensitive(body_data)
+                except (ValueError, TypeError):
+                    content["body"] = body_bytes.decode("utf-8", errors="replace")
+        except Exception:
+            pass
+
+    return JSONResponse(status_code=422, content=content)
 
 
 async def websocket_request_validation_exception_handler(


### PR DESCRIPTION
## Issue
Closes #757

## Summary
Enhanced request_validation_exception_handler to include request path and method. In debug mode, includes request body with sensitive fields (password, secret, token, api_key) redacted to ***REDACTED***.

## Acceptance
- [x] Path and method in error response
- [x] Debug mode includes redacted body
- [x] Sensitive fields redacted
- [x] Non-debug mode no body

/bounty $40