### PR TITLE
fix: resolve #796

### DIFF
--- a/fastapi/.provenance.json
+++ b/fastapi/.provenance.json
@@ -1,0 +1,15 @@
+{
+  "agent_name": "bounty-hunter-coder",
+  "created": "2026-06-24T00:00:00Z",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/796",
+  "summary": "Add router-level middleware support to APIRouter (Middleware tuples and simple callables) plus an add_middleware convenience method.",
+  "config_snapshot": {
+    "model": "claude-opus-4-8",
+    "auth": "subscription",
+    "roles": ["coder", "tester", "reviewer"],
+    "changed_files": [
+      "fastapi/fastapi/routing.py",
+      "fastapi/tests/test_router_middleware.py"
+    ]
+  }
+}

--- a/fastapi/fastapi/routing.py
+++ b/fastapi/fastapi/routing.py
@@ -26,6 +26,7 @@ from typing import (
     Annotated,
     Any,
     TypeVar,
+    Union,
     cast,
 )
 
@@ -74,6 +75,7 @@ from fastapi.utils import (
 )
 from starlette import routing
 from starlette._exception_handler import wrap_app_handling_exceptions
+from starlette.middleware import Middleware
 from starlette._utils import is_async_callable
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
@@ -1002,6 +1004,35 @@ class APIRoute(routing.Route):
         return match, child_scope
 
 
+# A router-level middleware entry. Either a Starlette `Middleware(cls, *args,
+# **kwargs)` wrapper, or a plain callable factory that takes the ASGI app it
+# wraps and returns a new ASGI app.
+_RouterMiddleware = Union[Middleware, Callable[[ASGIApp], ASGIApp]]
+
+
+def _wrap_app_with_middleware(
+    app: ASGIApp, middleware: Sequence[_RouterMiddleware]
+) -> ASGIApp:
+    """
+    Wrap an ASGI app with a sequence of router middleware.
+
+    Each entry is either a Starlette `Middleware(cls, *args, **kwargs)` wrapper or
+    a plain callable that takes the ASGI app and returns a new one wrapping it.
+
+    The first middleware in the sequence ends up as the outermost layer (it sees
+    the request first and the response last), mirroring how Starlette applies
+    `middleware` on `Router`, `Route`, and `Mount`.
+    """
+    for item in reversed(list(middleware)):
+        if isinstance(item, Middleware):
+            cls, args, kwargs = item.cls, item.args, item.kwargs
+            app = cls(app, *args, **kwargs)
+        else:
+            # A simple callable middleware: `app -> ASGIApp`.
+            app = item(app)
+    return app
+
+
 class APIRouter(routing.Router):
     """
     `APIRouter` class, used to group *path operations*, for example to structure
@@ -1162,6 +1193,27 @@ class APIRouter(routing.Router):
                 """
             ),
         ] = APIRoute,
+        middleware: Annotated[
+            Sequence[_RouterMiddleware] | None,
+            Doc(
+                """
+                A list of middleware to be applied to all the *path operations* in
+                this router.
+
+                Each entry can be a Starlette `Middleware(SomeMiddleware, **options)`
+                wrapper or a simple callable that takes the ASGI app it wraps and
+                returns a new ASGI app (`app -> app`).
+
+                The middleware is applied around each route when the router is
+                included (via `include_router` / `app.include_router`), so it wraps
+                the routes of this router (and of any nested routers) without
+                affecting routes that belong to other routers or to the app itself.
+
+                The first middleware in the list is the outermost layer, matching the
+                behavior of Starlette's `Middleware` on `Route` and `Mount`.
+                """
+            ),
+        ] = None,
         on_startup: Annotated[
             Sequence[Callable[[], Any]] | None,
             Doc(
@@ -1304,6 +1356,7 @@ class APIRouter(routing.Router):
         self.prefix = prefix
         self.tags: list[str | Enum] = tags or []
         self.dependencies = list(dependencies or [])
+        self.middleware: list[_RouterMiddleware] = list(middleware or [])
         self.deprecated = deprecated
         self.include_in_schema = include_in_schema
         self.responses = responses or {}
@@ -1313,6 +1366,33 @@ class APIRouter(routing.Router):
         self.default_response_class = default_response_class
         self.generate_unique_id_function = generate_unique_id_function
         self.strict_content_type = strict_content_type
+
+    def add_middleware(
+        self,
+        middleware_class: Annotated[
+            Callable[..., ASGIApp],
+            Doc(
+                """
+                The middleware class (or any callable factory) to apply to the
+                router's *path operations*. It is called as
+                `middleware_class(app, *args, **kwargs)` to wrap the app.
+                """
+            ),
+        ],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Add a single middleware to this router, mirroring `app.add_middleware`.
+
+        Like `Starlette.add_middleware`, the most recently added middleware becomes
+        the outermost layer, so it is inserted at the front of the router's
+        middleware list.
+
+        The middleware takes effect for the routes copied when the router is
+        included (via `include_router`), so add it before including the router.
+        """
+        self.middleware.insert(0, Middleware(middleware_class, *args, **kwargs))
 
     def route(
         self,
@@ -1730,6 +1810,9 @@ class APIRouter(routing.Router):
         if responses is None:
             responses = {}
         for route in router.routes:
+            # Track which routes get added for this source route so the included
+            # router's middleware can be wrapped around exactly those.
+            route_start_index = len(self.routes)
             if isinstance(route, APIRoute):
                 combined_responses = {**responses, **route.responses}
                 use_response_class = get_value_or_default(
@@ -1819,6 +1902,28 @@ class APIRouter(routing.Router):
                 self.add_websocket_route(
                     prefix + route.path, route.endpoint, name=route.name
                 )
+            # Wrap the just-copied route(s) with this router's middleware. The
+            # routes are rebuilt from their endpoints above, so the middleware
+            # cannot be carried over on the ASGI app; instead it is combined with
+            # any middleware inherited from nested routers (kept on the source
+            # route as metadata) and re-applied here. The included router's
+            # middleware goes on the outside, so an outer router wraps an inner
+            # one, and the metadata is stored again so further nesting compounds.
+            inherited_middleware: Sequence[_RouterMiddleware] = getattr(
+                route, "_fastapi_router_middleware", ()
+            )
+            combined_middleware = [*router.middleware, *inherited_middleware]
+            if combined_middleware:
+                for new_route in self.routes[route_start_index:]:
+                    if isinstance(new_route, (routing.Route, routing.WebSocketRoute)):
+                        new_route.app = _wrap_app_with_middleware(
+                            new_route.app, combined_middleware
+                        )
+                        setattr(
+                            new_route,
+                            "_fastapi_router_middleware",
+                            combined_middleware,
+                        )
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)
         for handler in router.on_shutdown:

--- a/fastapi/tests/test_router_middleware.py
+++ b/fastapi/tests/test_router_middleware.py
@@ -1,0 +1,206 @@
+from fastapi import APIRouter, FastAPI
+from fastapi.middleware import Middleware
+from fastapi.testclient import TestClient
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class TagMiddleware:
+    """Records that it ran by prepending its name to the ``x-mw`` header.
+
+    Prepending (instead of appending) means the resulting header, read left to
+    right, lists middleware from the outermost layer to the innermost one.
+    """
+
+    def __init__(self, app: ASGIApp, *, name: str) -> None:
+        self.app = app
+        self.name = name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                existing = headers.get("x-mw")
+                headers["x-mw"] = f"{self.name},{existing}" if existing else self.name
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+def test_router_middleware_wraps_its_own_routes_only() -> None:
+    app = FastAPI()
+
+    router_with = APIRouter(middleware=[Middleware(TagMiddleware, name="A")])
+
+    @router_with.get("/with")
+    def with_mw() -> dict[str, str]:
+        return {"ok": "with"}
+
+    router_without = APIRouter()
+
+    @router_without.get("/without")
+    def without_mw() -> dict[str, str]:
+        return {"ok": "without"}
+
+    app.include_router(router_with)
+    app.include_router(router_without)
+
+    client = TestClient(app)
+
+    response = client.get("/with")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"ok": "with"}
+    assert response.headers["x-mw"] == "A"
+
+    # The middleware must not leak onto routes from another router.
+    response = client.get("/without")
+    assert response.status_code == 200, response.text
+    assert "x-mw" not in response.headers
+
+
+def test_router_middleware_order_outermost_first() -> None:
+    app = FastAPI()
+    router = APIRouter(
+        middleware=[
+            Middleware(TagMiddleware, name="outer"),
+            Middleware(TagMiddleware, name="inner"),
+        ]
+    )
+
+    @router.get("/order")
+    def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/order")
+    assert response.status_code == 200, response.text
+    # First entry in the list is the outermost layer.
+    assert response.headers["x-mw"] == "outer,inner"
+
+
+def test_router_middleware_nested_routers_compound() -> None:
+    app = FastAPI()
+    inner = APIRouter(middleware=[Middleware(TagMiddleware, name="inner")])
+
+    @inner.get("/deep")
+    def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    outer = APIRouter(middleware=[Middleware(TagMiddleware, name="outer")])
+    outer.include_router(inner)
+    app.include_router(outer)
+
+    client = TestClient(app)
+
+    response = client.get("/deep")
+    assert response.status_code == 200, response.text
+    # The outer router's middleware wraps the inner router's middleware.
+    assert response.headers["x-mw"] == "outer,inner"
+
+
+def test_router_without_middleware_is_unaffected() -> None:
+    app = FastAPI()
+    default_router = APIRouter()
+    empty_router = APIRouter(middleware=[])
+
+    @default_router.get("/default")
+    def default_endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    @empty_router.get("/empty")
+    def empty_endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(default_router)
+    app.include_router(empty_router)
+
+    client = TestClient(app)
+
+    for path in ("/default", "/empty"):
+        response = client.get(path)
+        assert response.status_code == 200, response.text
+        assert "x-mw" not in response.headers
+
+
+def test_router_middleware_accepts_simple_callable() -> None:
+    app = FastAPI()
+
+    def add_tag(inner: ASGIApp) -> ASGIApp:
+        # A "simple callable" middleware: takes the ASGI app and returns a new
+        # one wrapping it, without going through `Middleware(...)`.
+        return TagMiddleware(inner, name="callable")
+
+    router = APIRouter(middleware=[add_tag])
+
+    @router.get("/callable")
+    def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/callable")
+    assert response.status_code == 200, response.text
+    assert response.headers["x-mw"] == "callable"
+
+
+def test_router_middleware_mixes_tuple_and_callable() -> None:
+    app = FastAPI()
+
+    router = APIRouter(
+        middleware=[
+            Middleware(TagMiddleware, name="tuple"),
+            lambda inner: TagMiddleware(inner, name="callable"),
+        ]
+    )
+
+    @router.get("/mixed")
+    def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/mixed")
+    assert response.status_code == 200, response.text
+    # Both forms are honored, in list order (first entry outermost).
+    assert response.headers["x-mw"] == "tuple,callable"
+
+
+def test_router_add_middleware_mirrors_app() -> None:
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/added")
+    def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    router.add_middleware(TagMiddleware, name="added")
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/added")
+    assert response.status_code == 200, response.text
+    assert response.headers["x-mw"] == "added"
+
+
+def test_router_add_middleware_last_added_is_outermost() -> None:
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/stacked")
+    def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    # Mirroring `app.add_middleware`: the most recently added middleware becomes
+    # the outermost layer.
+    router.add_middleware(TagMiddleware, name="inner")
+    router.add_middleware(TagMiddleware, name="outer")
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/stacked")
+    assert response.status_code == 200, response.text
+    assert response.headers["x-mw"] == "outer,inner"


### PR DESCRIPTION
Resolves #796.

Добавлена поддержка router-level middleware двух форм + метод-удобство `APIRouter.add_middleware` + обязательный артефакт `.provenance.json`.

/claim #796