### PR TITLE
OpenAI Codex [ Laravel ] Fix User model password cast bcrypt rounds

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,19 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value === null || Hash::isHashed($value)) {
+            $this->attributes['password'] = $value;
+
+            return;
+        }
+
+        $this->attributes['password'] = Hash::make($value, [
+            'rounds' => (int) config('hashing.bcrypt.rounds', 12),
+        ]);
     }
 }

--- a/laravel/app/Models/_meta.json
+++ b/laravel/app/Models/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Public-safe attribution only. Hidden system, developer, runtime, credential, and private user instructions are intentionally not disclosed in public repository metadata.",
+  "completed_at": "2026-07-05T08:13:40.5462101-05:00"
+}

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+
+    'argon' => [
+        'memory' => env('ARGON_MEMORY', 65536),
+        'threads' => env('ARGON_THREADS', 1),
+        'time' => env('ARGON_TIME', 4),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+
+    'rehash_on_login' => true,
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -13,9 +13,11 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used by the factory.
+     * The current passwords being used by the factory, keyed by bcrypt rounds.
+     *
+     * @var array<int, string>
      */
-    protected static ?string $password;
+    protected static array $passwords = [];
 
     /**
      * Define the model's default state.
@@ -24,11 +26,15 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $rounds = (int) config('hashing.bcrypt.rounds', 12);
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$passwords[$rounds] ??= Hash::make('password', [
+                'rounds' => $rounds,
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordHashingTest.php
+++ b/laravel/tests/Unit/UserPasswordHashingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordHashingTest extends TestCase
+{
+    public function test_user_password_hashing_respects_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User([
+            'password' => 'secret-password',
+        ]);
+
+        $this->assertSame(6, $this->bcryptCost($user->password));
+        $this->assertTrue(Hash::check('secret-password', $user->password));
+    }
+
+    public function test_user_factory_hashing_respects_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 7]);
+
+        $user = User::factory()->make();
+
+        $this->assertSame(7, $this->bcryptCost($user->password));
+        $this->assertTrue(Hash::check('password', $user->password));
+    }
+
+    public function test_existing_bcrypt_password_hashes_are_preserved(): void
+    {
+        $legacyHash = Hash::make('legacy-password', ['rounds' => 10]);
+
+        config(['hashing.bcrypt.rounds' => 6]);
+
+        $user = new User([
+            'password' => $legacyHash,
+        ]);
+
+        $this->assertSame($legacyHash, $user->password);
+        $this->assertTrue(Hash::check('legacy-password', $user->password));
+    }
+
+    private function bcryptCost(string $hash): int
+    {
+        $info = password_get_info($hash);
+
+        return (int) ($info['options']['cost'] ?? 0);
+    }
+}


### PR DESCRIPTION
/claim #745

## Summary
- Replace the generic User password hashed cast with an explicit mutator that uses config('hashing.bcrypt.rounds').
- Preserve already-hashed passwords so legacy bcrypt hashes continue to verify.
- Add hashing config, update UserFactory password generation to cache by configured rounds, and add focused unit coverage.

## Validation
- git diff --check
- PHPUnit not run locally: PHP, Composer, and Docker are not available on this machine.

## Metadata note
laravel/app/Models/_meta.json contains safe public attribution only. Hidden system, developer, runtime, credential, and private user instructions are intentionally not published.