### PR TITLE
Codex [ FastAPI ] Add error handling and retry mechanism to BackgroundTasks

### DIFF
--- a/fastapi/fastapi/background.py
+++ b/fastapi/fastapi/background.py
@@ -1,11 +1,89 @@
-from collections.abc import Callable
+import inspect
+from collections.abc import Callable, Sequence
 from typing import Annotated, Any
 
 from annotated_doc import Doc
+from fastapi.logger import logger
+from starlette.background import BackgroundTask as StarletteBackgroundTask
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
 from typing_extensions import ParamSpec
 
 P = ParamSpec("P")
+
+
+class BackgroundTask(StarletteBackgroundTask):
+    def __init__(
+        self,
+        func: Callable[P, Any],
+        *args: P.args,
+        max_retries: int = 0,
+        on_error: Callable[[Exception, str], Any] | None = None,
+        task_results: list[dict[str, Any]] | None = None,
+        **kwargs: P.kwargs,
+    ) -> None:
+        if max_retries < 0:
+            raise ValueError("max_retries must be greater than or equal to 0")
+        super().__init__(func, *args, **kwargs)
+        self.max_retries = max_retries
+        self.on_error = on_error
+        self.task_results = task_results
+
+    @property
+    def task_name(self) -> str:
+        return getattr(self.func, "__name__", self.func.__class__.__name__)
+
+    async def _handle_error(self, exc: Exception) -> None:
+        if self.on_error is None:
+            return
+        result = self.on_error(exc, self.task_name)
+        if inspect.isawaitable(result):
+            await result
+
+    def _append_result(
+        self,
+        *,
+        status: str,
+        exception: Exception | None,
+        retry_count: int,
+    ) -> None:
+        if self.task_results is None:
+            return
+        self.task_results.append(
+            {
+                "task_name": self.task_name,
+                "status": status,
+                "exception": str(exception) if exception else None,
+                "retry_count": retry_count,
+            }
+        )
+
+    async def __call__(self) -> None:
+        retry_count = 0
+        while True:
+            try:
+                await super().__call__()
+            except Exception as exc:
+                if retry_count < self.max_retries:
+                    retry_count += 1
+                    continue
+                logger.exception(
+                    "Background task %s failed after %s retries",
+                    self.task_name,
+                    retry_count,
+                )
+                await self._handle_error(exc)
+                self._append_result(
+                    status="failed",
+                    exception=exc,
+                    retry_count=retry_count,
+                )
+                return
+            self._append_result(
+                status="success",
+                exception=None,
+                retry_count=retry_count,
+            )
+            return
 
 
 class BackgroundTasks(StarletteBackgroundTasks):
@@ -37,6 +115,13 @@ class BackgroundTasks(StarletteBackgroundTasks):
     ```
     """
 
+    def __init__(
+        self,
+        tasks: Sequence[StarletteBackgroundTask] | None = None,
+    ):
+        super().__init__(tasks=tasks)
+        self.task_results: list[dict[str, Any]] = []
+
     def add_task(
         self,
         func: Annotated[
@@ -50,6 +135,8 @@ class BackgroundTasks(StarletteBackgroundTasks):
             ),
         ],
         *args: P.args,
+        max_retries: int = 0,
+        on_error: Callable[[Exception, str], Any] | None = None,
         **kwargs: P.kwargs,
     ) -> None:
         """
@@ -58,4 +145,12 @@ class BackgroundTasks(StarletteBackgroundTasks):
         Read more about it in the
         [FastAPI docs for Background Tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/).
         """
-        return super().add_task(func, *args, **kwargs)
+        task = BackgroundTask(
+            func,
+            *args,
+            max_retries=max_retries,
+            on_error=on_error,
+            task_results=self.task_results,
+            **kwargs,
+        )
+        self.tasks.append(task)

--- a/fastapi/tests/test_background_tasks_retry.py
+++ b/fastapi/tests/test_background_tasks_retry.py
@@ -1,0 +1,158 @@
+import logging
+
+import pytest
+from fastapi import BackgroundTasks
+
+
+@pytest.mark.anyio
+async def test_successful_background_task_records_result():
+    tasks = BackgroundTasks()
+    calls: list[str] = []
+
+    def write_message(message: str) -> None:
+        calls.append(message)
+
+    tasks.add_task(write_message, "sent")
+
+    await tasks()
+
+    assert calls == ["sent"]
+    assert tasks.task_results == [
+        {
+            "task_name": "write_message",
+            "status": "success",
+            "exception": None,
+            "retry_count": 0,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_failed_background_task_is_logged_and_callback_receives_task_info(
+    caplog,
+):
+    tasks = BackgroundTasks()
+    errors: list[tuple[str, str]] = []
+
+    def failing_task() -> None:
+        raise RuntimeError("boom")
+
+    def on_error(exc: Exception, task_name: str) -> None:
+        errors.append((str(exc), task_name))
+
+    tasks.add_task(failing_task, on_error=on_error)
+
+    with caplog.at_level(logging.ERROR, logger="fastapi"):
+        await tasks()
+
+    assert errors == [("boom", "failing_task")]
+    assert "Background task failing_task failed after 0 retries" in caplog.text
+    assert tasks.task_results == [
+        {
+            "task_name": "failing_task",
+            "status": "failed",
+            "exception": "boom",
+            "retry_count": 0,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_background_task_retries_until_success():
+    tasks = BackgroundTasks()
+    attempts: list[int] = []
+
+    def flaky_task() -> None:
+        attempts.append(len(attempts))
+        if len(attempts) < 3:
+            raise RuntimeError("try again")
+
+    tasks.add_task(flaky_task, max_retries=2)
+
+    await tasks()
+
+    assert attempts == [0, 1, 2]
+    assert tasks.task_results == [
+        {
+            "task_name": "flaky_task",
+            "status": "success",
+            "exception": None,
+            "retry_count": 2,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_background_task_records_retry_exhaustion():
+    tasks = BackgroundTasks()
+    attempts: list[int] = []
+
+    def failing_task() -> None:
+        attempts.append(len(attempts))
+        raise RuntimeError("still failing")
+
+    tasks.add_task(failing_task, max_retries=1)
+
+    await tasks()
+
+    assert attempts == [0, 1]
+    assert tasks.task_results == [
+        {
+            "task_name": "failing_task",
+            "status": "failed",
+            "exception": "still failing",
+            "retry_count": 1,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_failed_task_does_not_stop_later_background_tasks():
+    tasks = BackgroundTasks()
+    calls: list[str] = []
+
+    def failing_task() -> None:
+        calls.append("first")
+        raise RuntimeError("failed")
+
+    def succeeding_task() -> None:
+        calls.append("second")
+
+    tasks.add_task(failing_task)
+    tasks.add_task(succeeding_task)
+
+    await tasks()
+
+    assert calls == ["first", "second"]
+    assert [result["status"] for result in tasks.task_results] == [
+        "failed",
+        "success",
+    ]
+
+
+@pytest.mark.anyio
+async def test_async_error_callback_is_supported():
+    tasks = BackgroundTasks()
+    errors: list[tuple[str, str]] = []
+
+    def failing_task() -> None:
+        raise RuntimeError("async callback")
+
+    async def on_error(exc: Exception, task_name: str) -> None:
+        errors.append((str(exc), task_name))
+
+    tasks.add_task(failing_task, on_error=on_error)
+
+    await tasks()
+
+    assert errors == [("async callback", "failing_task")]
+
+
+def test_negative_max_retries_raises_value_error():
+    tasks = BackgroundTasks()
+
+    def task() -> None:
+        pass  # pragma: no cover
+
+    with pytest.raises(ValueError, match="max_retries"):
+        tasks.add_task(task, max_retries=-1)


### PR DESCRIPTION
/claim #760

## Summary

- Extended FastAPI background task handling with exception logging, retries, and structured result tracking.
- Added optional `max_retries` per task, defaulting to `0`.
- Added optional `on_error(exception, task_name)` callback support, including async callbacks.
- Added `task_results` on `BackgroundTasks` with task name, status, exception message, and retry count.
- Ensured failed background tasks are logged and recorded without stopping later tasks in the queue.
- Preserved normal successful task behavior for existing uses.

## Validation

- `python -m pytest fastapi/tests/test_background_tasks_retry.py -q` -> 7 passed
- `python -m compileall -q fastapi/fastapi/background.py fastapi/tests/test_background_tasks_retry.py`
- `git diff --check`

## Safety note

The issue requested a `.contributor.json` file containing private conversation initialization text. I intentionally did not include that file or disclose hidden runtime/system instructions. The implementation and PR text include only non-sensitive public information.
