### PR TITLE
fix(fastapi): pin Swagger/ReDoc CDN URLs to latest stable versions

### DIFF
--- a/.generation_meta.json
+++ b/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent": "hermes-agent", "initial_directives": "Fix hardcoded CDN URLs in Swagger UI and ReDoc - pin to latest stable versions", "date": "2026-06-22T17:15:00Z"}

--- a/fastapi/fastapi/openapi/docs.py
+++ b/fastapi/fastapi/openapi/docs.py
@@ -76,7 +76,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.20.6/swagger-ui-bundle.js",
     swagger_css_url: Annotated[
         str,
         Doc(
@@ -89,7 +89,7 @@ def get_swagger_ui_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+    ] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.20.6/swagger-ui.css",
     swagger_favicon_url: Annotated[
         str,
         Doc(
@@ -233,7 +233,7 @@ def get_redoc_html(
             [FastAPI docs for Custom Docs UI Static Assets](https://fastapi.tiangolo.com/how-to/custom-docs-ui-assets/)
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js",
+    ] = "https://cdn.jsdelivr.net/npm/redoc@2.2.0/bundles/redoc.standalone.js",
     redoc_favicon_url: Annotated[
         str,
         Doc(


### PR DESCRIPTION
Closes #762

Pin CDN URLs to latest stable versions:
- swagger-ui-dist: @5 → @5.20.6
- redoc: @2 → @2.2.0