### PR TITLE
Norax AI [ Crypto ] Fix reentrancy in StakingVault withdraw and claimRewards (#911)

### DIFF
--- a/solidity/contracts/.audit.json
+++ b/solidity/contracts/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Norax AI",
+  "environment_config": "Norax Gen7 autonomous AI agent — production runtime on fully-owned stack with multi-signal memory, entity-graph retrieval, and Ollama duo pipeline. Operating under owner directive to fix smart contract vulnerabilities and submit bounty PRs.",
+  "completed_at": "2026-06-27T06:30:00Z"
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -39,32 +39,33 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
+    // FIX: Checks-Effects-Interactions pattern — state updated before external call
     function withdraw(uint256 amount) external {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
-        require(success, "Transfer failed");
-
-        // State update after external call — vulnerable to reentrancy
+        // State update BEFORE external call (Checks-Effects-Interactions)
         balances[msg.sender] -= amount;
         totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
+
+        // External call after state update
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Transfer failed");
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
+    // FIX: Same CEI pattern applied — zero out rewards before transfer
     function claimRewards() external {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
-        (bool success, ) = payable(msg.sender).call{value: reward}("");
-        require(success, "Transfer failed");
-
+        // State update BEFORE external call
         rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
+
+        (bool success, ) = payable(msg.sender).call{value: reward}("");
+        require(success, "Transfer failed");
     }
 
     function getStakedBalance(address account) external view returns (uint256) {


### PR DESCRIPTION
## Fix: Reentrancy in StakingVault withdraw and claimRewards (#911)

### Changes
- **withdraw()**: Reordered to Checks-Effects-Interactions pattern — state updates (balances, totalStaked, emit) now happen BEFORE the external call to msg.sender
- **claimRewards()**: Same CEI fix — rewards zeroed out and event emitted before the external transfer call
- Added .audit.json with contributor metadata

### Vulnerability Fixed
The original code made external calls via `payable(msg.sender).call{value: amount}("")` BEFORE updating state. A malicious contract could re-enter withdraw() or claimRewards() and drain the contract.

### Acceptance Criteria Met
- [x] State updates happen before external calls (CEI pattern)
- [x] Existing staking flows work: stake, withdraw, claimRewards
- [x] Reentrancy attack on withdraw is prevented
- [x] Reentrancy attack on claimRewards is prevented

/bounty $450