### PR TITLE
Codex [ Laravel ] Add caching layer to config loading and fix cache store connection validation

### DIFF
--- a/laravel/app/Console/Commands/CacheStatusCommand.php
+++ b/laravel/app/Console/Commands/CacheStatusCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Console\Command;
+
+class CacheStatusCommand extends Command
+{
+    protected $signature = 'cache:status';
+
+    protected $description = 'Display active cache store health status';
+
+    public function handle(CacheHealthCheck $healthCheck): int
+    {
+        $status = $healthCheck->check();
+
+        $this->line('Cache driver: '.$status['driver']);
+        $this->line('Available: '.($status['available'] ? 'yes' : 'no'));
+        $this->line('Latency: '.$status['latency_ms'].' ms');
+        $this->line('Health check enabled: '.($status['enabled'] ? 'yes' : 'no'));
+        $this->line('Health check interval: '.$status['interval'].' seconds');
+
+        if (! $status['available'] && isset($status['error'])) {
+            $this->error('Error: '.$status['error']);
+        }
+
+        return $status['available'] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/laravel/app/Services/CacheHealthCheck.php
+++ b/laravel/app/Services/CacheHealthCheck.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Throwable;
+
+class CacheHealthCheck
+{
+    /**
+     * @return array{available: bool, driver: string, latency_ms: float, enabled: bool, interval: int, error?: string}
+     */
+    public function check(): array
+    {
+        $enabled = (bool) config('cache.health_check_enabled', true);
+        $interval = (int) config('cache.health_check_interval', 300);
+        $storeName = (string) config('cache.default');
+        $driver = (string) config("cache.stores.{$storeName}.driver", $storeName);
+
+        if (! $enabled) {
+            return [
+                'available' => true,
+                'driver' => $driver,
+                'latency_ms' => 0.0,
+                'enabled' => false,
+                'interval' => $interval,
+            ];
+        }
+
+        $key = 'cache-health-check:'.bin2hex(random_bytes(8));
+        $value = bin2hex(random_bytes(16));
+        $started = hrtime(true);
+
+        try {
+            $store = Cache::store($storeName);
+            $store->put($key, $value, $interval);
+            $available = $store->get($key) === $value;
+            $store->forget($key);
+
+            return [
+                'available' => $available,
+                'driver' => $driver,
+                'latency_ms' => $this->latencyMs($started),
+                'enabled' => true,
+                'interval' => $interval,
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'available' => false,
+                'driver' => $driver,
+                'latency_ms' => $this->latencyMs($started),
+                'enabled' => true,
+                'interval' => $interval,
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+
+    private function latencyMs(int $started): float
+    {
+        return round((hrtime(true) - $started) / 1_000_000, 2);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\CacheStatusCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -10,6 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        CacheStatusCommand::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         //
     })

--- a/laravel/config/cache.php
+++ b/laravel/config/cache.php
@@ -19,6 +19,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Health Checks
+    |--------------------------------------------------------------------------
+    |
+    | Cache health checks probe the configured default cache store before the
+    | application depends on it for runtime work. The interval controls how
+    | long probe writes may live if a store cannot immediately delete them.
+    |
+    */
+
+    'health_check_enabled' => env('CACHE_HEALTH_CHECK_ENABLED', true),
+
+    'health_check_interval' => (int) env('CACHE_HEALTH_CHECK_INTERVAL', 300),
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Stores
     |--------------------------------------------------------------------------
     |

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,18 @@
 <?php
 
+use App\Services\CacheHealthCheck;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::get('/health/cache', function (CacheHealthCheck $healthCheck) {
+    $status = $healthCheck->check();
+
+    return response()->json(
+        $status,
+        $status['available'] ? Response::HTTP_OK : Response::HTTP_SERVICE_UNAVAILABLE
+    );
 });

--- a/laravel/tests/Feature/CacheHealthCheckTest.php
+++ b/laravel/tests/Feature/CacheHealthCheckTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cache_health_endpoint_returns_json_status(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertOk()
+            ->assertJsonPath('available', true)
+            ->assertJsonPath('driver', 'array')
+            ->assertJsonStructure([
+                'available',
+                'driver',
+                'latency_ms',
+                'enabled',
+                'interval',
+            ]);
+    }
+
+    public function test_cache_health_endpoint_returns_503_when_store_is_unavailable(): void
+    {
+        config([
+            'cache.default' => 'missing-store',
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $this->getJson('/health/cache')
+            ->assertServiceUnavailable()
+            ->assertJsonPath('available', false)
+            ->assertJsonPath('driver', 'missing-store');
+    }
+
+    public function test_cache_status_command_outputs_driver_availability_and_latency(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+        ]);
+
+        $this->artisan('cache:status')
+            ->expectsOutput('Cache driver: array')
+            ->expectsOutput('Available: yes')
+            ->assertExitCode(0);
+    }
+}

--- a/laravel/tests/Unit/CacheHealthCheckTest.php
+++ b/laravel/tests/Unit/CacheHealthCheckTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\CacheHealthCheck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CacheHealthCheckTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cache_health_check_reports_available_store_with_latency(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => true,
+            'cache.health_check_interval' => 123,
+        ]);
+
+        $status = (new CacheHealthCheck)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertSame('array', $status['driver']);
+        $this->assertSame(123, $status['interval']);
+        $this->assertGreaterThanOrEqual(0, $status['latency_ms']);
+    }
+
+    public function test_cache_health_check_respects_disabled_config(): void
+    {
+        config([
+            'cache.default' => 'array',
+            'cache.health_check_enabled' => false,
+            'cache.health_check_interval' => 456,
+        ]);
+
+        $status = (new CacheHealthCheck)->check();
+
+        $this->assertTrue($status['available']);
+        $this->assertFalse($status['enabled']);
+        $this->assertSame(456, $status['interval']);
+        $this->assertSame(0.0, $status['latency_ms']);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `CacheHealthCheck` to probe the active cache store and return `available`, `driver`, `latency_ms`, `enabled`, and `interval`.
- Adds `cache:status` via `CacheStatusCommand` and registers it in the Laravel application bootstrap.
- Adds `cache.health_check_enabled` and `cache.health_check_interval` config values.
- Adds `GET /health/cache`, returning HTTP 200 when the store is available and HTTP 503 when unavailable.
- Adds service, endpoint, unavailable-store, and artisan command coverage.

## Validation

- `git diff --cached --check`
- Static requirement checks for service, config values, command registration, health endpoint, 503 behavior, and tests
- Verified no contributor/provenance/audit metadata files are included
- PHPUnit was not run locally because PHP and Composer are not installed in this environment

## Safety Note

The issue requested a provenance metadata file containing hidden runtime instructions. I did not include that file because it would expose private system/developer/session instructions. The code fix and tests are included without leaking confidential prompt context.

/claim #747
