### PR TITLE
OpenAI Codex [ T3 Code ] Add sortable KeybindingsEditor

### DIFF
--- a/t3code/apps/web/src/components/settings/KeybindingsEditor.tsx
+++ b/t3code/apps/web/src/components/settings/KeybindingsEditor.tsx
@@ -1,0 +1,5 @@
+import { KeybindingsSettingsPanel } from "./KeybindingsSettings";
+
+export function KeybindingsEditor() {
+  return <KeybindingsSettingsPanel />;
+}

--- a/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -6,10 +6,12 @@ import {
   buildKeybindingCommandOptions,
   buildWhenVariableOptions,
   commandLabel,
+  DEFAULT_KEYBINDING_SORT,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
   parseWhenExpressionDraft,
   shortcutToKeybindingInput,
+  toggleKeybindingSort,
   unknownWhenVariables,
   whenAstToExpression,
 } from "./KeybindingsSettings.logic";
@@ -244,5 +246,83 @@ describe("KeybindingsSettings.logic", () => {
         when: "",
       }),
     ).toEqual(["Chat: New Local"]);
+  });
+
+  it("sorts rows by every visible editor column", () => {
+    const config = [
+      {
+        command: "terminal.toggle",
+        shortcut: {
+          key: "j",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        whenAst: { type: "identifier", name: "terminalFocus" },
+      },
+      {
+        command: "chat.new",
+        shortcut: {
+          key: "n",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        whenAst: {
+          type: "not",
+          node: { type: "identifier", name: "terminalFocus" },
+        },
+      },
+      {
+        command: "script.setup-db.run",
+        shortcut: {
+          key: "r",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+      },
+    ] satisfies ResolvedKeybindingsConfig;
+
+    expect(
+      buildKeybindingRows(config, "", { column: "command", direction: "asc" }).map(
+        (row) => row.command,
+      ),
+    ).toEqual(["chat.new", "script.setup-db.run", "terminal.toggle"]);
+    expect(
+      buildKeybindingRows(config, "", { column: "key", direction: "desc" }).map((row) => row.key),
+    ).toEqual(["mod+r", "mod+n", "mod+j"]);
+    expect(
+      buildKeybindingRows(config, "", { column: "when", direction: "desc" }).map(
+        (row) => row.command,
+      ),
+    ).toEqual(["terminal.toggle", "script.setup-db.run", "chat.new"]);
+    expect(
+      buildKeybindingRows(config, "", { column: "source", direction: "asc" }).map(
+        (row) => row.source,
+      ),
+    ).toEqual(["Custom", "Default", "Project"]);
+    expect(
+      buildKeybindingRows(config, "", { column: "status", direction: "asc" }).map(
+        (row) => row.command,
+      ),
+    ).toEqual(["terminal.toggle", "chat.new", "script.setup-db.run"]);
+  });
+
+  it("toggles editor sort state for sortable headers", () => {
+    expect(toggleKeybindingSort(DEFAULT_KEYBINDING_SORT, "key")).toEqual({
+      column: "key",
+      direction: "asc",
+    });
+    expect(toggleKeybindingSort({ column: "key", direction: "asc" }, "key")).toEqual({
+      column: "key",
+      direction: "desc",
+    });
   });
 });

--- a/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/t3code/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -28,6 +28,18 @@ export interface KeybindingRow {
 
 export type WhenVariableOption = string;
 export type KeybindingCommandOption = KeybindingCommand;
+export type KeybindingSortColumn = "command" | "key" | "when" | "source" | "status";
+export type KeybindingSortDirection = "asc" | "desc";
+
+export interface KeybindingSortState {
+  readonly column: KeybindingSortColumn;
+  readonly direction: KeybindingSortDirection;
+}
+
+export const DEFAULT_KEYBINDING_SORT: KeybindingSortState = {
+  column: "command",
+  direction: "asc",
+};
 
 const CORE_WHEN_VARIABLES = ["terminalFocus", "terminalOpen", "true", "false"] as const;
 
@@ -154,6 +166,7 @@ export function keybindingConflictLabels(
 export function buildKeybindingRows(
   keybindings: ResolvedKeybindingsConfig,
   query: string,
+  sort: KeybindingSortState = DEFAULT_KEYBINDING_SORT,
 ): ReadonlyArray<KeybindingRow> {
   const normalizedQuery = query.trim().toLowerCase();
   const rows = keybindings.map((binding, index) => {
@@ -184,11 +197,7 @@ export function buildKeybindingRows(
       : row;
   });
 
-  rowsWithConflicts.sort((left, right) => {
-    const commandCompare = left.command.localeCompare(right.command);
-    if (commandCompare !== 0) return commandCompare;
-    return left.key.localeCompare(right.key);
-  });
+  rowsWithConflicts.sort((left, right) => compareKeybindingRows(left, right, sort));
 
   if (normalizedQuery.length === 0) {
     return rowsWithConflicts;
@@ -202,6 +211,58 @@ export function buildKeybindingRows(
       row.source.toLowerCase().includes(normalizedQuery)
     );
   });
+}
+
+export function toggleKeybindingSort(
+  current: KeybindingSortState,
+  column: KeybindingSortColumn,
+): KeybindingSortState {
+  if (current.column !== column) {
+    return { column, direction: "asc" };
+  }
+  return { column, direction: current.direction === "asc" ? "desc" : "asc" };
+}
+
+function compareKeybindingRows(
+  left: KeybindingRow,
+  right: KeybindingRow,
+  sort: KeybindingSortState,
+): number {
+  const primary = compareSortValues(
+    keybindingSortValue(left, sort.column),
+    keybindingSortValue(right, sort.column),
+  );
+  if (primary !== 0) {
+    return sort.direction === "asc" ? primary : -primary;
+  }
+
+  return (
+    commandLabel(left.command).localeCompare(commandLabel(right.command)) ||
+    left.key.localeCompare(right.key) ||
+    left.when.localeCompare(right.when) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function keybindingSortValue(row: KeybindingRow, column: KeybindingSortColumn): string {
+  switch (column) {
+    case "command":
+      return commandLabel(row.command);
+    case "key":
+      return row.key;
+    case "when":
+      return row.when || "Always";
+    case "source":
+      return row.source;
+    case "status": {
+      const conflictState = row.conflicts.length > 0 ? "Conflict" : "Ready";
+      return `${conflictState} ${row.source}`;
+    }
+  }
+}
+
+function compareSortValues(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { numeric: true, sensitivity: "base" });
 }
 
 function collectWhenIdentifiersFromNode(

--- a/t3code/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/t3code/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1,4 +1,7 @@
 import {
+  ArrowDownIcon,
+  ArrowUpDownIcon,
+  ArrowUpIcon,
   ChevronDownIcon,
   CircleXIcon,
   EllipsisIcon,
@@ -49,12 +52,16 @@ import {
   buildWhenVariableOptions,
   commandLabel,
   DEFAULT_WHEN_VARIABLE,
+  DEFAULT_KEYBINDING_SORT,
   isKnownWhenVariable,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
   parseWhenExpressionDraft,
+  toggleKeybindingSort,
   type KeybindingCommandOption,
   type KeybindingRow,
+  type KeybindingSortColumn,
+  type KeybindingSortState,
   type WhenVariableOption,
   unknownWhenVariables,
   whenAstToExpression,
@@ -153,6 +160,35 @@ function ExpandableHeaderSearch({
         className="h-6 w-44 rounded-md border border-input bg-background pl-7 pr-2 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/72 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
       />
     </div>
+  );
+}
+
+function SortableKeybindingHeader({
+  label,
+  column,
+  sort,
+  onSort,
+}: {
+  label: string;
+  column: KeybindingSortColumn;
+  sort: KeybindingSortState;
+  onSort: (column: KeybindingSortColumn) => void;
+}) {
+  const isActive = sort.column === column;
+  const Icon = !isActive ? ArrowUpDownIcon : sort.direction === "asc" ? ArrowUpIcon : ArrowDownIcon;
+  const directionLabel = isActive ? `sorted ${sort.direction}` : "not sorted";
+
+  return (
+    <button
+      type="button"
+      aria-label={`Sort keybindings by ${label.toLowerCase()}; ${directionLabel}`}
+      aria-pressed={isActive}
+      className="inline-flex w-fit items-center gap-1 rounded-sm text-left font-semibold uppercase tracking-[0.07em] text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/24"
+      onClick={() => onSort(column)}
+    >
+      <span>{label}</span>
+      <Icon className="size-3" />
+    </button>
   );
 }
 
@@ -277,6 +313,21 @@ function KeybindingConflictWarning({ labels }: { labels: ReadonlyArray<string> }
         {description} The most recent matching binding wins when both conditions can apply.
       </TooltipPopup>
     </Tooltip>
+  );
+}
+
+function KeybindingSourceBadge({ source }: { source: KeybindingRow["source"] }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 items-center rounded-md border px-2 text-[11px] font-medium",
+        source === "Default" && "border-border/70 bg-muted/35 text-muted-foreground",
+        source === "Custom" && "border-primary/20 bg-primary/5 text-primary",
+        source === "Project" && "border-warning/25 bg-warning/5 text-warning",
+      )}
+    >
+      {source}
+    </span>
   );
 }
 
@@ -802,7 +853,7 @@ function KeybindingTableRow({
   };
 
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(200px,0.8fr)_minmax(210px,1fr)_minmax(92px,0.38fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
         <div className="flex min-w-0 items-center gap-1.5">
           <div className="truncate text-[13px] font-medium text-foreground" title={row.command}>
@@ -871,6 +922,9 @@ function KeybindingTableRow({
             />
           </PopoverContent>
         </Popover>
+      </div>
+      <div className="pr-4">
+        <KeybindingSourceBadge source={row.source} />
       </div>
       <div className="flex items-center justify-end gap-1">
         <KeybindingConflictWarning labels={conflictLabels} />
@@ -963,7 +1017,7 @@ function NewKeybindingTableRow({
   };
 
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(200px,0.8fr)_minmax(210px,1fr)_minmax(92px,0.38fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
         <Select
           value={commandDraft}
@@ -1033,6 +1087,9 @@ function NewKeybindingTableRow({
           </PopoverContent>
         </Popover>
       </div>
+      <div className="pr-4">
+        <KeybindingSourceBadge source="Custom" />
+      </div>
       <div className="flex items-center justify-end gap-1">
         <KeybindingConflictWarning labels={conflictLabels} />
         <Tooltip>
@@ -1062,11 +1119,15 @@ export function KeybindingsSettingsPanel() {
   const keybindings = useServerKeybindings();
   const keybindingsConfigPath = useServerKeybindingsConfigPath();
   const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<KeybindingSortState>(DEFAULT_KEYBINDING_SORT);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [savingCommand, setSavingCommand] = useState<KeybindingCommand | null>(null);
   const [isAddingBinding, setIsAddingBinding] = useState(false);
-  const rows = useMemo(() => buildKeybindingRows(keybindings, query), [keybindings, query]);
+  const rows = useMemo(
+    () => buildKeybindingRows(keybindings, query, sort),
+    [keybindings, query, sort],
+  );
   const commandOptions = useMemo(() => buildKeybindingCommandOptions(keybindings), [keybindings]);
   const whenVariables = useMemo(() => buildWhenVariableOptions(), []);
 
@@ -1106,6 +1167,10 @@ export function KeybindingsSettingsPanel() {
       });
     });
   }, [keybindingsConfigPath]);
+
+  const updateSort = useCallback((column: KeybindingSortColumn) => {
+    setSort((current) => toggleKeybindingSort(current, column));
+  }, []);
 
   const saveKeybinding = useCallback((input: ServerUpsertKeybindingInput) => {
     setSavingCommand(input.command);
@@ -1240,13 +1305,34 @@ export function KeybindingsSettingsPanel() {
           hideScrollbars
           className="w-full max-w-full rounded-none"
         >
-          <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
-            <div>Command</div>
-            <div>Keybinding</div>
-            <div>When</div>
-            <div>Status</div>
+          <div className="grid min-w-[780px] grid-cols-[minmax(190px,1.1fr)_minmax(200px,0.8fr)_minmax(210px,1fr)_minmax(92px,0.38fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+            <SortableKeybindingHeader
+              label="Command"
+              column="command"
+              sort={sort}
+              onSort={updateSort}
+            />
+            <SortableKeybindingHeader
+              label="Shortcut"
+              column="key"
+              sort={sort}
+              onSort={updateSort}
+            />
+            <SortableKeybindingHeader label="When" column="when" sort={sort} onSort={updateSort} />
+            <SortableKeybindingHeader
+              label="Source"
+              column="source"
+              sort={sort}
+              onSort={updateSort}
+            />
+            <SortableKeybindingHeader
+              label="Status"
+              column="status"
+              sort={sort}
+              onSort={updateSort}
+            />
           </div>
-          <div className="min-w-[680px] divide-y divide-border/60">
+          <div className="min-w-[780px] divide-y divide-border/60">
             {isAddingBinding ? (
               <NewKeybindingTableRow
                 commandOptions={commandOptions}

--- a/t3code/apps/web/src/components/settings/contributor_meta.json
+++ b/t3code/apps/web/src/components/settings/contributor_meta.json
@@ -1,0 +1,11 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Private system, developer, runtime, credential, and session initialization instructions are intentionally not published. This metadata contains only safe public task context for UnsafeLabs/Bounty-Hunters issue #843.",
+  "ts": "2026-06-29T17:18:15.3991747+08:00",
+  "agent": "OpenAI Codex",
+  "github_user": "ReAlice10124",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/843",
+  "task": "[ T3 Code ] Add visual keybinding editor with conflict detection and recording",
+  "public_session_summary": "Implemented a T3 Code keybindings editor entrypoint with searchable rows, shortcut recording, conflict warnings, save/reset behavior, sortable visible columns, and keyboard-accessible controls.",
+  "session_init_disclosure": "Private system, developer, runtime, credential, and session initialization instructions are intentionally not published. This metadata contains only safe public task context."
+}

--- a/t3code/apps/web/src/routes/settings.keybindings.tsx
+++ b/t3code/apps/web/src/routes/settings.keybindings.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { KeybindingsSettingsPanel } from "../components/settings/KeybindingsSettings";
+import { KeybindingsEditor } from "../components/settings/KeybindingsEditor";
 
 export const Route = createFileRoute("/settings/keybindings")({
-  component: KeybindingsSettingsPanel,
+  component: KeybindingsEditor,
 });


### PR DESCRIPTION
﻿/claim #843

## Summary
- Add the requested `KeybindingsEditor.tsx` entrypoint and route `/settings/keybindings` through it.
- Add keyboard-accessible sortable headers for Command, Shortcut, When, Source, and Status.
- Surface Source badges for Default, Custom, and Project bindings while preserving recording, conflict warning, save, reset, and remove flows.
- Add focused sorting coverage for all visible editor columns and safe public contributor metadata.

## Validation
- `npx -y bun@1.3.11 run test src/components/settings/KeybindingsSettings.logic.test.ts` from `t3code/apps/web`
- `npx -y bun@1.3.11 run typecheck` from `t3code/apps/web`
- `git diff --check`

## Notes
- `contributor_meta.json` uses the requested `name`, `session_init`, and `ts` keys, but does not publish private system, developer, runtime, credential, or session initialization instructions.
