### PR TITLE
Codex [ Laravel ] Add log cleanup command and schedule

### DIFF
--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,46 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days of logs to keep}', function () {
+    $days = max(0, (int) $this->option('days'));
+    $cutoff = now()->subDays($days)->getTimestamp();
+    $deletedFiles = 0;
+    $freedBytes = 0;
+
+    foreach (File::glob(storage_path('logs/*.log')) ?: [] as $path) {
+        if (! File::isFile($path) || File::lastModified($path) >= $cutoff) {
+            continue;
+        }
+
+        $bytes = File::size($path);
+
+        if (File::delete($path)) {
+            $deletedFiles++;
+            $freedBytes += $bytes;
+        }
+    }
+
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $size = (float) $freedBytes;
+    $unitIndex = 0;
+
+    while ($size >= 1024 && $unitIndex < count($units) - 1) {
+        $size /= 1024;
+        $unitIndex++;
+    }
+
+    $freedSpace = $unitIndex === 0
+        ? "{$freedBytes} B"
+        : number_format($size, 2) . ' ' . $units[$unitIndex];
+
+    $this->info("Deleted {$deletedFiles} log file(s), freed {$freedSpace}.");
+})->purpose('Delete log files older than the configured retention window');
+
+Schedule::command('logs:clear')->dailyAt('00:00');

--- a/laravel/tests/Feature/LogCleanupCommandTest.php
+++ b/laravel/tests/Feature/LogCleanupCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class LogCleanupCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        foreach (File::glob(storage_path('logs/test-cleanup-*.log')) ?: [] as $path) {
+            File::delete($path);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_logs_clear_deletes_logs_older_than_seven_days_by_default(): void
+    {
+        $oldLog = $this->writeLogFile('test-cleanup-old.log', 'old log content', 8);
+        $recentLog = $this->writeLogFile('test-cleanup-recent.log', 'recent log content', 2);
+
+        $this->artisan('logs:clear')
+            ->expectsOutputToContain('Deleted 1 log file(s)')
+            ->expectsOutputToContain('freed')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($oldLog);
+        $this->assertFileExists($recentLog);
+    }
+
+    public function test_logs_clear_days_option_overrides_default_retention(): void
+    {
+        $twentyDayLog = $this->writeLogFile('test-cleanup-20-days.log', 'twenty days', 20);
+        $thirtyOneDayLog = $this->writeLogFile('test-cleanup-31-days.log', 'thirty one days', 31);
+
+        $this->artisan('logs:clear', ['--days' => 30])
+            ->expectsOutputToContain('Deleted 1 log file(s)')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($twentyDayLog);
+        $this->assertFileDoesNotExist($thirtyOneDayLog);
+    }
+
+    private function writeLogFile(string $name, string $contents, int $ageInDays): string
+    {
+        $path = storage_path("logs/{$name}");
+
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, $contents);
+        touch($path, now()->subDays($ageInDays)->getTimestamp());
+
+        return $path;
+    }
+}


### PR DESCRIPTION
/claim #753

Summary:
- Added a `logs:clear` closure command in `laravel/routes/console.php`.
- The command deletes `storage/logs/*.log` files older than 7 days by default.
- Added `--days=` support to override the retention period.
- Added output for deleted file count and human-readable freed space.
- Registered `logs:clear` to run daily at `00:00`.
- Added feature tests for default 7-day cleanup and `--days=30`.

Validation:
- `git diff --check` passed.
- PHP/Composer are not installed in this environment, so I could not run `php -l`, `php artisan test`, or PHPUnit locally.

Safety note:
- I did not add a public generation/provenance file containing private system, developer, or session initialization text.

