### PR TITLE
Codex [ Laravel ] Implement user notification preferences with channel routing

### DIFF
--- a/laravel/app/Http/Controllers/NotificationPreferenceController.php
+++ b/laravel/app/Http/Controllers/NotificationPreferenceController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class NotificationPreferenceController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $user = $this->resolveUser($request);
+
+        return response()->json(
+            $user->notificationPreferences()
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get()
+        );
+    }
+
+    public function update(Request $request, NotificationPreference $preference): JsonResponse
+    {
+        $this->authorizePreferenceAccess($request, $preference);
+
+        $validated = $request->validate([
+            'enabled' => ['required', 'boolean'],
+        ]);
+
+        $preference->update([
+            'enabled' => $validated['enabled'],
+        ]);
+
+        return response()->json($preference->refresh());
+    }
+
+    public function bulkUpdate(Request $request): JsonResponse
+    {
+        $user = $this->resolveUser($request);
+
+        $validated = $request->validate([
+            'preferences' => ['required', 'array', 'min:1'],
+            'preferences.*.id' => ['required', 'integer'],
+            'preferences.*.enabled' => ['required', 'boolean'],
+        ]);
+
+        $updates = collect($validated['preferences'])->keyBy('id');
+        $preferences = $user->notificationPreferences()
+            ->whereIn('id', $updates->keys())
+            ->get();
+
+        abort_unless($preferences->count() === $updates->count(), 404);
+
+        foreach ($preferences as $preference) {
+            $preference->update([
+                'enabled' => $updates->get($preference->id)['enabled'],
+            ]);
+        }
+
+        return response()->json(
+            $user->notificationPreferences()
+                ->orderBy('event_type')
+                ->orderBy('channel')
+                ->get()
+        );
+    }
+
+    private function resolveUser(Request $request): User
+    {
+        $user = $request->user();
+
+        if ($user instanceof User) {
+            return $user;
+        }
+
+        $validated = $request->validate([
+            'user_id' => ['required', 'integer', Rule::exists('users', 'id')],
+        ]);
+
+        return User::query()->findOrFail($validated['user_id']);
+    }
+
+    private function authorizePreferenceAccess(Request $request, NotificationPreference $preference): void
+    {
+        $user = $request->user();
+
+        if ($user instanceof User) {
+            abort_unless($preference->user_id === $user->id, 404);
+        }
+    }
+}

--- a/laravel/app/Models/NotificationPreference.php
+++ b/laravel/app/Models/NotificationPreference.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['user_id', 'channel', 'event_type', 'enabled'])]
+class NotificationPreference extends Model
+{
+    public const CHANNEL_MAIL = 'mail';
+
+    public const CHANNEL_SLACK = 'slack';
+
+    public const CHANNEL_DATABASE = 'database';
+
+    public const CHANNELS = [
+        self::CHANNEL_MAIL,
+        self::CHANNEL_SLACK,
+        self::CHANNEL_DATABASE,
+    ];
+
+    /**
+     * @return BelongsTo<User, NotificationPreference>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,6 +7,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -16,6 +17,14 @@ class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    /**
+     * @return HasMany<NotificationPreference>
+     */
+    public function notificationPreferences(): HasMany
+    {
+        return $this->hasMany(NotificationPreference::class);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Observers/UserObserver.php
+++ b/laravel/app/Observers/UserObserver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use App\Services\NotificationRouter;
+
+class UserObserver
+{
+    public function created(User $user): void
+    {
+        app(NotificationRouter::class)->seedDefaults($user);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 }

--- a/laravel/app/Services/NotificationRouter.php
+++ b/laravel/app/Services/NotificationRouter.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+class NotificationRouter
+{
+    public const DEFAULT_EVENT_TYPES = [
+        'account.created',
+        'security.alert',
+        'billing.updated',
+    ];
+
+    /**
+     * @param array<int, string> $channels
+     *
+     * @return array<int, string>
+     */
+    public function enabledChannelsFor(User $user, string $eventType, array $channels = NotificationPreference::CHANNELS): array
+    {
+        $preferences = $this->preferencesFor($user, $eventType)
+            ->keyBy('channel');
+
+        return array_values(array_filter(
+            $channels,
+            fn (string $channel): bool => (bool) ($preferences->get($channel)?->enabled ?? false)
+        ));
+    }
+
+    public function shouldSend(User $user, string $eventType, string $channel): bool
+    {
+        return in_array($channel, $this->enabledChannelsFor($user, $eventType, [$channel]), true);
+    }
+
+    /**
+     * @param array<int, string> $candidateChannels
+     * @param callable(string): void $send
+     *
+     * @return array<int, string>
+     */
+    public function dispatch(User $user, string $eventType, array $candidateChannels, callable $send): array
+    {
+        $enabledChannels = $this->enabledChannelsFor($user, $eventType, $candidateChannels);
+
+        foreach ($enabledChannels as $channel) {
+            $send($channel);
+        }
+
+        return $enabledChannels;
+    }
+
+    public function seedDefaults(User $user): void
+    {
+        foreach (self::DEFAULT_EVENT_TYPES as $eventType) {
+            foreach (NotificationPreference::CHANNELS as $channel) {
+                NotificationPreference::query()->firstOrCreate(
+                    [
+                        'user_id' => $user->id,
+                        'channel' => $channel,
+                        'event_type' => $eventType,
+                    ],
+                    [
+                        'enabled' => $channel !== NotificationPreference::CHANNEL_SLACK,
+                    ]
+                );
+            }
+        }
+    }
+
+    /**
+     * @return Collection<int, NotificationPreference>
+     */
+    private function preferencesFor(User $user, string $eventType): Collection
+    {
+        return $user->notificationPreferences()
+            ->where('event_type', $eventType)
+            ->get();
+    }
+}

--- a/laravel/database/migrations/2026_06_29_000793_create_notification_preferences_table.php
+++ b/laravel/database/migrations/2026_06_29_000793_create_notification_preferences_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('channel');
+            $table->string('event_type');
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'channel', 'event_type'], 'notification_preferences_unique');
+            $table->index(['user_id', 'event_type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Http\Controllers\NotificationPreferenceController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/notifications/preferences', [NotificationPreferenceController::class, 'index']);
+Route::put('/notifications/preferences/{preference}', [NotificationPreferenceController::class, 'update']);
+Route::post('/notifications/preferences/bulk', [NotificationPreferenceController::class, 'bulkUpdate']);

--- a/laravel/tests/Feature/NotificationPreferenceTest.php
+++ b/laravel/tests/Feature/NotificationPreferenceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Services\NotificationRouter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
+
+class NotificationPreferenceTest extends TestCase
+{
+    use RefreshDatabase, WithoutMiddleware;
+
+    public function test_new_users_get_default_notification_preferences(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertDatabaseCount(
+            'notification_preferences',
+            count(NotificationRouter::DEFAULT_EVENT_TYPES) * count(NotificationPreference::CHANNELS)
+        );
+
+        foreach (NotificationRouter::DEFAULT_EVENT_TYPES as $eventType) {
+            foreach (NotificationPreference::CHANNELS as $channel) {
+                $this->assertDatabaseHas('notification_preferences', [
+                    'user_id' => $user->id,
+                    'event_type' => $eventType,
+                    'channel' => $channel,
+                ]);
+            }
+        }
+    }
+
+    public function test_user_can_list_and_update_preferences(): void
+    {
+        $user = User::factory()->create();
+        $preference = $user->notificationPreferences()
+            ->where('channel', NotificationPreference::CHANNEL_MAIL)
+            ->where('event_type', 'account.created')
+            ->firstOrFail();
+
+        $this->actingAs($user)
+            ->getJson('/notifications/preferences')
+            ->assertOk()
+            ->assertJsonFragment([
+                'id' => $preference->id,
+                'channel' => NotificationPreference::CHANNEL_MAIL,
+                'event_type' => 'account.created',
+            ]);
+
+        $this->actingAs($user)
+            ->putJson("/notifications/preferences/{$preference->id}", [
+                'enabled' => false,
+            ])
+            ->assertOk()
+            ->assertJsonPath('enabled', false);
+
+        $this->assertDatabaseHas('notification_preferences', [
+            'id' => $preference->id,
+            'enabled' => false,
+        ]);
+    }
+
+    public function test_bulk_update_toggles_multiple_preferences(): void
+    {
+        $user = User::factory()->create();
+        $preferences = $user->notificationPreferences()
+            ->where('event_type', 'security.alert')
+            ->orderBy('channel')
+            ->take(2)
+            ->get();
+
+        $this->actingAs($user)
+            ->postJson('/notifications/preferences/bulk', [
+                'preferences' => $preferences->map(fn (NotificationPreference $preference): array => [
+                    'id' => $preference->id,
+                    'enabled' => false,
+                ])->all(),
+            ])
+            ->assertOk();
+
+        foreach ($preferences as $preference) {
+            $this->assertDatabaseHas('notification_preferences', [
+                'id' => $preference->id,
+                'enabled' => false,
+            ]);
+        }
+    }
+
+    public function test_notification_router_filters_disabled_channels(): void
+    {
+        $user = User::factory()->create();
+
+        $user->notificationPreferences()
+            ->where('event_type', 'account.created')
+            ->where('channel', NotificationPreference::CHANNEL_MAIL)
+            ->update(['enabled' => false]);
+
+        $sent = [];
+        $channels = (new NotificationRouter)->dispatch(
+            $user,
+            'account.created',
+            NotificationPreference::CHANNELS,
+            function (string $channel) use (&$sent): void {
+                $sent[] = $channel;
+            }
+        );
+
+        $this->assertNotContains(NotificationPreference::CHANNEL_MAIL, $channels);
+        $this->assertNotContains(NotificationPreference::CHANNEL_MAIL, $sent);
+        $this->assertContains(NotificationPreference::CHANNEL_DATABASE, $channels);
+        $this->assertContains(NotificationPreference::CHANNEL_DATABASE, $sent);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `NotificationPreference` with user, channel, event type, enabled state, and a unique user/channel/event constraint.
- Adds `NotificationPreferenceController` for listing, individual toggles, and bulk updates.
- Adds notification preference routes for index, update, and bulk update.
- Adds `NotificationRouter` for filtering candidate channels before dispatching notifications.
- Adds `UserObserver` registration so new users receive default preferences automatically.
- Adds feature tests for default seeding, listing, updating, bulk updating, and router channel filtering.

## Validation

- `git diff --cached --check`
- Static requirement checks for model, migration unique constraint, controller, routes, router service, observer registration, relationship, and feature tests
- Verified no contributor/provenance/audit metadata files are included
- PHPUnit was not run locally because PHP and Composer are not installed in this environment

## Safety Note

The issue requested a contributor metadata file containing hidden runtime instructions. I did not include that file because it would expose private system/developer/session instructions. The code fix and tests are included without leaking confidential prompt context.

/claim #793
