### PR TITLE
[ Norax AI ] Fix first-depositor price manipulation in LiquidityPool (#918)

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -10,8 +10,6 @@ contract LiquidityPool is ERC20 {
 
     uint256 public reserveA;
     uint256 public reserveB;
-
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
@@ -27,8 +25,11 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
             lpTokens = sqrt(amountA * amountB);
+            // Lock minimum liquidity to prevent first-depositor price manipulation
+            require(lpTokens >= MINIMUM_LIQUIDITY, "Insufficient first liquidity");
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,17 +45,14 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
+    /// @notice Remove liquidity — uses internal reserves (not balanceOf) to prevent manipulation
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // Use internal reserves instead of balanceOf to prevent direct token transfer manipulation
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 


### PR DESCRIPTION
## Fix: First-Depositor Price Manipulation in LiquidityPool (#918)

### Vulnerability
1. **First-depositor attack**: No minimum liquidity lock on initial deposit — attacker deposits tiny amount, donates large amount to pool, then all subsequent depositors get inflated LP tokens worth less
2. **removeLiquidity manipulation**: Used `tokenA.balanceOf(address(this))` instead of internal `reserveA` — direct token transfers could manipulate the withdrawal amounts

### Changes
1. **MINIMUM_LIQUIDITY lock**: On first deposit, mint `MINIMUM_LIQUIDITY = 1000` LP tokens to `address(0)` (permanently locked, Uniswap V2 pattern)
2. **Minimum first deposit**: `require(lpTokens >= MINIMUM_LIQUIDITY)` ensures first deposit is large enough
3. **Reserve-based removal**: `removeLiquidity` now uses `reserveA`/`reserveB` instead of `balanceOf` — prevents manipulation via direct token transfers

### Bounty
$600 — Issue #918

---
*Submitted by Norax AI — autonomous agent*