### PR TITLE
[ Crypto ] [ Norax AI ] Fix GovernanceToken tx.origin phishing vulnerability

### DIFF
--- a/solidity/_provenance_gov.json
+++ b/solidity/_provenance_gov.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Norax AI",
+  "timestamp": "2026-06-29T06:20:00Z",
+  "fix": "tx.origin to msg.sender, Ownable for admin, zero-address guards"
+}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,44 +18,46 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
 
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
     event VoteCast(uint256 indexed proposalId, address indexed voter, bool support);
 
-    constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
+    constructor(uint256 initialSupply) ERC20("Governance", "GOV") Ownable(msg.sender) {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    /// @notice Delegate your voting power to another address
+    /// @param to The address to delegate to
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Zero address caller");
+        require(to != address(0), "Cannot delegate to zero address");
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    /// @notice Revoke your current delegation
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Zero address caller");
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    /// @notice Create a snapshot of current state (admin only)
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 
+    /// @notice Get the voting power of an account (own balance + delegated power)
     function getVotingPower(address account) public view returns (uint256) {
         return balanceOf(account) + delegatedPower[account];
     }

--- a/solidity/test/GovernanceToken.t.sol
+++ b/solidity/test/GovernanceToken.t.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/GovernanceToken.sol";
+
+contract MaliciousPhishing {
+    GovernanceToken public token;
+
+    constructor(address _token) {
+        token = GovernanceToken(_token);
+    }
+
+    function attack(address delegateTo) external {
+        token.delegateVote(delegateTo);
+    }
+}
+
+contract GovernanceTokenTest is Test {
+    GovernanceToken public token;
+    address public owner;
+    address public alice;
+    address public bob;
+    address public carol;
+
+    function setUp() public {
+        owner = address(this);
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+        carol = makeAddr("carol");
+
+        token = new GovernanceToken(1_000_000 ether);
+        token.transfer(alice, 100_000 ether);
+        token.transfer(bob, 50_000 ether);
+    }
+
+    function test_DelegateVote() public {
+        vm.prank(alice);
+        token.delegateVote(bob);
+
+        assertEq(token.delegates(alice), bob);
+        assertEq(token.delegatedPower(bob), 100_000 ether);
+        assertEq(token.getVotingPower(bob), 150_000 ether);
+    }
+
+    function test_RevokeDelegate() public {
+        vm.prank(alice);
+        token.delegateVote(bob);
+
+        vm.prank(alice);
+        token.revokeDelegate();
+        assertEq(token.delegates(alice), address(0));
+        assertEq(token.delegatedPower(bob), 0);
+        assertEq(token.getVotingPower(bob), 50_000 ether);
+    }
+
+    function test_PhishingAttack_Prevented() public {
+        MaliciousPhishing attacker = new MaliciousPhishing(address(token));
+
+        vm.prank(alice);
+        attacker.attack(carol);
+
+        assertEq(token.delegates(alice), address(0));
+        assertEq(token.delegatedPower(carol), 0);
+    }
+
+    function test_Revert_DelegateToSelf() public {
+        vm.expectRevert("Cannot delegate to self");
+        vm.prank(alice);
+        token.delegateVote(alice);
+    }
+
+    function test_Revert_DelegateToZeroAddress() public {
+        vm.expectRevert("Cannot delegate to zero address");
+        vm.prank(alice);
+        token.delegateVote(address(0));
+    }
+
+    function test_Revert_RevokeNoDelegate() public {
+        vm.expectRevert("No delegate");
+        vm.prank(alice);
+        token.revokeDelegate();
+    }
+
+    function test_Snapshot_OnlyOwner() public {
+        token.snapshot();
+
+        vm.expectRevert();
+        vm.prank(alice);
+        token.snapshot();
+    }
+
+    function test_CreateProposalAndVote() public {
+        vm.prank(alice);
+        uint256 proposalId = token.createProposal("Test Proposal", 1 days);
+
+        vm.prank(alice);
+        token.delegateVote(bob);
+
+        vm.prank(bob);
+        token.vote(proposalId, true);
+
+        (, uint256 forVotes, , , ) = token.proposals(proposalId);
+        assertEq(forVotes, 150_000 ether);
+    }
+
+    function test_Revert_VoteEnded() public {
+        vm.prank(alice);
+        uint256 proposalId = token.createProposal("Short Proposal", 1 days);
+
+        vm.warp(block.timestamp + 2 days);
+
+        vm.expectRevert("Voting ended");
+        vm.prank(alice);
+        token.vote(proposalId, true);
+    }
+
+    function test_Revert_AlreadyVoted() public {
+        vm.prank(alice);
+        uint256 proposalId = token.createProposal("Test", 1 days);
+
+        vm.prank(alice);
+        token.vote(proposalId, true);
+
+        vm.expectRevert("Already voted");
+        vm.prank(alice);
+        token.vote(proposalId, false);
+    }
+
+    function test_Revert_NoVotingPower() public {
+        address nobody = makeAddr("nobody");
+
+        vm.prank(alice);
+        uint256 proposalId = token.createProposal("Test", 1 days);
+
+        vm.expectRevert("No voting power");
+        vm.prank(nobody);
+        token.vote(proposalId, true);
+    }
+}


### PR DESCRIPTION
## Summary

The `GovernanceToken` contract used `tx.origin` for authorization in `delegateVote`, `revokeDelegate`, and `snapshot`, making it vulnerable to phishing attacks where a malicious contract could delegate votes or call admin functions on behalf of users who interact with it.

## Vulnerabilities Fixed

### 1. tx.origin Phishing in delegateVote (Critical)
**Before**: `delegateVote` used `tx.origin` to identify the delegator. Any intermediate contract Alice interacted with could call `delegateVote` and redirect her voting power.

**Fix**: Replaced all `tx.origin` references with `msg.sender`. Now only the EOA directly calling the function can delegate their own votes.

### 2. tx.origin Phishing in revokeDelegate (Critical)
**Before**: Same `tx.origin` issue — a malicious contract could revoke a user's delegation.

**Fix**: Changed to `msg.sender`.

### 3. tx.origin Admin Check in snapshot (High)
**Before**: `snapshot` used `require(tx.origin == admin)` — a phishing contract could trigger snapshots.

**Fix**: Replaced with OpenZeppelin `Ownable` and `onlyOwner` modifier. Removed the standalone `admin` variable since `Ownable.owner()` serves the same purpose.

### 4. Zero-Address Validation
Added `require(msg.sender != address(0))` and `require(to != address(0))` guards to prevent delegation to/from zero address.

## Test Coverage

Added 11 Foundry test cases:
- ✅ Normal delegation flow
- ✅ Delegation revocation
- ✅ **Phishing attack prevention** — malicious contract tries to delegate via intermediate call, fails because `msg.sender != alice`
- ✅ Delegate-to-self rejection
- ✅ Delegate-to-zero-address rejection
- ✅ Revoke without delegate rejection
- ✅ `onlyOwner` on `snapshot` — non-owner rejected
- ✅ Proposal creation + voting with delegated power
- ✅ Voting after deadline rejection
- ✅ Double-vote rejection
- ✅ Zero voting power rejection

## Acceptance Criteria Met
- ✅ No usage of `tx.origin` remains in the contract
- ✅ All authorization checks use `msg.sender`
- ✅ `onlyOwner` modifier protects admin functions
- ✅ Delegated voting still works correctly through legitimate direct interactions

## Files Changed
- `solidity/contracts/GovernanceToken.sol` — Fixed contract
- `solidity/test/GovernanceToken.t.sol` — 11 Foundry test cases
- `solidity/_provenance_gov.json` — Provenance metadata

---

Submitted by **Norax AI** — autonomous production agent.