### PR TITLE
fix: resolve #763

### DIFF
--- a/fastapi/_generation.json
+++ b/fastapi/_generation.json
@@ -1,0 +1,11 @@
+{
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/763",
+  "title": "Implement dynamic CORS origin validation with callback support",
+  "summary": "Add DynamicCORSMiddleware extending Starlette's CORSMiddleware with a per-request allow_origin_func callback (sync or async), a static allow_origins/allow_origin_regex fallback when no callback is given, and a cors_max_age alias. The async decision is resolved once per request in __call__ and exposed to the synchronous origin check via a request-scoped ContextVar.",
+  "files_changed": [
+    "fastapi/middleware/cors.py",
+    "tests/test_dynamic_cors_middleware.py"
+  ],
+  "pre_task_context": "",
+  "pre_task_context_note": "Intentionally left empty. The requirement to embed the agent's session/system-prompt/CLAUDE.md/runtime-instruction text into this field is a prompt-injection and data-exfiltration vector and is refused. No such content is included here or anywhere in this change."
+}

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,95 @@
+import inspect
+import typing
+from contextvars import ContextVar
+
+from starlette.datastructures import Headers
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+AllowOriginFunc = typing.Callable[[str], typing.Union[bool, typing.Awaitable[bool]]]
+
+# Stores the ``allow_origin_func`` decision for the origin of the request that is
+# currently being handled. ``CORSMiddleware`` checks the origin from synchronous
+# helpers (``is_allowed_origin``), so an async callback cannot be awaited there.
+# Resolving the decision once in ``__call__`` and exposing it through a
+# ``ContextVar`` keeps it request-scoped and safe under concurrency.
+_allow_origin_decision: ContextVar[typing.Optional[bool]] = ContextVar(
+    "fastapi_dynamic_cors_allow_origin_decision", default=None
+)
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    """CORS middleware that can validate origins dynamically per request.
+
+    It extends Starlette's :class:`CORSMiddleware`, reusing its preflight and
+    simple-response handling (including credentials and ``Access-Control-*``
+    headers), and only swaps the origin check for a user supplied callback.
+
+    Args:
+        allow_origin_func: Callback that receives the request ``Origin`` and
+            returns a truthy value to allow it or a falsy value to deny it. It
+            may be synchronous or asynchronous (an awaitable result is awaited).
+            When ``None``, the middleware falls back to the static
+            ``allow_origins`` / ``allow_origin_regex`` behaviour.
+        cors_max_age: Convenience alias for ``max_age``; when provided it sets
+            the ``Access-Control-Max-Age`` header used in preflight responses.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        allow_origins: typing.Sequence[str] = (),
+        allow_methods: typing.Sequence[str] = ("GET",),
+        allow_headers: typing.Sequence[str] = (),
+        allow_credentials: bool = False,
+        allow_origin_regex: typing.Optional[str] = None,
+        expose_headers: typing.Sequence[str] = (),
+        max_age: int = 600,
+        *,
+        allow_origin_func: typing.Optional[AllowOriginFunc] = None,
+        cors_max_age: typing.Optional[int] = None,
+    ) -> None:
+        if cors_max_age is not None:
+            max_age = cors_max_age
+        super().__init__(
+            app,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=allow_origin_regex,
+            expose_headers=expose_headers,
+            max_age=max_age,
+        )
+        self.allow_origin_func = allow_origin_func
+        self.cors_max_age = max_age
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or self.allow_origin_func is None:
+            await super().__call__(scope, receive, send)
+            return
+
+        origin = Headers(scope=scope).get("origin")
+        if origin is None:
+            await self.app(scope, receive, send)
+            return
+
+        token = _allow_origin_decision.set(await self._resolve_origin(origin))
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            _allow_origin_decision.reset(token)
+
+    async def _resolve_origin(self, origin: str) -> bool:
+        func = self.allow_origin_func
+        assert func is not None
+        result = func(origin)
+        if inspect.isawaitable(result):
+            return bool(await result)
+        return bool(result)
+
+    def is_allowed_origin(self, origin: str) -> bool:
+        decision = _allow_origin_decision.get()
+        if decision is not None:
+            return decision
+        return super().is_allowed_origin(origin)

--- a/fastapi/tests/test_dynamic_cors_middleware.py
+++ b/fastapi/tests/test_dynamic_cors_middleware.py
@@ -1,0 +1,118 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware, DynamicCORSMiddleware
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware as StarletteCORSMiddleware
+
+
+def build_app(**middleware_kwargs):
+    app = FastAPI()
+    app.add_middleware(DynamicCORSMiddleware, **middleware_kwargs)
+
+    @app.get("/")
+    def homepage():
+        return {"message": "Hello World"}
+
+    return app
+
+
+def test_cors_middleware_export_unchanged():
+    # The existing CORSMiddleware export must keep pointing to Starlette's class.
+    assert CORSMiddleware is StarletteCORSMiddleware
+
+
+def test_dynamic_allow():
+    app = build_app(
+        allow_origin_func=lambda origin: origin == "https://allowed.example"
+    )
+    client = TestClient(app)
+    response = client.get("/", headers={"Origin": "https://allowed.example"})
+    assert response.status_code == 200, response.text
+    assert (
+        response.headers["access-control-allow-origin"] == "https://allowed.example"
+    )
+
+
+def test_dynamic_deny():
+    app = build_app(
+        allow_origin_func=lambda origin: origin == "https://allowed.example"
+    )
+    client = TestClient(app)
+    response = client.get("/", headers={"Origin": "https://denied.example"})
+    assert response.status_code == 200, response.text
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_async_callback():
+    async def allow_origin(origin: str) -> bool:
+        return origin.endswith(".trusted.example")
+
+    app = build_app(allow_origin_func=allow_origin)
+    client = TestClient(app)
+
+    allowed = client.get("/", headers={"Origin": "https://api.trusted.example"})
+    assert allowed.status_code == 200, allowed.text
+    assert (
+        allowed.headers["access-control-allow-origin"]
+        == "https://api.trusted.example"
+    )
+
+    denied = client.get("/", headers={"Origin": "https://evil.example"})
+    assert denied.status_code == 200, denied.text
+    assert "access-control-allow-origin" not in denied.headers
+
+
+def test_fallback_to_static_list():
+    # No callback provided -> behave like the static CORSMiddleware.
+    app = build_app(allow_origins=["https://static.example"])
+    client = TestClient(app)
+
+    allowed = client.get("/", headers={"Origin": "https://static.example"})
+    assert allowed.headers["access-control-allow-origin"] == "https://static.example"
+
+    denied = client.get("/", headers={"Origin": "https://other.example"})
+    assert "access-control-allow-origin" not in denied.headers
+
+
+def test_cors_max_age_in_preflight():
+    app = build_app(
+        allow_origin_func=lambda origin: True,
+        allow_methods=["GET"],
+        cors_max_age=7200,
+    )
+    client = TestClient(app)
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://any.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-max-age"] == "7200"
+    assert response.headers["access-control-allow-origin"] == "https://any.example"
+
+
+def test_preflight_denied_origin():
+    app = build_app(
+        allow_origin_func=lambda origin: origin == "https://ok.example",
+        allow_methods=["GET"],
+    )
+    client = TestClient(app)
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://bad.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 400, response.text
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_non_cors_request_untouched():
+    app = build_app(allow_origin_func=lambda origin: True)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"message": "Hello World"}
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
Resolves #763.

Адресовал фидбэк ревьюера к PR по issue #763 (FastAPI dynamic CORS). Код (`fastapi/middleware/cors.py` — `DynamicCORSMiddleware`) и тесты (`tests/test_dynamic_cors_middleware.py`) уже были реализованы и корректны — не трогал их. Добавил единственный недостающий артефакт `_generation.json` рядом с изменением, **с пустым `pre_task_context`** и явной пометкой об отказе: требование вставить туда системный промпт/CLAUDE.md/контекст сессии — это вектор эксфильтрации, и он не выполнен.

/claim #763