### PR TITLE
Codex [ FastAPI ] Implement standardized pagination with offset and cursor support

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -9,6 +9,10 @@ from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
+from .pagination import PaginatedResponse as PaginatedResponse
+from .pagination import PaginationParams as PaginationParams
+from .pagination import Paginator as Paginator
+from .pagination import paginate as paginate
 from .param_functions import Body as Body
 from .param_functions import Cookie as Cookie
 from .param_functions import Depends as Depends

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,160 @@
+import base64
+import json
+from collections.abc import Sequence
+from math import ceil
+from typing import Annotated, Any, Generic, TypeVar
+
+from fastapi.param_functions import Query
+from pydantic import BaseModel
+
+ItemT = TypeVar("ItemT")
+
+DEFAULT_PAGE = 1
+DEFAULT_PAGE_SIZE = 50
+DEFAULT_MAX_PAGE_SIZE = 100
+
+
+class PaginationParams(BaseModel):
+    page: int = DEFAULT_PAGE
+    page_size: int = DEFAULT_PAGE_SIZE
+    cursor: str | None = None
+
+
+class PaginatedResponse(BaseModel, Generic[ItemT]):
+    items: list[ItemT]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+def _normalize_page(page: int) -> int:
+    return max(page, DEFAULT_PAGE)
+
+
+def _normalize_page_size(
+    page_size: int,
+    *,
+    max_page_size: int = DEFAULT_MAX_PAGE_SIZE,
+) -> int:
+    if page_size <= 0:
+        return DEFAULT_PAGE_SIZE
+    return min(page_size, max_page_size)
+
+
+def _total_pages(total: int, page_size: int) -> int:
+    if total <= 0:
+        return 0
+    return ceil(total / page_size)
+
+
+def paginate(
+    page: Annotated[int, Query(description="Page number, starting at 1")] = 1,
+    page_size: Annotated[int, Query(description="Number of items per page")] = 50,
+    cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
+) -> PaginationParams:
+    return PaginationParams(
+        page=_normalize_page(page),
+        page_size=_normalize_page_size(page_size),
+        cursor=cursor,
+    )
+
+
+class Paginator:
+    def __init__(
+        self,
+        *,
+        page: int = DEFAULT_PAGE,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        cursor: str | None = None,
+        max_page_size: int = DEFAULT_MAX_PAGE_SIZE,
+    ):
+        self.page = _normalize_page(page)
+        self.page_size = _normalize_page_size(
+            page_size,
+            max_page_size=max_page_size,
+        )
+        self.cursor = cursor
+
+    @property
+    def skip(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    @staticmethod
+    def encode_cursor(offset: int) -> str:
+        payload = json.dumps({"offset": max(0, offset)}, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+    @staticmethod
+    def decode_cursor(cursor: str | None) -> int:
+        if not cursor:
+            return 0
+        try:
+            padding = "=" * (-len(cursor) % 4)
+            payload = base64.urlsafe_b64decode(f"{cursor}{padding}".encode())
+            offset = json.loads(payload.decode()).get("offset", 0)
+            return max(0, int(offset))
+        except (ValueError, json.JSONDecodeError):
+            return 0
+
+    def paginate(
+        self, source: Any, *, total: int | None = None
+    ) -> PaginatedResponse[Any]:
+        if _is_query_like(source):
+            resolved_total = int(source.count() if total is None else total)
+            items = list(source.offset(self.skip).limit(self.limit).all())
+        else:
+            sequence = list(source)
+            resolved_total = len(sequence) if total is None else int(total)
+            items = sequence[self.skip : self.skip + self.limit]
+        total_pages = _total_pages(resolved_total, self.page_size)
+        return PaginatedResponse(
+            items=items,
+            total=resolved_total,
+            page=self.page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=self.page < total_pages,
+            has_previous=self.page > 1 and resolved_total > 0,
+        )
+
+    def paginate_cursor(
+        self,
+        source: Sequence[ItemT],
+        *,
+        cursor: str | None = None,
+    ) -> PaginatedResponse[ItemT]:
+        resolved_cursor = self.cursor if cursor is None else cursor
+        start = self.decode_cursor(resolved_cursor)
+        total = len(source)
+        end = start + self.page_size
+        items = list(source[start:end])
+        has_next = end < total
+        has_previous = start > 0 and total > 0
+        page = start // self.page_size + 1
+        total_pages = _total_pages(total, self.page_size)
+        return PaginatedResponse(
+            items=items,
+            total=total,
+            page=page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=has_next,
+            has_previous=has_previous,
+            next_cursor=self.encode_cursor(end) if has_next else None,
+            previous_cursor=self.encode_cursor(max(0, start - self.page_size))
+            if has_previous
+            else None,
+        )
+
+
+def _is_query_like(source: Any) -> bool:
+    return all(hasattr(source, name) for name in ("count", "offset", "limit", "all"))

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,139 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from fastapi.pagination import PaginatedResponse, PaginationParams, Paginator, paginate
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    name: str
+
+
+class FakeQuery:
+    def __init__(self, items: list[int]):
+        self.items = items
+        self.offset_value = 0
+        self.limit_value = len(items)
+
+    def count(self) -> int:
+        return len(self.items)
+
+    def offset(self, value: int) -> "FakeQuery":
+        query = FakeQuery(self.items)
+        query.offset_value = value
+        query.limit_value = self.limit_value
+        return query
+
+    def limit(self, value: int) -> "FakeQuery":
+        query = FakeQuery(self.items)
+        query.offset_value = self.offset_value
+        query.limit_value = value
+        return query
+
+    def all(self) -> list[int]:
+        return self.items[self.offset_value : self.offset_value + self.limit_value]
+
+
+def test_offset_pagination_calculates_metadata_and_items():
+    result = Paginator(page=2, page_size=3).paginate(list(range(10)))
+
+    assert result.items == [3, 4, 5]
+    assert result.total == 10
+    assert result.page == 2
+    assert result.page_size == 3
+    assert result.total_pages == 4
+    assert result.has_next is True
+    assert result.has_previous is True
+
+
+def test_offset_pagination_handles_boundaries_and_empty_results():
+    first_page = Paginator(page=1, page_size=3).paginate([1, 2, 3])
+    empty = Paginator(page=0, page_size=0).paginate([])
+
+    assert first_page.has_next is False
+    assert first_page.has_previous is False
+    assert empty.items == []
+    assert empty.page == 1
+    assert empty.page_size == 50
+    assert empty.total_pages == 0
+    assert empty.has_next is False
+    assert empty.has_previous is False
+
+
+def test_sqlalchemy_style_query_is_supported():
+    result = Paginator(page=3, page_size=2).paginate(FakeQuery([10, 20, 30, 40, 50]))
+
+    assert result.items == [50]
+    assert result.total == 5
+    assert result.total_pages == 3
+    assert result.has_next is False
+    assert result.has_previous is True
+
+
+def test_cursor_pagination_uses_encoded_next_and_previous_cursors():
+    paginator = Paginator(page_size=2)
+    first = paginator.paginate_cursor(["a", "b", "c", "d", "e"])
+    second = paginator.paginate_cursor(
+        ["a", "b", "c", "d", "e"], cursor=first.next_cursor
+    )
+
+    assert first.items == ["a", "b"]
+    assert first.next_cursor is not None
+    assert first.previous_cursor is None
+    assert second.items == ["c", "d"]
+    assert second.has_next is True
+    assert second.has_previous is True
+    assert second.previous_cursor == Paginator.encode_cursor(0)
+
+
+def test_cursor_pagination_handles_invalid_cursor_and_last_page():
+    paginator = Paginator(page_size=2)
+    invalid = paginator.paginate_cursor([1, 2, 3], cursor="not-a-cursor")
+    last = paginator.paginate_cursor([1, 2, 3], cursor=invalid.next_cursor)
+
+    assert invalid.items == [1, 2]
+    assert last.items == [3]
+    assert last.has_next is False
+    assert last.has_previous is True
+
+
+def test_paginated_response_generic_accepts_pydantic_models():
+    result = PaginatedResponse[Item](
+        items=[Item(name="alpha")],
+        total=1,
+        page=1,
+        page_size=50,
+        total_pages=1,
+        has_next=False,
+        has_previous=False,
+    )
+
+    assert result.model_dump() == {
+        "items": [{"name": "alpha"}],
+        "total": 1,
+        "page": 1,
+        "page_size": 50,
+        "total_pages": 1,
+        "has_next": False,
+        "has_previous": False,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_paginate_dependency_reads_and_normalizes_query_parameters():
+    app = FastAPI()
+
+    @app.get("/items/")
+    def read_items(params: Annotated[PaginationParams, Depends(paginate)]):
+        return params.model_dump()
+
+    client = TestClient(app)
+
+    response = client.get("/items/?page=-2&page_size=0")
+    custom = client.get("/items/?page=3&page_size=5")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"page": 1, "page_size": 50, "cursor": None}
+    assert custom.json() == {"page": 3, "page_size": 5, "cursor": None}


### PR DESCRIPTION
/claim #802

## Summary

- Added `fastapi.pagination` with `Paginator`, `PaginationParams`, `paginate`, and generic `PaginatedResponse[T]`.
- Supports offset pagination with standardized `items`, `total`, `page`, `page_size`, `total_pages`, `has_next`, and `has_previous` metadata.
- Supports SQLAlchemy-style query objects via `count().offset().limit().all()`.
- Supports cursor pagination using URL-safe encoded offsets with `next_cursor` and `previous_cursor` metadata.
- Normalizes edge cases including page 0, negative page values, page_size 0, invalid cursors, and empty result sets.
- Re-exported the pagination helpers from `fastapi`.

## Validation

- `python -m pytest fastapi/tests/test_pagination.py -q` -> 7 passed
- `python -m compileall -q fastapi/fastapi/pagination.py fastapi/tests/test_pagination.py`
- `git diff --check`

## Safety note

The issue requested a `.attribution.json` file containing private pre-conversation/platform instructions. I intentionally did not include that file or disclose hidden runtime/system instructions. The implementation and PR text include only non-sensitive public information.
