### PR TITLE
OpenAI Codex [ FastAPI ] Fix duplicate operation IDs across routers

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Public-safe attribution only. Hidden system, developer, runtime, credential, and private user instructions are intentionally not disclosed in public repository metadata.",
+  "date": "2026-07-05T08:13:40.5462101-05:00"
+}

--- a/fastapi/fastapi/openapi/utils.py
+++ b/fastapi/fastapi/openapi/utils.py
@@ -233,6 +233,18 @@ def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:
     return route.name.replace("_", " ").title()
 
 
+def _deduplicate_operation_id(*, operation_id: str, operation_ids: set[str]) -> str:
+    if operation_id not in operation_ids:
+        return operation_id
+
+    suffix = 2
+    unique_operation_id = f"{operation_id}_{suffix}"
+    while unique_operation_id in operation_ids:
+        suffix += 1
+        unique_operation_id = f"{operation_id}_{suffix}"
+    return unique_operation_id
+
+
 def get_openapi_operation_metadata(
     *, route: routing.APIRoute, method: str, operation_ids: set[str]
 ) -> dict[str, Any]:
@@ -242,10 +254,16 @@ def get_openapi_operation_metadata(
     operation["summary"] = generate_operation_summary(route=route, method=method)
     if route.description:
         operation["description"] = route.description
-    operation_id = route.operation_id or route.unique_id
-    if operation_id in operation_ids:
+    base_operation_id = route.operation_id or route.unique_id
+    operation_id = _deduplicate_operation_id(
+        operation_id=base_operation_id, operation_ids=operation_ids
+    )
+    if operation_id != base_operation_id:
         endpoint_name = getattr(route.endpoint, "__name__", "<unnamed_endpoint>")
-        message = f"Duplicate Operation ID {operation_id} for function {endpoint_name}"
+        message = (
+            f"Duplicate Operation ID {base_operation_id} for function "
+            f"{endpoint_name}; using {operation_id}"
+        )
         file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
         if file_name:
             message += f" at {file_name}"

--- a/fastapi/fastapi/utils.py
+++ b/fastapi/fastapi/utils.py
@@ -93,10 +93,11 @@ def generate_operation_id_for_path(
 
 
 def generate_unique_id(route: "APIRoute") -> str:
-    operation_id = f"{route.name}{route.path_format}"
-    operation_id = re.sub(r"\W", "_", operation_id)
     assert route.methods
-    operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
+    method = sorted(route.methods)[0].lower()
+    operation_id = f"{method}_{route.path_format}_{route.name}"
+    operation_id = re.sub(r"\W+", "_", operation_id).strip("_").lower()
+    operation_id = re.sub(r"_+", "_", operation_id)
     return operation_id
 
 

--- a/fastapi/tests/test_generate_unique_id_function.py
+++ b/fastapi/tests/test_generate_unique_id_function.py
@@ -1697,3 +1697,73 @@ def test_warn_duplicate_operation_id():
         ]
         assert len(duplicate_warnings) > 0
         assert "Duplicate Operation ID" in str(duplicate_warnings[0].message)
+
+
+def test_default_operation_ids_include_method_path_and_name():
+    app = FastAPI()
+    users_router = APIRouter(prefix="/users")
+    admins_router = APIRouter(prefix="/admins")
+
+    @users_router.get("/")
+    def list_items():
+        return []  # pragma: nocover
+
+    def list_admin_items():
+        return []  # pragma: nocover
+
+    list_admin_items.__name__ = "list_items"
+    admins_router.add_api_route("/", list_admin_items, methods=["GET"])
+
+    app.include_router(users_router)
+    app.include_router(admins_router)
+
+    schema = TestClient(app).get("/openapi.json").json()
+    operation_ids = {
+        schema["paths"]["/users/"]["get"]["operationId"],
+        schema["paths"]["/admins/"]["get"]["operationId"],
+    }
+
+    assert operation_ids == {
+        "get_users_list_items",
+        "get_admins_list_items",
+    }
+
+
+def test_default_operation_ids_are_sanitized_lowercase():
+    app = FastAPI()
+
+    @app.post("/API v1/{Item-ID}")
+    def Create_Item():
+        return {}  # pragma: nocover
+
+    schema = TestClient(app).get("/openapi.json").json()
+
+    assert (
+        schema["paths"]["/API v1/{Item-ID}"]["post"]["operationId"]
+        == "post_api_v1_item_id_create_item"
+    )
+
+
+def test_generated_operation_id_collisions_get_numeric_suffix():
+    def colliding_operation_id(route: APIRoute):
+        return "get_items_read"
+
+    app = FastAPI(generate_unique_id_function=colliding_operation_id)
+
+    @app.get("/items")
+    def read_items():
+        return []  # pragma: nocover
+
+    @app.get("/items-alt")
+    def read_more_items():
+        return []  # pragma: nocover
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        schema = TestClient(app).get("/openapi.json").json()
+
+    assert schema["paths"]["/items"]["get"]["operationId"] == "get_items_read"
+    assert schema["paths"]["/items-alt"]["get"]["operationId"] == "get_items_read_2"
+    assert any(
+        "Duplicate Operation ID get_items_read" in str(item.message) for item in w
+    )


### PR DESCRIPTION
/claim #764

## Summary
- Generate default FastAPI operation IDs from deterministic method/path/name components.
- Sanitize generated IDs to lowercase alphanumeric characters and underscores.
- Append numeric suffixes when generated OpenAPI operation IDs still collide.
- Add focused regression coverage for duplicate endpoint names across routers, sanitization, and collision suffixing.

## Validation
- uv run pytest tests/test_generate_unique_id_function.py -q
- uv run ruff check fastapi/utils.py fastapi/openapi/utils.py tests/test_generate_unique_id_function.py
- uv run ruff format --check fastapi/utils.py fastapi/openapi/utils.py tests/test_generate_unique_id_function.py
- git diff --check

## Metadata note
fastapi/fastapi/.attribution.json contains safe public attribution only. Hidden system, developer, runtime, credential, and private user instructions are intentionally not published.