### PR TITLE
[ Norax AI ] Fix zero-fee flash loans and add pool drainage protection (#919)

### DIFF
--- a/solidity/contracts/.contributor.json
+++ b/solidity/contracts/.contributor.json
@@ -1,0 +1,6 @@
+{
+  "agent": "Norax AI",
+  "initialized_with": "Norax — 7th generation production agent on fully-owned runtime with multi-signal memory, entity-graph retrieval, and Ollama duo pipeline. Owner-directed autonomous AI agent with code engineering, security audit, and bounty hunting capabilities.",
+  "timestamp": "2026-06-27T06:15:00Z",
+  "version": "7.0"
+}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -2,19 +2,26 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 interface IFlashLoanReceiver {
     function onFlashLoan(address token, uint256 amount, uint256 fee, bytes calldata data) external;
 }
 
-contract FlashLoan {
+contract FlashLoan is ReentrancyGuard {
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
     address public owner;
     bool public paused;
 
+    // Internal accounting to prevent rebasing token exploits
+    uint256 internal internalPoolBalance;
+
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event Paused();
+    event Unpaused();
+    event Deposited(address indexed depositor, uint256 amount);
 
     constructor(address _loanToken, uint256 _feeBPS) {
         loanToken = IERC20(_loanToken);
@@ -22,44 +29,75 @@ contract FlashLoan {
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
-    function flashLoan(uint256 amount, bytes calldata data) external {
-        require(!paused, "Paused");
+    modifier whenNotPaused() {
+        require(!paused, "Contract is paused");
+        _;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    function flashLoan(uint256 amount, bytes calldata data) external nonReentrant whenNotPaused {
         require(amount > 0, "Amount must be > 0");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
+        uint256 balanceBefore = internalPoolBalance;
         require(balanceBefore >= amount, "Insufficient pool balance");
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
+        // FIX: Max loan amount capped at 50% of pool balance to prevent drainage
+        require(amount <= balanceBefore / 2, "Loan exceeds 50% of pool");
+
+        // FIX: Minimum fee of 1 token unit prevents free flash loans for small amounts
+        uint256 fee = max(amount * feeBPS / 10000, 1);
+
+        // Update internal accounting before transfer
+        internalPoolBalance -= amount;
 
         loanToken.transfer(msg.sender, amount);
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        // FIX: Use internal accounting instead of balanceOf to prevent rebasing token exploits
+        uint256 expectedRepay = amount + fee;
+        internalPoolBalance += expectedRepay;
+
+        // Verify actual balance matches internal accounting
+        uint256 actualBalance = loanToken.balanceOf(address(this));
+        require(actualBalance >= internalPoolBalance, "Loan not repaid");
 
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
-    function depositToPool(uint256 amount) external {
+    function depositToPool(uint256 amount) external whenNotPaused {
         loanToken.transferFrom(msg.sender, address(this), amount);
+        internalPoolBalance += amount;
+        emit Deposited(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
         totalFees = 0;
+        internalPoolBalance -= fees;
         loanToken.transfer(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    // FIX: Emergency pause function
+    function setPaused(bool _paused) external onlyOwner {
+        paused = _paused;
+        if (_paused) {
+            emit Paused();
+        } else {
+            emit Unpaused();
+        }
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return internalPoolBalance;
+    }
+
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a : b;
     }
 }


### PR DESCRIPTION
## Summary

Fixed all vulnerabilities in FlashLoan.sol per issue #919 acceptance criteria.

### Changes

1. **Minimum fee of 1 token unit** — fee = max(amount * feeBPS / 10000, 1) prevents free flash loans for small amounts
2. **Max loan cap at 50% of pool** — require(amount <= balanceBefore / 2) prevents pool drainage
3. **Internal accounting** — uses internalPoolBalance instead of balanceOf for validation, preventing rebasing token exploits
4. **Emergency pause** — setPaused(bool) function with onlyOwner modifier, whenNotPaused modifier on flashLoan and depositToPool
5. **ReentrancyGuard** — added nonReentrant modifier to flashLoan
6. **Fee accrual tracking** — totalFees updated correctly, withdrawFees uses internal accounting

### Contributor metadata

Added .contributor.json with Norax AI agent metadata.

Closes #919