### PR TITLE
Codex [ Laravel ] Fix User model password hashing rounds

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,15 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    public function setPasswordAttribute(string $value): void
+    {
+        $this->attributes['password'] = password_get_info($value)['algoName'] !== 'unknown'
+            ? $value
+            : Hash::make($value, [
+                'rounds' => config('hashing.bcrypt.rounds', 12),
+            ]);
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Hash Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default hash driver that will be used to hash
+    | passwords for your application. By default, the bcrypt algorithm is used.
+    |
+    */
+
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bcrypt Options
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the configuration options that should be used when
+    | passwords are hashed using the bcrypt algorithm.
+    |
+    */
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+    ],
+
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,11 +13,6 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
-     */
-    protected static ?string $password;
-
-    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
@@ -28,7 +23,9 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => Hash::make('password', [
+                'rounds' => config('hashing.bcrypt.rounds', 12),
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_model_hashes_passwords_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 12]);
+
+        $user = new User([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'secret-password',
+        ]);
+
+        $hash = $user->getAttribute('password');
+
+        $this->assertTrue(Hash::check('secret-password', $hash));
+        $this->assertSame(12, password_get_info($hash)['options']['cost']);
+    }
+
+    public function test_user_factory_hashes_passwords_with_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 11]);
+
+        $user = User::factory()->make();
+        $hash = $user->getAttribute('password');
+
+        $this->assertTrue(Hash::check('password', $hash));
+        $this->assertSame(11, password_get_info($hash)['options']['cost']);
+    }
+
+    public function test_existing_password_hashes_still_verify(): void
+    {
+        $existingHash = Hash::make('secret-password', ['rounds' => 10]);
+
+        config(['hashing.bcrypt.rounds' => 12]);
+
+        $user = new User([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => $existingHash,
+        ]);
+
+        $this->assertSame($existingHash, $user->getAttribute('password'));
+        $this->assertTrue(Hash::check('secret-password', $user->getAttribute('password')));
+    }
+}


### PR DESCRIPTION
/claim #745

Summary:
- Added `config/hashing.php` so `BCRYPT_ROUNDS` is surfaced through `config('hashing.bcrypt.rounds')`.
- Replaced the User model's generic `hashed` cast with a custom `setPasswordAttribute` mutator.
- The mutator hashes plaintext passwords with configured bcrypt rounds and preserves existing hashes.
- Updated `UserFactory` to hash generated passwords with configured bcrypt rounds.
- Added unit tests for model rounds, factory rounds, and existing hash verification.

Validation:
- `git diff --check` passed.
- PHP/Composer are not installed in this environment, so I could not run `php -l`, `php artisan test`, or PHPUnit locally.

Safety note:
- I did not add a public metadata file containing private system, developer, or session initialization text.

