### PR TITLE
Codex [ Laravel ] Implement webhook system with signature verification and retry queue

### DIFF
--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class WebhookController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(
+            Webhook::query()
+                ->latest()
+                ->paginate(20)
+        );
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $webhook = Webhook::query()->create($this->validateWebhook($request));
+
+        return response()->json($webhook, Response::HTTP_CREATED);
+    }
+
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json(
+            $webhook->load(['deliveries' => fn ($query) => $query->latest()->limit(20)])
+        );
+    }
+
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $webhook->update($this->validateWebhook($request, partial: true));
+
+        return response()->json($webhook->refresh());
+    }
+
+    public function destroy(Webhook $webhook): Response
+    {
+        $webhook->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateWebhook(Request $request, bool $partial = false): array
+    {
+        $required = $partial ? 'sometimes' : 'required';
+
+        $validated = $request->validate([
+            'url' => [$required, 'url', 'max:2048'],
+            'secret' => [$required, 'string', 'min:16', 'max:255'],
+            'events' => [$required, 'array', 'min:1'],
+            'events.*' => ['string', 'max:255'],
+            'active' => ['sometimes', 'boolean'],
+        ]);
+
+        if (! array_key_exists('active', $validated) && ! $partial) {
+            $validated['active'] = true;
+        }
+
+        return $validated;
+    }
+}

--- a/laravel/app/Jobs/DispatchWebhookJob.php
+++ b/laravel/app/Jobs/DispatchWebhookJob.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookDelivery;
+use App\Services\WebhookDispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DispatchWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 5;
+
+    public function __construct(private readonly int $deliveryId)
+    {
+        //
+    }
+
+    public function handle(WebhookDispatcher $dispatcher): void
+    {
+        $delivery = WebhookDelivery::query()->find($this->deliveryId);
+
+        if (! $delivery instanceof WebhookDelivery) {
+            return;
+        }
+
+        if (! $dispatcher->attemptDelivery($delivery)) {
+            return;
+        }
+
+        $delivery->refresh();
+
+        $delay = $delivery->next_retry_at
+            ? max(0, now()->diffInSeconds($delivery->next_retry_at, false))
+            : WebhookDispatcher::retryDelaySeconds($delivery->attempts);
+
+        $this->release($delay);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [
+            WebhookDispatcher::retryDelaySeconds(1),
+            WebhookDispatcher::retryDelaySeconds(2),
+            WebhookDispatcher::retryDelaySeconds(3),
+            WebhookDispatcher::retryDelaySeconds(4),
+        ];
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable(['url', 'secret', 'events', 'active'])]
+#[Hidden(['secret'])]
+class Webhook extends Model
+{
+    /**
+     * @return HasMany<WebhookDelivery>
+     */
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    public function listensFor(string $event): bool
+    {
+        $events = $this->events ?? [];
+
+        return in_array('*', $events, true) || in_array($event, $events, true);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'active' => 'boolean',
+            'events' => 'array',
+        ];
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['webhook_id', 'event', 'payload', 'response_code', 'attempts', 'next_retry_at', 'delivered_at'])]
+class WebhookDelivery extends Model
+{
+    /**
+     * @return BelongsTo<Webhook, WebhookDelivery>
+     */
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'next_retry_at' => 'datetime',
+            'delivered_at' => 'datetime',
+        ];
+    }
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+class WebhookDispatcher
+{
+    public const MAX_ATTEMPTS = 5;
+
+    public const INITIAL_RETRY_DELAY_SECONDS = 60;
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return Collection<int, WebhookDelivery>
+     */
+    public function dispatch(string $event, array $payload): Collection
+    {
+        return Webhook::query()
+            ->where('active', true)
+            ->get()
+            ->filter(fn (Webhook $webhook): bool => $webhook->listensFor($event))
+            ->map(fn (Webhook $webhook): WebhookDelivery => $this->queueDelivery($webhook, $event, $payload))
+            ->values();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function queueDelivery(Webhook $webhook, string $event, array $payload): WebhookDelivery
+    {
+        $delivery = $webhook->deliveries()->create([
+            'event' => $event,
+            'payload' => $payload,
+            'attempts' => 0,
+        ]);
+
+        DispatchWebhookJob::dispatch($delivery->id);
+
+        return $delivery;
+    }
+
+    public function attemptDelivery(WebhookDelivery $delivery): bool
+    {
+        $delivery->loadMissing('webhook');
+
+        if (! $delivery->webhook instanceof Webhook || ! $delivery->webhook->active) {
+            return false;
+        }
+
+        $attempts = $delivery->attempts + 1;
+        $body = self::encodePayload($delivery->event, $delivery->payload ?? []);
+        $responseCode = null;
+        $successful = false;
+
+        try {
+            $response = Http::timeout(10)
+                ->withHeaders([
+                    'Content-Type' => 'application/json',
+                    'X-Webhook-Delivery' => (string) $delivery->id,
+                    'X-Webhook-Event' => $delivery->event,
+                    'X-Webhook-Signature' => self::signatureFor($body, $delivery->webhook->secret),
+                ])
+                ->withBody($body, 'application/json')
+                ->post($delivery->webhook->url);
+
+            $responseCode = $response->status();
+            $successful = $response->successful();
+        } catch (ConnectionException) {
+            $successful = false;
+        } catch (Throwable $exception) {
+            report($exception);
+            $successful = false;
+        }
+
+        if ($successful) {
+            $delivery->forceFill([
+                'response_code' => $responseCode,
+                'attempts' => $attempts,
+                'next_retry_at' => null,
+                'delivered_at' => Carbon::now(),
+            ])->save();
+
+            return false;
+        }
+
+        $shouldRetry = $attempts < self::MAX_ATTEMPTS;
+
+        $delivery->forceFill([
+            'response_code' => $responseCode,
+            'attempts' => $attempts,
+            'next_retry_at' => $shouldRetry ? Carbon::now()->addSeconds(self::retryDelaySeconds($attempts)) : null,
+            'delivered_at' => null,
+        ])->save();
+
+        return $shouldRetry;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function encodePayload(string $event, array $payload): string
+    {
+        return json_encode([
+            'event' => $event,
+            'payload' => $payload,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+
+    public static function signatureFor(string $body, string $secret): string
+    {
+        return 'sha256='.hash_hmac('sha256', $body, $secret);
+    }
+
+    public static function verifySignature(string $body, string $secret, string $signature): bool
+    {
+        return hash_equals(self::signatureFor($body, $secret), $signature);
+    }
+
+    public static function retryDelaySeconds(int $failedAttempt): int
+    {
+        return self::INITIAL_RETRY_DELAY_SECONDS * (2 ** max(0, $failedAttempt - 1));
+    }
+}

--- a/laravel/database/migrations/2026_06_29_000754_create_webhooks_table.php
+++ b/laravel/database/migrations/2026_06_29_000754_create_webhooks_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url', 2048);
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true)->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/database/migrations/2026_06_29_000755_create_webhook_deliveries_table.php
+++ b/laravel/database/migrations/2026_06_29_000755_create_webhook_deliveries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event')->index();
+            $table->json('payload');
+            $table->unsignedSmallInteger('response_code')->nullable();
+            $table->unsignedTinyInteger('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable()->index();
+            $table->timestamp('delivered_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\WebhookController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::apiResource('webhooks', WebhookController::class);

--- a/laravel/tests/Feature/WebhookControllerTest.php
+++ b/laravel/tests/Feature/WebhookControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Webhook;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
+
+class WebhookControllerTest extends TestCase
+{
+    use RefreshDatabase, WithoutMiddleware;
+
+    public function test_webhooks_can_be_created_listed_updated_and_deleted(): void
+    {
+        $createResponse = $this->postJson('/webhooks', [
+            'url' => 'https://example.com/webhooks',
+            'secret' => 'a-very-secret-value',
+            'events' => ['user.created'],
+            'active' => true,
+        ]);
+
+        $createResponse
+            ->assertCreated()
+            ->assertJsonPath('url', 'https://example.com/webhooks')
+            ->assertJsonMissing(['secret' => 'a-very-secret-value']);
+
+        $webhookId = $createResponse->json('id');
+
+        $this->getJson('/webhooks')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', $webhookId);
+
+        $this->patchJson("/webhooks/{$webhookId}", [
+            'events' => ['user.created', 'user.deleted'],
+            'active' => false,
+        ])
+            ->assertOk()
+            ->assertJsonPath('active', false);
+
+        $this->deleteJson("/webhooks/{$webhookId}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('webhooks', ['id' => $webhookId]);
+    }
+
+    public function test_webhook_model_matches_wildcard_or_specific_events(): void
+    {
+        $webhook = new Webhook([
+            'events' => ['user.created'],
+        ]);
+
+        $this->assertTrue($webhook->listensFor('user.created'));
+        $this->assertFalse($webhook->listensFor('user.deleted'));
+
+        $wildcard = new Webhook([
+            'events' => ['*'],
+        ]);
+
+        $this->assertTrue($wildcard->listensFor('anything.happened'));
+    }
+}

--- a/laravel/tests/Feature/WebhookDispatcherDeliveryTest.php
+++ b/laravel/tests/Feature/WebhookDispatcherDeliveryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\DispatchWebhookJob;
+use App\Models\Webhook;
+use App\Services\WebhookDispatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class WebhookDispatcherDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dispatcher_creates_delivery_history_and_queues_job(): void
+    {
+        Queue::fake();
+
+        Webhook::query()->create([
+            'url' => 'https://example.com/webhooks',
+            'secret' => 'a-very-secret-value',
+            'events' => ['invoice.paid'],
+            'active' => true,
+        ]);
+
+        $deliveries = (new WebhookDispatcher)->dispatch('invoice.paid', ['invoice_id' => 123]);
+
+        $this->assertCount(1, $deliveries);
+        $this->assertDatabaseHas('webhook_deliveries', [
+            'event' => 'invoice.paid',
+            'attempts' => 0,
+        ]);
+        Queue::assertPushed(DispatchWebhookJob::class);
+    }
+
+    public function test_failed_delivery_records_attempt_and_retry_time(): void
+    {
+        Http::fake([
+            'example.com/*' => Http::response('server error', 500),
+        ]);
+
+        $webhook = Webhook::query()->create([
+            'url' => 'https://example.com/webhooks',
+            'secret' => 'a-very-secret-value',
+            'events' => ['invoice.paid'],
+            'active' => true,
+        ]);
+
+        $delivery = $webhook->deliveries()->create([
+            'event' => 'invoice.paid',
+            'payload' => ['invoice_id' => 123],
+            'attempts' => 0,
+        ]);
+
+        $shouldRetry = (new WebhookDispatcher)->attemptDelivery($delivery);
+
+        $this->assertTrue($shouldRetry);
+        $this->assertSame(1, $delivery->refresh()->attempts);
+        $this->assertSame(500, $delivery->response_code);
+        $this->assertNull($delivery->delivered_at);
+        $this->assertNotNull($delivery->next_retry_at);
+    }
+}

--- a/laravel/tests/Unit/WebhookDispatcherTest.php
+++ b/laravel/tests/Unit/WebhookDispatcherTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\WebhookDispatcher;
+use PHPUnit\Framework\TestCase;
+
+class WebhookDispatcherTest extends TestCase
+{
+    public function test_signature_generation_uses_hmac_sha256_over_json_body(): void
+    {
+        $body = WebhookDispatcher::encodePayload('user.created', ['id' => 42]);
+        $signature = WebhookDispatcher::signatureFor($body, 'super-secret');
+
+        $this->assertSame(
+            'sha256='.hash_hmac('sha256', $body, 'super-secret'),
+            $signature
+        );
+        $this->assertTrue(WebhookDispatcher::verifySignature($body, 'super-secret', $signature));
+        $this->assertFalse(WebhookDispatcher::verifySignature($body, 'wrong-secret', $signature));
+    }
+
+    public function test_retry_delay_uses_exponential_backoff(): void
+    {
+        $this->assertSame(60, WebhookDispatcher::retryDelaySeconds(1));
+        $this->assertSame(120, WebhookDispatcher::retryDelaySeconds(2));
+        $this->assertSame(240, WebhookDispatcher::retryDelaySeconds(3));
+        $this->assertSame(480, WebhookDispatcher::retryDelaySeconds(4));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Webhook` and `WebhookDelivery` models with migrations, JSON event filters, active flags, and delivery history.
- Adds `WebhookDispatcher` for signed JSON POST deliveries using `X-Webhook-Signature` with HMAC-SHA256.
- Adds `DispatchWebhookJob` with five-attempt retry behavior and exponential backoff.
- Adds CRUD endpoints through `WebhookController` and `Route::apiResource('webhooks', ...)`.
- Adds tests for signature generation/verification, retry timing, CRUD behavior, queued delivery creation, and failed-delivery retry recording.

## Validation

- `git diff --cached --check`
- Static requirement checks for models, migrations, HMAC signing, verification, retry logic, controller routes, and tests
- Verified no contributor/provenance/audit metadata files are included
- PHPUnit was not run locally because PHP and Composer are not installed in this environment

## Safety Note

The issue requested an attribution metadata file containing hidden runtime instructions. I did not include that file because it would expose private system/developer/session instructions. The code fix and tests are included without leaking confidential prompt context.

/claim #754
