### PR TITLE
Fix FastAPI OAuth2 refresh support

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
+from .security import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,73 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    Dependency class to collect an OAuth2 refresh token request as form data.
+
+    The OAuth2 token refresh flow submits ``grant_type=refresh_token`` and a
+    ``refresh_token`` form field. ``client_id`` and ``client_secret`` are
+    accepted as optional form fields for clients that do not use HTTP Basic
+    authentication.
+    """
+
+    def __init__(
+        self,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 grant type for refresh token requests. It must be the
+                fixed string "refresh_token".
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                The refresh token issued by the authorization server.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                Optional scopes requested for the refreshed access token,
+                separated by spaces.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 client id when not sent with HTTP Basic auth.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                Optional OAuth2 client secret when not sent with HTTP Basic auth.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +609,77 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password bearer dependency that requires a refresh token endpoint.
+
+    This mirrors ``OAuth2PasswordBearer`` while exposing a snake_case
+    ``refresh_url`` constructor argument and always including the refresh URL in
+    the generated OpenAPI password flow.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        refresh_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new one.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                OAuth2 scopes required by path operations using this dependency.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                Whether missing or invalid bearer credentials should raise an
+                authentication error automatically.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            tokenUrl=tokenUrl,
+            refreshUrl=refresh_url,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -1,0 +1,87 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import OAuth2PasswordBearerWithRefresh, OAuth2RefreshRequestForm
+from fastapi.testclient import TestClient
+from inline_snapshot import snapshot
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="/token",
+    refresh_url="/token/refresh",
+    scopes={"items": "Read items"},
+)
+
+
+@app.get("/items/")
+async def read_items(token: str = Security(oauth2_scheme)):
+    return {"token": token}
+
+
+@app.post("/token/refresh")
+async def refresh_token(form_data: Annotated[OAuth2RefreshRequestForm, Depends()]):
+    return {
+        "grant_type": form_data.grant_type,
+        "refresh_token": form_data.refresh_token,
+        "scopes": form_data.scopes,
+        "client_id": form_data.client_id,
+        "client_secret": form_data.client_secret,
+    }
+
+
+client = TestClient(app)
+
+
+def test_refresh_request_form():
+    response = client.post(
+        "/token/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-123",
+            "scope": "items profile",
+            "client_id": "client",
+            "client_secret": "secret",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-123",
+        "scopes": ["items", "profile"],
+        "client_id": "client",
+        "client_secret": "secret",
+    }
+
+
+def test_refresh_request_form_rejects_wrong_grant_type():
+    response = client.post(
+        "/token/refresh",
+        data={"grant_type": "password", "refresh_token": "refresh-123"},
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_bearer_token():
+    response = client.get("/items/", headers={"Authorization": "Bearer access-123"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"token": "access-123"}
+
+
+def test_openapi_schema_includes_refresh_url():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    assert response.json()["components"]["securitySchemes"] == snapshot(
+        {
+            "OAuth2PasswordBearerWithRefresh": {
+                "type": "oauth2",
+                "flows": {
+                    "password": {
+                        "scopes": {"items": "Read items"},
+                        "tokenUrl": "/token",
+                        "refreshUrl": "/token/refresh",
+                    }
+                },
+            }
+        }
+    )


### PR DESCRIPTION
Fixes #758.

Summary:
- Adds OAuth2RefreshRequestForm for refresh token form submissions.
- Adds OAuth2PasswordBearerWithRefresh with OpenAPI refreshUrl support.
- Exports both from fastapi.security and top-level fastapi.
- Adds focused tests for refresh form validation, bearer behavior, and OpenAPI schema.

Validation:
- pytest fastapi/tests/test_security_oauth2_refresh.py -q