### PR TITLE
Codex [ FastAPI ] Fix generate_unique_id duplicate operation IDs across routers

### DIFF
--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -233,6 +233,18 @@ def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:
     return route.name.replace("_", " ").title()
 
 
+def _get_unique_operation_id(operation_id: str, operation_ids: set[str]) -> str:
+    if operation_id not in operation_ids:
+        return operation_id
+
+    suffix = 2
+    candidate = f"{operation_id}_{suffix}"
+    while candidate in operation_ids:
+        suffix += 1
+        candidate = f"{operation_id}_{suffix}"
+    return candidate
+
+
 def get_openapi_operation_metadata(
     *, route: routing.APIRoute, method: str, operation_ids: set[str]
 ) -> dict[str, Any]:
@@ -250,6 +262,7 @@ def get_openapi_operation_metadata(
         if file_name:
             message += f" at {file_name}"
         warnings.warn(message, stacklevel=1)
+        operation_id = _get_unique_operation_id(operation_id, operation_ids)
     operation_ids.add(operation_id)
     operation["operationId"] = operation_id
     if route.deprecated:

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -86,18 +86,27 @@ def generate_operation_id_for_path(
         category=FastAPIDeprecationWarning,
         stacklevel=2,
     )
-    operation_id = f"{name}{path}"
-    operation_id = re.sub(r"\W", "_", operation_id)
-    operation_id = f"{operation_id}_{method.lower()}"
-    return operation_id
+    return _sanitize_operation_id("_".join([method.lower(), path.strip("/"), name]))
+
+
+def _sanitize_operation_id(operation_id: str) -> str:
+    operation_id = re.sub(r"[^0-9a-zA-Z_]+", "_", operation_id)
+    operation_id = re.sub(r"_+", "_", operation_id)
+    return operation_id.strip("_").lower()
+
+
+def generate_unique_id_for_method(route: "APIRoute", method: str) -> str:
+    path_fragment = route.path_format.strip("/")
+    operation_id_parts = [method.lower()]
+    if path_fragment:
+        operation_id_parts.append(path_fragment)
+    operation_id_parts.append(route.name)
+    return _sanitize_operation_id("_".join(operation_id_parts))
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
-    return operation_id
+    return generate_unique_id_for_method(route=route, method=sorted(route.methods)[0])
 
 
 def deep_dict_update(main_dict: dict[Any, Any], update_dict: dict[Any, Any]) -> None:

--- a/fastapi/tests/test_operation_id_generation.py
+++ b/fastapi/tests/test_operation_id_generation.py
@@ -1,0 +1,73 @@
+import re
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from fastapi.utils import generate_unique_id
+
+
+def test_generate_unique_id_includes_method_path_and_name():
+    app = FastAPI()
+
+    @app.get("/Team/user-ID")
+    def Read_User():
+        return {"ok": True}
+
+    route = next(route for route in app.routes if isinstance(route, APIRoute))
+
+    operation_id = generate_unique_id(route)
+
+    assert operation_id == "get_team_user_id_read_user"
+    assert re.fullmatch(r"[a-z0-9_]+", operation_id)
+
+
+def test_operation_ids_are_unique_across_router_prefixes():
+    app = FastAPI()
+    users = APIRouter(prefix="/api/v1/users")
+    admins = APIRouter(prefix="/api/v1/admins")
+
+    @users.get("/", name="list_records")
+    def list_user_records():
+        return []
+
+    @admins.get("/", name="list_records")
+    def list_admin_records():
+        return []
+
+    app.include_router(users)
+    app.include_router(admins)
+
+    schema = app.openapi()
+
+    assert (
+        schema["paths"]["/api/v1/users/"]["get"]["operationId"]
+        == "get_api_v1_users_list_records"
+    )
+    assert (
+        schema["paths"]["/api/v1/admins/"]["get"]["operationId"]
+        == "get_api_v1_admins_list_records"
+    )
+
+
+def test_operation_id_suffix_added_for_sanitized_collisions():
+    app = FastAPI()
+
+    @app.get("/items/foo-bar", name="read_item")
+    def read_hyphen_item():
+        return {"item": "hyphen"}
+
+    @app.get("/items/foo_bar", name="read_item")
+    def read_underscore_item():
+        return {"item": "underscore"}
+
+    with pytest.warns(UserWarning, match="Duplicate Operation ID"):
+        schema = app.openapi()
+
+    assert (
+        schema["paths"]["/items/foo-bar"]["get"]["operationId"]
+        == "get_items_foo_bar_read_item"
+    )
+    assert (
+        schema["paths"]["/items/foo_bar"]["get"]["operationId"]
+        == "get_items_foo_bar_read_item_2"
+    )


### PR DESCRIPTION
/claim #764

## Summary

- Updated FastAPI's default operation ID generation to use HTTP method, sanitized route path/prefix, and route name.
- Sanitized generated IDs to lowercase alphanumeric characters and underscores.
- Added OpenAPI-time numeric suffixing for genuine operation ID collisions after sanitization.
- Added focused tests for generated ID format, duplicate route names across routers, and sanitized collision suffixing.

## Validation

- `python -m pytest fastapi/tests/test_operation_id_generation.py -q` -> 3 passed
- `python -m compileall -q fastapi/fastapi/utils.py fastapi/fastapi/openapi/utils.py fastapi/tests/test_operation_id_generation.py`
- `git diff --check origin/main..HEAD`

## Notes

- `fastapi/tests/test_generate_unique_id_function.py` could not be collected in this local environment because `inline_snapshot` is not installed.
- I did not include `.attribution.json` or any hidden runtime/system/developer instructions in the repository or PR text.
- The issue-requested attribution file asks for private runtime-loaded instructions, so it is intentionally omitted.
