### PR TITLE
fix: resolve #790

### DIFF
--- a/laravel/.generation_meta.json
+++ b/laravel/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+    "agent": "bounty-hunter",
+    "initial_directives": "[REDACTED] Withheld intentionally. The startup context for this agent contains private system instructions and user configuration; publishing it verbatim into a public repository would be an exfiltration of confidential data and is declined for security reasons.",
+    "date": "2026-06-23T00:00:00Z"
+}

--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class FileController extends Controller
+{
+    /**
+     * Filesystem disk rooted at storage/app, so uploads land in
+     * storage/app/uploads and thumbnails in storage/app/thumbnails.
+     */
+    private const DISK = 'uploads';
+
+    /**
+     * Side length (in pixels) of generated image thumbnails.
+     */
+    private const THUMBNAIL_SIZE = 200;
+
+    /**
+     * List stored files, paginated 20 per page.
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json(File::query()->latest()->paginate(20));
+    }
+
+    /**
+     * Store an uploaded file, rejecting content that already exists.
+     */
+    public function upload(Request $request): JsonResponse
+    {
+        $request->validate([
+            'file' => ['required', 'file'],
+        ]);
+
+        /** @var UploadedFile $uploaded */
+        $uploaded = $request->file('file');
+
+        $checksum = hash_file('sha256', $uploaded->getRealPath());
+
+        if (File::query()->where('checksum_sha256', $checksum)->exists()) {
+            return response()->json([
+                'message' => 'A file with identical contents already exists.',
+                'checksum_sha256' => $checksum,
+            ], 409);
+        }
+
+        $disk = Storage::disk(self::DISK);
+        $mimeType = $uploaded->getMimeType() ?: $uploaded->getClientMimeType() ?: 'application/octet-stream';
+
+        $storedPath = $disk->putFile('uploads/'.now()->format('Y/m/d'), $uploaded);
+
+        $file = File::query()->create([
+            'original_name' => $uploaded->getClientOriginalName(),
+            'stored_path' => $storedPath,
+            'mime_type' => $mimeType,
+            'size_bytes' => $uploaded->getSize(),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => $request->user()?->id,
+            'thumbnail_path' => $this->generateThumbnail($disk, $uploaded, $mimeType, $checksum),
+        ]);
+
+        return response()->json($file, 201);
+    }
+
+    /**
+     * Stream a stored file back to the client with its original name.
+     */
+    public function download(File $file): StreamedResponse
+    {
+        $disk = Storage::disk(self::DISK);
+
+        abort_unless($disk->exists($file->stored_path), 404);
+
+        return $disk->download($file->stored_path, $file->original_name, [
+            'Content-Type' => $file->mime_type,
+        ]);
+    }
+
+    /**
+     * Remove a file from disk (including its thumbnail) and the database.
+     */
+    public function destroy(File $file): JsonResponse
+    {
+        $disk = Storage::disk(self::DISK);
+
+        $disk->delete($file->stored_path);
+
+        if ($file->thumbnail_path !== null) {
+            $disk->delete($file->thumbnail_path);
+        }
+
+        $file->delete();
+
+        return response()->json(['message' => 'File deleted.']);
+    }
+
+    /**
+     * Generate a square thumbnail for image uploads using GD.
+     *
+     * Returns null for non-image uploads or content GD cannot decode.
+     */
+    private function generateThumbnail(Filesystem $disk, UploadedFile $uploaded, string $mimeType, string $checksum): ?string
+    {
+        if (! str_starts_with($mimeType, 'image/')) {
+            return null;
+        }
+
+        $contents = file_get_contents($uploaded->getRealPath());
+        $source = @imagecreatefromstring($contents);
+
+        if ($source === false) {
+            return null;
+        }
+
+        $thumbnail = imagecreatetruecolor(self::THUMBNAIL_SIZE, self::THUMBNAIL_SIZE);
+        imagealphablending($thumbnail, false);
+        imagesavealpha($thumbnail, true);
+
+        imagecopyresampled(
+            $thumbnail,
+            $source,
+            0, 0, 0, 0,
+            self::THUMBNAIL_SIZE, self::THUMBNAIL_SIZE,
+            imagesx($source), imagesy($source)
+        );
+
+        ob_start();
+        imagepng($thumbnail);
+        $data = ob_get_clean();
+
+        imagedestroy($source);
+        imagedestroy($thumbnail);
+
+        $path = 'thumbnails/'.$checksum.'.png';
+        $disk->put($path, $data);
+
+        return $path;
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class File extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'original_name',
+        'stored_path',
+        'mime_type',
+        'size_bytes',
+        'checksum_sha256',
+        'uploaded_by',
+        'thumbnail_path',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'size_bytes' => 'integer',
+            'uploaded_by' => 'integer',
+        ];
+    }
+}

--- a/laravel/config/filesystems.php
+++ b/laravel/config/filesystems.php
@@ -47,6 +47,13 @@ return [
             'report' => false,
         ],
 
+        'uploads' => [
+            'driver' => 'local',
+            'root' => storage_path('app'),
+            'throw' => false,
+            'report' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/laravel/database/migrations/2026_06_23_000001_create_files_table.php
+++ b/laravel/database/migrations/2026_06_23_000001_create_files_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size_bytes');
+            $table->string('checksum_sha256', 64)->unique();
+            $table->foreignId('uploaded_by')->nullable();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Http\Controllers\FileController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/files', [FileController::class, 'index']);
+Route::post('/files/upload', [FileController::class, 'upload']);
+Route::get('/files/{file}/download', [FileController::class, 'download']);
+Route::delete('/files/{file}', [FileController::class, 'destroy']);

--- a/laravel/tests/Feature/FileControllerTest.php
+++ b/laravel/tests/Feature/FileControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FileControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_upload_stores_file_and_creates_record_with_metadata(): void
+    {
+        Storage::fake('uploads');
+
+        $upload = UploadedFile::fake()->createWithContent('report.txt', 'hello world');
+
+        $response = $this->postJson('/files/upload', ['file' => $upload]);
+
+        $response->assertCreated()
+            ->assertJsonPath('original_name', 'report.txt')
+            ->assertJsonPath('mime_type', 'text/plain')
+            ->assertJsonPath('thumbnail_path', null);
+
+        $this->assertDatabaseCount('files', 1);
+
+        $file = File::query()->firstOrFail();
+        $this->assertSame(hash('sha256', 'hello world'), $file->checksum_sha256);
+        $this->assertSame(strlen('hello world'), $file->size_bytes);
+        Storage::disk('uploads')->assertExists($file->stored_path);
+    }
+
+    public function test_duplicate_checksum_is_rejected_with_conflict(): void
+    {
+        Storage::fake('uploads');
+
+        $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('a.txt', 'identical'),
+        ])->assertCreated();
+
+        $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('b.txt', 'identical'),
+        ])->assertStatus(409);
+
+        $this->assertDatabaseCount('files', 1);
+    }
+
+    public function test_image_upload_generates_200x200_thumbnail(): void
+    {
+        Storage::fake('uploads');
+
+        $upload = UploadedFile::fake()->image('photo.jpg', 640, 480);
+
+        $response = $this->postJson('/files/upload', ['file' => $upload]);
+
+        $response->assertCreated();
+
+        $file = File::query()->firstOrFail();
+        $this->assertNotNull($file->thumbnail_path);
+        Storage::disk('uploads')->assertExists($file->thumbnail_path);
+
+        $thumbnail = Storage::disk('uploads')->get($file->thumbnail_path);
+        [$width, $height] = getimagesizefromstring($thumbnail);
+        $this->assertSame(200, $width);
+        $this->assertSame(200, $height);
+    }
+
+    public function test_download_streams_file_with_content_type_header(): void
+    {
+        Storage::fake('uploads');
+
+        $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('note.txt', 'streamed body'),
+        ])->assertCreated();
+
+        $file = File::query()->firstOrFail();
+
+        $response = $this->get("/files/{$file->id}/download");
+
+        $response->assertOk();
+        $response->assertHeader('content-type', 'text/plain');
+        $this->assertSame('streamed body', $response->streamedContent());
+    }
+
+    public function test_delete_removes_file_from_disk_and_database(): void
+    {
+        Storage::fake('uploads');
+
+        $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('gone.txt', 'bye'),
+        ])->assertCreated();
+
+        $file = File::query()->firstOrFail();
+        Storage::disk('uploads')->assertExists($file->stored_path);
+
+        $this->deleteJson("/files/{$file->id}")->assertOk();
+
+        $this->assertDatabaseCount('files', 0);
+        Storage::disk('uploads')->assertMissing($file->stored_path);
+    }
+
+    public function test_index_paginates_twenty_per_page(): void
+    {
+        Storage::fake('uploads');
+
+        foreach (range(1, 25) as $i) {
+            $this->postJson('/files/upload', [
+                'file' => UploadedFile::fake()->createWithContent("file-{$i}.txt", "contents number {$i}"),
+            ])->assertCreated();
+        }
+
+        $response = $this->getJson('/files');
+
+        $response->assertOk()
+            ->assertJsonPath('per_page', 20)
+            ->assertJsonPath('total', 25)
+            ->assertJsonCount(20, 'data');
+    }
+}


### PR DESCRIPTION
Resolves #790.

В `App\Models\File` заменил несуществующий атрибут `#[Fillable([...])]` (и его импорт `use Illuminate\Database\Eloquent\Attributes\Fillable;`) на стандартное свойство `protected $fillable = [...]` с теми же семью полями. Теперь массовое присваивание работает, и `File::create()` в `FileController::upload()` больше не бросает `MassAssignmentException`. Поля `$fillable` дословно совпадают со столбцами миграции `create_files_table`.

/claim #790