### PR TITLE
SKYJAMES777 [ T3 Code ] Add system theme following and real-time theme switching

### DIFF
--- a/t3code/apps/desktop/src/electron/theme.ts
+++ b/t3code/apps/desktop/src/electron/theme.ts
@@ -1,0 +1,36 @@
+// System theme following utility
+import { nativeTheme } from "electron";
+import Store from "electron-store";
+
+const store = new Store({ defaults: { theme: "system" } });
+
+export type Theme = "light" | "dark" | "system";
+
+export function getTheme(): Theme {
+    return store.get("theme", "system") as Theme;
+}
+
+export function setTheme(theme: Theme): void {
+    store.set("theme", theme);
+    applyTheme(theme);
+}
+
+export function initTheme(): void {
+    const theme = getTheme();
+    applyTheme(theme);
+    
+    nativeTheme.on("updated", () => {
+        if (getTheme() === "system") {
+            applyTheme("system");
+        }
+    });
+}
+
+function applyTheme(theme: Theme): void {
+    const isDark = theme === "system"
+        ? nativeTheme.shouldUseDarkColors
+        : theme === "dark";
+    
+    document.documentElement.classList.toggle("dark", isDark);
+    document.documentElement.classList.toggle("light", !isDark);
+}


### PR DESCRIPTION
Closes #855

Added three theme options (light, dark, system) with OS preference following in real-time via nativeTheme.on('updated'). Theme preference persisted in electron-store.