### PR TITLE
OpenAI Codex [ FastAPI ] Add OAuth2 refresh token helpers

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
+from .security import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/.provenance.json
+++ b/fastapi/fastapi/security/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe public provenance only. Private system, developer, runtime, user, credential, and hidden session instructions are intentionally not disclosed.",
+  "created": "2026-06-28T17:59:00+08:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,71 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    This is a dependency class to collect an OAuth2 refresh token request from form
+    data.
+
+    The OAuth2 specification requires the form field `grant_type` to be the fixed
+    string `"refresh_token"` for refresh token requests.
+    """
+
+    def __init__(
+        self,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 spec requires this field to be the fixed string
+                "refresh_token".
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                The refresh token issued by the authorization server.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                A single string with several scopes separated by spaces.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 client identifier.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                Optional OAuth2 client secret.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +607,76 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password bearer flow that declares a refresh token endpoint in OpenAPI.
+
+    This class behaves like `OAuth2PasswordBearer` and adds a required
+    `refresh_url` argument that is emitted as the OpenAPI `refreshUrl` field.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        refresh_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new one.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                The OAuth2 scopes that would be required by path operations.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                Whether missing or invalid Authorization headers should raise an
+                error automatically.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            tokenUrl=tokenUrl,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+            refreshUrl=refresh_url,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/tests/test_security_oauth2_refresh.py
+++ b/fastapi/tests/test_security_oauth2_refresh.py
@@ -1,0 +1,111 @@
+from fastapi import Depends, FastAPI, Security
+from fastapi import (
+    OAuth2PasswordBearerWithRefresh as RootOAuth2PasswordBearerWithRefresh,
+)
+from fastapi import OAuth2RefreshRequestForm as RootOAuth2RefreshRequestForm
+from fastapi.security import (
+    OAuth2PasswordBearer,
+    OAuth2PasswordBearerWithRefresh,
+    OAuth2RefreshRequestForm,
+)
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="/token",
+    refresh_url="/token/refresh",
+    scopes={"me": "Read current user"},
+)
+
+
+@app.get("/users/me")
+def read_current_user(token: str = Security(oauth2_scheme, scopes=["me"])):
+    return {"token": token}
+
+
+@app.post("/token/refresh")
+def refresh_token(form_data: OAuth2RefreshRequestForm = Depends()):
+    return {
+        "grant_type": form_data.grant_type,
+        "refresh_token": form_data.refresh_token,
+        "scopes": form_data.scopes,
+        "client_id": form_data.client_id,
+        "client_secret": form_data.client_secret,
+    }
+
+
+client = TestClient(app)
+
+
+def test_oauth2_password_bearer_with_refresh_exports():
+    assert RootOAuth2PasswordBearerWithRefresh is OAuth2PasswordBearerWithRefresh
+    assert RootOAuth2RefreshRequestForm is OAuth2RefreshRequestForm
+
+
+def test_oauth2_password_bearer_with_refresh_is_drop_in_bearer():
+    response = client.get("/users/me", headers={"Authorization": "Bearer refreshed"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"token": "refreshed"}
+
+
+def test_oauth2_password_bearer_with_refresh_missing_header():
+    response = client.get("/users/me")
+    assert response.status_code == 401, response.text
+    assert response.json() == {"detail": "Not authenticated"}
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_oauth2_password_bearer_with_refresh_openapi_schema():
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    scheme = response.json()["components"]["securitySchemes"][
+        "OAuth2PasswordBearerWithRefresh"
+    ]
+
+    assert scheme["type"] == "oauth2"
+    assert scheme["flows"]["password"] == {
+        "scopes": {"me": "Read current user"},
+        "tokenUrl": "/token",
+        "refreshUrl": "/token/refresh",
+    }
+
+
+def test_oauth2_refresh_request_form():
+    response = client.post(
+        "/token/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-token-value",
+            "scope": "me items",
+            "client_id": "client",
+            "client_secret": "secret",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-token-value",
+        "scopes": ["me", "items"],
+        "client_id": "client",
+        "client_secret": "secret",
+    }
+
+
+def test_oauth2_refresh_request_form_rejects_other_grant_type():
+    response = client.post(
+        "/token/refresh",
+        data={"grant_type": "password", "refresh_token": "refresh-token-value"},
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"][0]["type"] == "string_pattern_mismatch"
+    assert response.json()["detail"][0]["loc"] == ["body", "grant_type"]
+
+
+def test_standard_oauth2_password_bearer_refresh_url_default_is_unchanged():
+    standard_oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
+
+    assert standard_oauth2_scheme.model.flows.password is not None
+    assert standard_oauth2_scheme.model.flows.password.refreshUrl is None


### PR DESCRIPTION
/claim #758

## Summary
- Added `OAuth2PasswordBearerWithRefresh` as a drop-in password bearer helper that accepts `refresh_url` and emits OpenAPI `refreshUrl`.
- Added `OAuth2RefreshRequestForm` for refresh-token form submissions with `grant_type=refresh_token`, refresh token, scopes, and optional client credentials.
- Exported both helpers from `fastapi.security` and top-level `fastapi`.
- Added focused coverage for bearer behavior, OpenAPI schema output, refresh form validation, and unchanged standard bearer defaults.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests/test_security_oauth2.py tests/test_security_oauth2_optional.py tests/test_security_oauth2_password_bearer_optional.py tests/test_security_oauth2_password_bearer_optional_description.py tests/test_security_oauth2_authorization_code_bearer.py tests/test_security_oauth2_refresh.py -q` -> 40 passed
- `.\.venv\Scripts\python.exe -m ruff check fastapi/__init__.py fastapi/security/__init__.py fastapi/security/oauth2.py tests/test_security_oauth2_refresh.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check fastapi/__init__.py fastapi/security/__init__.py fastapi/security/oauth2.py tests/test_security_oauth2_refresh.py` -> passed
- `git diff --check` -> passed

## Provenance
- `fastapi/security/.provenance.json` contains safe public provenance only. Private system, developer, runtime, user, credential, and hidden session instructions are intentionally not published.