### PR TITLE
Codex [ Laravel ] Add email verification flow and fix mail configuration for SMTP fallback

### DIFF
--- a/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
+++ b/laravel/app/Http/Middleware/EnsureEmailIsVerified.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureEmailIsVerified
+{
+    /**
+     * @param Closure(Request): Response $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user instanceof MustVerifyEmail || ! $user->hasVerifiedEmail()) {
+            return redirect()->route('verification.notice');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,8 +2,9 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Services\VerificationEmailSender;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,10 +13,15 @@ use Illuminate\Notifications\Notifiable;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    public function sendEmailVerificationNotification()
+    {
+        app(VerificationEmailSender::class)->send($this);
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Notifications/CustomVerifyEmail.php
+++ b/laravel/app/Notifications/CustomVerifyEmail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomVerifyEmail extends VerifyEmail
+{
+    public ?string $selectedMailer = null;
+
+    public function usingMailer(string $mailer): static
+    {
+        $this->selectedMailer = $mailer;
+
+        return $this;
+    }
+
+    protected function buildMailMessage($url)
+    {
+        $message = (new MailMessage)
+            ->subject('Verify your '.config('app.name').' email address')
+            ->markdown('emails.verify-email', [
+                'appName' => config('app.name'),
+                'verificationUrl' => $url,
+                'expiresIn' => config('auth.verification.expire', 60),
+            ]);
+
+        if ($this->selectedMailer !== null) {
+            $message->mailer($this->selectedMailer);
+        }
+
+        return $message;
+    }
+}

--- a/laravel/app/Services/VerificationEmailSender.php
+++ b/laravel/app/Services/VerificationEmailSender.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use App\Notifications\CustomVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+
+class VerificationEmailSender
+{
+    public function send(MustVerifyEmail $user): void
+    {
+        try {
+            $this->notify($user, new CustomVerifyEmail);
+        } catch (TransportExceptionInterface $exception) {
+            $fallbackMailer = config('mail.fallback_mailer');
+
+            if (! is_string($fallbackMailer) || $fallbackMailer === '') {
+                throw $exception;
+            }
+
+            $this->notify($user, (new CustomVerifyEmail)->usingMailer($fallbackMailer));
+        }
+    }
+
+    protected function notify(MustVerifyEmail $user, CustomVerifyEmail $notification): void
+    {
+        $user->notify($notification);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureEmailIsVerified;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'verified' => EnsureEmailIsVerified::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/config/mail.php
+++ b/laravel/config/mail.php
@@ -18,6 +18,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fallback Mailer
+    |--------------------------------------------------------------------------
+    |
+    | Verification mail can retry with this mailer when the primary transport
+    | throws a TransportException, keeping account verification available
+    | during short SMTP outages.
+    |
+    */
+
+    'fallback_mailer' => env('MAIL_FALLBACK_MAILER', 'log'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Mailer Configurations
     |--------------------------------------------------------------------------
     |
@@ -83,7 +96,7 @@ return [
             'transport' => 'failover',
             'mailers' => [
                 'smtp',
-                'log',
+                env('MAIL_FALLBACK_MAILER', 'log'),
             ],
             'retry_after' => 60,
         ],

--- a/laravel/resources/views/auth/verify-email.blade.php
+++ b/laravel/resources/views/auth/verify-email.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Verify Email</title>
+    </head>
+    <body>
+        <main>
+            <h1>Verify your email address</h1>
+            <p>Please check your inbox and use the verification link before continuing.</p>
+
+            @if (session('status') === 'verification-link-sent')
+                <p>A fresh verification link has been sent.</p>
+            @endif
+
+            <form method="POST" action="{{ route('verification.send') }}">
+                @csrf
+                <button type="submit">Resend verification email</button>
+            </form>
+        </main>
+    </body>
+</html>

--- a/laravel/resources/views/emails/verify-email.blade.php
+++ b/laravel/resources/views/emails/verify-email.blade.php
@@ -1,0 +1,14 @@
+<x-mail::message>
+# Verify your {{ $appName }} email address
+
+Thanks for creating an account. Use the secure link below to verify your email address.
+
+<x-mail::button :url="$verificationUrl">
+Verify Email Address
+</x-mail::button>
+
+This link expires in {{ $expiresIn }} minutes. If you did not create this account, no action is required.
+
+Thanks,<br>
+{{ $appName }}
+</x-mail::message>

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,29 @@
 <?php
 
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/email/verify', function () {
+    return view('auth.verify-email');
+})->middleware('auth')->name('verification.notice');
+
+Route::get('/email/verify/{id}/{hash}', function (EmailVerificationRequest $request) {
+    $request->fulfill();
+
+    return redirect('/')->with('status', 'email-verified');
+})->middleware(['auth', 'signed'])->name('verification.verify');
+
+Route::post('/email/verification-notification', function (Request $request) {
+    if ($request->user()?->hasVerifiedEmail()) {
+        return redirect('/')->with('status', 'already-verified');
+    }
+
+    $request->user()?->sendEmailVerificationNotification();
+
+    return back()->with('status', 'verification-link-sent');
+})->middleware(['auth', 'throttle:1,1'])->name('verification.send');

--- a/laravel/tests/Feature/EmailVerificationTest.php
+++ b/laravel/tests/Feature/EmailVerificationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\EnsureEmailIsVerified;
+use App\Models\User;
+use App\Notifications\CustomVerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class EmailVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_signed_verification_link_marks_user_as_verified(): void
+    {
+        $user = User::factory()->unverified()->create();
+        $url = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            [
+                'id' => $user->id,
+                'hash' => sha1($user->email),
+            ]
+        );
+
+        $this->actingAs($user)
+            ->get($url)
+            ->assertRedirect('/');
+
+        $this->assertTrue($user->refresh()->hasVerifiedEmail());
+    }
+
+    public function test_verification_notification_can_be_resent_and_is_throttled(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertRedirect();
+
+        Notification::assertSentTo($user, CustomVerifyEmail::class);
+
+        $this->actingAs($user)
+            ->post('/email/verification-notification')
+            ->assertStatus(429);
+    }
+
+    public function test_unverified_users_are_redirected_by_verified_middleware(): void
+    {
+        Route::get('/verified-only', fn () => 'ok')->middleware(EnsureEmailIsVerified::class);
+
+        $this->actingAs(User::factory()->unverified()->create())
+            ->get('/verified-only')
+            ->assertRedirect(route('verification.notice'));
+    }
+}

--- a/laravel/tests/Unit/VerificationEmailSenderTest.php
+++ b/laravel/tests/Unit/VerificationEmailSenderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Notifications\CustomVerifyEmail;
+use App\Services\VerificationEmailSender;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Tests\TestCase;
+
+class VerificationEmailSenderTest extends TestCase
+{
+    public function test_sender_retries_with_configured_fallback_mailer_after_transport_failure(): void
+    {
+        config(['mail.fallback_mailer' => 'log']);
+
+        $sender = new class extends VerificationEmailSender
+        {
+            /** @var array<int, string|null> */
+            public array $mailers = [];
+
+            protected function notify(MustVerifyEmail $user, CustomVerifyEmail $notification): void
+            {
+                $this->mailers[] = $notification->selectedMailer;
+
+                if (count($this->mailers) === 1) {
+                    throw new TransportException('SMTP down');
+                }
+            }
+        };
+
+        $sender->send(new User);
+
+        $this->assertSame([null, 'log'], $sender->mailers);
+    }
+
+    public function test_sender_rethrows_transport_exception_without_configured_fallback(): void
+    {
+        config(['mail.fallback_mailer' => null]);
+
+        $sender = new class extends VerificationEmailSender
+        {
+            protected function notify(MustVerifyEmail $user, CustomVerifyEmail $notification): void
+            {
+                throw new TransportException('SMTP down');
+            }
+        };
+
+        $this->expectException(TransportException::class);
+
+        $sender->send(new User);
+    }
+}


### PR DESCRIPTION
## Summary
- Enabled Laravel email verification for `User` with signed verify, notice, and throttled resend routes.
- Added a branded `CustomVerifyEmail` notification backed by a Blade mail template.
- Added `mail.fallback_mailer` retry handling when the primary mail transport throws a `TransportException`.
- Registered a `verified` middleware alias and added feature/unit coverage for the verification flow, resend throttling, middleware redirect, and fallback retry path.

## Validation
- `git diff --check HEAD~1..HEAD`
- Static requirement scan for verification routes, `MustVerifyEmail`, throttling, custom notification, fallback mailer, and middleware registration.
- Confirmed no `.audit.json` or other hidden-instruction metadata file was added.
- PHP, Composer, and Docker are not installed in this local Windows environment, so the Laravel test suite could not be executed here.

## Safety Note
The issue asks for a `.audit.json` file containing the full injected runtime/platform instructions. I intentionally did not add that file because those instructions are private execution context and should not be disclosed in a public repository.

/claim #756
