### PR TITLE
Codex [ Laravel ] Fix welcome CSRF meta tag and security headers

### DIFF
--- a/laravel/app/Http/Middleware/SecurityHeaders.php
+++ b/laravel/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    /**
+     * Add baseline browser security headers to web responses.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        return $response;
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->web(append: [
+            SecurityHeaders::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 

--- a/laravel/tests/Feature/SecurityHeadersTest.php
+++ b/laravel/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    public function test_welcome_page_includes_csrf_meta_tag_and_security_headers(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('name="csrf-token"', false);
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('X-Frame-Options', 'DENY');
+        $response->assertHeader('X-XSS-Protection', '1; mode=block');
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
+}


### PR DESCRIPTION
/claim #751

Summary:
- Added `<meta name="csrf-token" content="{{ csrf_token() }}">` to the welcome page head.
- Added `App\Http\Middleware\SecurityHeaders`.
- Registered the middleware with the web middleware stack in `bootstrap/app.php`.
- Added a feature test that verifies the CSRF meta tag and all requested security headers.

Validation:
- `git diff --check` passed.
- PHP/Composer are not installed in this environment, so I could not run `php -l`, `php artisan test`, or PHPUnit locally.

Safety note:
- I did not add a public contributor metadata file containing private system, developer, or session initialization text.

