### PR TITLE
OpenAI Codex [ Laravel ] Implement lightweight role-based access control with permissions

### DIFF
--- a/laravel/.provenance_rbac.json
+++ b/laravel/.provenance_rbac.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "You are a coding agent running in the Codex CLI. You are expected to be precise, safe, and helpful. Execute the user_s task autonomously. Fix root causes. Keep changes minimal.",
+  "date": "2026-06-22T14:35:00Z"
+}

--- a/laravel/app/Http/Middleware/CheckRole.php
+++ b/laravel/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        if (!$request->user() || !$request->user()->hasRole($role)) {
+            abort(403, "Unauthorized. Required role: ".$role);
+        }
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Permission.php
+++ b/laravel/app/Models/Permission.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    protected $fillable = ["name", "guard_name"];
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, "role_has_permissions");
+    }
+}

--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    protected $fillable = ["name", "guard_name"];
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, "role_has_permissions");
+    }
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, "model_has_roles");
+    }
+
+    public function hasPermission(string $permission): bool
+    {
+        return $this->permissions()->where("name", $permission)->exists();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,13 +9,14 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Traits\HasRoles;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/HasRoles.php
+++ b/laravel/app/Traits/HasRoles.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Role;
+use App\Models\Permission;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+trait HasRoles
+{
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, "model_has_roles");
+    }
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, "model_has_permissions");
+    }
+
+    public function assignRole(string $roleName): void
+    {
+        $role = Role::where("name", $roleName)->first();
+        if ($role && !$this->roles()->where("role_id", $role->id)->exists()) {
+            $this->roles()->attach($role);
+        }
+    }
+
+    public function removeRole(string $roleName): void
+    {
+        $role = Role::where("name", $roleName)->first();
+        if ($role) {
+            $this->roles()->detach($role);
+        }
+    }
+
+    public function hasRole(string $roleName): bool
+    {
+        return $this->roles()->where("name", $roleName)->exists();
+    }
+
+    public function hasPermission(string $permissionName): bool
+    {
+        // Check direct permissions
+        if ($this->permissions()->where("name", $permissionName)->exists()) {
+            return true;
+        }
+        // Check permissions through roles
+        foreach ($this->roles as $role) {
+            if ($role->hasPermission($permissionName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function getAllPermissions(): array
+    {
+        $permissions = [];
+        // From roles
+        foreach ($this->roles as $role) {
+            foreach ($role->permissions as $perm) {
+                $permissions[$perm->name] = $perm;
+            }
+        }
+        // Direct permissions
+        foreach ($this->permissions as $perm) {
+            $permissions[$perm->name] = $perm;
+        }
+        return array_values($permissions);
+    }
+}

--- a/laravel/database/migrations/2026_06_22_000002_create_rbac_tables.php
+++ b/laravel/database/migrations/2026_06_22_000002_create_rbac_tables.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create("roles", function (Blueprint $table) {
+            $table->id();
+            $table->string("name")->unique();
+            $table->string("guard_name")->default("web");
+            $table->timestamps();
+        });
+
+        Schema::create("permissions", function (Blueprint $table) {
+            $table->id();
+            $table->string("name")->unique();
+            $table->string("guard_name")->default("web");
+            $table->timestamps();
+        });
+
+        Schema::create("role_has_permissions", function (Blueprint $table) {
+            $table->foreignId("role_id")->constrained()->cascadeOnDelete();
+            $table->foreignId("permission_id")->constrained()->cascadeOnDelete();
+            $table->primary(["role_id", "permission_id"]);
+        });
+
+        Schema::create("model_has_roles", function (Blueprint $table) {
+            $table->foreignId("role_id")->constrained()->cascadeOnDelete();
+            $table->morphs("model");
+            $table->primary(["role_id", "model_id", "model_type"]);
+        });
+
+        Schema::create("model_has_permissions", function (Blueprint $table) {
+            $table->foreignId("permission_id")->constrained()->cascadeOnDelete();
+            $table->morphs("model");
+            $table->primary(["permission_id", "model_id", "model_type"]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists("model_has_permissions");
+        Schema::dropIfExists("model_has_roles");
+        Schema::dropIfExists("role_has_permissions");
+        Schema::dropIfExists("permissions");
+        Schema::dropIfExists("roles");
+    }
+};

--- a/laravel/tests/Feature/RBACTest.php
+++ b/laravel/tests/Feature/RBACTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Role;
+use App\Models\Permission;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RBACTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_role()
+    {
+        $role = Role::create(["name" => "admin"]);
+        $this->assertEquals("admin", $role->name);
+    }
+
+    public function test_assign_role_to_user()
+    {
+        $role = Role::create(["name" => "editor"]);
+        $user = User::factory()->create(["active" => 1]);
+        $user->assignRole("editor");
+
+        $this->assertTrue($user->hasRole("editor"));
+    }
+
+    public function test_remove_role_from_user()
+    {
+        $role = Role::create(["name" => "moderator"]);
+        $user = User::factory()->create(["active" => 1]);
+        $user->assignRole("moderator");
+        $user->removeRole("moderator");
+
+        $this->assertFalse($user->hasRole("moderator"));
+    }
+
+    public function test_role_permission_checking()
+    {
+        $role = Role::create(["name" => "admin"]);
+        $perm = Permission::create(["name" => "manage-users"]);
+        $role->permissions()->attach($perm);
+
+        $user = User::factory()->create(["active" => 1]);
+        $user->assignRole("admin");
+
+        $this->assertTrue($user->hasPermission("manage-users"));
+        $this->assertFalse($user->hasPermission("nonexistent"));
+    }
+}


### PR DESCRIPTION
Closes #788

Implemented lightweight RBAC system:
- Role and Permission models with many-to-many relationships
- HasRoles trait with assignRole, removeRole, hasRole, hasPermission, getAllPermissions
- CheckRole middleware returns 403 for unauthorized
- Users inherit permissions through roles
- Migration creates roles, permissions, role_has_permissions, model_has_roles, model_has_permissions tables
- Applies HasRoles trait to User model

/bounty 