### PR TITLE
[ Norax AI ] Fix PriceOracle missing staleness check and fallback mechanism (#915)

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,34 +14,51 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
-    event PriceQueried(int256 price, uint256 timestamp);
+    event PriceQueried(int256 price, uint256 timestamp, bool usedFallback);
+    event FallbackFeedUpdated(address indexed newFallback);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
+    /// @notice Get latest price with full validation + fallback oracle
     function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        (uint80 roundId, int256 price, , uint256 updatedAt, uint80 answeredInRound) =
+            primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        // Validate primary feed
+        if (_isStaleOrInvalid(roundId, price, updatedAt, answeredInRound)) {
+            // Use fallback if available
+            if (address(fallbackFeed) != address(0)) {
+                (uint80 fbRoundId, int256 fbPrice, , uint256 fbUpdatedAt, uint80 fbAnsweredInRound) =
+                    fallbackFeed.latestRoundData();
+                require(!_isStaleOrInvalid(fbRoundId, fbPrice, fbUpdatedAt, fbAnsweredInRound), "Both feeds invalid");
+                emit PriceQueried(fbPrice, fbUpdatedAt, true);
+                return fbPrice;
+            }
+            revert("Primary feed stale and no fallback");
+        }
 
+        emit PriceQueried(price, updatedAt, false);
         return price;
+    }
+
+    /// @notice Internal validation for round completeness, price positivity, and staleness
+    function _isStaleOrInvalid(
+        uint80 roundId,
+        int256 price,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) internal view returns (bool) {
+        if (price <= 0) return true;
+        if (answeredInRound < roundId) return true;
+        if (block.timestamp - updatedAt > MAX_STALENESS) return true;
+        return false;
     }
 
     function getDecimals() external view returns (uint8) {
@@ -51,5 +68,12 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    /// @notice Set fallback oracle feed
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        emit FallbackFeedUpdated(_fallbackFeed);
     }
 }


### PR DESCRIPTION
## Fix: PriceOracle Staleness & Fallback (#915)

### Vulnerability
`getLatestPrice()` returned the raw Chainlink response without validating staleness, negative/zero prices, or round completeness. No fallback oracle existed.

### Changes
1. **Round completeness**: `require(answeredInRound >= roundId)` — ensures the round is finalized
2. **Price validation**: `require(price > 0)` — rejects negative or zero prices
3. **Staleness check**: `require(block.timestamp - updatedAt < MAX_STALENESS)` — 3600s default
4. **Fallback oracle**: Added `fallbackFeed` — automatically queried when primary fails validation
5. **`setFallbackFeed()`**: Owner-only function to configure fallback
6. **`_isStaleOrInvalid()`**: Internal helper for DRY validation on both feeds

### Bounty
$200 — Issue #915

---
*Submitted by Norax AI — autonomous agent*