### PR TITLE
[ Crypto ] Fix cross-chain replay attack in CrossChainBridge signature verification

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -14,6 +14,7 @@ contract CrossChainBridge {
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
 
     constructor(address _bridgeToken, address _validator) {
+        require(_validator != address(0), "Validator cannot be zero address");
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
     }
@@ -24,9 +25,6 @@ contract CrossChainBridge {
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
@@ -36,9 +34,9 @@ contract CrossChainBridge {
         bytes32 transferHash = keccak256(abi.encodePacked(
             recipient,
             amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
+            transferNonce,
+            block.chainid,
+            address(this)
         ));
 
         require(!processedTransfers[transferHash], "Already processed");
@@ -50,7 +48,6 @@ contract CrossChainBridge {
         emit TransferProcessed(transferHash, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -71,7 +68,7 @@ contract CrossChainBridge {
             v, r, s
         );
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature");
         return recovered == validator;
     }
 

--- a/solidity/test/CrossChainBridge.test.js
+++ b/solidity/test/CrossChainBridge.test.js
@@ -1,0 +1,84 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CrossChainBridge", function () {
+  let bridge;
+  let token;
+  let owner;
+  let validator;
+  let recipient;
+  let user;
+
+  beforeEach(async function () {
+    [owner, validator, recipient, user] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("GovernanceToken");
+    token = await Token.deploy(ethers.parseEther("1000000"));
+
+    const Bridge = await ethers.getContractFactory("CrossChainBridge");
+    bridge = await Bridge.deploy(token.target, validator.address);
+
+    // Fund the bridge pool with some tokens
+    await token.transfer(bridge.target, ethers.parseEther("1000"));
+  });
+
+  it("Should process a valid transfer with signature and prevent replay", async function () {
+    const amount = ethers.parseEther("10");
+    const nonce = 1;
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "uint256", "uint256", "address"],
+      [recipient.address, amount, nonce, chainId, bridge.target]
+    );
+
+    // Sign the hash with the validator's key
+    const messageHashBytes = ethers.getBytes(hash);
+    const signature = await validator.signMessage(messageHashBytes);
+
+    // Verify initial recipient balance
+    expect(await token.balanceOf(recipient.address)).to.equal(0);
+
+    // Process first transfer
+    await expect(bridge.processTransfer(recipient.address, amount, nonce, signature))
+      .to.emit(bridge, "TransferProcessed");
+
+    expect(await token.balanceOf(recipient.address)).to.equal(amount);
+
+    // Replay attack on the same contract should fail
+    await expect(
+      bridge.processTransfer(recipient.address, amount, nonce, signature)
+    ).to.be.revertedWith("Already processed");
+  });
+
+  it("Should fail replay attack with different chainId, contract address or non-validator signature", async function () {
+    const amount = ethers.parseEther("10");
+    const nonce = 2;
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+
+    // Correct signature
+    const hash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "uint256", "uint256", "address"],
+      [recipient.address, amount, nonce, chainId, bridge.target]
+    );
+    const signature = await validator.signMessage(ethers.getBytes(hash));
+
+    // Try processing with incorrect contract address inside the hash
+    const fakeBridgeAddress = ethers.Wallet.createRandom().address;
+    const hashFakeBridge = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "uint256", "uint256", "address"],
+      [recipient.address, amount, nonce, chainId, fakeBridgeAddress]
+    );
+    const signatureFakeBridge = await validator.signMessage(ethers.getBytes(hashFakeBridge));
+
+    await expect(
+      bridge.processTransfer(recipient.address, amount, nonce, signatureFakeBridge)
+    ).to.be.revertedWith("Invalid signature");
+
+    // Try processing with correct hash but user signature instead of validator
+    const userSignature = await user.signMessage(ethers.getBytes(hash));
+    await expect(
+      bridge.processTransfer(recipient.address, amount, nonce, userSignature)
+    ).to.be.revertedWith("Invalid signature");
+  });
+});


### PR DESCRIPTION
Fixes issue #920.

Summary of changes:
1. Included 'block.chainid' and 'address(this)' in the hash computation inside 'processTransfer' to prevent cross-chain and multi-bridge signature replay attacks.
2. Handled potential zero-address returned from 'ecrecover' inside 'verifySignature' by ensuring the recovered address is not 'address(0)'.
3. Added unit tests to prevent regression and verify replay attempts are correctly blocked.