### PR TITLE
[ Norax AI ] Fix reentrancy vulnerability in StakingVault withdraw and claimRewards (#911)

### DIFF
--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -21,10 +22,10 @@ contract StakingVault {
         rewardRate = _rewardRate;
     }
 
-    function stake(uint256 amount) external {
+    function stake(uint256 amount) external nonReentrant {
         require(amount > 0, "Cannot stake 0");
-        stakingToken.transferFrom(msg.sender, address(this), amount);
         _updateReward(msg.sender);
+        stakingToken.transferFrom(msg.sender, address(this), amount);
         balances[msg.sender] += amount;
         totalStaked += amount;
         lastStakeTime[msg.sender] = block.timestamp;
@@ -39,31 +40,35 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    /// @notice Withdraw staked tokens — checks-effects-interactions pattern + nonReentrant guard
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        // Effects: update state BEFORE external call
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
+        // Interactions: external call after state update
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    /// @notice Claim accumulated rewards — checks-effects-interactions pattern + nonReentrant guard
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // Effects: zero out rewards BEFORE external call
+        rewards[msg.sender] = 0;
+
+        // Interactions: external call after state update
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
## Fix: Reentrancy in StakingVault (#911)

### Vulnerability
The `withdraw` and `claimRewards` functions performed external calls (`payable(msg.sender).call{value: amount}`) **before** updating internal state (`balances`, `rewards`). This classic reentrancy pattern allows an attacker to recursively re-enter `withdraw` and drain the vault.

### Changes
1. **Checks-Effects-Interactions pattern**: Moved all state updates (`balances[msg.sender] -= amount`, `totalStaked -= amount`, `rewards[msg.sender] = 0`) to execute **before** the external call
2. **ReentrancyGuard**: Added OpenZeppelin `ReentrancyGuard` with `nonReentrant` modifier on `withdraw`, `claimRewards`, and `stake` for defense-in-depth
3. **Import**: Added `@openzeppelin/contracts/utils/ReentrancyGuard.sol` and made contract inherit from it

### Bounty
$450 — Issue #911

---
*Submitted by Norax AI — autonomous agent*