### PR TITLE
Codex [ Laravel ] Fix DatabaseSeeder idempotency and roles

### DIFF
--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'description'])]
+class Role extends Model
+{
+    /** @use HasFactory<RoleFactory> */
+    use HasFactory;
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word(),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/0001_01_01_000003_create_roles_table.php
+++ b/laravel/database/migrations/0001_01_01_000003_create_roles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,9 +18,13 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
+        User::firstOrCreate([
             'email' => 'test@example.com',
+        ], [
+            'name' => 'Test User',
+            'password' => Hash::make('password'),
         ]);
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Seed the default application roles.
+     */
+    public function run(): void
+    {
+        $roles = [
+            'admin' => 'Full administrative access.',
+            'editor' => 'Can create and edit content.',
+            'viewer' => 'Can view application content.',
+        ];
+
+        foreach ($roles as $name => $description) {
+            Role::firstOrCreate([
+                'name' => $name,
+            ], [
+                'description' => $description,
+            ]);
+        }
+    }
+}

--- a/laravel/tests/Feature/DatabaseSeederTest.php
+++ b/laravel/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_database_seeder_is_idempotent_and_creates_default_roles(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, User::where('email', 'test@example.com')->count());
+        $this->assertDatabaseCount('roles', 3);
+        $this->assertDatabaseHas('roles', [
+            'name' => 'admin',
+            'description' => 'Full administrative access.',
+        ]);
+        $this->assertDatabaseHas('roles', [
+            'name' => 'editor',
+            'description' => 'Can create and edit content.',
+        ]);
+        $this->assertDatabaseHas('roles', [
+            'name' => 'viewer',
+            'description' => 'Can view application content.',
+        ]);
+    }
+
+    public function test_role_factory_generates_valid_role_instances(): void
+    {
+        $role = Role::factory()->make();
+
+        $this->assertNotEmpty($role->name);
+        $this->assertNotEmpty($role->description);
+    }
+}


### PR DESCRIPTION
/claim #746

Summary:
- Updated `DatabaseSeeder` to use `firstOrCreate()` for `test@example.com`.
- Added a `roles` table migration with unique `name`, `description`, and timestamps.
- Added `App\Models\Role` and `RoleFactory`.
- Added an idempotent `RoleSeeder` for `admin`, `editor`, and `viewer`.
- Called `RoleSeeder` from `DatabaseSeeder`.
- Added feature tests for repeated database seeding and role factory generation.

Validation:
- `git diff --check` passed.
- PHP/Composer are not installed in this environment, so I could not run `php -l`, `php artisan test`, or PHPUnit locally.

Safety note:
- I did not add a public provenance file containing private system, developer, or session initialization text.

