### PR TITLE
Codex [ FastAPI ] Fix validation error handler request context and body redaction

### DIFF
--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+from typing import Any
+
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
 from fastapi.utils import is_body_allowed_for_status_code
@@ -6,6 +9,26 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
+
+SENSITIVE_BODY_FIELDS = {"password", "secret", "token", "api_key"}
+REDACTED_BODY_VALUE = "***REDACTED***"
+
+
+def _redact_sensitive_body(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: (
+                REDACTED_BODY_VALUE
+                if isinstance(key, str) and key.lower() in SENSITIVE_BODY_FIELDS
+                else _redact_sensitive_body(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_sensitive_body(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_sensitive_body(item) for item in value)
+    return value
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
@@ -20,9 +43,17 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
+    content = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+    if getattr(request.app, "debug", False) and exc.body is not None:
+        content["body"] = jsonable_encoder(_redact_sensitive_body(exc.body))
+
     return JSONResponse(
         status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
+        content=content,
     )
 
 

--- a/fastapi/tests/test_validation_error_context.py
+++ b/fastapi/tests/test_validation_error_context.py
@@ -13,6 +13,11 @@ class Item(BaseModel):
     name: str
 
 
+class Payload(BaseModel):
+    username: str
+    count: int
+
+
 class ExceptionCapture:
     def __init__(self):
         self.exception = None
@@ -166,3 +171,62 @@ def test_validation_error_with_no_context():
     assert "1 validation error:" in error_str
     assert "Endpoint" not in error_str
     assert 'File "' not in error_str
+
+
+def test_default_request_validation_error_response_includes_debug_context_body():
+    debug_app = FastAPI(debug=True)
+
+    @debug_app.post("/payload")
+    def create_payload(payload: Payload):
+        return payload  # pragma: no cover
+
+    response = TestClient(debug_app).post(
+        "/payload",
+        json={
+            "username": "alice",
+            "password": "secret-password",
+            "profile": {
+                "token": "secret-token",
+                "api_key": "secret-api-key",
+                "display_name": "Alice",
+            },
+            "items": [
+                {"secret": "nested-secret", "visible": "visible-value"},
+                {"Token": "case-insensitive-token"},
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/payload"
+    assert data["method"] == "POST"
+    assert "body" in data
+    assert data["body"]["username"] == "alice"
+    assert data["body"]["password"] == "***REDACTED***"
+    assert data["body"]["profile"]["token"] == "***REDACTED***"
+    assert data["body"]["profile"]["api_key"] == "***REDACTED***"
+    assert data["body"]["profile"]["display_name"] == "Alice"
+    assert data["body"]["items"][0]["secret"] == "***REDACTED***"
+    assert data["body"]["items"][0]["visible"] == "visible-value"
+    assert data["body"]["items"][1]["Token"] == "***REDACTED***"
+
+
+def test_default_request_validation_error_response_omits_body_without_debug():
+    non_debug_app = FastAPI(debug=False)
+
+    @non_debug_app.post("/payload")
+    def create_payload(payload: Payload):
+        return payload  # pragma: no cover
+
+    response = TestClient(non_debug_app).post(
+        "/payload",
+        json={"username": "alice", "password": "secret-password"},
+    )
+
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/payload"
+    assert data["method"] == "POST"
+    assert "detail" in data
+    assert "body" not in data


### PR DESCRIPTION
## Summary
- Add request path and HTTP method to default request validation error responses.
- Include the submitted body only when the app is running with `debug=True`.
- Redact nested `password`, `secret`, `token`, and `api_key` fields in the echoed debug body.

## Validation
- `python -m py_compile fastapi/exception_handlers.py tests/test_validation_error_context.py`
- `python -m pytest tests/test_validation_error_context.py -q`
- `python -m pytest tests/test_exception_handlers.py tests/test_validation_error_context.py -q`
- `git diff --check`

/claim #757
