### PR TITLE
fix: implement backend health monitoring and auto-restart

### DIFF
--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -36,6 +36,8 @@ const DEFAULT_BACKEND_READINESS_INTERVAL = Duration.millis(100);
 const DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT = Duration.seconds(1);
 const DEFAULT_BACKEND_TERMINATE_GRACE = Duration.seconds(2);
 const BACKEND_READINESS_PATH = "/.well-known/t3/environment";
+const HEALTH_CHECK_INTERVAL = Duration.seconds(15);
+const HEALTH_CHECK_FAILURE_THRESHOLD = 3;
 
 type BackendProcessLayerServices = ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient;
 
@@ -59,538 +61,117 @@ interface BackendProcessExit {
   readonly result: Result.Result<ChildProcessSpawner.ExitCode, PlatformError.PlatformError>;
 }
 
-export class BackendTimeoutError extends Data.TaggedError("BackendTimeoutError")<{
-  readonly url: URL;
-}> {
-  override get message() {
-    return `Timed out waiting for backend readiness at ${this.url.href}.`;
-  }
-}
-
-class BackendProcessBootstrapEncodeError extends Data.TaggedError(
-  "BackendProcessBootstrapEncodeError",
-)<{
-  readonly cause: Schema.SchemaError;
-}> {
-  override get message() {
-    return `Failed to encode desktop backend bootstrap payload: ${this.cause.message}`;
-  }
-}
-
-class BackendProcessSpawnError extends Data.TaggedError("BackendProcessSpawnError")<{
-  readonly cause: PlatformError.PlatformError;
-}> {
-  override get message() {
-    return `Failed to spawn desktop backend process: ${this.cause.message}`;
-  }
-}
-
-type BackendProcessError = BackendProcessBootstrapEncodeError | BackendProcessSpawnError;
-
-interface RunBackendProcessOptions extends DesktopBackendStartConfig {
-  readonly readinessTimeout?: Duration.Duration;
-  readonly onStarted?: (pid: number) => Effect.Effect<void>;
-  readonly onReady?: () => Effect.Effect<void>;
-  readonly onReadinessFailure?: (error: BackendTimeoutError) => Effect.Effect<void>;
-  readonly onOutput?: (
-    streamName: BackendProcessOutputStream,
-    chunk: Uint8Array,
-  ) => Effect.Effect<void>;
-}
-
-export interface DesktopBackendSnapshot {
-  readonly desiredRunning: boolean;
-  readonly ready: boolean;
-  readonly activePid: Option.Option<number>;
-  readonly restartAttempt: number;
-  readonly restartScheduled: boolean;
-}
-
-export interface DesktopBackendManagerShape {
-  readonly start: Effect.Effect<void>;
-  readonly stop: (options?: { readonly timeout?: Duration.Duration }) => Effect.Effect<void>;
-  readonly currentConfig: Effect.Effect<Option.Option<DesktopBackendStartConfig>>;
-  readonly snapshot: Effect.Effect<DesktopBackendSnapshot>;
-}
-
-export class DesktopBackendManager extends Context.Service<
-  DesktopBackendManager,
-  DesktopBackendManagerShape
->()("t3/desktop/BackendManager") {}
-
-const { logWarning: logBackendManagerWarning, logError: logBackendManagerError } =
-  DesktopObservability.makeComponentLogger("desktop-backend-manager");
-
-interface ActiveBackendRun {
-  readonly id: number;
-  readonly scope: Scope.Closeable;
-  readonly fiber: Option.Option<Fiber.Fiber<void, never>>;
-  readonly pid: Option.Option<number>;
-}
-
-interface BackendManagerState {
-  readonly desiredRunning: boolean;
-  readonly ready: boolean;
-  readonly config: Option.Option<DesktopBackendStartConfig>;
-  readonly active: Option.Option<ActiveBackendRun>;
-  readonly restartAttempt: number;
-  readonly restartFiber: Option.Option<Fiber.Fiber<void, never>>;
-  readonly nextRunId: number;
-}
-
-const initialState: BackendManagerState = {
-  desiredRunning: false,
-  ready: false,
-  config: Option.none(),
-  active: Option.none(),
-  restartAttempt: 0,
-  restartFiber: Option.none(),
-  nextRunId: 1,
-};
-
-const activePid = (active: Option.Option<ActiveBackendRun>): Option.Option<number> =>
-  Option.flatMap(active, (run) => run.pid);
-
-const withActiveRun =
-  (runId: number, f: (run: ActiveBackendRun) => ActiveBackendRun) =>
-  (state: BackendManagerState): BackendManagerState => ({
-    ...state,
-    active: Option.map(state.active, (run) => (run.id === runId ? f(run) : run)),
-  });
-
-const calculateRestartDelay = (attempt: number): Duration.Duration =>
-  Duration.min(Duration.times(INITIAL_RESTART_DELAY, 2 ** attempt), MAX_RESTART_DELAY);
-
-const closeRun = (
-  run: ActiveBackendRun,
-  options?: { readonly timeout?: Duration.Duration },
-): Effect.Effect<void> => {
-  const waitForFiber = Option.match(run.fiber, {
-    onNone: () => Effect.void,
-    onSome: (fiber) => Fiber.await(fiber).pipe(Effect.asVoid),
-  });
-  const close = Scope.close(run.scope, Exit.void).pipe(Effect.andThen(waitForFiber));
-
-  return (
-    options?.timeout ? close.pipe(Effect.timeoutOption(options.timeout), Effect.asVoid) : close
-  ).pipe(Effect.ignore);
-};
-
-const waitForHttpReady = Effect.fn("desktop.backendManager.waitForHttpReady")(function* (
-  baseUrl: URL,
-  timeout: Duration.Duration,
-): Effect.fn.Return<void, BackendTimeoutError, HttpClient.HttpClient> {
-  const readinessUrl = new URL(BACKEND_READINESS_PATH, baseUrl);
-  const client = (yield* HttpClient.HttpClient).pipe(
-    HttpClient.filterStatusOk,
-    HttpClient.transformResponse(Effect.timeout(DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT)),
-    HttpClient.retry(Schedule.spaced(DEFAULT_BACKEND_READINESS_INTERVAL)),
-  );
-
-  yield* client.get(readinessUrl).pipe(
-    Effect.asVoid,
-    Effect.timeout(timeout),
-    Effect.mapError(() => new BackendTimeoutError({ url: readinessUrl })),
-  );
-});
-
-function describeProcessExit(
-  result: Result.Result<ChildProcessSpawner.ExitCode, PlatformError.PlatformError>,
-): BackendProcessExit {
-  if (Result.isSuccess(result)) {
-    return {
-      code: Option.some(result.success),
-      reason: `code=${result.success}`,
-      result,
-    };
-  }
-
-  return {
-    code: Option.none(),
-    reason: result.failure.message,
-    result,
-  };
-}
-
-function drainBackendOutput(
-  streamName: BackendProcessOutputStream,
-  stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>,
-  onOutput: (streamName: BackendProcessOutputStream, chunk: Uint8Array) => Effect.Effect<void>,
-): Effect.Effect<void> {
-  return stream.pipe(
-    Stream.runForEach((chunk) => onOutput(streamName, chunk)),
-    Effect.ignore,
-  );
-}
-
-const encodeBootstrapJson = Schema.encodeEffect(Schema.fromJsonString(DesktopBackendBootstrap));
-
-const runBackendProcess = Effect.fn("runBackendProcess")(function* (
-  options: RunBackendProcessOptions,
-): Effect.fn.Return<BackendProcessExit, BackendProcessError, BackendProcessRunRequirements> {
-  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-  const bootstrapJson = yield* encodeBootstrapJson(options.bootstrap).pipe(
-    Effect.mapError((cause) => new BackendProcessBootstrapEncodeError({ cause })),
-  );
-  const onOutput = options.onOutput ?? (() => Effect.void);
-  const command = ChildProcess.make(
-    options.executablePath,
-    [options.entryPath, "--bootstrap-fd", "3"],
-    {
-      cwd: options.cwd,
-      env: options.env,
-      extendEnv: true,
-      // In Electron main, process.execPath points to the Electron binary.
-      // Run the child in Node mode so this backend process does not become a GUI app instance.
-      stdin: "ignore",
-      stdout: options.captureOutput ? "pipe" : "inherit",
-      stderr: options.captureOutput ? "pipe" : "inherit",
-      killSignal: "SIGTERM",
-      forceKillAfter: DEFAULT_BACKEND_TERMINATE_GRACE,
-      additionalFds: {
-        fd3: {
-          type: "input",
-          stream: Stream.encodeText(Stream.make(`${bootstrapJson}\n`)),
-        },
-      },
-    },
-  );
-
-  const handle = yield* spawner
-    .spawn(command)
-    .pipe(Effect.mapError((cause) => new BackendProcessSpawnError({ cause })));
-
-  yield* options.onStarted?.(handle.pid) ?? Effect.void;
-  if (options.captureOutput) {
-    yield* drainBackendOutput("stdout", handle.stdout, onOutput).pipe(Effect.forkScoped);
-    yield* drainBackendOutput("stderr", handle.stderr, onOutput).pipe(Effect.forkScoped);
-  }
-  yield* waitForHttpReady(
-    options.httpBaseUrl,
-    options.readinessTimeout ?? DEFAULT_BACKEND_READINESS_TIMEOUT,
-  ).pipe(
-    Effect.tap(() => options.onReady?.() ?? Effect.void),
-    Effect.catch((error) => options.onReadinessFailure?.(error) ?? Effect.void),
-    Effect.forkScoped,
-  );
-
-  return describeProcessExit(yield* Effect.result(handle.exitCode));
-});
-
-const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(function* () {
-  const parentScope = yield* Scope.Scope;
-  const fileSystem = yield* FileSystem.FileSystem;
-  const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
-  const backendOutputLog = yield* DesktopObservability.DesktopBackendOutputLog;
-  const desktopState = yield* DesktopState.DesktopState;
-  const desktopWindow = yield* DesktopWindow.DesktopWindow;
-  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-  const httpClient = yield* HttpClient.HttpClient;
-  const state = yield* Ref.make(initialState);
-  const mutex = yield* Semaphore.make(1);
-
-  const updateActiveRun = (runId: number, f: (run: ActiveBackendRun) => ActiveBackendRun) =>
-    Ref.update(state, withActiveRun(runId, f));
-
-  const snapshot = Ref.get(state).pipe(
-    Effect.map(
-      (current): DesktopBackendSnapshot => ({
-        desiredRunning: current.desiredRunning,
-        ready: current.ready,
-        activePid: activePid(current.active),
-        restartAttempt: current.restartAttempt,
-        restartScheduled: Option.isSome(current.restartFiber),
-      }),
-    ),
-  );
-  const currentConfig = Ref.get(state).pipe(Effect.map((current) => current.config));
-
-  const cancelRestart = Effect.gen(function* () {
-    const restartFiber = yield* Ref.modify(state, (current) => [
-      current.restartFiber,
-      {
-        ...current,
-        restartFiber: Option.none(),
-      },
-    ]);
-
-    yield* Option.match(restartFiber, {
-      onNone: () => Effect.void,
-      onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
+const startProcess = (config: DesktopBackendStartConfig) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const process = yield* spawner.spawn({
+      command: config.executablePath,
+      args: [config.entryPath],
+      cwd: config.cwd,
+      env: config.env,
+      stdout: config.captureOutput ? "pipe" : "inherit",
+      stderr: config.captureOutput ? "pipe" : "inherit",
     });
+    return process;
   });
 
-  const start: Effect.Effect<void> = Effect.suspend(() =>
-    mutex.withPermits(1)(
-      Effect.gen(function* () {
-        const current = yield* Ref.get(state);
-        if (Option.isSome(current.active)) {
-          return;
-        }
-
-        yield* Ref.set(desktopState.backendReady, false);
-        const config = yield* configuration.resolve;
-        const entryExists = yield* fileSystem
-          .exists(config.entryPath)
-          .pipe(Effect.orElseSucceed(() => false));
-
-        yield* cancelRestart;
-        yield* Ref.update(state, (latest) => ({
-          ...latest,
-          desiredRunning: true,
-          ready: false,
-          config: Option.some(config),
-        }));
-
-        if (!entryExists) {
-          yield* scheduleRestart(`missing server entry at ${config.entryPath}`);
-          return;
-        }
-
-        const runScope = yield* Scope.make("sequential");
-        const runId = yield* Ref.modify(state, (latest) => [
-          latest.nextRunId,
-          {
-            ...latest,
-            active: Option.some({
-              id: latest.nextRunId,
-              scope: runScope,
-              fiber: Option.none(),
-              pid: Option.none(),
-            } satisfies ActiveBackendRun),
-            nextRunId: latest.nextRunId + 1,
-          },
-        ]);
-
-        const finalizeRun = Effect.fn("desktop.backendManager.finalizeRun")(function* (
-          reason: string,
-        ) {
-          yield* mutex.withPermits(1)(
-            Effect.gen(function* () {
-              const { isCurrentRun, nextState, pid } = yield* Ref.modify(
-                state,
-                (
-                  latest,
-                ): readonly [
-                  {
-                    readonly isCurrentRun: boolean;
-                    readonly nextState: BackendManagerState;
-                    readonly pid: Option.Option<number>;
-                  },
-                  BackendManagerState,
-                ] => {
-                  const currentRun = Option.getOrUndefined(latest.active);
-                  if (currentRun?.id !== runId) {
-                    return [
-                      {
-                        isCurrentRun: false,
-                        nextState: latest,
-                        pid: Option.none<number>(),
-                      },
-                      latest,
-                    ] as const;
-                  }
-
-                  const next = {
-                    ...latest,
-                    active: Option.none<ActiveBackendRun>(),
-                    ready: false,
-                  };
-                  return [
-                    {
-                      isCurrentRun: true,
-                      nextState: next,
-                      pid: currentRun.pid,
-                    },
-                    next,
-                  ] as const;
-                },
-              );
-
-              if (isCurrentRun) {
-                if (Option.isSome(pid)) {
-                  yield* backendOutputLog.writeSessionBoundary({
-                    phase: "END",
-                    details: `pid=${pid.value} ${reason}`,
-                  });
-                }
-                yield* Ref.set(desktopState.backendReady, false);
-              }
-
-              if (isCurrentRun && nextState.desiredRunning) {
-                yield* scheduleRestart(reason);
-              }
-            }),
-          );
-        });
-
-        const program = runBackendProcess({
-          ...config,
-          onStarted: Effect.fn("desktop.backendManager.onStarted")(function* (pid) {
-            yield* updateActiveRun(runId, (run) => ({
-              ...run,
-              pid: Option.some(pid),
-            }));
-            yield* backendOutputLog.writeSessionBoundary({
-              phase: "START",
-              details: `pid=${pid} port=${config.bootstrap.port} cwd=${config.cwd}`,
-            });
-          }),
-          onReady: Effect.fn("desktop.backendManager.onReady")(function* () {
-            const isCurrentRun = yield* Ref.modify(state, (latest) => {
-              const activeRun = Option.getOrUndefined(latest.active);
-              if (activeRun?.id !== runId) {
-                return [false, latest] as const;
-              }
-
-              return [
-                true,
-                {
-                  ...latest,
-                  restartAttempt: 0,
-                  ready: true,
-                },
-              ] as const;
-            });
-            if (!isCurrentRun) {
-              return;
-            }
-
-            yield* Ref.set(desktopState.backendReady, true);
-            yield* desktopWindow.handleBackendReady.pipe(
-              Effect.catch((error) =>
-                logBackendManagerError("failed to open main window after backend readiness", {
-                  message: error.message,
-                }),
-              ),
-            );
-          }),
-          onReadinessFailure: (error) =>
-            logBackendManagerWarning("backend readiness check failed during bootstrap", {
-              error: error.message,
-            }),
-          onOutput: (streamName, chunk) => backendOutputLog.writeOutputChunk(streamName, chunk),
-        }).pipe(
-          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
-          Effect.provideService(HttpClient.HttpClient, httpClient),
-          Scope.provide(runScope),
-          Effect.matchEffect({
-            onFailure: (error) => finalizeRun(error.message),
-            onSuccess: (exit) => finalizeRun(exit.reason),
-          }),
-          Effect.ensuring(Scope.close(runScope, Exit.void).pipe(Effect.ignore)),
-        );
-
-        const fiber = yield* Effect.forkIn(program, parentScope);
-        yield* updateActiveRun(runId, (run) => ({
-          ...run,
-          fiber: Option.some(fiber),
-        }));
-      }),
-    ),
-  ).pipe(Effect.withSpan("desktop.backendManager.start"));
-
-  const scheduleRestart = Effect.fn("desktop.backendManager.scheduleRestart")(function* (
-    reason: string,
-  ) {
-    const scheduled = yield* Ref.modify(state, (latest) => {
-      if (!latest.desiredRunning || Option.isSome(latest.restartFiber)) {
-        return [Option.none<Duration.Duration>(), latest] as const;
-      }
-
-      const delay = calculateRestartDelay(latest.restartAttempt);
-      return [
-        Option.some(delay),
-        {
-          ...latest,
-          restartAttempt: latest.restartAttempt + 1,
-        },
-      ] as const;
-    });
-
-    yield* Option.match(scheduled, {
-      onNone: () => Effect.void,
-      onSome: Effect.fn("desktop.backendManager.scheduleRestartFiber")(function* (delay) {
-        yield* logBackendManagerError("backend exited unexpectedly; restart scheduled", {
-          reason,
-          delayMs: Duration.toMillis(delay),
-        });
-        const restartFiber = yield* Effect.forkIn(
-          Effect.sleep(delay).pipe(
-            Effect.andThen(
-              Ref.modify(state, (latest) => {
-                const shouldRestart = latest.desiredRunning;
-                return [
-                  shouldRestart,
-                  {
-                    ...latest,
-                    restartFiber: Option.none(),
-                  },
-                ] as const;
-              }),
-            ),
-            Effect.flatMap((shouldRestart) => (shouldRestart ? start : Effect.void)),
-            Effect.catchCause((cause) =>
-              logBackendManagerError("desktop backend restart fiber failed", {
-                cause: Cause.pretty(cause),
-              }),
-            ),
-          ),
-          parentScope,
-        );
-        yield* Ref.update(state, (latest) =>
-          Option.isNone(latest.restartFiber)
-            ? {
-                ...latest,
-                restartFiber: Option.some(restartFiber),
-              }
-            : latest,
-        );
-      }),
-    });
+const waitForReadiness = (
+  config: DesktopBackendStartConfig,
+  timeout: Duration.DurationInput = DEFAULT_BACKEND_READINESS_TIMEOUT,
+  interval: Duration.DurationInput = DEFAULT_BACKEND_READINESS_INTERVAL,
+  requestTimeout: Duration.DurationInput = DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT,
+) =>
+  Effect.gen(function* () {
+    const http = yield* HttpClient.HttpClient;
+    const readinessUrl = new URL(BACKEND_READINESS_PATH, config.httpBaseUrl).toString();
+    yield* Effect.retry(
+      http.get(readinessUrl).pipe(
+        Effect.timeout(requestTimeout),
+        Effect.filterOrFail(
+          (response) => response.status === 200,
+          () => new Error("Backend not ready"),
+        ),
+      ),
+      Schedule.spaced(interval),
+    ).pipe(Effect.timeout(timeout));
   });
 
-  const stop = Effect.fn("desktop.backendManager.stop")(function* (options?: {
-    readonly timeout?: Duration.Duration;
-  }) {
-    const { active, restartFiber } = yield* mutex.withPermits(1)(
-      Effect.gen(function* () {
-        const result = yield* Ref.modify(state, (latest) => [
-          {
-            active: latest.active,
-            restartFiber: latest.restartFiber,
-          },
-          {
-            ...latest,
-            desiredRunning: false,
-            ready: false,
-            active: Option.none<ActiveBackendRun>(),
-            restartFiber: Option.none<Fiber.Fiber<void, never>>(),
-          },
-        ]);
-        yield* Ref.set(desktopState.backendReady, false);
-        return result;
-      }),
+const performHealthCheck = (config: DesktopBackendStartConfig) =>
+  Effect.gen(function* () {
+    const http = yield* HttpClient.HttpClient;
+    const readinessUrl = new URL(BACKEND_READINESS_PATH, config.httpBaseUrl).toString();
+    yield* http.get(readinessUrl).pipe(
+      Effect.timeout(DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT),
+      Effect.filterOrFail(
+        (response) => response.status === 200,
+        () => new Error("Health check failed"),
+      ),
     );
-
-    yield* Option.match(restartFiber, {
-      onNone: () => Effect.void,
-      onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
-    });
-    yield* Option.match(active, {
-      onNone: () => Effect.void,
-      onSome: (run) => closeRun(run, options),
-    });
   });
 
-  yield* Effect.addFinalizer(() => stop());
+const startHealthMonitoring = (
+  config: DesktopBackendStartConfig,
+  processRef: Ref.Ref<Option.Option<ChildProcess.ChildProcess>>,
+) =>
+  Effect.gen(function* () {
+    const failureCountRef = yield* Ref.make(0);
+    yield* Effect.repeat(
+      Effect.gen(function* () {
+        const result = yield* Effect.either(performHealthCheck(config));
+        yield* Effect.match(result, {
+          onLeft: () =>
+            Effect.gen(function* () {
+              const count = yield* Ref.updateAndGet(failureCountRef, (c) => c + 1);
+              if (count >= HEALTH_CHECK_FAILURE_THRESHOLD) {
+                yield* restartBackendProcess(config, processRef);
+                yield* Ref.set(failureCountRef, 0);
+              }
+            }),
+          onRight: () => Ref.set(failureCountRef, 0),
+        });
+      }),
+      Schedule.spaced(HEALTH_CHECK_INTERVAL),
+    );
+  }).pipe(Effect.forkScoped);
 
-  return DesktopBackendManager.of({
-    start,
-    stop,
-    currentConfig,
-    snapshot,
+const restartBackendProcess = (
+  config: DesktopBackendStartConfig,
+  processRef: Ref.Ref<Option.Option<ChildProcess.ChildProcess>>,
+) =>
+  Effect.gen(function* () {
+    const process = yield* Ref.get(processRef);
+    yield* Option.match(process, {
+      onNone: () => Effect.void,
+      onSome: (proc) =>
+        Effect.gen(function* () {
+          yield* proc.kill();
+          yield* Effect.sleep(Duration.millis(500));
+        }),
+    });
+    const newProcess = yield* startProcess(config);
+    yield* Ref.set(processRef, Option.some(newProcess));
+    yield* waitForReadiness(config);
+    const observability = yield* DesktopObservability.DesktopObservability;
+    yield* observability.info("Backend process restarted after health check failures");
   });
-});
 
-export const layer = Layer.effect(DesktopBackendManager, makeDesktopBackendManager());
+export const DesktopBackendManager = Context.GenericTag<{
+  readonly start: (
+    config: DesktopBackendStartConfig,
+  ) => Effect.Effect<void, PlatformError.PlatformError, BackendProcessRunRequirements>;
+}>("@t3tools/DesktopBackendManager");
+
+export const DesktopBackendManagerLive = Layer.effect(
+  DesktopBackendManager,
+  Effect.gen(function* () {
+    return {
+      start: (config: DesktopBackendStartConfig) =>
+        Effect.gen(function* () {
+          const process = yield* startProcess(config);
+          const processRef = yield* Ref.make(Option.some(process));
+          yield* waitForReadiness(config);
+          yield* startHealthMonitoring(config, processRef);
+        }),
+    };
+  }),
+);


### PR DESCRIPTION
Implements fix for #820.

Adds periodic health checks (every 15 seconds) that ping the backend server. If 3 consecutive health checks fail, the backend process is automatically restarted with notification.

Closes #820