### PR TITLE
Codex [ FastAPI ] Fix encoders.py bytes and memoryview encoding

### DIFF
--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -15,7 +16,7 @@ from ipaddress import (
 from pathlib import Path, PurePath
 from re import Pattern
 from types import GeneratorType
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from annotated_doc import Doc
@@ -30,6 +31,8 @@ from ._compat import (
     Url,
     is_pydantic_v1_model_instance,
 )
+
+BytesEncoding = Literal["base64", "hex"]
 
 try:
     # pydantic.color.Color is deprecated since v2.0b3, but supporting for bwd-compat
@@ -215,6 +218,14 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        BytesEncoding,
+        Doc(
+            """
+            The encoding to use for bytes and memoryview objects.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -240,9 +251,17 @@ def jsonable_encoder(
         include = set(include)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     if exclude is not None and not isinstance(exclude, (set, dict)):
         exclude = set(exclude)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    if bytes_encoding not in ("base64", "hex"):
+        raise ValueError("bytes_encoding must be 'base64' or 'hex'")
+    if isinstance(obj, memoryview):
+        obj = obj.tobytes()
+    if isinstance(obj, bytes):
+        if bytes_encoding == "hex":
+            return obj.hex()
+        return base64.b64encode(obj).decode("ascii")
     if isinstance(obj, BaseModel):
         obj_dict = obj.model_dump(
-            mode="json",
+            mode="python",
             include=include,
             exclude=exclude,
             by_alias=by_alias,
@@ -255,6 +274,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +289,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -302,6 +323,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +332,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +350,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +385,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/fastapi/routing.py
+++ b/fastapi/fastapi/routing.py
@@ -32,6 +32,7 @@ from typing import (
 import anyio
 from annotated_doc import Doc
 from anyio.abc import ObjectReceiveStream
+from pydantic_core import PydanticSerializationError
 from fastapi import params
 from fastapi._compat import (
     ModelField,
@@ -303,15 +304,34 @@ async def serialize_response(
                 endpoint_ctx=ctx,
             )
         serializer = field.serialize_json if dump_json else field.serialize
-        return serializer(
-            value,
-            include=include,
-            exclude=exclude,
-            by_alias=by_alias,
-            exclude_unset=exclude_unset,
-            exclude_defaults=exclude_defaults,
-            exclude_none=exclude_none,
-        )
+        try:
+            return serializer(
+                value,
+                include=include,
+                exclude=exclude,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+        except PydanticSerializationError:
+            fallback_content = jsonable_encoder(
+                field.serialize(
+                    value,
+                    mode="python",
+                    include=include,
+                    exclude=exclude,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                )
+            )
+            if dump_json:
+                return json.dumps(fallback_content, separators=(",", ":")).encode(
+                    "utf-8"
+                )
+            return fallback_content
 
     else:
         return jsonable_encoder(response_content)

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -84,6 +84,45 @@ def test_encode_dict():
     }
 
 
+def test_encode_bytes_defaults_to_base64():
+    assert jsonable_encoder(b"\x00\xffbinary") == "AP9iaW5hcnk="
+
+
+def test_encode_memoryview_defaults_to_base64():
+    assert jsonable_encoder(memoryview(b"\x00\xffbinary")) == "AP9iaW5hcnk="
+
+
+def test_encode_bytes_as_hex():
+    assert (
+        jsonable_encoder(b"\x00\xffbinary", bytes_encoding="hex")
+        == "00ff62696e617279"
+    )
+
+
+def test_encode_nested_bytes_uses_selected_encoding():
+    assert jsonable_encoder(
+        {"payload": [b"\x00\xff", memoryview(b"ok")]}, bytes_encoding="hex"
+    ) == {"payload": ["00ff", "6f6b"]}
+
+
+def test_encode_model_bytes_defaults_to_base64():
+    class ModelWithBytes(BaseModel):
+        payload: bytes
+
+    assert jsonable_encoder(ModelWithBytes(payload=b"\x00\xffbinary")) == {
+        "payload": "AP9iaW5hcnk="
+    }
+
+
+def test_encode_model_bytes_as_hex():
+    class ModelWithBytes(BaseModel):
+        payload: bytes
+
+    assert jsonable_encoder(
+        ModelWithBytes(payload=b"\x00\xffbinary"), bytes_encoding="hex"
+    ) == {"payload": "00ff62696e617279"}
+
+
 def test_encode_dict_include_exclude_list():
     pet = {"name": "Firulais", "owner": {"name": "Foo"}}
     assert jsonable_encoder(pet) == {"name": "Firulais", "owner": {"name": "Foo"}}

--- a/fastapi/tests/test_serialize_response.py
+++ b/fastapi/tests/test_serialize_response.py
@@ -11,6 +11,10 @@ class Item(BaseModel):
     owner_ids: list[int] | None = None
 
 
+class BytesItem(BaseModel):
+    payload: bytes
+
+
 @app.get("/items/valid", response_model=Item)
 def get_valid():
     return {"name": "valid", "price": 1.0}
@@ -28,6 +32,11 @@ def get_validlist():
         {"name": "bar", "price": 1.0},
         {"name": "baz", "price": 2.0, "owner_ids": [1, 2, 3]},
     ]
+
+
+@app.get("/items/bytes", response_model=BytesItem)
+def get_bytes():
+    return {"payload": b"\x00\xffbinary"}
 
 
 client = TestClient(app)
@@ -53,3 +62,9 @@ def test_validlist():
         {"name": "bar", "price": 1.0, "owner_ids": None},
         {"name": "baz", "price": 2.0, "owner_ids": [1, 2, 3]},
     ]
+
+
+def test_response_model_bytes_defaults_to_base64():
+    response = client.get("/items/bytes")
+    response.raise_for_status()
+    assert response.json() == {"payload": "AP9iaW5hcnk="}


### PR DESCRIPTION
/claim #759

Summary:
- Added `bytes_encoding` to `jsonable_encoder`, defaulting to base64 and supporting hex output.
- Encoded `bytes` and `memoryview` directly, including nested containers and BaseModel values.
- Added a response serialization fallback so non-UTF-8 bytes in response models are encoded through `jsonable_encoder` instead of failing Pydantic JSON serialization.
- Kept the existing Pydantic `dump_json` fast path intact when it succeeds.

Validation:
- `python -m py_compile fastapi/fastapi/encoders.py fastapi/fastapi/routing.py fastapi/tests/test_jsonable_encoder.py fastapi/tests/test_serialize_response.py` passed.
- `python -m pytest tests/test_jsonable_encoder.py tests/test_serialize_response.py tests/test_dump_json_fast_path.py -q` passed: 37 passed, 1 skipped.
- `git diff --check` passed.

Safety note:
- I did not add a public provenance file containing private system, developer, or session initialization text.

