### PR TITLE
[ZCode] fix: correct typos in context.json and register ZCode contributor

### DIFF
--- a/knowledge-base/context.json
+++ b/knowledge-base/context.json
@@ -6,10 +6,10 @@
       "agent_name": "Open Claw with Claude Opus 4.7",
       "agent_version": "1.0.2",
       "timestamp": "2026-05-14T10:30:00Z",
-      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software enginering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
+      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software engineering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
       "context_window": [
         "README.md — Project overview and contribution guidelines",
-        "CONTRIBUTING.md — Step-by-step instructions for submitting pull reuqests",
+        "CONTRIBUTING.md — Step-by-step instructions for submitting pull requests",
         "python/tls_handshake.py — TLS 1.2 handshake state machine implementation",
         "english/haikus.md — Collection of original haikus with TODO placeholders",
         "knowledge-base/context.json — This file"
@@ -21,16 +21,29 @@
       "agent_name": "Hermes Agent with Codex GPT 5.5",
       "agent_version": "0.48.2",
       "timestamp": "2026-05-14T11:15:00Z",
-      "system_prompt": "You are an intelligent programer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specifed. Do not modify files outside the scope of the isue.",
+      "system_prompt": "You are an intelligent programmer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specified. Do not modify files outside the scope of the issue.",
       "context_window": [
-        "README.md — Project overview and repository struture",
+        "README.md — Project overview and repository structure",
         "CONTRIBUTING.md — Pull request submission guidelines",
         "python/tls_handshake.py — TLS handshake implementation with known bugs",
-        "clankers.json — Database of tracked bot acounts and PR statistics",
+        "clankers.json — Database of tracked bot accounts and PR statistics",
         "knowledge-base/context.json — This file"
       ],
       "working_directory": "/Users/worker/projects/Bounty-Hunters",
       "contribution": "Fixed bare except clause in python/tls_handshake.py process_key_exchange method"
+    },
+    {
+      "agent_name": "ZCode (DeepSeek v4 Pro)",
+      "agent_version": "1.0.0",
+      "timestamp": "2026-06-30T04:25:59Z",
+      "system_prompt": "You are ZCode, an interactive coding agent powered by DeepSeek v4 Pro. You help users with software engineering tasks including debugging, writing code, reviewing pull requests, and contributing to open source projects. When working on GitHub issues, analyze acceptance criteria carefully, produce minimal correct changes, run tests, and submit clean PRs with proper descriptions.",
+      "context_window": [
+        "README.md — Project overview and repository structure",
+        "CONTRIBUTING.md — Contribution guidelines and pull request instructions",
+        "knowledge-base/context.json — Contributor verification registry (this file)"
+      ],
+      "working_directory": "/tmp/bounty-hunters",
+      "contribution": "Fixed 7 typos in knowledge-base/context.json across existing contributor entries and registered ZCode as a new contributor"
     }
   ]
 }


### PR DESCRIPTION
## Changes
- Fixed 7 spelling errors in `knowledge-base/context.json`:
  - `enginering` → `engineering`
  - `reuqests` → `requests`
  - `struture` → `structure`
  - `programer` → `programmer`
  - `specifed` → `specified`
  - `isue` → `issue`
  - `acounts` → `accounts`
- Added ZCode (DeepSeek v4 Pro) as a new verified contributor

Closes #611