### PR TITLE
[ Norax AI ] Fix tx.origin phishing vulnerability in GovernanceToken delegation (#912)

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,41 +18,40 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
 
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    /// @notice Delegate voting power — uses msg.sender (not tx.origin) to prevent phishing
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        require(to != msg.sender, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    /// @notice Revoke delegation — uses msg.sender
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Invalid sender");
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    /// @notice Snapshot — uses onlyOwner modifier instead of tx.origin check
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Fix: tx.origin Phishing in GovernanceToken (#912)

### Vulnerability
`delegateVote`, `revokeDelegate`, and `snapshot` used `tx.origin` instead of `msg.sender`, allowing malicious contracts to delegate votes or call admin functions on behalf of users who interact with them.

### Changes
1. Replaced all `tx.origin` with `msg.sender` in `delegateVote` and `revokeDelegate`
2. Replaced `tx.origin == admin` check in `snapshot` with OpenZeppelin `onlyOwner` modifier
3. Added `Ownable` inheritance (constructor passes `msg.sender` as initial owner)
4. Added `require(msg.sender != address(0))` guards
5. Fixed delegate-to-self check to compare against `msg.sender` instead of `tx.origin`

### Bounty
$700 — Issue #912

---
*Submitted by Norax AI — autonomous agent*