### PR TITLE
fix: resolve #865

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "claude-code",
+  "automated": true,
+  "issue": 865,
+  "ts": "2026-06-24T12:00:00Z"
+}

--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -74,6 +74,14 @@ export const terminalRestartsTotal = Metric.counter("t3_terminal_restarts_total"
   description: "Total terminal restart requests handled.",
 });
 
+export const providerCacheHitsTotal = Metric.counter("t3_provider_cache_hits_total", {
+  description: "Total provider cache reads served from cache without a provider API call.",
+});
+
+export const providerCacheMissesTotal = Metric.counter("t3_provider_cache_misses_total", {
+  description: "Total provider cache misses that triggered a fresh provider API lookup.",
+});
+
 export const metricAttributes = (
   attributes: Readonly<Record<string, unknown>>,
 ): ReadonlyArray<[string, string]> => Object.entries(compactMetricAttributes(attributes));

--- a/t3code/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/t3code/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -40,6 +40,7 @@ import {
   ProviderService,
   type ProviderServiceShape,
 } from "../../provider/Services/ProviderService.ts";
+import { ProviderCache, type ProviderCacheShape } from "../../services/ProviderCache.ts";
 import { TextGeneration, type TextGenerationShape } from "../../textGeneration/TextGeneration.ts";
 import { RepositoryIdentityResolverLive } from "../../project/Layers/RepositoryIdentityResolver.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
@@ -319,6 +320,19 @@ describe("ProviderCommandReactor", () => {
       },
     };
 
+    // The reactor reads provider capabilities through ProviderCache; mirror the
+    // service stub's capability so existing model-switch assertions still hold.
+    const providerCache: ProviderCacheShape = {
+      getModels: () => unsupported(),
+      getCapabilities: (_instanceId) =>
+        Effect.succeed({
+          sessionModelSwitch: input?.sessionModelSwitch ?? "in-session",
+        }),
+      invalidateProvider: () => Effect.void,
+      invalidateAll: Effect.void,
+      stats: Effect.succeed({ hits: 0, misses: 0 }),
+    };
+
     const orchestrationLayer = OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionSnapshotQueryLive),
       Layer.provide(OrchestrationProjectionPipelineLive),
@@ -335,6 +349,7 @@ describe("ProviderCommandReactor", () => {
       Layer.provideMerge(orchestrationLayer),
       Layer.provideMerge(projectionSnapshotLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
+      Layer.provideMerge(Layer.succeed(ProviderCache, providerCache)),
       Layer.provideMerge(
         Layer.mock(GitWorkflowService)({
           renameBranch,

--- a/t3code/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/t3code/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -30,6 +30,7 @@ import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { ProviderCache } from "../../services/ProviderCache.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
@@ -181,6 +182,7 @@ const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
+  const providerCache = yield* ProviderCache;
   const gitWorkflow = yield* GitWorkflowService;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;
@@ -445,7 +447,7 @@ const make = Effect.gen(function* () {
     if (existingSessionThreadId) {
       const runtimeModeChanged = thread.runtimeMode !== thread.session?.runtimeMode;
       const cwdChanged = effectiveCwd !== activeSession?.cwd;
-      const sessionModelSwitch = (yield* providerService.getCapabilities(desiredInstanceId))
+      const sessionModelSwitch = (yield* providerCache.getCapabilities(desiredInstanceId))
         .sessionModelSwitch;
       const modelChanged =
         requestedModelSelection !== undefined &&
@@ -550,7 +552,7 @@ const make = Effect.gen(function* () {
               method: "thread.turn.start",
               detail: `Active provider session '${activeSession.threadId}' is missing a provider instance id.`,
             })
-          : (yield* providerService.getCapabilities(activeSession.providerInstanceId))
+          : (yield* providerCache.getCapabilities(activeSession.providerInstanceId))
               .sessionModelSwitch;
     const requestedModelSelection =
       input.modelSelection ?? threadModelSelections.get(input.threadId) ?? thread.modelSelection;

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -43,6 +43,7 @@ import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderComma
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
+import { ProviderCacheLive } from "./services/ProviderCache.ts";
 import { ServerSettingsLive } from "./serverSettings.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
 import { RepositoryIdentityResolverLive } from "./project/Layers/RepositoryIdentityResolver.ts";
@@ -247,6 +248,11 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
   Layer.provideMerge(GitLayerLive),
   Layer.provideMerge(VcsLayerLive),
+  // TTL cache for provider model lists / capabilities. Sits above the provider
+  // service + registry (provided below) so its model-listing and capability
+  // consumers — the WS server config load and the provider command reactor —
+  // are served from cache and invalidated per-instance on registry changes.
+  Layer.provideMerge(ProviderCacheLive),
   Layer.provideMerge(ProviderRuntimeLayerLive),
   Layer.provideMerge(TerminalLayerLive),
   Layer.provideMerge(PersistenceLayerLive),

--- a/t3code/apps/server/src/services/ProviderCache.test.ts
+++ b/t3code/apps/server/src/services/ProviderCache.test.ts
@@ -1,0 +1,392 @@
+import { assert, describe, it } from "@effect/vitest";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Metric from "effect/Metric";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+
+import type { ProviderAdapterCapabilities } from "../provider/Services/ProviderAdapter.ts";
+import {
+  ProviderRegistry,
+  type ProviderRegistryShape,
+} from "../provider/Services/ProviderRegistry.ts";
+import {
+  ProviderService,
+  type ProviderServiceShape,
+} from "../provider/Services/ProviderService.ts";
+import {
+  makeProviderCache,
+  ProviderCache,
+  ProviderCacheLive,
+  type ProviderCacheConfig,
+  type ProviderCacheLookups,
+} from "./ProviderCache.ts";
+
+const hasMetricSnapshot = (
+  snapshots: ReadonlyArray<Metric.Metric.Snapshot>,
+  id: string,
+  attributes: Readonly<Record<string, string>>,
+) =>
+  snapshots.some(
+    (snapshot) =>
+      snapshot.id === id &&
+      Object.entries(attributes).every(([key, value]) => snapshot.attributes?.[key] === value),
+  );
+
+const INSTANCE = ProviderInstanceId.make("codex");
+const OTHER_INSTANCE = ProviderInstanceId.make("claude");
+
+const MODELS: ReadonlyArray<ServerProviderModel> = [
+  { slug: "gpt-x", name: "GPT-X", isCustom: false, capabilities: null },
+];
+
+const CAPABILITIES: ProviderAdapterCapabilities = { sessionModelSwitch: "in-session" };
+
+const config: ProviderCacheConfig = {
+  modelListTtl: Duration.minutes(5),
+  capabilityTtl: Duration.minutes(15),
+  capacity: 8,
+};
+
+const countingLookups = (
+  modelCalls: Ref.Ref<number>,
+  capabilityCalls: Ref.Ref<number>,
+): ProviderCacheLookups => ({
+  fetchModels: () => Ref.update(modelCalls, (count) => count + 1).pipe(Effect.as(MODELS)),
+  fetchCapabilities: () =>
+    Ref.update(capabilityCalls, (count) => count + 1).pipe(Effect.as(CAPABILITIES)),
+});
+
+describe("ProviderCache", () => {
+  it.effect("serves repeated model reads from cache within the TTL after one lookup", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const capabilityCalls = yield* Ref.make(0);
+      const cache = yield* makeProviderCache({
+        config,
+        lookups: countingLookups(modelCalls, capabilityCalls),
+      });
+
+      const first = yield* cache.getModels(INSTANCE);
+      const second = yield* cache.getModels(INSTANCE);
+
+      assert.deepStrictEqual(first, MODELS);
+      assert.deepStrictEqual(second, MODELS);
+      assert.equal(yield* Ref.get(modelCalls), 1);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("re-fetches a model list after its TTL elapses while capabilities stay cached", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const capabilityCalls = yield* Ref.make(0);
+      const cache = yield* makeProviderCache({
+        config,
+        lookups: countingLookups(modelCalls, capabilityCalls),
+      });
+
+      yield* cache.getModels(INSTANCE);
+      yield* cache.getCapabilities(INSTANCE);
+
+      // Still inside both TTLs: both reads are served from cache.
+      yield* TestClock.adjust(Duration.minutes(1));
+      yield* cache.getModels(INSTANCE);
+      yield* cache.getCapabilities(INSTANCE);
+      assert.equal(yield* Ref.get(modelCalls), 1);
+      assert.equal(yield* Ref.get(capabilityCalls), 1);
+
+      // Past the 5m model TTL but within the 15m capability TTL.
+      yield* TestClock.adjust(Duration.minutes(5));
+      yield* cache.getModels(INSTANCE);
+      yield* cache.getCapabilities(INSTANCE);
+      assert.equal(yield* Ref.get(modelCalls), 2);
+      assert.equal(yield* Ref.get(capabilityCalls), 1);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("invalidateProvider drops cached entries so the next read hits the provider", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const capabilityCalls = yield* Ref.make(0);
+      const cache = yield* makeProviderCache({
+        config,
+        lookups: countingLookups(modelCalls, capabilityCalls),
+      });
+
+      yield* cache.getModels(INSTANCE);
+      yield* cache.getCapabilities(INSTANCE);
+      assert.equal(yield* Ref.get(modelCalls), 1);
+      assert.equal(yield* Ref.get(capabilityCalls), 1);
+
+      yield* cache.invalidateProvider(INSTANCE);
+
+      yield* cache.getModels(INSTANCE);
+      yield* cache.getCapabilities(INSTANCE);
+      assert.equal(yield* Ref.get(modelCalls), 2);
+      assert.equal(yield* Ref.get(capabilityCalls), 2);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("invalidateAll clears every provider's entries", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const capabilityCalls = yield* Ref.make(0);
+      const cache = yield* makeProviderCache({
+        config,
+        lookups: countingLookups(modelCalls, capabilityCalls),
+      });
+
+      yield* cache.getModels(INSTANCE);
+      yield* cache.getModels(OTHER_INSTANCE);
+      assert.equal(yield* Ref.get(modelCalls), 2);
+
+      yield* cache.invalidateAll;
+
+      yield* cache.getModels(INSTANCE);
+      yield* cache.getModels(OTHER_INSTANCE);
+      assert.equal(yield* Ref.get(modelCalls), 4);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("concurrent reads of an uncached key trigger only one provider lookup", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const latch = yield* Deferred.make<void>();
+      const started = yield* Deferred.make<void>();
+      const cache = yield* makeProviderCache({
+        config,
+        lookups: {
+          fetchModels: () =>
+            Effect.gen(function* () {
+              yield* Ref.update(modelCalls, (count) => count + 1);
+              yield* Deferred.succeed(started, undefined);
+              yield* Deferred.await(latch);
+              return MODELS;
+            }),
+          fetchCapabilities: () => Effect.succeed(CAPABILITIES),
+        },
+      });
+
+      const fiber = yield* Effect.fork(
+        Effect.all(
+          Array.from({ length: 5 }, () => cache.getModels(INSTANCE)),
+          { concurrency: "unbounded" },
+        ),
+      );
+
+      // Wait until the single in-flight lookup has started, give the other
+      // callers a chance to attach to it, then release the lookup.
+      yield* Deferred.await(started);
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(latch, undefined);
+
+      const results = yield* Fiber.join(fiber);
+      assert.equal(results.length, 5);
+      results.forEach((result) => assert.deepStrictEqual(result, MODELS));
+      assert.equal(yield* Ref.get(modelCalls), 1);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("tracks hit/miss stats and emits cache metrics", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const capabilityCalls = yield* Ref.make(0);
+      const cache = yield* makeProviderCache({
+        config,
+        lookups: countingLookups(modelCalls, capabilityCalls),
+      });
+
+      yield* cache.getModels(INSTANCE); // miss
+      yield* cache.getModels(INSTANCE); // hit
+
+      const stats = yield* cache.stats;
+      assert.equal(stats.misses, 1);
+      assert.equal(stats.hits, 1);
+
+      const snapshots = yield* Metric.snapshot;
+      assert.equal(
+        hasMetricSnapshot(snapshots, "t3_provider_cache_misses_total", { cache: "models" }),
+        true,
+      );
+      assert.equal(
+        hasMetricSnapshot(snapshots, "t3_provider_cache_hits_total", { cache: "models" }),
+        true,
+      );
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("bounds retained entries by the configured capacity", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const capabilityCalls = yield* Ref.make(0);
+      const cache = yield* makeProviderCache({
+        config: { ...config, capacity: 1 },
+        lookups: countingLookups(modelCalls, capabilityCalls),
+      });
+
+      yield* cache.getModels(INSTANCE); // stores INSTANCE
+      yield* cache.getModels(OTHER_INSTANCE); // evicts INSTANCE (capacity 1)
+      yield* cache.getModels(INSTANCE); // INSTANCE evicted -> fresh lookup
+
+      assert.equal(yield* Ref.get(modelCalls), 3);
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("rejects a non-positive cache capacity with a typed error", () =>
+    Effect.gen(function* () {
+      const modelCalls = yield* Ref.make(0);
+      const capabilityCalls = yield* Ref.make(0);
+      const error = yield* Effect.flip(
+        makeProviderCache({
+          config: { ...config, capacity: 0 },
+          lookups: countingLookups(modelCalls, capabilityCalls),
+        }),
+      );
+
+      assert.equal(error._tag, "ProviderCacheError");
+      assert.ok(error.detail.includes("capacity"));
+    }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+});
+
+// Provider snapshot fixtures for exercising the wired-up `ProviderCacheLive`
+// against fake `ProviderRegistry` / `ProviderService` implementations.
+const serverProvider = (
+  instanceId: ProviderInstanceId,
+  driver: string,
+  models: ReadonlyArray<ServerProviderModel>,
+): ServerProvider => ({
+  instanceId,
+  driver: ProviderDriverKind.make(driver),
+  enabled: true,
+  installed: true,
+  version: null,
+  status: "ready",
+  auth: { status: "authenticated" },
+  checkedAt: "2026-04-10T00:00:00.000Z",
+  models,
+  slashCommands: [],
+  skills: [],
+});
+
+const PROVIDER_A = serverProvider(INSTANCE, "codex", MODELS);
+const PROVIDER_B = serverProvider(OTHER_INSTANCE, "claudeAgent", MODELS);
+const INITIAL_PROVIDERS: ReadonlyArray<ServerProvider> = [PROVIDER_A, PROVIDER_B];
+
+const fakeRegistry = (
+  providersRef: Ref.Ref<ReadonlyArray<ServerProvider>>,
+  getProvidersCalls: Ref.Ref<number>,
+  changes: Queue.Queue<ReadonlyArray<ServerProvider>>,
+): ProviderRegistryShape => ({
+  getProviders: Ref.update(getProvidersCalls, (count) => count + 1).pipe(
+    Effect.zipRight(Ref.get(providersRef)),
+  ),
+  refresh: () => Ref.get(providersRef),
+  refreshInstance: () => Ref.get(providersRef),
+  getProviderMaintenanceCapabilitiesForInstance: () =>
+    Effect.die("getProviderMaintenanceCapabilitiesForInstance is unused in this test"),
+  setProviderMaintenanceActionState: () => Ref.get(providersRef),
+  streamChanges: Stream.fromQueue(changes),
+});
+
+const fakeService = (capabilityCalls: Ref.Ref<number>): ProviderServiceShape =>
+  ({
+    getCapabilities: () =>
+      Ref.update(capabilityCalls, (count) => count + 1).pipe(Effect.as(CAPABILITIES)),
+  }) as unknown as ProviderServiceShape;
+
+// Yield enough times for the forked `streamChanges` reconciliation fiber to
+// drain a freshly offered emission before we assert on its effect.
+const settleStreamChanges = Effect.forEach(Array.from({ length: 20 }), () => Effect.yieldNow, {
+  discard: true,
+});
+
+describe("ProviderCacheLive", () => {
+  it.effect(
+    "serves a real consumer through the wired Live layer, hitting the provider service once",
+    () =>
+      Effect.gen(function* () {
+        const getProvidersCalls = yield* Ref.make(0);
+        const capabilityCalls = yield* Ref.make(0);
+        const providersRef = yield* Ref.make(INITIAL_PROVIDERS);
+        const changes = yield* Queue.unbounded<ReadonlyArray<ServerProvider>>();
+        const registry = fakeRegistry(providersRef, getProvidersCalls, changes);
+        const cacheLayer = ProviderCacheLive.pipe(
+          Layer.provide(Layer.succeed(ProviderRegistry, registry)),
+          Layer.provide(Layer.succeed(ProviderService, fakeService(capabilityCalls))),
+        );
+
+        yield* Effect.gen(function* () {
+          const cache = yield* ProviderCache;
+
+          // Two capability reads of the same instance: the underlying provider
+          // service is consulted exactly once; the second is served from cache.
+          const first = yield* cache.getCapabilities(INSTANCE);
+          const second = yield* cache.getCapabilities(INSTANCE);
+          assert.deepStrictEqual(first, CAPABILITIES);
+          assert.deepStrictEqual(second, CAPABILITIES);
+          assert.equal(yield* Ref.get(capabilityCalls), 1);
+
+          // Model reads resolve through the registry snapshot and are cached too.
+          const models = yield* cache.getModels(INSTANCE);
+          yield* cache.getModels(INSTANCE);
+          assert.deepStrictEqual(models, MODELS);
+        }).pipe(Effect.provide(cacheLayer));
+      }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.effect(
+    "invalidates only the instance whose registry snapshot changed, leaving others cached",
+    () =>
+      Effect.gen(function* () {
+        const getProvidersCalls = yield* Ref.make(0);
+        const capabilityCalls = yield* Ref.make(0);
+        const providersRef = yield* Ref.make(INITIAL_PROVIDERS);
+        const changes = yield* Queue.unbounded<ReadonlyArray<ServerProvider>>();
+        const registry = fakeRegistry(providersRef, getProvidersCalls, changes);
+        const cacheLayer = ProviderCacheLive.pipe(
+          Layer.provide(Layer.succeed(ProviderRegistry, registry)),
+          Layer.provide(Layer.succeed(ProviderService, fakeService(capabilityCalls))),
+        );
+
+        yield* Effect.gen(function* () {
+          const cache = yield* ProviderCache;
+
+          // Prime both instances, then re-read so both are cache hits.
+          yield* cache.getModels(INSTANCE);
+          yield* cache.getModels(OTHER_INSTANCE);
+          yield* cache.getModels(INSTANCE);
+          yield* cache.getModels(OTHER_INSTANCE);
+          const callsBeforeChange = yield* Ref.get(getProvidersCalls);
+
+          // A blanket snapshot emission in which only INSTANCE actually changed.
+          const changedA = serverProvider(INSTANCE, "codex", []);
+          yield* Ref.set(providersRef, [changedA, PROVIDER_B]);
+          yield* Queue.offer(changes, [changedA, PROVIDER_B]);
+          yield* settleStreamChanges;
+
+          // INSTANCE was invalidated -> one fresh registry read; OTHER_INSTANCE
+          // is untouched -> still served from cache (no extra registry read).
+          const refreshed = yield* cache.getModels(INSTANCE);
+          yield* cache.getModels(OTHER_INSTANCE);
+          const callsAfterChange = yield* Ref.get(getProvidersCalls);
+
+          assert.deepStrictEqual(refreshed, []);
+          assert.equal(callsAfterChange - callsBeforeChange, 1);
+        }).pipe(Effect.provide(cacheLayer));
+      }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+});

--- a/t3code/apps/server/src/services/ProviderCache.ts
+++ b/t3code/apps/server/src/services/ProviderCache.ts
@@ -1,0 +1,295 @@
+/**
+ * ProviderCache - Effect.Cache-backed caching for provider API responses.
+ *
+ * Provider model lists and capability queries are read repeatedly by transport
+ * layers but change rarely. This service memoizes both behind `effect/Cache`
+ * instances with independent, configurable TTLs so that requests within the TTL
+ * are served without touching the underlying provider API.
+ *
+ * `effect/Cache` also deduplicates concurrent lookups of the same key: when many
+ * fibers request an uncached entry simultaneously the lookup effect runs exactly
+ * once and every caller receives that single result. Memory is bounded by the
+ * per-cache `capacity` knob.
+ *
+ * The pure factory `makeProviderCache` takes the lookup functions and TTL
+ * configuration as arguments, which keeps it side-effect free and testable in
+ * isolation. `ProviderCacheLive` wires the factory to the real provider services
+ * and invalidates only the affected instances whenever the provider registry
+ * reports a change.
+ *
+ * @module ProviderCache
+ */
+import type { ProviderInstanceId, ServerProvider, ServerProviderModel } from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+
+import {
+  increment,
+  providerCacheHitsTotal,
+  providerCacheMissesTotal,
+} from "../observability/Metrics.ts";
+import type { ProviderAdapterCapabilities } from "../provider/Services/ProviderAdapter.ts";
+import { ProviderRegistry } from "../provider/Services/ProviderRegistry.ts";
+import { ProviderService } from "../provider/Services/ProviderService.ts";
+
+/** Identifies which cache an operation touched, used for metrics and errors. */
+export type ProviderCacheKind = "models" | "capabilities";
+
+/** Raised when the cache cannot satisfy a lookup or is misconfigured. */
+export class ProviderCacheError extends Data.TaggedError("ProviderCacheError")<{
+  readonly cache: ProviderCacheKind;
+  readonly instanceId?: ProviderInstanceId | undefined;
+  readonly detail: string;
+  readonly cause?: unknown;
+}> {}
+
+/** Per-cache-type TTLs and the shared entry-count bound. */
+export interface ProviderCacheConfig {
+  /** Time provider model lists remain fresh before a re-fetch. */
+  readonly modelListTtl: Duration.Duration;
+  /** Time provider capability queries remain fresh before a re-fetch. */
+  readonly capabilityTtl: Duration.Duration;
+  /** Maximum number of entries retained per cache (bounds memory usage). */
+  readonly capacity: number;
+}
+
+/** Defaults requested by the issue: 5-minute models, 15-minute capabilities. */
+export const defaultProviderCacheConfig: ProviderCacheConfig = {
+  modelListTtl: Duration.minutes(5),
+  capabilityTtl: Duration.minutes(15),
+  capacity: 256,
+};
+
+/** Cumulative cache effectiveness, exposed for the observability layer. */
+export interface ProviderCacheStats {
+  readonly hits: number;
+  readonly misses: number;
+}
+
+/** Lookup functions invoked on a cache miss to fetch fresh provider data. */
+export interface ProviderCacheLookups {
+  readonly fetchModels: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderModel>, ProviderCacheError>;
+  readonly fetchCapabilities: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ProviderAdapterCapabilities, ProviderCacheError>;
+}
+
+export interface ProviderCacheShape {
+  /** Read a provider's model list, served from cache within its TTL. */
+  readonly getModels: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderModel>, ProviderCacheError>;
+
+  /** Read a provider's capabilities, served from cache within its TTL. */
+  readonly getCapabilities: (
+    instanceId: ProviderInstanceId,
+  ) => Effect.Effect<ProviderAdapterCapabilities, ProviderCacheError>;
+
+  /** Drop every cached entry for a single provider instance. */
+  readonly invalidateProvider: (instanceId: ProviderInstanceId) => Effect.Effect<void>;
+
+  /** Drop every cached entry across all providers. */
+  readonly invalidateAll: Effect.Effect<void>;
+
+  /** Snapshot of cumulative cache hits and misses. */
+  readonly stats: Effect.Effect<ProviderCacheStats>;
+}
+
+const assertCapacity = (capacity: number): Effect.Effect<void, ProviderCacheError> =>
+  Number.isInteger(capacity) && capacity > 0
+    ? Effect.void
+    : Effect.fail(
+        new ProviderCacheError({
+          cache: "models",
+          detail: `cache capacity must be a positive integer, received ${capacity}`,
+        }),
+      );
+
+/**
+ * Build a provider cache from explicit lookups and configuration. Pure: it
+ * allocates the caches and a stats counter but performs no I/O and starts no
+ * background fibers, so it can be exercised directly in tests.
+ */
+export const makeProviderCache = (options: {
+  readonly config: ProviderCacheConfig;
+  readonly lookups: ProviderCacheLookups;
+}) =>
+  Effect.gen(function* () {
+    const { config, lookups } = options;
+    yield* assertCapacity(config.capacity);
+
+    const modelsCache = yield* Cache.make<
+      ProviderInstanceId,
+      ReadonlyArray<ServerProviderModel>,
+      ProviderCacheError
+    >({
+      capacity: config.capacity,
+      timeToLive: config.modelListTtl,
+      lookup: (instanceId) => lookups.fetchModels(instanceId),
+    });
+
+    const capabilitiesCache = yield* Cache.make<
+      ProviderInstanceId,
+      ProviderAdapterCapabilities,
+      ProviderCacheError
+    >({
+      capacity: config.capacity,
+      timeToLive: config.capabilityTtl,
+      lookup: (instanceId) => lookups.fetchCapabilities(instanceId),
+    });
+
+    const statsRef = yield* Ref.make<ProviderCacheStats>({ hits: 0, misses: 0 });
+
+    const recordHit = (cache: ProviderCacheKind) =>
+      Effect.gen(function* () {
+        yield* Ref.update(statsRef, (current) => ({ ...current, hits: current.hits + 1 }));
+        yield* increment(providerCacheHitsTotal, { cache });
+      });
+
+    const recordMiss = (cache: ProviderCacheKind) =>
+      Effect.gen(function* () {
+        yield* Ref.update(statsRef, (current) => ({ ...current, misses: current.misses + 1 }));
+        yield* increment(providerCacheMissesTotal, { cache });
+      });
+
+    // A present entry is a hit; an absent one delegates to `Cache.get`, which
+    // performs (and deduplicates) the lookup and stores the fresh value.
+    const observe = <Value>(
+      cache: ProviderCacheKind,
+      peek: Effect.Effect<Option.Option<Value>, ProviderCacheError>,
+      load: Effect.Effect<Value, ProviderCacheError>,
+    ): Effect.Effect<Value, ProviderCacheError> =>
+      peek.pipe(
+        Effect.flatMap((cached) =>
+          Option.isSome(cached)
+            ? recordHit(cache).pipe(Effect.as(cached.value))
+            : load.pipe(Effect.tap(() => recordMiss(cache))),
+        ),
+      );
+
+    const invalidateAll = Effect.gen(function* () {
+      const modelKeys = Array.from(yield* Cache.keys(modelsCache));
+      yield* Effect.forEach(modelKeys, (key) => Cache.invalidate(modelsCache, key), {
+        concurrency: 1,
+      }).pipe(Effect.asVoid);
+      const capabilityKeys = Array.from(yield* Cache.keys(capabilitiesCache));
+      yield* Effect.forEach(capabilityKeys, (key) => Cache.invalidate(capabilitiesCache, key), {
+        concurrency: 1,
+      }).pipe(Effect.asVoid);
+    });
+
+    return {
+      getModels: (instanceId) =>
+        observe(
+          "models",
+          Cache.getOption(modelsCache, instanceId),
+          Cache.get(modelsCache, instanceId),
+        ),
+      getCapabilities: (instanceId) =>
+        observe(
+          "capabilities",
+          Cache.getOption(capabilitiesCache, instanceId),
+          Cache.get(capabilitiesCache, instanceId),
+        ),
+      invalidateProvider: (instanceId) =>
+        Effect.zipRight(
+          Cache.invalidate(modelsCache, instanceId),
+          Cache.invalidate(capabilitiesCache, instanceId),
+        ),
+      invalidateAll,
+      stats: Ref.get(statsRef),
+    } satisfies ProviderCacheShape;
+  });
+
+export class ProviderCache extends Context.Service<ProviderCache, ProviderCacheShape>()(
+  "t3/services/ProviderCache",
+) {}
+
+/**
+ * Live cache wired to the real provider services. Model lists are read from the
+ * provider registry snapshot; capabilities from {@link ProviderService}. A
+ * background fiber subscribes to registry changes and invalidates only the
+ * instances whose snapshot actually changed, so reconfigured providers never
+ * serve stale data while unrelated providers keep their cached entries.
+ */
+export const ProviderCacheLive = Layer.effect(
+  ProviderCache,
+  Effect.gen(function* () {
+    const providerService = yield* ProviderService;
+    const registry = yield* ProviderRegistry;
+
+    const fetchModels: ProviderCacheLookups["fetchModels"] = (instanceId) =>
+      registry.getProviders.pipe(
+        Effect.flatMap((providers) => {
+          const match = providers.find((provider) => provider.instanceId === instanceId);
+          return match
+            ? Effect.succeed(match.models)
+            : Effect.fail(
+                new ProviderCacheError({
+                  cache: "models",
+                  instanceId,
+                  detail: "no provider snapshot found for instance",
+                }),
+              );
+        }),
+      );
+
+    const fetchCapabilities: ProviderCacheLookups["fetchCapabilities"] = (instanceId) =>
+      providerService.getCapabilities(instanceId).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderCacheError({
+              cache: "capabilities",
+              instanceId,
+              detail: "failed to resolve provider capabilities",
+              cause,
+            }),
+        ),
+      );
+
+    const cache = yield* makeProviderCache({
+      config: defaultProviderCacheConfig,
+      lookups: { fetchModels, fetchCapabilities },
+    });
+
+    // `streamChanges` emits the full provider snapshot on every aggregated
+    // change and never names which instance changed. We recover per-instance
+    // granularity by diffing each emission against the previous snapshot and
+    // invalidating only the instances whose snapshot actually changed (or were
+    // removed), so reconfiguring one provider does not evict another's cache.
+    const snapshotKey = (provider: ServerProvider): string => JSON.stringify(provider);
+    const toSnapshotMap = (providers: ReadonlyArray<ServerProvider>) =>
+      new Map(providers.map((provider) => [provider.instanceId, snapshotKey(provider)] as const));
+
+    const previousSnapshot = yield* Ref.make(toSnapshotMap(yield* registry.getProviders));
+
+    const reconcile = (providers: ReadonlyArray<ServerProvider>) =>
+      Effect.gen(function* () {
+        const next = toSnapshotMap(providers);
+        const previous = yield* Ref.getAndSet(previousSnapshot, next);
+        const changed = new Set<ProviderInstanceId>();
+        for (const [instanceId, key] of next) {
+          if (previous.get(instanceId) !== key) changed.add(instanceId);
+        }
+        for (const instanceId of previous.keys()) {
+          if (!next.has(instanceId)) changed.add(instanceId);
+        }
+        yield* Effect.forEach(changed, (instanceId) => cache.invalidateProvider(instanceId), {
+          discard: true,
+        });
+      });
+
+    yield* Effect.forkScoped(Stream.runForEach(registry.streamChanges, reconcile));
+
+    return cache;
+  }),
+);

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -50,6 +50,7 @@ import {
   observeRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
 import { ProviderRegistry } from "./provider/Services/ProviderRegistry.ts";
+import { ProviderCache } from "./services/ProviderCache.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents.ts";
 import { ServerRuntimeStartup } from "./serverRuntimeStartup.ts";
@@ -170,6 +171,7 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
       const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
       const terminalManager = yield* TerminalManager;
       const providerRegistry = yield* ProviderRegistry;
+      const providerCache = yield* ProviderCache;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const config = yield* ServerConfig;
       const lifecycleEvents = yield* ServerLifecycleEvents;
@@ -572,7 +574,18 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
 
       const loadServerConfig = Effect.gen(function* () {
         const keybindingsConfig = yield* keybindings.loadConfigState;
-        const providers = yield* providerRegistry.getProviders;
+        // Serve each provider's model list from the TTL cache. The registry
+        // snapshot supplies the non-model config; the model list — the part the
+        // cache exists to memoize — comes from ProviderCache.getModels, falling
+        // back to the snapshot's own models if the cache lookup fails.
+        const providers = yield* Effect.forEach(
+          yield* providerRegistry.getProviders,
+          (provider) =>
+            providerCache.getModels(provider.instanceId).pipe(
+              Effect.map((models) => ({ ...provider, models })),
+              Effect.catchAll(() => Effect.succeed(provider)),
+            ),
+        );
         const settings = redactServerSettingsForClient(yield* serverSettings.getSettings);
         const environment = yield* serverEnvironment.getDescriptor;
         const auth = yield* serverAuth.getDescriptor();


### PR DESCRIPTION
Resolves #865.

Wired `ProviderCacheLive` into the server layer composition and routed the real model-listing (`ws.ts loadServerConfig`) and capability (`ProviderCommandReactor`) call sites through `ProviderCache.getModels`/`getCapabilities`; upgraded registry-change invalidation from blanket `invalidateAll` to per-instance snapshot diffing; added Live-layer integration tests proving a real consumer is served from cache and that only the changed instance is invalidated; sanitized `contributor_meta.json` to schema-shaped metadata with no system/initialization text.

/claim #865