### PR TITLE
Codex-CLI [ Laravel ] Implement API authentication controller with token auth

### DIFF
--- a/laravel/.generation_meta.json
+++ b/laravel/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex-CLI",
+  "initial_directives": "Task: Implement API authentication controller with token auth (Issue #752, $200). Laravel Sanctum.",
+  "date": "2026-06-23T00:55:00+08:00"
+}

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+
+class AuthController extends Controller
+{
+    public function register(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => $request->password,
+        ]);
+
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        return response()->json([
+            'user' => $user,
+            'token' => $token,
+        ], 201);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => 'required|string|email',
+            'password' => 'required|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $user = User::where('email', $request->email)->first();
+
+        if (!$user || !Hash::check($request->password, $user->password)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        return response()->json([
+            'user' => $user,
+            'token' => $token,
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(['message' => 'Logged out successfully']);
+    }
+}

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout']);
+
+    Route::get('/user', function (\Illuminate\Http\Request $request) {
+        return response()->json($request->user());
+    });
+});


### PR DESCRIPTION
## Issue
Closes #752

## Summary
Created AuthController with register, login, logout methods. Added api.php routes with Sanctum token auth. Registration returns 201 + token, login returns token + user, logout revokes token. Input validation on all endpoints.

## Acceptance
- [x] AuthController with register/login/logout
- [x] Registration validates and returns token
- [x] Login returns 401 for invalid credentials
- [x] Logout revokes token
- [x] All JSON responses

/bounty $200