### PR TITLE
fix: resolve #829

### DIFF
--- a/t3code/packages/effect-acp/src/_internal/authRefresh.test.ts
+++ b/t3code/packages/effect-acp/src/_internal/authRefresh.test.ts
@@ -1,0 +1,108 @@
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+
+import { assert, it } from "@effect/vitest";
+
+import * as AuthRefresh from "./authRefresh.ts";
+import * as AcpError from "../errors.ts";
+
+const sessionExpired = AcpError.AcpRequestError.authRequired("Session expired");
+
+// Builds a request that fails with the session-expired error on its first
+// invocation and succeeds with `value` afterwards, mirroring an expired token
+// that becomes valid again once the client re-authenticates.
+const failOnceThenSucceed = <A>(value: A) =>
+  Effect.map(Ref.make(0), (tries) =>
+    Effect.flatMap(Ref.updateAndGet(tries, (count) => count + 1), (count) =>
+      count === 1 ? Effect.fail(sessionExpired) : Effect.succeed(value),
+    ),
+  );
+
+it.effect("invokes onSessionExpired with the session id before re-authenticating", () =>
+  Effect.gen(function* () {
+    const events = yield* Ref.make<Array<string>>([]);
+    const refresh = yield* AuthRefresh.make(
+      {
+        authenticate: { methodId: "cursor_login" },
+        onSessionExpired: (sessionId) =>
+          Ref.update(events, (current) => [...current, `expired:${sessionId}`]),
+      },
+      () => Ref.update(events, (current) => [...current, "authenticate"]),
+    );
+    const request = yield* failOnceThenSucceed("ok");
+
+    const value = yield* refresh.wrap("session-1", request);
+
+    assert.equal(value, "ok");
+    assert.deepEqual(yield* Ref.get(events), ["expired:session-1", "authenticate"]);
+  }),
+);
+
+it.effect("coalesces concurrent re-authentication for simultaneously expired requests", () =>
+  Effect.gen(function* () {
+    const authCount = yield* Ref.make(0);
+    const failures = yield* Ref.make(0);
+    // Holds the first re-authentication open until both requests have failed,
+    // guaranteeing the refreshes genuinely overlap rather than running serially.
+    const bothFailed = yield* Deferred.make<void>();
+    const refresh = yield* AuthRefresh.make({ authenticate: { methodId: "cursor_login" } }, () =>
+      Deferred.await(bothFailed).pipe(Effect.andThen(Ref.update(authCount, (count) => count + 1))),
+    );
+
+    const makeRequest = (value: string) =>
+      Effect.map(Ref.make(0), (tries) =>
+        refresh.wrap(
+          value,
+          Effect.flatMap(Ref.updateAndGet(tries, (count) => count + 1), (count) =>
+            count === 1
+              ? Effect.flatMap(Ref.updateAndGet(failures, (total) => total + 1), (total) =>
+                  (total === 2 ? Deferred.succeed(bothFailed, void 0) : Effect.void).pipe(
+                    Effect.andThen(Effect.fail(sessionExpired)),
+                  ),
+                )
+              : Effect.succeed(value),
+          ),
+        ),
+      );
+
+    const requestA = yield* makeRequest("a");
+    const requestB = yield* makeRequest("b");
+    const results = yield* Effect.all([requestA, requestB], { concurrency: "unbounded" });
+
+    assert.deepEqual(results, ["a", "b"]);
+    assert.equal(yield* Ref.get(authCount), 1);
+  }),
+);
+
+it.effect("retries up to the configured budget then surfaces the auth error", () =>
+  Effect.gen(function* () {
+    const authCount = yield* Ref.make(0);
+    const refresh = yield* AuthRefresh.make(
+      { authenticate: { methodId: "cursor_login" }, maxRetries: 2 },
+      () => Ref.update(authCount, (count) => count + 1),
+    );
+
+    const error = yield* Effect.flip(refresh.wrap("session-1", Effect.fail(sessionExpired)));
+
+    assert.equal(error._tag, "AcpRequestError");
+    assert.equal((error as AcpError.AcpRequestError).code, AuthRefresh.AUTH_REQUIRED_ERROR_CODE);
+    assert.equal(yield* Ref.get(authCount), 2);
+  }),
+);
+
+it.effect("does not re-authenticate for errors unrelated to authentication", () =>
+  Effect.gen(function* () {
+    const authCount = yield* Ref.make(0);
+    const refresh = yield* AuthRefresh.make({ authenticate: { methodId: "cursor_login" } }, () =>
+      Ref.update(authCount, (count) => count + 1),
+    );
+
+    const error = yield* Effect.flip(
+      refresh.wrap("session-1", Effect.fail(AcpError.AcpRequestError.internalError("boom"))),
+    );
+
+    assert.equal((error as AcpError.AcpRequestError).errorMessage, "boom");
+    assert.equal(yield* Ref.get(authCount), 0);
+  }),
+);

--- a/t3code/packages/effect-acp/src/_internal/authRefresh.ts
+++ b/t3code/packages/effect-acp/src/_internal/authRefresh.ts
@@ -1,0 +1,102 @@
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
+
+import * as AcpError from "../errors.ts";
+import type * as AcpSchema from "../_generated/schema.gen.ts";
+
+/**
+ * JSON-RPC error code an ACP agent returns when (re-)authentication is required.
+ * @see AcpRequestError.authRequired
+ */
+export const AUTH_REQUIRED_ERROR_CODE = -32000;
+
+export interface AcpAuthRefreshOptions {
+  /**
+   * Re-authentication request replayed against the agent when a request fails
+   * because the session expired. The agent re-runs its login flow for the given
+   * `methodId` and refreshes the underlying token.
+   * @see https://agentclientprotocol.com/protocol/schema#authenticate
+   */
+  readonly authenticate: AcpSchema.AuthenticateRequest;
+  /**
+   * Invoked with the expired session id (when the failing request carried one)
+   * immediately before re-authentication is attempted. Useful for surfacing the
+   * expiry to callers or invalidating cached session state.
+   */
+  readonly onSessionExpired?: (
+    sessionId: AcpSchema.SessionId | undefined,
+  ) => Effect.Effect<void, never>;
+  /**
+   * Maximum number of automatic re-authentication attempts per request.
+   * @defaultValue 1
+   */
+  readonly maxRetries?: number;
+}
+
+export interface AuthRefresh {
+  /**
+   * Wraps an agent request so that an "authentication required" failure triggers
+   * a single coalesced re-authentication and a retry of the original request.
+   */
+  readonly wrap: <A>(
+    sessionId: AcpSchema.SessionId | undefined,
+    request: Effect.Effect<A, AcpError.AcpError>,
+  ) => Effect.Effect<A, AcpError.AcpError>;
+}
+
+export const isSessionExpiredError = (error: AcpError.AcpError): boolean =>
+  error._tag === "AcpRequestError" && error.code === AUTH_REQUIRED_ERROR_CODE;
+
+export const make = (
+  options: AcpAuthRefreshOptions,
+  authenticate: (
+    payload: AcpSchema.AuthenticateRequest,
+  ) => Effect.Effect<unknown, AcpError.AcpError>,
+): Effect.Effect<AuthRefresh> =>
+  Effect.gen(function* () {
+    const maxRetries = options.maxRetries ?? 1;
+    // `generation` advances once per completed re-authentication so concurrent
+    // expired requests coalesce onto a single refresh instead of stampeding the
+    // agent; `semaphore` serializes the refresh critical section.
+    const generation = yield* Ref.make(0);
+    const semaphore = yield* Semaphore.make(1);
+
+    const refresh = (startGeneration: number, sessionId: AcpSchema.SessionId | undefined) =>
+      semaphore.withPermits(1)(
+        Effect.flatMap(Ref.get(generation), (current) =>
+          current !== startGeneration
+            ? // Another request already refreshed while we waited for the permit.
+              Effect.void
+            : (options.onSessionExpired
+                ? options.onSessionExpired(sessionId)
+                : Effect.void
+              ).pipe(
+                Effect.andThen(authenticate(options.authenticate)),
+                Effect.andThen(Ref.update(generation, (value) => value + 1)),
+                Effect.asVoid,
+              ),
+        ),
+      );
+
+    const wrap = <A>(
+      sessionId: AcpSchema.SessionId | undefined,
+      request: Effect.Effect<A, AcpError.AcpError>,
+    ): Effect.Effect<A, AcpError.AcpError> => {
+      const attempt = (remaining: number): Effect.Effect<A, AcpError.AcpError> =>
+        Effect.flatMap(Ref.get(generation), (startGeneration) =>
+          request.pipe(
+            Effect.catchIf(isSessionExpiredError, (error) =>
+              remaining <= 0
+                ? Effect.fail(error)
+                : refresh(startGeneration, sessionId).pipe(
+                    Effect.andThen(attempt(remaining - 1)),
+                  ),
+            ),
+          ),
+        );
+      return attempt(maxRetries);
+    };
+
+    return { wrap };
+  });

--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -375,6 +375,51 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
     }),
   );
 
+  it.effect("re-authenticates and retries a prompt after the session expires", () =>
+    Effect.gen(function* () {
+      const expiredSessions = yield* Ref.make<Array<string | undefined>>([]);
+      const handle = yield* makeHandle({ ACP_MOCK_AUTH_EXPIRE: "1" });
+      const scope = yield* Scope.make();
+      const acpLayer = AcpClient.layerChildProcess(handle, {
+        authRefresh: {
+          authenticate: { methodId: "cursor_login" },
+          onSessionExpired: (sessionId) =>
+            Ref.update(expiredSessions, (current) => [...current, sessionId]),
+        },
+      });
+      const context = yield* Layer.buildWithScope(acpLayer, scope);
+
+      const prompt = yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.AcpClient;
+
+        yield* acp.agent.initialize({
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: false, writeTextFile: false },
+            terminal: false,
+          },
+          clientInfo: {
+            name: "effect-acp-test",
+            version: "0.0.0",
+          },
+        });
+
+        const session = yield* acp.agent.createSession({
+          cwd: process.cwd(),
+          mcpServers: [],
+        });
+
+        return yield* acp.agent.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hello" }],
+        });
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+      assert.equal(prompt.stopReason, "end_turn");
+      assert.deepEqual(yield* Ref.get(expiredSessions), ["mock-session-1"]);
+    }),
+  );
+
   it.effect("uses distinct ids for RPC calls and extension requests", () =>
     Effect.gen(function* () {
       const { stdio, input, output } = yield* makeInMemoryStdio();

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -21,11 +21,21 @@ import {
   runHandler,
 } from "./_internal/shared.ts";
 import { makeChildStdio, makeTerminationError } from "./_internal/stdio.ts";
+import * as AuthRefresh from "./_internal/authRefresh.ts";
+
+export type { AcpAuthRefreshOptions } from "./_internal/authRefresh.ts";
 
 export interface AcpClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
+  /**
+   * Enables automatic token refresh: when an agent request fails because the
+   * session expired (`-32000`), the client re-authenticates once and retries the
+   * request, coalescing concurrent refreshes onto a single re-authentication.
+   * When omitted, requests are issued unchanged.
+   */
+  readonly authRefresh?: AuthRefresh.AcpAuthRefreshOptions;
 }
 
 type AcpClientRaw = {
@@ -456,6 +466,23 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     generateRequestId: () => nextRpcRequestId++ as never,
   }).pipe(Effect.provideService(RpcClient.Protocol, transport.clientProtocol));
 
+  const authRefresh = options.authRefresh
+    ? yield* AuthRefresh.make(options.authRefresh, (payload) =>
+        callRpc(rpc[AGENT_METHODS.authenticate](payload)),
+      )
+    : undefined;
+
+  const sessionIdOf = (payload: unknown): AcpSchema.SessionId | undefined =>
+    typeof payload === "object" && payload !== null && "sessionId" in payload
+      ? (payload as { readonly sessionId?: AcpSchema.SessionId }).sessionId
+      : undefined;
+
+  const withAuthRefresh = <A>(
+    payload: unknown,
+    request: Effect.Effect<A, AcpError.AcpError>,
+  ): Effect.Effect<A, AcpError.AcpError> =>
+    authRefresh ? authRefresh.wrap(sessionIdOf(payload), request) : request;
+
   return AcpClient.of({
     raw: {
       notifications: transport.incoming,
@@ -466,16 +493,24 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
       initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
       authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
       logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
-      closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      createSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_new](payload))),
+      loadSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_load](payload))),
+      listSessions: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_list](payload))),
+      forkSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_fork](payload))),
+      resumeSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_resume](payload))),
+      closeSession: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_close](payload))),
+      setSessionModel: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_set_model](payload))),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_set_config_option](payload))),
+      prompt: (payload) =>
+        withAuthRefresh(payload, callRpc(rpc[AGENT_METHODS.session_prompt](payload))),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>

--- a/t3code/packages/effect-acp/test/fixtures/acp-mock-peer.ts
+++ b/t3code/packages/effect-acp/test/fixtures/acp-mock-peer.ts
@@ -1,10 +1,12 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 
 import * as AcpAgent from "../../src/agent.ts";
+import * as AcpError from "../../src/errors.ts";
 
 if (process.env.ACP_MOCK_MALFORMED_OUTPUT === "1") {
   process.stdout.write("{not-json}\n");
@@ -17,8 +19,13 @@ if (process.env.ACP_MOCK_EXIT_IMMEDIATELY_CODE !== undefined) {
 
 const sessionId = "mock-session-1";
 
+// When set, the agent treats the session as expired until it observes a
+// (re-)authenticate call, letting tests exercise the client's token refresh.
+const requireReauth = process.env.ACP_MOCK_AUTH_EXPIRE === "1";
+
 const program = Effect.gen(function* () {
   const agent = yield* AcpAgent.AcpAgent;
+  const authenticated = yield* Ref.make(false);
 
   yield* agent.handleInitialize(() =>
     Effect.succeed({
@@ -35,7 +42,7 @@ const program = Effect.gen(function* () {
     }),
   );
 
-  yield* agent.handleAuthenticate(() => Effect.succeed({}));
+  yield* agent.handleAuthenticate(() => Ref.set(authenticated, true).pipe(Effect.as({})));
   yield* agent.handleLogout(() => Effect.succeed({}));
   yield* agent.handleCreateSession(() =>
     Effect.succeed({
@@ -56,6 +63,15 @@ const program = Effect.gen(function* () {
 
   yield* agent.handlePrompt(() =>
     Effect.gen(function* () {
+      if (requireReauth) {
+        if (!(yield* Ref.get(authenticated))) {
+          return yield* Effect.fail(AcpError.AcpRequestError.authRequired("Session expired"));
+        }
+        return {
+          stopReason: "end_turn" as const,
+        };
+      }
+
       yield* agent.client.requestPermission({
         sessionId,
         options: [


### PR DESCRIPTION
Resolves #829.

Implemented automatic token refresh in the `effect-acp` ACP client. Added `_internal/authRefresh.ts` (a coalescing, generation-guarded re-authentication wrapper) and wired an opt-in `authRefresh` option into `AcpClientOptions`/`make` so every session-scoped agent request (`createSession`, `loadSession`, `listSessions`, `forkSession`, `resumeSession`, `closeSession`, `setSessionModel`, `setSessionConfigOption`, `prompt`) retries once after re-authenticating when the agent reports session expiry (`-32000`). Added a deterministic unit test (`authRefresh.test.ts`) and an end-to-end client test, plus an `ACP_MOCK_AUTH_EXPIRE` mode in the mock peer fixture.

/claim #829