### PR TITLE
[OpenAI Codex] Fix EMS PRF label in _derive_master_secret()

### DIFF
--- a/python/tls_handshake.py
+++ b/python/tls_handshake.py
@@ -296,9 +296,8 @@ class TLSHandshake:
         seed = self.client_random + self.server_random
 
         if self.negotiated_ems:
-            # BUG 5: should use "extended master secret" label per RFC 7627,
-            # but incorrectly uses the standard "master secret" label
-            label = b"master secret"
+            label = b"extended master secret"
+            seed = self.handshake_hash.copy().digest()
         else:
             label = b"master secret"
 


### PR DESCRIPTION
Closes #573

Fixed EMS derivation per RFC 7627:
- Changed EMS branch to use label b"extended master secret"
- Changed EMS branch seed to use session hash
- Non-EMS branch unchanged

/bounty 