### PR TITLE
[vincent1566] [ FastAPI ] Fix page_size validation and boundary tests

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "vincent1566",
+  "platform_config": "Claude Code CLI session - FastAPI pagination bounty #802 implementation. Task: Implement standardized pagination with offset and cursor support for FastAPI with SQLAlchemy/Pydantic data sources.",
+  "date": "2026-06-23T12:00:00Z"
+}

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,263 @@
+"""Pagination utilities for FastAPI with offset and cursor support."""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from fastapi import Query
+from pydantic import BaseModel, Field
+
+T = TypeVar("T")
+
+
+class PaginationParams(BaseModel):
+    """Query parameters for offset-based pagination."""
+
+    page: int = Field(default=1, ge=1, description="Page number (1-indexed)")
+    page_size: int = Field(
+        default=20, ge=1, le=100, description="Number of items per page"
+    )
+
+    @property
+    def skip(self) -> int:
+        """Calculate the number of items to skip."""
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        """Alias for page_size for clarity in queries."""
+        return self.page_size
+
+
+class CursorPaginationParams(BaseModel):
+    """Query parameters for cursor-based pagination."""
+
+    cursor: str | None = Field(
+        default=None,
+        description="Opaque cursor for the next page. Omit for the first page.",
+    )
+    page_size: int = Field(
+        default=20, ge=1, le=100, description="Number of items per page"
+    )
+
+
+@dataclass
+class CursorInfo:
+    """Encodes/decodes cursor information."""
+
+    offset: int
+
+    def encode(self) -> str:
+        """Encode offset into an opaque cursor string."""
+        payload = json.dumps({"o": self.offset})
+        return base64.urlsafe_b64encode(payload.encode()).decode()
+
+    @classmethod
+    def decode(cls, cursor: str) -> CursorInfo:
+        """Decode an opaque cursor string back into a CursorInfo."""
+        try:
+            payload = json.loads(base64.urlsafe_b64decode(cursor.encode()))
+            offset = int(payload["o"])
+            if offset < 0:
+                raise ValueError("Negative offset")
+            return cls(offset=offset)
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            raise ValueError(f"Invalid cursor: {cursor}") from e
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    """Standardized paginated response wrapper.
+
+    Works with any Pydantic model as the item type via Generic[T].
+    """
+
+    items: list[T] = Field(description="List of items in the current page")
+    total: int = Field(description="Total number of items across all pages")
+    page: int = Field(description="Current page number (1-indexed)")
+    page_size: int = Field(description="Number of items per page")
+    total_pages: int = Field(description="Total number of pages")
+    has_next: bool = Field(description="Whether there is a next page")
+    has_previous: bool = Field(description="Whether there is a previous page")
+
+
+class CursorPaginatedResponse(BaseModel, Generic[T]):
+    """Standardized cursor-based paginated response wrapper."""
+
+    items: list[T] = Field(description="List of items in the current page")
+    next_cursor: str | None = Field(
+        default=None,
+        description="Cursor for the next page, or None if this is the last page",
+    )
+    previous_cursor: str | None = Field(
+        default=None,
+        description="Cursor for the previous page, or None if this is the first page",
+    )
+    has_next: bool = Field(description="Whether there is a next page")
+    has_previous: bool = Field(description="Whether there is a previous page")
+    page_size: int = Field(description="Number of items per page")
+
+
+class Paginator:
+    """Utility class for creating paginated queries.
+
+    Supports both offset-based and cursor-based pagination strategies.
+
+    Usage with offset pagination::
+
+        paginator = Paginator()
+
+        @app.get("/items")
+        async def list_items(
+            pagination: PaginationParams = Depends(paginator.paginate_offset),
+        ):
+            items = await get_items(skip=pagination.skip, limit=pagination.limit)
+            total = await count_items()
+            return paginator.offset_response(items, total, pagination)
+
+    Usage with cursor pagination::
+
+        paginator = Paginator()
+
+        @app.get("/items")
+        async def list_items(
+            pagination: CursorPaginationParams = Depends(paginator.paginate_cursor),
+        ):
+            offset = CursorInfo.decode(pagination.cursor).offset if pagination.cursor else 0
+            items = await get_items(skip=offset, limit=pagination.page_size + 1)
+            has_next = len(items) > pagination.page_size
+            items = items[:pagination.page_size]
+            return paginator.cursor_response(items, has_next, pagination)
+    """
+
+    def __init__(
+        self,
+        default_page_size: int = 20,
+        max_page_size: int = 100,
+    ) -> None:
+        self.default_page_size = default_page_size
+        self.max_page_size = max_page_size
+
+    def paginate_offset(
+        self,
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+        page_size: int | None = Query(
+            default=None, ge=1, le=100, description="Number of items per page"
+        ),
+    ) -> PaginationParams:
+        """FastAPI dependency for offset-based pagination parameters.
+
+        Inject via ``Depends(paginator.paginate_offset)``.
+        """
+        effective_page_size = (
+            page_size if page_size is not None else self.default_page_size
+        )
+        clamped_page_size = min(effective_page_size, self.max_page_size)
+        return PaginationParams(page=max(1, page), page_size=clamped_page_size)
+
+    def paginate_cursor(
+        self,
+        cursor: str | None = Query(
+            default=None,
+            description="Opaque cursor for the next page. Omit for the first page.",
+        ),
+        page_size: int | None = Query(
+            default=None, ge=1, le=100, description="Number of items per page"
+        ),
+    ) -> CursorPaginationParams:
+        """FastAPI dependency for cursor-based pagination parameters.
+
+        Inject via ``Depends(paginator.paginate_cursor)``.
+        """
+        effective_page_size = (
+            page_size if page_size is not None else self.default_page_size
+        )
+        clamped_page_size = min(effective_page_size, self.max_page_size)
+        return CursorPaginationParams(cursor=cursor, page_size=clamped_page_size)
+
+    @staticmethod
+    def offset_response(
+        items: Sequence[Any],
+        total: int,
+        params: PaginationParams,
+    ) -> dict[str, Any]:
+        """Build a standardized offset-based paginated response dict.
+
+        Returns a dict matching :class:`PaginatedResponse` schema so FastAPI
+        can serialize it directly or validate against a typed model.
+        """
+        total_pages = max(1, math.ceil(total / params.page_size)) if total > 0 else 1
+        return {
+            "items": list(items),
+            "total": total,
+            "page": params.page,
+            "page_size": params.page_size,
+            "total_pages": total_pages,
+            "has_next": params.page < total_pages,
+            "has_previous": params.page > 1,
+        }
+
+    @staticmethod
+    def cursor_response(
+        items: Sequence[Any],
+        has_next: bool,
+        params: CursorPaginationParams,
+        *,
+        current_offset: int = 0,
+    ) -> dict[str, Any]:
+        """Build a standardized cursor-based paginated response dict.
+
+        ``current_offset`` is the offset of the first item in *items* within
+        the full dataset, used to compute ``previous_cursor``.
+        """
+        next_cursor: str | None = None
+        previous_cursor: str | None = None
+
+        if has_next:
+            next_cursor = CursorInfo(
+                offset=current_offset + len(items)
+            ).encode()
+
+        if current_offset > 0:
+            prev_offset = max(0, current_offset - params.page_size)
+            previous_cursor = CursorInfo(offset=prev_offset).encode()
+
+        return {
+            "items": list(items),
+            "next_cursor": next_cursor,
+            "previous_cursor": previous_cursor,
+            "has_next": has_next,
+            "has_previous": current_offset > 0,
+            "page_size": params.page_size,
+        }
+
+
+# Convenience default instance for simple use-cases
+_default_paginator = Paginator()
+
+
+def paginate_offset(
+    page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+    page_size: int = Query(
+        default=20, ge=1, le=100, description="Number of items per page"
+    ),
+) -> PaginationParams:
+    """Module-level dependency for offset pagination (uses default Paginator)."""
+    return _default_paginator.paginate_offset(page=page, page_size=page_size)
+
+
+def paginate_cursor(
+    cursor: str | None = Query(
+        default=None,
+        description="Opaque cursor for the next page. Omit for the first page.",
+    ),
+    page_size: int = Query(
+        default=20, ge=1, le=100, description="Number of items per page"
+    ),
+) -> CursorPaginationParams:
+    """Module-level dependency for cursor pagination (uses default Paginator)."""
+    return _default_paginator.paginate_cursor(cursor=cursor, page_size=page_size)

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -139,6 +139,17 @@ class Paginator:
         default_page_size: int = 20,
         max_page_size: int = 100,
     ) -> None:
+        if default_page_size < 1:
+            raise ValueError(
+                f"default_page_size must be >= 1, got {default_page_size}"
+            )
+        if max_page_size < 1:
+            raise ValueError(f"max_page_size must be >= 1, got {max_page_size}")
+        if default_page_size > max_page_size:
+            raise ValueError(
+                f"default_page_size ({default_page_size}) must not exceed "
+                f"max_page_size ({max_page_size})"
+            )
         self.default_page_size = default_page_size
         self.max_page_size = max_page_size
 
@@ -156,7 +167,7 @@ class Paginator:
         effective_page_size = (
             page_size if page_size is not None else self.default_page_size
         )
-        clamped_page_size = min(effective_page_size, self.max_page_size)
+        clamped_page_size = max(1, min(effective_page_size, self.max_page_size))
         return PaginationParams(page=max(1, page), page_size=clamped_page_size)
 
     def paginate_cursor(
@@ -176,7 +187,7 @@ class Paginator:
         effective_page_size = (
             page_size if page_size is not None else self.default_page_size
         )
-        clamped_page_size = min(effective_page_size, self.max_page_size)
+        clamped_page_size = max(1, min(effective_page_size, self.max_page_size))
         return CursorPaginationParams(cursor=cursor, page_size=clamped_page_size)
 
     @staticmethod

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,398 @@
+"""Tests for fastapi.pagination module."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Depends
+from fastapi.pagination import (
+    CursorInfo,
+    CursorPaginatedResponse,
+    CursorPaginationParams,
+    PaginatedResponse,
+    PaginationParams,
+    Paginator,
+    paginate_cursor,
+    paginate_offset,
+)
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+ALL_ITEMS = [Item(id=i, name=f"item-{i}") for i in range(1, 51)]  # 50 items
+
+
+def _get_items_page(skip: int, limit: int) -> list[Item]:
+    return ALL_ITEMS[skip : skip + limit]
+
+
+def _create_offset_app(paginator: Paginator | None = None) -> FastAPI:
+    paginator = paginator or Paginator()
+    app = FastAPI()
+
+    @app.get("/items")
+    async def list_items(
+        pagination: PaginationParams = Depends(paginator.paginate_offset),
+    ):
+        items = _get_items_page(pagination.skip, pagination.limit)
+        return paginator.offset_response(items, total=len(ALL_ITEMS), params=pagination)
+
+    return app
+
+
+def _create_cursor_app(paginator: Paginator | None = None) -> FastAPI:
+    paginator = paginator or Paginator()
+    app = FastAPI()
+
+    @app.get("/items")
+    async def list_items(
+        pagination: CursorPaginationParams = Depends(paginator.paginate_cursor),
+    ):
+        offset = 0
+        if pagination.cursor:
+            offset = CursorInfo.decode(pagination.cursor).offset
+
+        # Fetch one extra to detect has_next
+        raw = _get_items_page(offset, pagination.page_size + 1)
+        has_next = len(raw) > pagination.page_size
+        items = raw[: pagination.page_size]
+        return paginator.cursor_response(
+            items, has_next, pagination, current_offset=offset
+        )
+
+    return app
+
+
+def _create_module_level_app() -> FastAPI:
+    """App using the module-level convenience functions."""
+    app = FastAPI()
+
+    @app.get("/offset")
+    async def offset_items(
+        pagination: PaginationParams = Depends(paginate_offset),
+    ):
+        items = _get_items_page(pagination.skip, pagination.limit)
+        return Paginator.offset_response(items, total=len(ALL_ITEMS), params=pagination)
+
+    @app.get("/cursor")
+    async def cursor_items(
+        pagination: CursorPaginationParams = Depends(paginate_cursor),
+    ):
+        offset = 0
+        if pagination.cursor:
+            offset = CursorInfo.decode(pagination.cursor).offset
+        raw = _get_items_page(offset, pagination.page_size + 1)
+        has_next = len(raw) > pagination.page_size
+        items = raw[: pagination.page_size]
+        return Paginator.cursor_response(
+            items, has_next, pagination, current_offset=offset
+        )
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# PaginationParams (model)
+# ---------------------------------------------------------------------------
+
+
+class TestPaginationParams:
+    def test_defaults(self):
+        p = PaginationParams()
+        assert p.page == 1
+        assert p.page_size == 20
+        assert p.skip == 0
+        assert p.limit == 20
+
+    def test_skip_calculation(self):
+        p = PaginationParams(page=3, page_size=10)
+        assert p.skip == 20
+        assert p.limit == 10
+
+    def test_page_1(self):
+        p = PaginationParams(page=1, page_size=15)
+        assert p.skip == 0
+
+    def test_boundary_values(self):
+        p = PaginationParams(page=1, page_size=1)
+        assert p.skip == 0
+        assert p.limit == 1
+
+
+class TestCursorPaginationParams:
+    def test_defaults(self):
+        c = CursorPaginationParams()
+        assert c.cursor is None
+        assert c.page_size == 20
+
+    def test_with_cursor(self):
+        info = CursorInfo(offset=40)
+        c = CursorPaginationParams(cursor=info.encode(), page_size=10)
+        assert c.cursor is not None
+
+
+# ---------------------------------------------------------------------------
+# CursorInfo (encode/decode round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestCursorInfo:
+    def test_round_trip(self):
+        for offset in (0, 1, 10, 999, 0):
+            info = CursorInfo(offset=offset)
+            encoded = info.encode()
+            decoded = CursorInfo.decode(encoded)
+            assert decoded.offset == offset
+
+    def test_encode_is_url_safe(self):
+        info = CursorInfo(offset=42)
+        encoded = info.encode()
+        # base64url should not contain + / =
+        assert "+" not in encoded
+        assert "/" not in encoded
+        assert "=" not in encoded
+
+    def test_decode_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid cursor"):
+            CursorInfo.decode("not-a-valid-cursor!!!")
+
+    def test_decode_negative_offset_raises(self):
+        import base64, json
+        payload = json.dumps({"o": -1})
+        bad = base64.urlsafe_b64encode(payload.encode()).decode()
+        with pytest.raises(ValueError, match="Invalid cursor"):
+            CursorInfo.decode(bad)
+
+
+# ---------------------------------------------------------------------------
+# Offset-based pagination (HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestOffsetPagination:
+    def test_first_page(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 1, "page_size": 10})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["page"] == 1
+        assert data["page_size"] == 10
+        assert data["total"] == 50
+        assert data["total_pages"] == 5
+        assert data["has_next"] is True
+        assert data["has_previous"] is False
+        assert len(data["items"]) == 10
+        assert data["items"][0]["id"] == 1
+
+    def test_last_page(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 5, "page_size": 10})
+        data = resp.json()
+        assert data["has_next"] is False
+        assert data["has_previous"] is True
+        assert len(data["items"]) == 10
+
+    def test_middle_page(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 3, "page_size": 10})
+        data = resp.json()
+        assert data["has_next"] is True
+        assert data["has_previous"] is True
+        assert data["items"][0]["id"] == 21
+
+    def test_page_beyond_total(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 100, "page_size": 10})
+        data = resp.json()
+        assert data["items"] == []
+        assert data["has_next"] is False
+        assert data["has_previous"] is True
+
+    def test_defaults(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items")
+        data = resp.json()
+        assert data["page"] == 1
+        assert data["page_size"] == 20
+        assert len(data["items"]) == 20
+
+    def test_total_pages_with_remainder(self):
+        """50 items / 15 per page = 4 pages (3x15 + 1x5)."""
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 1, "page_size": 15})
+        data = resp.json()
+        assert data["total_pages"] == 4
+
+    def test_single_item_per_page(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 1, "page_size": 1})
+        data = resp.json()
+        assert data["total_pages"] == 50
+        assert len(data["items"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cursor-based pagination (HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestCursorPagination:
+    def test_first_page_no_cursor(self):
+        client = TestClient(_create_cursor_app())
+        resp = client.get("/items", params={"page_size": 10})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["has_next"] is True
+        assert data["has_previous"] is False
+        assert data["next_cursor"] is not None
+        assert data["previous_cursor"] is None
+        assert len(data["items"]) == 10
+        assert data["items"][0]["id"] == 1
+
+    def test_follow_cursor(self):
+        client = TestClient(_create_cursor_app())
+        # Page 1
+        resp1 = client.get("/items", params={"page_size": 10})
+        data1 = resp1.json()
+        cursor = data1["next_cursor"]
+
+        # Page 2
+        resp2 = client.get("/items", params={"page_size": 10, "cursor": cursor})
+        data2 = resp2.json()
+        assert data2["items"][0]["id"] == 11
+        assert data2["has_previous"] is True
+        assert data2["previous_cursor"] is not None
+
+    def test_last_page(self):
+        client = TestClient(_create_cursor_app())
+        # Navigate to last page
+        resp = client.get("/items", params={"page_size": 20})
+        data = resp.json()
+        cursor = data["next_cursor"]
+        assert cursor is not None
+
+        resp2 = client.get("/items", params={"page_size": 20, "cursor": cursor})
+        data2 = resp2.json()
+        assert len(data2["items"]) == 20
+        assert data2["next_cursor"] is not None
+
+        resp3 = client.get(
+            "/items", params={"page_size": 20, "cursor": data2["next_cursor"]}
+        )
+        data3 = resp3.json()
+        assert len(data3["items"]) == 10  # 50 - 40 = 10
+        assert data3["has_next"] is False
+
+    def test_invalid_cursor(self):
+        client = TestClient(_create_cursor_app(), raise_server_exceptions=False)
+        resp = client.get("/items", params={"cursor": "garbage!!!", "page_size": 10})
+        assert resp.status_code == 500
+
+    def test_default_page_size(self):
+        client = TestClient(_create_cursor_app())
+        resp = client.get("/items")
+        data = resp.json()
+        assert data["page_size"] == 20
+        assert len(data["items"]) == 20
+
+
+# ---------------------------------------------------------------------------
+# Paginator class configuration
+# ---------------------------------------------------------------------------
+
+
+class TestPaginatorConfig:
+    def test_custom_default_page_size(self):
+        p = Paginator(default_page_size=5)
+        app = _create_offset_app(p)
+        client = TestClient(app)
+        resp = client.get("/items")
+        data = resp.json()
+        assert data["page_size"] == 5
+
+    def test_max_page_size_clamping(self):
+        p = Paginator(max_page_size=25)
+        app = _create_offset_app(p)
+        client = TestClient(app)
+        resp = client.get("/items", params={"page_size": 100})
+        data = resp.json()
+        assert data["page_size"] == 25
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_dataset(self):
+        """Paginator should handle zero items gracefully."""
+        app = FastAPI()
+        paginator = Paginator()
+
+        @app.get("/items")
+        async def list_items(
+            pagination: PaginationParams = Depends(paginator.paginate_offset),
+        ):
+            return paginator.offset_response([], total=0, params=pagination)
+
+        client = TestClient(app)
+        resp = client.get("/items")
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["total_pages"] == 1
+        assert data["has_next"] is False
+        assert data["has_previous"] is False
+
+    def test_page_zero_clamped_to_one(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 0, "page_size": 10})
+        # Query(ge=1) should reject page=0 with 422
+        assert resp.status_code == 422
+
+    def test_negative_page_rejected(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": -1, "page_size": 10})
+        assert resp.status_code == 422
+
+    def test_page_size_zero_rejected(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 1, "page_size": 0})
+        assert resp.status_code == 422
+
+    def test_page_size_over_max_rejected(self):
+        client = TestClient(_create_offset_app())
+        resp = client.get("/items", params={"page": 1, "page_size": 101})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions
+# ---------------------------------------------------------------------------
+
+
+class TestModuleLevel:
+    def test_paginate_offset_dependency(self):
+        app = _create_module_level_app()
+        client = TestClient(app)
+        resp = client.get("/offset", params={"page": 2, "page_size": 10})
+        data = resp.json()
+        assert data["page"] == 2
+        assert data["items"][0]["id"] == 11
+
+    def test_paginate_cursor_dependency(self):
+        app = _create_module_level_app()
+        client = TestClient(app)
+        resp = client.get("/cursor", params={"page_size": 10})
+        data = resp.json()
+        assert data["has_next"] is True
+        assert len(data["items"]) == 10

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -374,6 +374,64 @@ class TestEdgeCases:
         resp = client.get("/items", params={"page": 1, "page_size": 101})
         assert resp.status_code == 422
 
+    def test_total_exact_multiple_of_page_size(self):
+        """When total == page_size * page, has_next should be False."""
+        app = FastAPI()
+        paginator = Paginator()
+        # 20 items, page_size=10 → exactly 2 pages
+        items = [Item(id=i, name=f"item-{i}") for i in range(1, 21)]
+
+        @app.get("/items")
+        async def list_items(
+            pagination: PaginationParams = Depends(paginator.paginate_offset),
+        ):
+            page_items = items[pagination.skip : pagination.skip + pagination.limit]
+            return paginator.offset_response(page_items, total=20, params=pagination)
+
+        client = TestClient(app)
+
+        # Last page: page=2, page_size=10, total=20
+        resp = client.get("/items", params={"page": 2, "page_size": 10})
+        data = resp.json()
+        assert data["total"] == 20
+        assert data["total_pages"] == 2
+        assert data["has_next"] is False
+        assert data["has_previous"] is True
+        assert len(data["items"]) == 10
+
+        # First page should have has_next=True
+        resp1 = client.get("/items", params={"page": 1, "page_size": 10})
+        data1 = resp1.json()
+        assert data1["has_next"] is True
+        assert data1["has_previous"] is False
+
+
+class TestPaginatorValidation:
+    def test_default_page_size_zero_raises(self):
+        with pytest.raises(ValueError, match="default_page_size must be >= 1"):
+            Paginator(default_page_size=0)
+
+    def test_default_page_size_negative_raises(self):
+        with pytest.raises(ValueError, match="default_page_size must be >= 1"):
+            Paginator(default_page_size=-5)
+
+    def test_max_page_size_zero_raises(self):
+        with pytest.raises(ValueError, match="max_page_size must be >= 1"):
+            Paginator(max_page_size=0)
+
+    def test_max_page_size_negative_raises(self):
+        with pytest.raises(ValueError, match="max_page_size must be >= 1"):
+            Paginator(max_page_size=-1)
+
+    def test_default_exceeds_max_raises(self):
+        with pytest.raises(ValueError, match="must not exceed"):
+            Paginator(default_page_size=50, max_page_size=10)
+
+    def test_valid_custom_values(self):
+        p = Paginator(default_page_size=5, max_page_size=50)
+        assert p.default_page_size == 5
+        assert p.max_page_size == 50
+
 
 # ---------------------------------------------------------------------------
 # Module-level convenience functions


### PR DESCRIPTION
## Summary

Fixes #802 — addresses review feedback on page_size validation and boundary test coverage.

### Changes

**fastapi/fastapi/pagination.py:**
- Added validation to `Paginator.__init__` to enforce `default_page_size >= 1`, `max_page_size >= 1`, and `default_page_size <= max_page_size`
- Added `max(1, ...)` clamping in `paginate_offset` and `paginate_cursor` to ensure `page_size` is always positive after dependency resolution

**fastapi/tests/test_pagination.py:**
- Added `test_total_exact_multiple_of_page_size` — verifies `has_next=False` and `has_previous=True` when `total == page_size * page`
- Added `TestPaginatorValidation` class with 6 tests covering zero, negative, and invalid default/max page size values

### Review Feedback Addressed

> Paginator default page sizes do not enforce positive integer values
✅ Fixed via `__init__` validation + `max(1, ...)` clamping

> Boundary check logic does not verify total exact multiple of page_size
✅ Fixed via `test_total_exact_multiple_of_page_size` test case

/claim #802