### PR TITLE
Codex [ Laravel ] Implement audit logging trait for Eloquent model change tracking

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+#[Fillable(['auditable_type', 'auditable_id', 'event', 'old_values', 'new_values', 'user_id', 'ip_address', 'user_agent'])]
+class AuditLog extends Model
+{
+    /**
+     * @return MorphTo<Model, AuditLog>
+     */
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'old_values' => 'array',
+            'new_values' => 'array',
+        ];
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use Auditable, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Arr;
+
+trait Auditable
+{
+    /**
+     * @return MorphMany<AuditLog>
+     */
+    public function auditLogs(): MorphMany
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+
+    /**
+     * @return MorphMany<AuditLog>
+     */
+    public function getAuditHistory(): MorphMany
+    {
+        return $this->auditLogs()->latest();
+    }
+
+    protected static function bootAuditable(): void
+    {
+        static::created(function (Model $model): void {
+            $model->writeAuditLog('created', [], $model->auditAttributes($model->getAttributes()));
+        });
+
+        static::updated(function (Model $model): void {
+            $changes = Arr::except($model->getChanges(), ['created_at', 'updated_at']);
+
+            if ($changes === []) {
+                return;
+            }
+
+            $oldValues = [];
+
+            foreach (array_keys($changes) as $attribute) {
+                $oldValues[$attribute] = $model->getOriginal($attribute);
+            }
+
+            $model->writeAuditLog(
+                'updated',
+                $model->auditAttributes($oldValues),
+                $model->auditAttributes($changes)
+            );
+        });
+
+        static::deleted(function (Model $model): void {
+            $model->writeAuditLog('deleted', $model->auditAttributes($model->getOriginal()), []);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $oldValues
+     * @param array<string, mixed> $newValues
+     */
+    protected function writeAuditLog(string $event, array $oldValues, array $newValues): void
+    {
+        AuditLog::query()->create([
+            'auditable_type' => $this->getMorphClass(),
+            'auditable_id' => $this->getKey(),
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => auth()->id(),
+            'ip_address' => request()?->ip(),
+            'user_agent' => request()?->userAgent(),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     *
+     * @return array<string, mixed>
+     */
+    protected function auditAttributes(array $attributes): array
+    {
+        return Arr::except($attributes, $this->auditHiddenAttributes());
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function auditHiddenAttributes(): array
+    {
+        return array_values(array_unique(array_merge(
+            method_exists($this, 'getHidden') ? $this->getHidden() : [],
+            ['password', 'remember_token']
+        )));
+    }
+}

--- a/laravel/database/migrations/2026_06_29_000786_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_06_29_000786_create_audit_logs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type')->index();
+            $table->unsignedBigInteger('auditable_id')->index();
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/laravel/tests/Feature/AuditableTest.php
+++ b/laravel/tests/Feature/AuditableTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class AuditableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_user_writes_created_audit_log_without_sensitive_fields(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Alice',
+            'email' => 'alice@example.com',
+            'password' => 'secret',
+        ]);
+
+        $log = AuditLog::query()->where('event', 'created')->firstOrFail();
+
+        $this->assertSame(User::class, $log->auditable_type);
+        $this->assertSame($user->id, $log->auditable_id);
+        $this->assertSame([], $log->old_values);
+        $this->assertSame('Alice', $log->new_values['name']);
+        $this->assertSame('alice@example.com', $log->new_values['email']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+        $this->assertArrayNotHasKey('remember_token', $log->new_values);
+    }
+
+    public function test_updating_user_writes_changed_old_and_new_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Before',
+            'email' => 'before@example.com',
+        ]);
+
+        $user->update([
+            'name' => 'After',
+        ]);
+
+        $log = AuditLog::query()->where('event', 'updated')->latest()->firstOrFail();
+
+        $this->assertSame(['name' => 'Before'], $log->old_values);
+        $this->assertSame(['name' => 'After'], $log->new_values);
+    }
+
+    public function test_deleting_user_writes_deleted_log_with_old_values(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Deleted User',
+            'email' => 'deleted@example.com',
+        ]);
+
+        $user->delete();
+
+        $log = AuditLog::query()->where('event', 'deleted')->latest()->firstOrFail();
+
+        $this->assertSame($user->id, $log->auditable_id);
+        $this->assertSame('Deleted User', $log->old_values['name']);
+        $this->assertSame('deleted@example.com', $log->old_values['email']);
+        $this->assertSame([], $log->new_values);
+    }
+
+    public function test_get_audit_history_returns_logs_newest_first(): void
+    {
+        $user = User::factory()->create();
+
+        $user->update(['name' => 'First change']);
+        $user->update(['name' => 'Second change']);
+
+        $events = $user->getAuditHistory()
+            ->pluck('event')
+            ->all();
+
+        $this->assertSame(['updated', 'updated', 'created'], $events);
+    }
+
+    public function test_audit_logs_include_authenticated_user_and_request_metadata(): void
+    {
+        $actor = User::factory()->create();
+
+        Route::post('/audit-test-user', function () {
+            return User::query()->create([
+                'name' => 'Audited',
+                'email' => 'audited-'.uniqid().'@example.com',
+                'password' => 'password',
+            ]);
+        });
+
+        $this->actingAs($actor)
+            ->withHeader('User-Agent', 'AuditTest/1.0')
+            ->post('/audit-test-user');
+
+        $log = AuditLog::query()
+            ->where('event', 'created')
+            ->where('user_id', $actor->id)
+            ->latest()
+            ->firstOrFail();
+
+        $this->assertSame($actor->id, $log->user_id);
+        $this->assertSame('AuditTest/1.0', $log->user_agent);
+        $this->assertNotNull($log->ip_address);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an `Auditable` trait that records `created`, `updated`, and `deleted` model events.
- Adds an `AuditLog` model and migration with polymorphic auditable fields, event name, old/new JSON values, user ID, IP address, user agent, and timestamps.
- Excludes sensitive fields such as `password` and `remember_token` from audit payloads.
- Adds `getAuditHistory()` to return audit logs in reverse chronological order.
- Applies the trait to the `User` model as the example auditable model.
- Adds feature tests for create, update, delete, history ordering, and authenticated request metadata.

## Validation

- `git diff --cached --check`
- Static requirement checks for trait hooks, model, migration, old/new JSON casts, metadata capture, history method, User model usage, and feature tests
- Verified no contributor/provenance/audit metadata files are included
- PHPUnit was not run locally because PHP and Composer are not installed in this environment

## Safety Note

The issue requested a provenance metadata file containing hidden runtime instructions. I did not include that file because it would expose private system/developer/session instructions. The code fix and tests are included without leaking confidential prompt context.

/claim #786
