### PR TITLE
Codex [ T3 Code ] Add CLI version command

### DIFF
--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -16,7 +16,8 @@ import * as CliError from "effect/unstable/cli/CliError";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
-import { cli } from "./bin.ts";
+import packageJson from "../package.json" with { type: "json" };
+import { cli, formatVersionInfo } from "./bin.ts";
 import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "./config.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
@@ -150,6 +151,30 @@ const withLiveProjectCliServer = <A, E, R>(baseDir: string, run: () => Effect.Ef
   });
 
 it.layer(NodeServices.layer)("bin cli parsing", (it) => {
+  it.effect("formats detailed version output", () =>
+    Effect.sync(() => {
+      assert.equal(
+        formatVersionInfo({
+          version: "1.2.3",
+          runtime: { name: "bun", version: "1.3.11" },
+          platform: "darwin",
+          arch: "arm64",
+        }),
+        "t3code v1.2.3 (bun 1.3.11, darwin arm64)",
+      );
+    }),
+  );
+
+  it.effect("prints detailed version information from the version subcommand", () =>
+    Effect.gen(function* () {
+      const { output } = yield* captureStdout(runCli(["version"]));
+
+      assert.equal(output.startsWith(`t3code v${packageJson.version} (`), true);
+      assert.equal(output.includes("node ") || output.includes("bun "), true);
+      assert.equal(output.endsWith(`, ${process.platform} ${process.arch})`), true);
+    }),
+  );
+
   it.effect("accepts the built-in lowercase log-level flag values", () =>
     runCliWithRuntime(["--log-level", "debug", "--version"]),
   );

--- a/t3code/apps/server/src/bin.ts
+++ b/t3code/apps/server/src/bin.ts
@@ -1,5 +1,6 @@
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Command } from "effect/unstable/cli";
@@ -13,14 +14,49 @@ import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
+export type CliRuntimeInfo = {
+  readonly name: "bun" | "node";
+  readonly version: string;
+};
+
+export const formatVersionInfo = (input: {
+  readonly version: string;
+  readonly runtime: CliRuntimeInfo;
+  readonly platform: string;
+  readonly arch: string;
+}) =>
+  `t3code v${input.version} (${input.runtime.name} ${input.runtime.version}, ${input.platform} ${input.arch})`;
+
+const getRuntimeInfo = (): CliRuntimeInfo => {
+  const bunVersion = (globalThis as { readonly Bun?: { readonly version?: string } }).Bun
+    ?.version;
+  if (typeof bunVersion === "string" && bunVersion.length > 0) {
+    return { name: "bun", version: bunVersion };
+  }
+  return { name: "node", version: process.versions.node };
+};
+
+export const getVersionInfo = () =>
+  formatVersionInfo({
+    version: packageJson.version,
+    runtime: getRuntimeInfo(),
+    platform: process.platform,
+    arch: process.arch,
+  });
+
+export const versionCommand = Command.make("version").pipe(
+  Command.withDescription("Print the T3 Code version and runtime information."),
+  Command.withHandler(() => Console.log(getVersionInfo())),
+);
+
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, versionCommand]),
 );
 
 if (import.meta.main) {
-  Command.run(cli, { version: packageJson.version }).pipe(
+  Command.run(cli, { version: getVersionInfo() }).pipe(
     Effect.scoped,
     Effect.provide(CliRuntimeLayer),
     NodeRuntime.runMain,


### PR DESCRIPTION
/claim #821

Summary:
- Added a `t3 version` subcommand that prints detailed version/runtime metadata.
- Kept root `--version` on Effect CLI's built-in version path and now passes the same detailed package-derived version string from the binary entry point.
- Read the CLI package version from `apps/server/package.json`.
- Added focused test coverage for the exact requested formatter shape and for `t3 version` command output.

Validation:
- `node --check apps/server/src/bin.ts` passed.
- `node --check apps/server/src/bin.test.ts` passed.
- `git diff --check` passed.

Environment note:
- Full Vitest was not run locally because this sparse checkout has no `node_modules` and the workspace uses `bun.lock`; Bun is not installed in this environment.

Safety note:
- I did not add a public file containing private system, developer, or session initialization text.

