### PR TITLE
[OpenAI Codex] [ Laravel ] Add public compression caching and runtime hardening

### DIFF
--- a/laravel/public/.htaccess
+++ b/laravel/public/.htaccess
@@ -1,3 +1,31 @@
+<IfModule mod_headers.c>
+    Header set X-Content-Type-Options "nosniff"
+</IfModule>
+
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/html
+    AddOutputFilterByType DEFLATE text/css
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE application/json
+    AddOutputFilterByType DEFLATE image/svg+xml
+</IfModule>
+
+<IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType image/jpeg "access plus 30 days"
+    ExpiresByType image/png "access plus 30 days"
+    ExpiresByType image/gif "access plus 30 days"
+    ExpiresByType image/webp "access plus 30 days"
+    ExpiresByType image/svg+xml "access plus 30 days"
+    ExpiresByType image/x-icon "access plus 30 days"
+    ExpiresByType text/css "access plus 7 days"
+    ExpiresByType application/javascript "access plus 7 days"
+    ExpiresByType font/woff "access plus 365 days"
+    ExpiresByType font/woff2 "access plus 365 days"
+    ExpiresByType application/font-woff "access plus 365 days"
+    ExpiresByType application/font-woff2 "access plus 365 days"
+</IfModule>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes

--- a/laravel/public/index.php
+++ b/laravel/public/index.php
@@ -5,6 +5,9 @@ use Illuminate\Http\Request;
 
 define('LARAVEL_START', microtime(true));
 
+ini_set('display_errors', '0');
+ini_set('expose_php', '0');
+
 // Determine if the application is in maintenance mode...
 if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
     require $maintenance;


### PR DESCRIPTION
## Summary
- Add `mod_headers` nosniff protection in `laravel/public/.htaccess`.
- Add `mod_deflate` compression for HTML, CSS, JavaScript, JSON, and SVG responses.
- Add `mod_expires` cache durations for images, CSS/JS, and fonts.
- Disable PHP error display and PHP version exposure before Laravel's autoloader runs.

## Validation
- `git diff --check`
- PowerShell assertions verified all required `.htaccess` directives and `index.php` runtime settings.

PHP syntax checks were not run because PHP/Composer are not installed in this environment.

## Safety Note
The issue text requested a contributor file containing private runtime instructions. I did not include that file because it would disclose non-public instructions unrelated to the project.

/claim #755
