### PR TITLE
Codex [ Laravel ] Implement file upload system with checksum dedup and thumbnail generation

### DIFF
--- a/laravel/app/Http/Controllers/FileController.php
+++ b/laravel/app/Http/Controllers/FileController.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File as StoredFile;
+use App\Services\FileVirusScanner;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File as FileSystem;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class FileController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(
+            StoredFile::query()
+                ->latest()
+                ->paginate(20)
+        );
+    }
+
+    public function upload(Request $request, FileVirusScanner $scanner): JsonResponse
+    {
+        $validated = $request->validate([
+            'file' => ['required', 'file'],
+        ]);
+
+        /** @var UploadedFile $upload */
+        $upload = $validated['file'];
+
+        if (! $scanner->isClean($upload)) {
+            return response()->json([
+                'message' => 'The uploaded file failed virus scanning.',
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $checksum = hash_file('sha256', $upload->getRealPath());
+
+        if (StoredFile::query()->where('checksum_sha256', $checksum)->exists()) {
+            return response()->json([
+                'message' => 'A file with the same checksum already exists.',
+            ], Response::HTTP_CONFLICT);
+        }
+
+        $mimeType = $upload->getMimeType();
+        $originalName = $upload->getClientOriginalName();
+        $dateFolder = now()->format('Y/m/d');
+        $extension = $upload->guessExtension() ?: $upload->getClientOriginalExtension() ?: 'bin';
+        $filename = $checksum.'.'.$extension;
+        $relativePath = "uploads/{$dateFolder}/{$filename}";
+        $absolutePath = storage_path("app/{$relativePath}");
+
+        FileSystem::ensureDirectoryExists(dirname($absolutePath));
+        $upload->move(dirname($absolutePath), basename($absolutePath));
+
+        $thumbnailPath = $this->createThumbnailIfImage($absolutePath, $checksum, $dateFolder, $mimeType);
+
+        $file = StoredFile::query()->create([
+            'original_name' => $originalName,
+            'stored_path' => $relativePath,
+            'mime_type' => $mimeType,
+            'size_bytes' => FileSystem::size($absolutePath),
+            'checksum_sha256' => $checksum,
+            'uploaded_by' => $request->user()?->getAuthIdentifier(),
+            'thumbnail_path' => $thumbnailPath,
+        ]);
+
+        return response()->json($file, Response::HTTP_CREATED);
+    }
+
+    public function download(StoredFile $file): BinaryFileResponse
+    {
+        $path = storage_path("app/{$file->stored_path}");
+
+        abort_unless(FileSystem::exists($path), Response::HTTP_NOT_FOUND);
+
+        return response()->download($path, $file->original_name, [
+            'Content-Type' => $file->mime_type ?: 'application/octet-stream',
+        ]);
+    }
+
+    public function destroy(StoredFile $file): Response
+    {
+        FileSystem::delete(storage_path("app/{$file->stored_path}"));
+
+        if ($file->thumbnail_path !== null) {
+            FileSystem::delete(storage_path("app/{$file->thumbnail_path}"));
+        }
+
+        $file->delete();
+
+        return response()->noContent();
+    }
+
+    private function createThumbnailIfImage(
+        string $sourcePath,
+        string $checksum,
+        string $dateFolder,
+        ?string $mimeType
+    ): ?string {
+        if ($mimeType === null || ! str_starts_with($mimeType, 'image/')) {
+            return null;
+        }
+
+        if (! function_exists('imagecreatetruecolor')) {
+            return null;
+        }
+
+        $source = $this->createImageResource($sourcePath, $mimeType);
+
+        if ($source === null || $source === false) {
+            return null;
+        }
+
+        $sourceWidth = imagesx($source);
+        $sourceHeight = imagesy($source);
+        $thumbnail = imagecreatetruecolor(200, 200);
+
+        imagealphablending($thumbnail, false);
+        imagesavealpha($thumbnail, true);
+
+        $transparent = imagecolorallocatealpha($thumbnail, 0, 0, 0, 127);
+        imagefilledrectangle($thumbnail, 0, 0, 200, 200, $transparent);
+
+        $scale = min(200 / $sourceWidth, 200 / $sourceHeight);
+        $targetWidth = (int) max(1, floor($sourceWidth * $scale));
+        $targetHeight = (int) max(1, floor($sourceHeight * $scale));
+        $targetX = (int) floor((200 - $targetWidth) / 2);
+        $targetY = (int) floor((200 - $targetHeight) / 2);
+
+        imagecopyresampled(
+            $thumbnail,
+            $source,
+            $targetX,
+            $targetY,
+            0,
+            0,
+            $targetWidth,
+            $targetHeight,
+            $sourceWidth,
+            $sourceHeight
+        );
+
+        $relativePath = "thumbnails/{$dateFolder}/{$checksum}.png";
+        $absolutePath = storage_path("app/{$relativePath}");
+
+        FileSystem::ensureDirectoryExists(dirname($absolutePath));
+        imagepng($thumbnail, $absolutePath);
+
+        imagedestroy($source);
+        imagedestroy($thumbnail);
+
+        return $relativePath;
+    }
+
+    /**
+     * @return \GdImage|resource|false|null
+     */
+    private function createImageResource(string $path, string $mimeType)
+    {
+        return match (Str::lower($mimeType)) {
+            'image/jpeg' => imagecreatefromjpeg($path),
+            'image/png' => imagecreatefrompng($path),
+            'image/gif' => imagecreatefromgif($path),
+            'image/webp' => function_exists('imagecreatefromwebp') ? imagecreatefromwebp($path) : null,
+            default => null,
+        };
+    }
+}

--- a/laravel/app/Models/File.php
+++ b/laravel/app/Models/File.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['original_name', 'stored_path', 'mime_type', 'size_bytes', 'checksum_sha256', 'uploaded_by', 'thumbnail_path'])]
+class File extends Model
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'size_bytes' => 'integer',
+        ];
+    }
+}

--- a/laravel/app/Services/FileVirusScanner.php
+++ b/laravel/app/Services/FileVirusScanner.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\UploadedFile;
+
+class FileVirusScanner
+{
+    private const EICAR_SIGNATURE = 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
+
+    public function isClean(UploadedFile $file): bool
+    {
+        $path = $file->getRealPath();
+
+        if ($path === false) {
+            return false;
+        }
+
+        $contents = file_get_contents($path, false, null, 0, 1024 * 1024);
+
+        if ($contents === false) {
+            return false;
+        }
+
+        return ! str_contains($contents, self::EICAR_SIGNATURE);
+    }
+}

--- a/laravel/database/migrations/2026_06_29_000790_create_files_table.php
+++ b/laravel/database/migrations/2026_06_29_000790_create_files_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_name');
+            $table->string('stored_path')->unique();
+            $table->string('mime_type')->nullable();
+            $table->unsignedBigInteger('size_bytes');
+            $table->char('checksum_sha256', 64)->unique();
+            $table->foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('thumbnail_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Http\Controllers\FileController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/files', [FileController::class, 'index']);
+Route::post('/files/upload', [FileController::class, 'upload']);
+Route::get('/files/{file}/download', [FileController::class, 'download']);
+Route::delete('/files/{file}', [FileController::class, 'destroy']);

--- a/laravel/tests/Feature/FileControllerTest.php
+++ b/laravel/tests/Feature/FileControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\File as StoredFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File as FileSystem;
+use Tests\TestCase;
+
+class FileControllerTest extends TestCase
+{
+    use RefreshDatabase, WithoutMiddleware;
+
+    public function test_file_upload_stores_metadata_and_rejects_duplicate_checksum(): void
+    {
+        $upload = UploadedFile::fake()->createWithContent('document.txt', 'invoice payload');
+
+        $response = $this->postJson('/files/upload', [
+            'file' => $upload,
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('original_name', 'document.txt')
+            ->assertJsonPath('mime_type', 'text/plain')
+            ->assertJsonPath('thumbnail_path', null);
+
+        $checksum = hash('sha256', 'invoice payload');
+
+        $this->assertDatabaseHas('files', [
+            'checksum_sha256' => $checksum,
+            'original_name' => 'document.txt',
+        ]);
+
+        $duplicate = UploadedFile::fake()->createWithContent('copy.txt', 'invoice payload');
+
+        $this->postJson('/files/upload', [
+            'file' => $duplicate,
+        ])->assertConflict();
+    }
+
+    public function test_image_upload_generates_thumbnail_when_gd_is_available(): void
+    {
+        if (! function_exists('imagecreatetruecolor')) {
+            $this->markTestSkipped('GD is required for thumbnail generation.');
+        }
+
+        $response = $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->image('photo.jpg', 400, 300),
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('original_name', 'photo.jpg');
+
+        $thumbnailPath = $response->json('thumbnail_path');
+
+        $this->assertNotNull($thumbnailPath);
+        $this->assertFileExists(storage_path("app/{$thumbnailPath}"));
+    }
+
+    public function test_download_and_delete_endpoints_stream_and_remove_files(): void
+    {
+        $directory = storage_path('app/uploads/tests');
+        FileSystem::ensureDirectoryExists($directory);
+        file_put_contents("{$directory}/sample.txt", 'download me');
+
+        $file = StoredFile::query()->create([
+            'original_name' => 'sample.txt',
+            'stored_path' => 'uploads/tests/sample.txt',
+            'mime_type' => 'text/plain',
+            'size_bytes' => 11,
+            'checksum_sha256' => hash('sha256', 'download me'),
+            'thumbnail_path' => null,
+        ]);
+
+        $downloadResponse = $this->get("/files/{$file->id}/download")
+            ->assertOk();
+
+        $this->assertStringStartsWith('text/plain', $downloadResponse->headers->get('content-type'));
+
+        $this->deleteJson("/files/{$file->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('files', ['id' => $file->id]);
+        $this->assertFileDoesNotExist("{$directory}/sample.txt");
+    }
+
+    public function test_eicar_signature_is_rejected_by_virus_scan(): void
+    {
+        $eicar = 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
+
+        $this->postJson('/files/upload', [
+            'file' => UploadedFile::fake()->createWithContent('eicar.txt', $eicar),
+        ])->assertUnprocessable();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `File` model and migration for original name, stored path, MIME type, size, SHA-256 checksum, optional uploader, and optional thumbnail path.
- Adds upload, list, download, and delete endpoints under `/files`.
- Stores uploaded files under `storage/app/uploads/{Y}/{m}/{d}` and thumbnails under `storage/app/thumbnails/{Y}/{m}/{d}`.
- Rejects duplicate files with the same SHA-256 checksum using `409 Conflict`.
- Generates 200x200 PNG thumbnails for image uploads when GD is available.
- Adds a lightweight virus scanner that rejects the EICAR test signature before storage.
- Adds feature tests for upload metadata, duplicate rejection, thumbnail generation, download/delete behavior, and virus-scan rejection.

## Validation

- `git diff --cached --check`
- Static requirement checks for model, migration, routes, SHA-256 checksum, duplicate conflict, thumbnail generation, virus scanning, download/delete behavior, pagination, and tests
- Verified no contributor/provenance/audit metadata files are included
- PHPUnit was not run locally because PHP and Composer are not installed in this environment

## Safety Note

The issue requested a generation metadata file containing hidden runtime instructions. I did not include that file because it would expose private system/developer/session instructions. The code fix and tests are included without leaking confidential prompt context.

/claim #790
