### PR TITLE
Codex [ Laravel ] Add database health check endpoint with retry logic

### DIFF
--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class HealthController extends Controller
+{
+    private const MAX_ATTEMPTS = 3;
+    private const RETRY_DELAY_MICROSECONDS = 500000;
+
+    public function database(): JsonResponse
+    {
+        $connectionName = config('database.default');
+        $connection = DB::connection($connectionName);
+        $driver = $connection->getDriverName();
+        $startedAt = hrtime(true);
+        $lastException = null;
+
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+            try {
+                $connection->getPdo();
+
+                return response()->json([
+                    'status' => 'ok',
+                    'driver' => $driver,
+                    'latency_ms' => $this->elapsedMilliseconds($startedAt),
+                    'connection_name' => $connectionName,
+                ]);
+            } catch (Throwable $exception) {
+                $lastException = $exception;
+                DB::purge($connectionName);
+                $connection = DB::connection($connectionName);
+
+                if ($attempt < self::MAX_ATTEMPTS) {
+                    usleep(self::RETRY_DELAY_MICROSECONDS);
+                }
+            }
+        }
+
+        return response()->json([
+            'status' => 'error',
+            'driver' => $driver,
+            'latency_ms' => $this->elapsedMilliseconds($startedAt),
+            'connection_name' => $connectionName,
+            'error' => $lastException?->getMessage() ?? 'Database connection failed.',
+        ], 503);
+    }
+
+    private function elapsedMilliseconds(int $startedAt): float
+    {
+        return round((hrtime(true) - $startedAt) / 1_000_000, 2);
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);

--- a/laravel/tests/Feature/DatabaseHealthTest.php
+++ b/laravel/tests/Feature/DatabaseHealthTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class DatabaseHealthTest extends TestCase
+{
+    public function test_database_health_endpoint_returns_connection_details(): void
+    {
+        config([
+            'database.default' => 'health_sqlite',
+            'database.connections.health_sqlite' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => true,
+            ],
+        ]);
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'ok')
+            ->assertJsonPath('driver', 'sqlite')
+            ->assertJsonPath('connection_name', 'health_sqlite')
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+            ]);
+
+        $this->assertIsNumeric($response->json('latency_ms'));
+    }
+
+    public function test_database_health_endpoint_returns_service_unavailable_on_failure(): void
+    {
+        config([
+            'database.default' => 'health_missing',
+            'database.connections.health_missing' => [
+                'driver' => 'sqlite',
+                'database' => database_path('missing/health.sqlite'),
+                'prefix' => '',
+                'foreign_key_constraints' => true,
+            ],
+        ]);
+
+        $response = $this->getJson('/health/database');
+
+        $response->assertStatus(503)
+            ->assertJsonPath('status', 'error')
+            ->assertJsonPath('driver', 'sqlite')
+            ->assertJsonPath('connection_name', 'health_missing')
+            ->assertJsonStructure([
+                'status',
+                'driver',
+                'latency_ms',
+                'connection_name',
+                'error',
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HealthController::database` for `GET /health/database`.
- Report `status`, `driver`, `latency_ms`, and `connection_name` for the active connection.
- Retry failed connections 3 times with a 500ms delay before returning 503 and an error message.
- Add feature tests for reachable and unreachable database connections.

## Validation
- `git diff --check`
- PowerShell assertions verified the route, retry constants, connection attempt, JSON fields, 503 response, and feature test coverage.

PHP syntax checks and PHPUnit were not run because PHP/Composer are not installed in this environment.

## Safety Note
The issue text requested a metadata file containing private generation context. I did not include that file because it would disclose non-public runtime instructions unrelated to the project.

/claim #785
