### PR TITLE
[OpenAI Codex] [ T3 Code ] Add server environment validation

### DIFF
--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -49,6 +49,34 @@ const captureStdout = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     return { result, output };
   }).pipe(Effect.provide(Layer.mergeAll(CliRuntimeLayer, TestConsole.layer)));
 
+const withIsolatedServerEnv = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const snapshot = new Map<string, string | undefined>();
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith("T3CODE_") || key === "VITE_DEV_SERVER_URL") {
+          snapshot.set(key, process.env[key]);
+          delete process.env[key];
+        }
+      }
+      return snapshot;
+    }),
+    () => effect,
+    (snapshot) =>
+      Effect.sync(() => {
+        for (const key of Object.keys(process.env)) {
+          if (key.startsWith("T3CODE_") || key === "VITE_DEV_SERVER_URL") {
+            delete process.env[key];
+          }
+        }
+        for (const [key, value] of snapshot) {
+          if (value !== undefined) {
+            process.env[key] = value;
+          }
+        }
+      }),
+  );
+
 const makeCliTestServerConfig = (baseDir: string) =>
   Effect.gen(function* () {
     const derivedPaths = yield* deriveServerPaths(baseDir, undefined);
@@ -156,6 +184,19 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
 
   it.effect("accepts canonical --no-<flag> boolean negation", () =>
     runCliWithRuntime(["--no-log-websocket-events", "--version"]),
+  );
+
+  it.effect("--validate-config reports configuration without starting the server", () =>
+    Effect.gen(function* () {
+      const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-validate-config-"));
+      const { output } = yield* withIsolatedServerEnv(
+        captureStdout(runCli(["--validate-config", "--base-dir", baseDir, "--port", "3773"])),
+      );
+
+      expect(output).toContain("Server environment validation passed.");
+      expect(output).toContain("T3CODE_PORT");
+      expect(output).toContain("T3CODE_TAILSCALE_SERVE_PORT");
+    }),
   );
 
   it.effect("rejects invalid log-level casing before launching the server", () =>

--- a/t3code/apps/server/src/cli/config.ts
+++ b/t3code/apps/server/src/cli/config.ts
@@ -80,6 +80,10 @@ export const tailscaleServePortFlag = Flag.integer("tailscale-serve-port").pipe(
   Flag.withDescription("HTTPS port for Tailscale Serve when --tailscale-serve is enabled."),
   Flag.optional,
 );
+export const validateConfigFlag = Flag.boolean("validate-config").pipe(
+  Flag.withDescription("Validate server environment configuration and exit without starting."),
+  Flag.optional,
+);
 
 const EnvServerConfig = Config.all({
   logLevel: Config.logLevel("T3CODE_LOG_LEVEL").pipe(Config.withDefault("Info")),
@@ -151,6 +155,7 @@ export interface CliServerFlags {
   readonly logWebSocketEvents: Option.Option<boolean>;
   readonly tailscaleServeEnabled: Option.Option<boolean>;
   readonly tailscaleServePort: Option.Option<number>;
+  readonly validateConfig?: Option.Option<boolean>;
 }
 
 export interface CliAuthLocationFlags {
@@ -185,6 +190,7 @@ export const sharedServerCommandFlags = {
   logWebSocketEvents: logWebSocketEventsFlag,
   tailscaleServeEnabled: tailscaleServeFlag,
   tailscaleServePort: tailscaleServePortFlag,
+  validateConfig: validateConfigFlag,
 } as const;
 
 export const authLocationFlags = sharedServerLocationFlags;
@@ -230,6 +236,7 @@ export const resolveServerConfig = (
       logWebSocketEvents: flags.logWebSocketEvents ?? Option.none(),
       tailscaleServeEnabled: flags.tailscaleServeEnabled ?? Option.none(),
       tailscaleServePort: flags.tailscaleServePort ?? Option.none(),
+      validateConfig: flags.validateConfig ?? Option.none(),
     } satisfies CliServerFlags;
     const bootstrapFd = Option.getOrUndefined(normalizedFlags.bootstrapFd) ?? env.bootstrapFd;
     const bootstrapEnvelope =
@@ -397,6 +404,7 @@ export const resolveCliAuthConfig = (
       logWebSocketEvents: Option.none(),
       tailscaleServeEnabled: Option.none(),
       tailscaleServePort: Option.none(),
+      validateConfig: Option.none(),
     },
     cliLogLevel,
   );

--- a/t3code/apps/server/src/cli/envValidation.test.ts
+++ b/t3code/apps/server/src/cli/envValidation.test.ts
@@ -1,0 +1,69 @@
+import { assert, expect, it } from "@effect/vitest";
+
+import {
+  assertValidServerEnvironment,
+  formatServerEnvironmentValidationTable,
+  ServerEnvironmentValidationError,
+  validateServerEnvironment,
+} from "./envValidation.ts";
+
+it("documents defaulted optional environment variables", () => {
+  const result = validateServerEnvironment({});
+
+  expect(result.valid).toBe(true);
+  expect(result.entries.find((entry) => entry.name === "T3CODE_PORT")).toMatchObject({
+    status: "default",
+    defaultValue: "auto",
+  });
+  expect(result.entries.find((entry) => entry.name === "T3CODE_TAILSCALE_SERVE_PORT"))
+    .toMatchObject({
+      status: "default",
+      defaultValue: "443",
+    });
+
+  const table = formatServerEnvironmentValidationTable(result);
+  expect(table).toContain("Server environment validation passed.");
+  expect(table).toContain("T3CODE_PORT");
+  expect(table).toContain("platform default");
+});
+
+it("reports invalid environment variable values with expected formats", () => {
+  const result = validateServerEnvironment({
+    T3CODE_PORT: "not-a-port",
+    T3CODE_NO_BROWSER: "sometimes",
+    VITE_DEV_SERVER_URL: "localhost:5173",
+  });
+
+  expect(result.valid).toBe(false);
+  expect(result.entries.find((entry) => entry.name === "T3CODE_PORT")).toMatchObject({
+    status: "invalid",
+    expected: "port 1-65535",
+    received: "not-a-port",
+  });
+  expect(result.entries.find((entry) => entry.name === "T3CODE_NO_BROWSER")).toMatchObject({
+    status: "invalid",
+    expected: "boolean",
+    received: "sometimes",
+  });
+  expect(result.entries.find((entry) => entry.name === "VITE_DEV_SERVER_URL")).toMatchObject({
+    status: "invalid",
+    expected: "absolute URL",
+    received: "localhost:5173",
+  });
+
+  const table = formatServerEnvironmentValidationTable(result, { onlyProblems: true });
+  expect(table).toContain("Server environment validation failed.");
+  expect(table).toContain("not-a-port");
+  expect(table).toContain("expected boolean");
+  expect(table).not.toContain("T3CODE_HOME");
+});
+
+it("throws a validation error before config resolution when env values are invalid", () => {
+  try {
+    assertValidServerEnvironment({ T3CODE_TRACE_MAX_FILES: "0" });
+    assert.fail("expected validation to fail");
+  } catch (error) {
+    assert.instanceOf(error, ServerEnvironmentValidationError);
+    expect((error as ServerEnvironmentValidationError).result.valid).toBe(false);
+  }
+});

--- a/t3code/apps/server/src/cli/envValidation.ts
+++ b/t3code/apps/server/src/cli/envValidation.ts
@@ -1,0 +1,320 @@
+import * as Schema from "effect/Schema";
+
+export const EnvValidationStatus = Schema.Literals(["ok", "missing", "invalid", "default"]);
+export type EnvValidationStatus = typeof EnvValidationStatus.Type;
+
+export const EnvValidationEntry = Schema.Struct({
+  name: Schema.String,
+  status: EnvValidationStatus,
+  expected: Schema.String,
+  description: Schema.String,
+  required: Schema.Boolean,
+  received: Schema.optional(Schema.String),
+  defaultValue: Schema.optional(Schema.String),
+  message: Schema.optional(Schema.String),
+});
+export type EnvValidationEntry = typeof EnvValidationEntry.Type;
+
+export const EnvValidationResult = Schema.Struct({
+  valid: Schema.Boolean,
+  entries: Schema.Array(EnvValidationEntry),
+});
+export type EnvValidationResult = typeof EnvValidationResult.Type;
+
+interface EnvVariableSpec {
+  readonly name: string;
+  readonly expected: string;
+  readonly description: string;
+  readonly required?: boolean;
+  readonly defaultValue?: string;
+  readonly validate: (value: string) => string | undefined;
+}
+
+const ok = () => undefined;
+const nonEmpty = (value: string) => (value.trim().length > 0 ? undefined : "value is empty");
+const integer =
+  (minimum?: number, maximum?: number) =>
+  (value: string): string | undefined => {
+    if (!/^-?\d+$/.test(value)) return "expected an integer";
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isSafeInteger(parsed)) return "expected a safe integer";
+    if (minimum !== undefined && parsed < minimum) return `expected >= ${minimum}`;
+    if (maximum !== undefined && parsed > maximum) return `expected <= ${maximum}`;
+    return undefined;
+  };
+const oneOf =
+  (values: readonly string[]) =>
+  (value: string): string | undefined =>
+    values.includes(value) ? undefined : `expected one of ${values.join(", ")}`;
+const boolean = (value: string): string | undefined =>
+  /^(true|false|1|0|yes|no|on|off)$/i.test(value)
+    ? undefined
+    : "expected boolean: true/false, 1/0, yes/no, or on/off";
+const url = (value: string): string | undefined => {
+  try {
+    new URL(value);
+    return undefined;
+  } catch {
+    return "expected a valid absolute URL";
+  }
+};
+
+export const serverEnvironmentVariableSpecs: readonly EnvVariableSpec[] = [
+  {
+    name: "T3CODE_LOG_LEVEL",
+    expected: "All | Fatal | Error | Warn | Warning | Info | Debug | Trace | None",
+    description: "Minimum process log level.",
+    defaultValue: "Info",
+    validate: oneOf(["All", "Fatal", "Error", "Warn", "Warning", "Info", "Debug", "Trace", "None"]),
+  },
+  {
+    name: "T3CODE_TRACE_MIN_LEVEL",
+    expected: "All | Fatal | Error | Warn | Warning | Info | Debug | Trace | None",
+    description: "Minimum trace event level.",
+    defaultValue: "Info",
+    validate: oneOf(["All", "Fatal", "Error", "Warn", "Warning", "Info", "Debug", "Trace", "None"]),
+  },
+  {
+    name: "T3CODE_TRACE_TIMING_ENABLED",
+    expected: "boolean",
+    description: "Enable trace timing fields.",
+    defaultValue: "true",
+    validate: boolean,
+  },
+  {
+    name: "T3CODE_TRACE_FILE",
+    expected: "file path",
+    description: "Override server trace file path.",
+    validate: nonEmpty,
+  },
+  {
+    name: "T3CODE_TRACE_MAX_BYTES",
+    expected: "integer >= 1",
+    description: "Maximum bytes per trace file.",
+    defaultValue: String(10 * 1024 * 1024),
+    validate: integer(1),
+  },
+  {
+    name: "T3CODE_TRACE_MAX_FILES",
+    expected: "integer >= 1",
+    description: "Maximum retained trace files.",
+    defaultValue: "10",
+    validate: integer(1),
+  },
+  {
+    name: "T3CODE_TRACE_BATCH_WINDOW_MS",
+    expected: "integer >= 0",
+    description: "Trace batching window in milliseconds.",
+    defaultValue: "200",
+    validate: integer(0),
+  },
+  {
+    name: "T3CODE_OTLP_TRACES_URL",
+    expected: "absolute URL",
+    description: "OTLP traces endpoint.",
+    validate: url,
+  },
+  {
+    name: "T3CODE_OTLP_METRICS_URL",
+    expected: "absolute URL",
+    description: "OTLP metrics endpoint.",
+    validate: url,
+  },
+  {
+    name: "T3CODE_OTLP_EXPORT_INTERVAL_MS",
+    expected: "integer >= 1",
+    description: "OTLP export interval in milliseconds.",
+    defaultValue: "10000",
+    validate: integer(1),
+  },
+  {
+    name: "T3CODE_OTLP_SERVICE_NAME",
+    expected: "non-empty string",
+    description: "OTLP service.name resource attribute.",
+    defaultValue: "t3-server",
+    validate: nonEmpty,
+  },
+  {
+    name: "T3CODE_MODE",
+    expected: "web | desktop",
+    description: "Runtime mode.",
+    defaultValue: "web",
+    validate: oneOf(["web", "desktop"]),
+  },
+  {
+    name: "T3CODE_PORT",
+    expected: "port 1-65535",
+    description: "HTTP/WebSocket listen port.",
+    defaultValue: "auto",
+    validate: integer(1, 65535),
+  },
+  {
+    name: "T3CODE_HOST",
+    expected: "hostname or IP address",
+    description: "HTTP/WebSocket bind host.",
+    validate: nonEmpty,
+  },
+  {
+    name: "T3CODE_HOME",
+    expected: "directory path",
+    description: "Base directory for runtime state.",
+    defaultValue: "platform default",
+    validate: nonEmpty,
+  },
+  {
+    name: "VITE_DEV_SERVER_URL",
+    expected: "absolute URL",
+    description: "Development web server URL.",
+    validate: url,
+  },
+  {
+    name: "T3CODE_NO_BROWSER",
+    expected: "boolean",
+    description: "Disable automatic browser opening.",
+    defaultValue: "depends on mode",
+    validate: boolean,
+  },
+  {
+    name: "T3CODE_BOOTSTRAP_FD",
+    expected: "integer >= 0",
+    description: "File descriptor for desktop bootstrap envelope.",
+    validate: integer(0),
+  },
+  {
+    name: "T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD",
+    expected: "boolean",
+    description: "Create a startup project for the current working directory.",
+    defaultValue: "depends on mode",
+    validate: boolean,
+  },
+  {
+    name: "T3CODE_LOG_WS_EVENTS",
+    expected: "boolean",
+    description: "Log outbound WebSocket event traffic.",
+    defaultValue: "enabled for dev URL",
+    validate: boolean,
+  },
+  {
+    name: "T3CODE_TAILSCALE_SERVE",
+    expected: "boolean",
+    description: "Enable Tailscale Serve setup.",
+    defaultValue: "false",
+    validate: boolean,
+  },
+  {
+    name: "T3CODE_TAILSCALE_SERVE_PORT",
+    expected: "port 1-65535",
+    description: "HTTPS port for Tailscale Serve.",
+    defaultValue: "443",
+    validate: integer(1, 65535),
+  },
+];
+
+export class ServerEnvironmentValidationError extends Error {
+  readonly _tag = "ServerEnvironmentValidationError";
+
+  constructor(readonly result: EnvValidationResult) {
+    super(formatServerEnvironmentValidationTable(result, { onlyProblems: true }));
+    this.name = "ServerEnvironmentValidationError";
+  }
+}
+
+export const validateServerEnvironment = (
+  env: NodeJS.ProcessEnv = process.env,
+): EnvValidationResult => {
+  const entries = serverEnvironmentVariableSpecs.map((spec): EnvValidationEntry => {
+    const raw = env[spec.name];
+    const required = spec.required === true;
+    const value = raw?.trim();
+    if (value === undefined || value.length === 0) {
+      if (required) {
+        return {
+          name: spec.name,
+          status: "missing",
+          expected: spec.expected,
+          description: spec.description,
+          required,
+          defaultValue: spec.defaultValue,
+          message: "required variable is not set",
+        };
+      }
+      return {
+        name: spec.name,
+        status: spec.defaultValue !== undefined ? "default" : "ok",
+        expected: spec.expected,
+        description: spec.description,
+        required,
+        defaultValue: spec.defaultValue,
+      };
+    }
+
+    const message = spec.validate(value);
+    if (message !== undefined) {
+      return {
+        name: spec.name,
+        status: "invalid",
+        expected: spec.expected,
+        description: spec.description,
+        required,
+        received: raw,
+        defaultValue: spec.defaultValue,
+        message,
+      };
+    }
+
+    return {
+      name: spec.name,
+      status: "ok",
+      expected: spec.expected,
+      description: spec.description,
+      required,
+      received: raw,
+      defaultValue: spec.defaultValue,
+    };
+  });
+
+  return {
+    valid: entries.every((entry) => entry.status !== "missing" && entry.status !== "invalid"),
+    entries,
+  };
+};
+
+export const formatServerEnvironmentValidationTable = (
+  result: EnvValidationResult,
+  options: { readonly onlyProblems?: boolean } = {},
+): string => {
+  const entries = options.onlyProblems
+    ? result.entries.filter((entry) => entry.status === "missing" || entry.status === "invalid")
+    : result.entries;
+  const rows = [
+    ["Variable", "Status", "Expected", "Value", "Description"],
+    ...entries.map((entry) => [
+      entry.name,
+      entry.status,
+      entry.expected,
+      entry.received ?? entry.defaultValue ?? "<unset>",
+      entry.message ?? entry.description,
+    ]),
+  ];
+  const widths = rows[0]?.map((_, index) =>
+    Math.max(...rows.map((row) => row[index]?.length ?? 0)),
+  );
+  const render = (row: readonly string[]) =>
+    row.map((cell, index) => cell.padEnd(widths[index] ?? 0)).join(" | ");
+  const separator = (widths ?? []).map((width) => "-".repeat(width)).join("-|-");
+  const rendered = [render(rows[0] ?? []), separator, ...rows.slice(1).map(render)];
+  return [
+    result.valid ? "Server environment validation passed." : "Server environment validation failed.",
+    ...rendered,
+  ].join("\n");
+};
+
+export const assertValidServerEnvironment = (
+  env: NodeJS.ProcessEnv = process.env,
+): EnvValidationResult => {
+  const result = validateServerEnvironment(env);
+  if (!result.valid) {
+    throw new ServerEnvironmentValidationError(result);
+  }
+  return result;
+};

--- a/t3code/apps/server/src/cli/server.ts
+++ b/t3code/apps/server/src/cli/server.ts
@@ -1,9 +1,16 @@
 import * as Effect from "effect/Effect";
+import * as Console from "effect/Console";
+import * as Option from "effect/Option";
 import { Command, GlobalFlag } from "effect/unstable/cli";
 
 import { ServerConfig, type StartupPresentation } from "../config.ts";
 import { runServer } from "../server.ts";
 import { type CliServerFlags, resolveServerConfig, sharedServerCommandFlags } from "./config.ts";
+import {
+  assertValidServerEnvironment,
+  formatServerEnvironmentValidationTable,
+  ServerEnvironmentValidationError,
+} from "./envValidation.ts";
 
 export const runServerCommand = (
   flags: CliServerFlags,
@@ -14,8 +21,31 @@ export const runServerCommand = (
 ) =>
   Effect.gen(function* () {
     const logLevel = yield* GlobalFlag.LogLevel;
+    const normalizedValidateConfig = flags.validateConfig ?? Option.none();
+    const validation = yield* Effect.try({
+      try: () => assertValidServerEnvironment(),
+      catch: (error) => error,
+    });
     const config = yield* resolveServerConfig(flags, logLevel, options);
+    if (Option.getOrElse(normalizedValidateConfig, () => false)) {
+      yield* Console.log(formatServerEnvironmentValidationTable(validation));
+      return;
+    }
     return yield* runServer.pipe(Effect.provideService(ServerConfig, config));
+  }).pipe(
+    Effect.catchIf(
+      (error): error is ServerEnvironmentValidationError =>
+        error instanceof ServerEnvironmentValidationError,
+      (error) =>
+        Effect.gen(function* () {
+          yield* Console.error(
+            formatServerEnvironmentValidationTable(error.result, {
+              onlyProblems: true,
+            }),
+          );
+          return yield* Effect.fail(error);
+        }),
+    ),
   });
 
 export const startCommand = Command.make("start", { ...sharedServerCommandFlags }).pipe(


### PR DESCRIPTION
## Summary
- Add a server environment validation module with Effect Schema result shapes and type checks for all documented server env vars.
- Validate environment values before resolving the server config or starting services.
- Add `--validate-config` to print the validation table and exit before starting the server.
- Add tests for defaulted variables, invalid values, validation errors, and the CLI validation path.

## Validation
- `node --check apps/server/src/cli/envValidation.ts`
- `node --check apps/server/src/cli/envValidation.test.ts`
- `node --check apps/server/src/cli/server.ts`
- `node --check apps/server/src/cli/config.ts`
- `node --check apps/server/src/bin.test.ts`
- `git diff --check`

Vitest was not run because this checkout has no `node_modules` and `bun` is not installed in the environment.

## Safety Note
The issue text requested a provenance file containing private boot context. I did not include that file because it would disclose non-public runtime instructions unrelated to the project.

/claim #853
