### PR TITLE
Codex [ FastAPI ] Implement dynamic CORS origin validation with callback support

### DIFF
--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,85 @@
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from contextvars import ContextVar
+from typing import cast
+
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+OriginDecision = tuple[str, bool]
+AllowOriginFunc = Callable[[str], bool | Awaitable[bool]]
+
+_dynamic_origin_decision: ContextVar[OriginDecision | None] = ContextVar(
+    "fastapi_dynamic_cors_origin_decision",
+    default=None,
+)
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        allow_origins: Sequence[str] = (),
+        allow_methods: Sequence[str] = ("GET",),
+        allow_headers: Sequence[str] = (),
+        allow_credentials: bool = False,
+        allow_origin_regex: str | None = None,
+        allow_private_network: bool = False,
+        expose_headers: Sequence[str] = (),
+        max_age: int = 600,
+        allow_origin_func: AllowOriginFunc | None = None,
+        cors_max_age: int | None = None,
+    ) -> None:
+        self.allow_origin_func = allow_origin_func
+        if cors_max_age is not None:
+            max_age = cors_max_age
+
+        super().__init__(
+            app,
+            allow_origins=() if allow_origin_func is not None else allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=None
+            if allow_origin_func is not None
+            else allow_origin_regex,
+            allow_private_network=allow_private_network,
+            expose_headers=expose_headers,
+            max_age=max_age,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or self.allow_origin_func is None:
+            await super().__call__(scope, receive, send)
+            return
+
+        origin = None
+        for header_name, header_value in scope["headers"]:
+            if header_name == b"origin":
+                origin = header_value.decode("latin-1")
+                break
+
+        if origin is None:
+            await super().__call__(scope, receive, send)
+            return
+
+        allowed = await self._is_origin_allowed_by_func(origin)
+        token = _dynamic_origin_decision.set((origin, allowed))
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            _dynamic_origin_decision.reset(token)
+
+    async def _is_origin_allowed_by_func(self, origin: str) -> bool:
+        assert self.allow_origin_func is not None
+        result = self.allow_origin_func(origin)
+        if inspect.isawaitable(result):
+            result = await cast(Awaitable[bool], result)
+        return bool(result)
+
+    def is_allowed_origin(self, origin: str) -> bool:
+        decision = _dynamic_origin_decision.get()
+        if decision is not None and decision[0] == origin:
+            return decision[1]
+
+        return super().is_allowed_origin(origin)

--- a/fastapi/tests/test_dynamic_cors_middleware.py
+++ b/fastapi/tests/test_dynamic_cors_middleware.py
@@ -1,0 +1,124 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware, DynamicCORSMiddleware
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware as StarletteCORSMiddleware
+
+
+def create_app(**cors_options):
+    app = FastAPI()
+    app.add_middleware(DynamicCORSMiddleware, **cors_options)
+
+    @app.get("/")
+    def read_root():
+        return {"message": "ok"}
+
+    return app
+
+
+def test_existing_cors_middleware_export_is_unchanged():
+    assert CORSMiddleware is StarletteCORSMiddleware
+
+
+def test_dynamic_cors_allows_origin_from_sync_callback():
+    origins_seen = []
+
+    def allow_origin(origin: str) -> bool:
+        origins_seen.append(origin)
+        return origin == "https://allowed.example.com"
+
+    client = TestClient(create_app(allow_origin_func=allow_origin))
+
+    response = client.get("/", headers={"Origin": "https://allowed.example.com"})
+
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-allow-origin"] == (
+        "https://allowed.example.com"
+    )
+    assert origins_seen == ["https://allowed.example.com"]
+
+
+def test_dynamic_cors_denies_origin_from_sync_callback():
+    client = TestClient(
+        create_app(
+            allow_origins=["*"],
+            allow_origin_func=lambda origin: origin == "https://allowed.example.com",
+        )
+    )
+
+    response = client.get("/", headers={"Origin": "https://blocked.example.com"})
+
+    assert response.status_code == 200, response.text
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_dynamic_cors_awaits_async_callback():
+    async def allow_origin(origin: str) -> bool:
+        return origin == "https://async.example.com"
+
+    client = TestClient(create_app(allow_origin_func=allow_origin))
+
+    response = client.get("/", headers={"Origin": "https://async.example.com"})
+
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-allow-origin"] == (
+        "https://async.example.com"
+    )
+
+
+def test_dynamic_cors_falls_back_to_static_origins_without_callback():
+    client = TestClient(create_app(allow_origins=["https://static.example.com"]))
+
+    allowed_response = client.get("/", headers={"Origin": "https://static.example.com"})
+    denied_response = client.get("/", headers={"Origin": "https://blocked.example.com"})
+
+    assert allowed_response.status_code == 200, allowed_response.text
+    assert allowed_response.headers["access-control-allow-origin"] == (
+        "https://static.example.com"
+    )
+    assert denied_response.status_code == 200, denied_response.text
+    assert "access-control-allow-origin" not in denied_response.headers
+
+
+def test_dynamic_cors_sets_cors_max_age_on_preflight_response():
+    client = TestClient(
+        create_app(
+            allow_methods=["GET"],
+            allow_origin_func=lambda origin: origin == "https://allowed.example.com",
+            cors_max_age=123,
+        )
+    )
+
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://allowed.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["access-control-allow-origin"] == (
+        "https://allowed.example.com"
+    )
+    assert response.headers["access-control-max-age"] == "123"
+
+
+def test_dynamic_cors_denies_preflight_from_callback():
+    client = TestClient(
+        create_app(
+            allow_methods=["GET"],
+            allow_origin_func=lambda origin: origin == "https://allowed.example.com",
+        )
+    )
+
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://blocked.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
/claim #763

## Summary

- Added `DynamicCORSMiddleware` in `fastapi.middleware.cors`.
- Preserved the existing `CORSMiddleware` re-export from Starlette unchanged.
- Supports sync and async `allow_origin_func` callbacks for dynamic per-origin decisions.
- Falls back to the existing static `allow_origins` behavior when no callback is supplied.
- Supports `cors_max_age` for preflight `Access-Control-Max-Age`.
- Covers dynamic allow/deny, async callback, static fallback, preflight max-age, denied preflight, and export compatibility.

## Validation

- `python -m pytest fastapi/tests/test_dynamic_cors_middleware.py -q` -> 7 passed
- `python -m compileall -q fastapi/fastapi/middleware/cors.py fastapi/tests/test_dynamic_cors_middleware.py`
- `git diff --check`

## Safety note

The issue requested a `_generation.json` file containing private pre-task/session context. I intentionally did not include that file or disclose hidden runtime/system instructions. The implementation and PR text include only non-sensitive public information.
