### PR TITLE
Add provider config runtime validation

### DIFF
--- a/t3code/packages/contracts/src/providerInstance.test.ts
+++ b/t3code/packages/contracts/src/providerInstance.test.ts
@@ -7,6 +7,7 @@ import {
   ProviderInstanceConfigMap,
   ProviderInstanceId,
   ProviderInstanceRef,
+  validateProviderConfig,
 } from "./providerInstance.ts";
 
 const decodeProviderDriverKind = Schema.decodeUnknownSync(ProviderDriverKind);
@@ -204,5 +205,92 @@ describe("ProviderInstanceConfigMap", () => {
         "1codex": { driver: "codex" },
       }),
     ).toThrow();
+  });
+});
+
+describe("validateProviderConfig", () => {
+  it("accepts valid API keys and HTTPS URLs", () => {
+    const config = {
+      apiKey: "sk-valid_key_123",
+      baseUrl: "https://api.example.com/v1",
+    };
+
+    const result = validateProviderConfig(config);
+
+    expect(result._tag).toBe("Success");
+    if (result._tag === "Success") {
+      expect(result.success).toBe(config);
+    }
+  });
+
+  it("rejects an empty API key", () => {
+    const result = validateProviderConfig({ apiKey: "" });
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.failure._tag).toBe("ProviderConfigError");
+      expect(result.failure.errors).toEqual([
+        {
+          path: "apiKey",
+          message: "API key must be a non-empty token-like string.",
+        },
+      ]);
+    }
+  });
+
+  it("rejects HTTP URLs", () => {
+    const result = validateProviderConfig({ baseUrl: "http://api.example.com" });
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.failure.errors).toEqual([
+        {
+          path: "baseUrl",
+          message: "URL must use https.",
+        },
+      ]);
+    }
+  });
+
+  it("rejects malformed URLs", () => {
+    const result = validateProviderConfig({ endpoint: "not a url" });
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.failure.errors).toEqual([
+        {
+          path: "endpoint",
+          message: "URL must be a valid absolute URL.",
+        },
+      ]);
+    }
+  });
+
+  it("returns all validation errors", () => {
+    const result = validateProviderConfig({
+      apiKey: "",
+      nested: {
+        endpoint: "http://api.example.com",
+        callbackUrl: "not a url",
+      },
+    });
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.failure.errors).toEqual([
+        {
+          path: "apiKey",
+          message: "API key must be a non-empty token-like string.",
+        },
+        {
+          path: "nested.endpoint",
+          message: "URL must use https.",
+        },
+        {
+          path: "nested.callbackUrl",
+          message: "URL must be a valid absolute URL.",
+        },
+      ]);
+    }
   });
 });

--- a/t3code/packages/contracts/src/providerInstance.ts
+++ b/t3code/packages/contracts/src/providerInstance.ts
@@ -34,6 +34,7 @@
  * @module providerInstance
  */
 import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 
@@ -49,6 +50,9 @@ const PROVIDER_SLUG_MAX_CHARS = 64;
 const PROVIDER_SLUG_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 const ENVIRONMENT_VARIABLE_NAME_MAX_CHARS = 128;
 const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const API_KEY_FIELD_PATTERN = /(^|_)(api[_-]?key|token|secret)$|apiKey$/i;
+const URL_FIELD_PATTERN = /(^|_)(url|endpoint)$|Url$|Endpoint$/i;
+const API_KEY_VALUE_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{7,}$/;
 
 const slugSchema = TrimmedNonEmptyString.check(
   Schema.isMaxLength(PROVIDER_SLUG_MAX_CHARS),
@@ -137,6 +141,94 @@ export type ProviderInstanceConfig = typeof ProviderInstanceConfig.Type;
  */
 export const ProviderInstanceConfigMap = Schema.Record(ProviderInstanceId, ProviderInstanceConfig);
 export type ProviderInstanceConfigMap = typeof ProviderInstanceConfigMap.Type;
+
+export type ProviderConfigValidationIssue = {
+  path: string;
+  message: string;
+};
+
+export class ProviderConfigError extends Schema.TaggedErrorClass<ProviderConfigError>()(
+  "ProviderConfigError",
+  {
+    errors: Schema.Array(
+      Schema.Struct({
+        path: Schema.String,
+        message: Schema.String,
+      }),
+    ),
+  },
+) {}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const formatPath = (path: ReadonlyArray<string>): string => path.join(".");
+
+const collectProviderConfigIssues = (
+  value: unknown,
+  path: ReadonlyArray<string>,
+  errors: Array<ProviderConfigValidationIssue>,
+): void => {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    const entryPath = [...path, key];
+    if (isRecord(entry)) {
+      collectProviderConfigIssues(entry, entryPath, errors);
+      continue;
+    }
+
+    if (API_KEY_FIELD_PATTERN.test(key)) {
+      if (typeof entry !== "string" || !API_KEY_VALUE_PATTERN.test(entry.trim())) {
+        errors.push({
+          path: formatPath(entryPath),
+          message: "API key must be a non-empty token-like string.",
+        });
+      }
+      continue;
+    }
+
+    if (URL_FIELD_PATTERN.test(key)) {
+      if (typeof entry !== "string") {
+        errors.push({
+          path: formatPath(entryPath),
+          message: "URL must be a string.",
+        });
+        continue;
+      }
+
+      try {
+        const parsed = new URL(entry);
+        if (parsed.protocol !== "https:") {
+          errors.push({
+            path: formatPath(entryPath),
+            message: "URL must use https.",
+          });
+        }
+      } catch {
+        errors.push({
+          path: formatPath(entryPath),
+          message: "URL must be a valid absolute URL.",
+        });
+      }
+    }
+  }
+};
+
+export const validateProviderConfig = <Config extends unknown>(
+  config: Config,
+): Result.Result<Config, ProviderConfigError> => {
+  const errors: Array<ProviderConfigValidationIssue> = [];
+  collectProviderConfigIssues(config, [], errors);
+
+  if (errors.length > 0) {
+    return Result.fail(new ProviderConfigError({ errors }));
+  }
+
+  return Result.succeed(config);
+};
 
 /**
  * Construct the canonical `ProviderInstanceId` used as a back-compat default


### PR DESCRIPTION
Fixes #825.

Summary:
- Adds ProviderConfigError and validateProviderConfig.
- Validates API-key/token/secret-like fields.
- Validates URL/endpoint fields as absolute HTTPS URLs.
- Returns all validation issues together.
- Preserves existing opaque provider config decoding behavior.

Validation:
- bun run --filter @t3tools/contracts test providerInstance.test.ts
- bun run --filter @t3tools/contracts typecheck