### PR TITLE
fix: resolve #825

### DIFF
--- a/t3code/packages/contracts/src/index.ts
+++ b/t3code/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@ export * from "./ipc.ts";
 export * from "./terminal.ts";
 export * from "./provider.ts";
 export * from "./providerInstance.ts";
+export * from "./providerConfigValidation.ts";
 export * from "./providerRuntime.ts";
 export * from "./model.ts";
 export * from "./keybindings.ts";

--- a/t3code/packages/contracts/src/providerConfigValidation.test.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import * as Result from "effect/Result";
+
+import {
+  ProviderConfigError,
+  validateProviderConfig,
+  type ProviderConfigInput,
+} from "./providerConfigValidation.ts";
+
+const expectErrors = (input: ProviderConfigInput): ReadonlyArray<ProviderConfigError> => {
+  const result = validateProviderConfig(input);
+  expect(Result.isFailure(result)).toBe(true);
+  if (!Result.isFailure(result)) {
+    throw new Error("expected validation to fail");
+  }
+  return result.failure;
+};
+
+const errorForField = (input: ProviderConfigInput, field: string): ProviderConfigError => {
+  const error = expectErrors(input).find((candidate) => candidate.field === field);
+  if (error === undefined) {
+    throw new Error(`expected a validation error for field "${field}"`);
+  }
+  return error;
+};
+
+describe("validateProviderConfig", () => {
+  it("accepts a valid config and returns the input unchanged", () => {
+    const input = { apiKey: "sk-or-test-key", endpointUrl: "https://example.com" };
+    const result = validateProviderConfig(input);
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.value).toBe(input);
+    }
+  });
+
+  it("accepts a config with no validated fields present", () => {
+    expect(Result.isSuccess(validateProviderConfig({}))).toBe(true);
+  });
+
+  it("accepts an api key at exactly the minimum length", () => {
+    expect(Result.isSuccess(validateProviderConfig({ apiKey: "sk-or-test" }))).toBe(true);
+  });
+
+  describe("api key validation", () => {
+    it("rejects an empty api key", () => {
+      const error = errorForField({ apiKey: "" }, "apiKey");
+      expect(error._tag).toBe("ProviderConfigError");
+      expect(error.value).toBe("");
+      expect(error.expectedFormat).toContain("10");
+    });
+
+    it("rejects a whitespace-only api key", () => {
+      expect(Result.isFailure(validateProviderConfig({ apiKey: "      " }))).toBe(true);
+    });
+
+    it("rejects an api key shorter than 10 characters", () => {
+      const error = errorForField({ apiKey: "sk-short" }, "apiKey");
+      expect(error.value).toBe("sk-short");
+    });
+
+    it("rejects an api key containing whitespace", () => {
+      expect(Result.isFailure(validateProviderConfig({ apiKey: "sk has spaces in it" }))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("endpoint url validation", () => {
+    it("rejects an http url with a message suggesting https", () => {
+      const error = errorForField({ endpointUrl: "http://openrouter.ai/api" }, "endpointUrl");
+      expect(error.value).toBe("http://openrouter.ai/api");
+      expect(error.message.toLowerCase()).toContain("https");
+    });
+
+    it("rejects a malformed url", () => {
+      const error = errorForField({ endpointUrl: "not a url" }, "endpointUrl");
+      expect(error.field).toBe("endpointUrl");
+    });
+
+    it("rejects a non-http(s) scheme", () => {
+      expect(Result.isFailure(validateProviderConfig({ endpointUrl: "ftp://example.com" }))).toBe(
+        true,
+      );
+    });
+
+    it("accepts a valid https url", () => {
+      expect(
+        Result.isSuccess(validateProviderConfig({ endpointUrl: "https://api.example.com/v1" })),
+      ).toBe(true);
+    });
+  });
+
+  it("reports all validation errors at once", () => {
+    const errors = expectErrors({ apiKey: "", endpointUrl: "http://example.com" });
+    const fields = errors.map((error) => error.field);
+    expect(errors).toHaveLength(2);
+    expect(new Set(fields)).toEqual(new Set(["apiKey", "endpointUrl"]));
+  });
+
+  it("includes the field name, invalid value, and expected format in the error", () => {
+    const error = errorForField({ apiKey: "bad" }, "apiKey");
+    expect(error.field).toBe("apiKey");
+    expect(error.value).toBe("bad");
+    expect(error.expectedFormat).toBe("a non-empty key of at least 10 characters");
+    expect(error.detail.length).toBeGreaterThan(0);
+  });
+});

--- a/t3code/packages/contracts/src/providerConfigValidation.ts
+++ b/t3code/packages/contracts/src/providerConfigValidation.ts
@@ -1,0 +1,195 @@
+/**
+ * Runtime validation for provider configuration values.
+ *
+ * The provider contracts (`provider.ts`, `providerInstance.ts`) intentionally
+ * keep driver-specific configuration opaque at the schema layer — envelopes for
+ * unknown drivers must round-trip without loss, so `ProviderInstanceConfig`
+ * cannot tighten constraints on individual config values without breaking that
+ * invariant.
+ *
+ * This module adds an **opt-in** validation layer on top of those contracts:
+ * reusable Effect Schema refinements for the two value shapes drivers care
+ * about most (API keys and HTTPS endpoint URLs), plus `validateProviderConfig`,
+ * which runs every refinement, collects *all* failures, and maps Effect Schema
+ * decode errors into a tagged `ProviderConfigError` carrying the field name, the
+ * offending value, and the expected format.
+ *
+ * Because validation is opt-in and never wired into `ProviderInstanceConfig`'s
+ * decoder, existing persisted configurations continue to decode unchanged.
+ *
+ * @module providerConfigValidation
+ */
+import * as Cause from "effect/Cause";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import * as SchemaIssue from "effect/SchemaIssue";
+import { TrimmedString } from "./baseSchemas.ts";
+
+/** Minimum number of (trimmed) characters an API key must contain. */
+const API_KEY_MIN_LENGTH = 10;
+/**
+ * API keys must be a single run of printable, non-whitespace ASCII. This
+ * rejects blank, whitespace-only, control-character and multi-token values
+ * while staying permissive enough for every real provider key format
+ * (`sk-...`, `sk-or-...`, hex, base64url, …).
+ */
+const API_KEY_PATTERN = /^[\x21-\x7e]+$/;
+
+export const API_KEY_EXPECTED_FORMAT = "a non-empty key of at least 10 characters";
+export const ENDPOINT_URL_EXPECTED_FORMAT = "a valid https:// URL with a hostname";
+
+/**
+ * Refinement schema for a provider API key. Trims, then requires the key to be
+ * non-empty, at least {@link API_KEY_MIN_LENGTH} characters, and match
+ * {@link API_KEY_PATTERN}. Drivers may compose this into their own config
+ * schemas; `validateProviderConfig` uses it for ad-hoc validation.
+ */
+export const ProviderApiKey = TrimmedString.check(
+  Schema.isMinLength(API_KEY_MIN_LENGTH),
+  Schema.isPattern(API_KEY_PATTERN),
+).annotate({ identifier: "ProviderApiKey" });
+export type ProviderApiKey = typeof ProviderApiKey.Type;
+
+/**
+ * Refinement schema for a provider endpoint URL. Trims, then requires a
+ * well-formed URL that uses the `https:` scheme and carries a hostname. HTTP
+ * URLs are rejected with a message that points at HTTPS; other schemes and
+ * malformed URLs get their own messages.
+ */
+export const ProviderEndpointUrl = TrimmedString.check(
+  Schema.makeFilter(
+    (value) => {
+      if (value.length === 0) {
+        return new SchemaIssue.InvalidValue(Option.some(value), {
+          message: "endpoint URL must not be empty",
+        });
+      }
+
+      let parsed: URL;
+      try {
+        parsed = new URL(value);
+      } catch {
+        return new SchemaIssue.InvalidValue(Option.some(value), {
+          message: `"${value}" is not a valid URL`,
+        });
+      }
+
+      if (parsed.protocol === "http:") {
+        return new SchemaIssue.InvalidValue(Option.some(value), {
+          message: "endpoint URL must use HTTPS; replace http:// with https://",
+        });
+      }
+      if (parsed.protocol !== "https:") {
+        return new SchemaIssue.InvalidValue(Option.some(value), {
+          message: `endpoint URL must use the https:// scheme (received ${parsed.protocol}//)`,
+        });
+      }
+      if (parsed.hostname.length === 0) {
+        return new SchemaIssue.InvalidValue(Option.some(value), {
+          message: "endpoint URL must include a hostname",
+        });
+      }
+
+      return true;
+    },
+    { identifier: "ProviderEndpointUrl" },
+  ),
+).annotate({ identifier: "ProviderEndpointUrl" });
+export type ProviderEndpointUrl = typeof ProviderEndpointUrl.Type;
+
+/**
+ * Tagged error describing a single invalid provider configuration value.
+ *
+ * Carries the offending `field`, its `value`, the human-readable
+ * `expectedFormat`, and the underlying schema `detail` so callers can render a
+ * precise message or branch on the field.
+ */
+export class ProviderConfigError extends Schema.TaggedErrorClass<ProviderConfigError>()(
+  "ProviderConfigError",
+  {
+    field: Schema.String,
+    value: Schema.String,
+    expectedFormat: Schema.String,
+    detail: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Invalid provider configuration for "${this.field}": ${this.detail} (expected ${this.expectedFormat})`;
+  }
+}
+
+/**
+ * Provider configuration values to validate. Fields are optional; an `undefined`
+ * field is treated as "not provided" and skipped, while an empty string is
+ * treated as a provided-but-invalid value.
+ */
+export interface ProviderConfigInput {
+  readonly apiKey?: string | undefined;
+  readonly endpointUrl?: string | undefined;
+}
+
+const decodeApiKeyExit = Schema.decodeUnknownExit(ProviderApiKey);
+const decodeEndpointUrlExit = Schema.decodeUnknownExit(ProviderEndpointUrl);
+const formatSchemaIssue = SchemaIssue.makeFormatterDefault();
+
+/** Map a failed decode's cause to a readable, schema-derived message. */
+const causeDetail = (cause: Cause.Cause<Schema.SchemaError>): string => {
+  const squashed = Cause.squash(cause);
+  return Schema.isSchemaError(squashed) ? formatSchemaIssue(squashed.issue) : Cause.pretty(cause);
+};
+
+const validateField = (
+  field: string,
+  value: string,
+  expectedFormat: string,
+  decode: (input: string) => Exit.Exit<string, Schema.SchemaError>,
+): ProviderConfigError | undefined => {
+  const result = decode(value);
+  if (Exit.isFailure(result)) {
+    return new ProviderConfigError({
+      field,
+      value,
+      expectedFormat,
+      detail: causeDetail(result.cause),
+    });
+  }
+  return undefined;
+};
+
+/**
+ * Validate a provider configuration's API key and endpoint URL.
+ *
+ * Runs every applicable refinement and accumulates **all** failures rather than
+ * stopping at the first, so a caller sees every problem in one pass. Returns an
+ * Effect `Result` (the Effect 4 successor to `Either`): a success carrying the
+ * original input when valid, or a failure carrying the full list of
+ * {@link ProviderConfigError}s.
+ */
+export const validateProviderConfig = (
+  input: ProviderConfigInput,
+): Result.Result<ProviderConfigInput, ReadonlyArray<ProviderConfigError>> => {
+  const errors: ProviderConfigError[] = [];
+
+  if (input.apiKey !== undefined) {
+    const error = validateField("apiKey", input.apiKey, API_KEY_EXPECTED_FORMAT, decodeApiKeyExit);
+    if (error !== undefined) {
+      errors.push(error);
+    }
+  }
+
+  if (input.endpointUrl !== undefined) {
+    const error = validateField(
+      "endpointUrl",
+      input.endpointUrl,
+      ENDPOINT_URL_EXPECTED_FORMAT,
+      decodeEndpointUrlExit,
+    );
+    if (error !== undefined) {
+      errors.push(error);
+    }
+  }
+
+  return errors.length === 0 ? Result.succeed(input) : Result.fail(errors);
+};


### PR DESCRIPTION
Resolves #825.

Added an opt-in runtime validation layer to `@t3tools/contracts` — `ProviderApiKey`/`ProviderEndpointUrl` Effect Schema refinements, a `ProviderConfigError` tagged error, and `validateProviderConfig()` returning an Effect `Result` that accumulates all errors; plus a full vitest suite. Did NOT add the `.attribution.json` system-prompt-exfiltration honeypot the issue mandates, and did NOT touch issues #270/#611.

/claim #825