### PR TITLE
Codex [ Laravel ] Add structured logging and separate error channel

### DIFF
--- a/laravel/app/Logging/JsonLogFormatter.php
+++ b/laravel/app/Logging/JsonLogFormatter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Logging;
+
+use DateTimeInterface;
+use JsonException;
+use Monolog\Formatter\JsonFormatter;
+use Monolog\LogRecord;
+
+class JsonLogFormatter extends JsonFormatter
+{
+    /**
+     * @throws JsonException
+     */
+    public function format(LogRecord $record): string
+    {
+        return json_encode([
+            'timestamp' => $record->datetime->format(DateTimeInterface::ATOM),
+            'level' => $record->level->getName(),
+            'message' => $record->message,
+            'context' => $this->normalize($record->context),
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n";
+    }
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\JsonLogFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -71,6 +72,24 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
             'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => env('LOG_ERROR_LEVEL', 'error'),
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => storage_path('logs/structured.log'),
+            ],
+            'formatter' => JsonLogFormatter::class,
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'slack' => [

--- a/laravel/tests/Unit/LoggingConfigurationTest.php
+++ b/laravel/tests/Unit/LoggingConfigurationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Logging\JsonLogFormatter;
+use DateTimeImmutable;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Tests\TestCase;
+
+class LoggingConfigurationTest extends TestCase
+{
+    public function test_stack_channel_sends_logs_to_daily_and_error_channels(): void
+    {
+        $this->assertSame(['daily', 'error'], config('logging.channels.stack.channels'));
+    }
+
+    public function test_daily_and_error_channels_use_expected_retention_and_levels(): void
+    {
+        $this->assertSame(14, config('logging.channels.daily.days'));
+        $this->assertSame('error', config('logging.channels.error.level'));
+        $this->assertStringEndsWith('logs/error.log', config('logging.channels.error.path'));
+    }
+
+    public function test_json_channel_uses_structured_formatter(): void
+    {
+        $this->assertSame('monolog', config('logging.channels.json.driver'));
+        $this->assertSame(StreamHandler::class, config('logging.channels.json.handler'));
+        $this->assertSame(JsonLogFormatter::class, config('logging.channels.json.formatter'));
+    }
+
+    public function test_json_formatter_outputs_required_fields(): void
+    {
+        $formatter = new JsonLogFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-06-29T00:00:00+00:00'),
+            channel: 'testing',
+            level: Level::Info,
+            message: 'User updated profile',
+            context: ['user_id' => 123],
+        );
+
+        $formatted = json_decode($formatter->format($record), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('2026-06-29T00:00:00+00:00', $formatted['timestamp']);
+        $this->assertSame('INFO', $formatted['level']);
+        $this->assertSame('User updated profile', $formatted['message']);
+        $this->assertSame(['user_id' => 123], $formatted['context']);
+    }
+}


### PR DESCRIPTION
## Summary
- Change the default Laravel log stack to include both `daily` and `error` channels.
- Add an `error` channel writing ERROR and above messages to `storage/logs/error.log`.
- Keep daily log retention at 14 days.
- Add a `json` Monolog channel with a structured formatter that emits `timestamp`, `level`, `message`, and `context`.
- Add unit tests for the logging config and JSON formatter output.

## Validation
- `git diff --check`
- PowerShell assertions verified the stack channels, error channel path/level, daily retention, JSON channel formatter, formatter output fields, and unit test coverage.

PHP syntax checks and PHPUnit were not run because PHP/Composer are not installed in this environment.

## Safety Note
The issue text requested a `_provenance.json` file containing private boot context. I did not include that file because it would disclose non-public runtime instructions unrelated to the project.

/claim #787
