### PR TITLE
Codex [ FastAPI ] Add file size and content type validation to UploadFile

### DIFF
--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -1,13 +1,14 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import (
     Annotated,
     Any,
     BinaryIO,
     TypeVar,
-    cast,
 )
 
 from annotated_doc import Doc
+from fastapi.exceptions import HTTPException
 from pydantic import GetJsonSchemaHandler
 from starlette.datastructures import URL as URL  # noqa: F401
 from starlette.datastructures import Address as Address  # noqa: F401
@@ -16,6 +17,13 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    is_valid: bool
+    file_size: int | None
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +70,88 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+    max_size: Annotated[
+        int | None,
+        Doc("The maximum allowed file size in bytes before validation fails."),
+    ]
+    allowed_content_types: Annotated[
+        tuple[str, ...] | None,
+        Doc("Allowed MIME content types before validation fails."),
+    ]
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(file=file, size=size, filename=filename, headers=headers)
+        self.max_size = max_size
+        self.allowed_content_types = (
+            tuple(allowed_content_types) if allowed_content_types is not None else None
+        )
+
+    def _get_file_size(self) -> int | None:
+        if self.size is not None:
+            return self.size
+
+        try:
+            current_position = self.file.tell()
+        except (AttributeError, OSError):
+            return None
+
+        try:
+            self.file.seek(0, 2)
+            file_size = self.file.tell()
+        except (AttributeError, OSError):
+            return None
+        try:
+            self.file.seek(current_position)
+        except (AttributeError, OSError):
+            return None
+        return file_size
+
+    def _raise_for_invalid_content_type(self) -> None:
+        if self.allowed_content_types is None:
+            return
+
+        normalized_allowed = {
+            content_type.lower() for content_type in self.allowed_content_types
+        }
+        content_type = self.content_type
+        if content_type is None or content_type.lower() not in normalized_allowed:
+            raise HTTPException(
+                status_code=415,
+                detail="Unsupported upload content type",
+            )
+
+    def _raise_for_invalid_size(self, file_size: int | None) -> None:
+        if (
+            self.max_size is not None
+            and file_size is not None
+            and file_size > self.max_size
+        ):
+            raise HTTPException(
+                status_code=413,
+                detail="Uploaded file exceeds the configured size limit",
+            )
+
+    async def validate(self) -> ValidationResult:
+        """
+        Validate this upload against the configured size and content type limits.
+        """
+        file_size = self._get_file_size()
+        self._raise_for_invalid_size(file_size)
+        self._raise_for_invalid_content_type()
+        return ValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=self.content_type,
+        )
 
     async def write(
         self,
@@ -81,6 +171,10 @@ class UploadFile(StarletteUploadFile):
 
         To be awaitable, compatible with async, this is run in threadpool.
         """
+        if self.max_size is not None or self.allowed_content_types is not None:
+            validation_result = await self.validate()
+            if self.max_size is not None and validation_result.file_size is not None:
+                self._raise_for_invalid_size(validation_result.file_size + len(data))
         return await super().write(data)
 
     async def read(
@@ -99,6 +193,8 @@ class UploadFile(StarletteUploadFile):
 
         To be awaitable, compatible with async, this is run in threadpool.
         """
+        if self.max_size is not None or self.allowed_content_types is not None:
+            await self.validate()
         return await super().read(size)
 
     async def seek(
@@ -133,7 +229,14 @@ class UploadFile(StarletteUploadFile):
     def _validate(cls, __input_value: Any, _: Any) -> "UploadFile":
         if not isinstance(__input_value, StarletteUploadFile):
             raise ValueError(f"Expected UploadFile, received: {type(__input_value)}")
-        return cast(UploadFile, __input_value)
+        if isinstance(__input_value, cls):
+            return __input_value
+        return cls(
+            file=__input_value.file,
+            size=__input_value.size,
+            filename=__input_value.filename,
+            headers=__input_value.headers,
+        )
 
     @classmethod
     def __get_pydantic_json_schema__(

--- a/fastapi/tests/test_upload_file_validation.py
+++ b/fastapi/tests/test_upload_file_validation.py
@@ -1,0 +1,114 @@
+import io
+
+import pytest
+from fastapi import FastAPI, UploadFile
+from fastapi.exceptions import HTTPException
+from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_large_file():
+    upload = UploadFile(
+        file=io.BytesIO(b"larger than allowed"),
+        filename="large.txt",
+        size=19,
+        max_size=8,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_upload_file_read_rejects_disallowed_content_type():
+    upload = UploadFile(
+        file=io.BytesIO(b"not json"),
+        filename="data.txt",
+        headers=Headers({"content-type": "text/plain"}),
+        allowed_content_types=["application/json"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload.read()
+
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_allows_unconfigured_constraints():
+    upload = UploadFile(
+        file=io.BytesIO(b"unrestricted"),
+        filename="any.bin",
+        headers=Headers({"content-type": "application/octet-stream"}),
+    )
+
+    result = await upload.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 12
+    assert result.content_type == "application/octet-stream"
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_returns_metadata_and_preserves_position():
+    stream = io.BytesIO(b"abcdef")
+    stream.seek(3)
+    upload = UploadFile(
+        file=stream,
+        filename="letters.txt",
+        headers=Headers({"content-type": "text/plain"}),
+        max_size=6,
+        allowed_content_types=["text/plain"],
+    )
+
+    result = await upload.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 6
+    assert result.content_type == "text/plain"
+    assert stream.tell() == 3
+
+
+@pytest.mark.anyio
+async def test_upload_file_write_checks_projected_size():
+    upload = UploadFile(
+        file=io.BytesIO(b"abc"),
+        filename="letters.txt",
+        size=3,
+        max_size=4,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload.write(b"de")
+
+    assert exc_info.value.status_code == 413
+
+
+def test_request_upload_file_is_wrapped_with_validation_method():
+    app = FastAPI()
+
+    @app.post("/upload")
+    async def upload(file: UploadFile):
+        result = await file.validate()
+        return {
+            "is_fastapi_upload": isinstance(file, UploadFile),
+            "file_size": result.file_size,
+            "content_type": result.content_type,
+        }
+
+    client = TestClient(app)
+
+    response = client.post(
+        "/upload",
+        files={"file": ("hello.txt", b"hello", "text/plain")},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "is_fastapi_upload": True,
+        "file_size": 5,
+        "content_type": "text/plain",
+    }


### PR DESCRIPTION
/claim #761

## Summary

- Added optional `max_size` and `allowed_content_types` constraints to FastAPI's `UploadFile`.
- Added `ValidationResult` plus async `validate()` metadata checks for file size and content type.
- Raise HTTP 413 for oversized uploads and HTTP 415 for unsupported content types when configured.
- Preserve existing unconstrained UploadFile behavior, wrap Starlette upload instances as FastAPI UploadFile instances, and keep file position stable while measuring size.
- Added focused coverage for size/type rejection, no-op defaults, metadata accuracy, pointer preservation, projected write size checks, and request upload wrapping.

## Validation

- `python -m pytest fastapi/tests/test_upload_file_validation.py fastapi/tests/test_datastructures.py -q` -> 11 passed
- `python -m compileall -q fastapi/fastapi/datastructures.py fastapi/tests/test_upload_file_validation.py`
- `git diff --check origin/main..HEAD`

## Safety

- I did not include `contributor_meta.json` or any hidden runtime/system/developer instructions in the repository or PR text.
- The issue-requested metadata file asks for private session initialization text, so it is intentionally omitted.
