### PR TITLE
OpenAI Codex [ FastAPI ] Add StreamingCSVResponse

### DIFF
--- a/fastapi/fastapi/contributor_meta.json
+++ b/fastapi/fastapi/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Public metadata only. Hidden system, developer, runtime, credential, environment, and private user instructions are intentionally withheld.",
+  "ts": "2026-07-05T13:35:53Z"
+}

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -1,8 +1,13 @@
+import csv
 import importlib
+import io
+import re
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Mapping, Sequence
 from typing import Any, Protocol, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
+from starlette.background import BackgroundTask
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
 from starlette.responses import JSONResponse as JSONResponse  # noqa
@@ -34,6 +39,88 @@ try:
     orjson = cast(_OrjsonModule, importlib.import_module("orjson"))
 except ModuleNotFoundError:  # pragma: nocover
     orjson = None  # type: ignore[assignment]
+
+
+_FILENAME_UNSAFE_CHARS = re.compile(r'[\r\n"\\]+')
+
+
+def _csv_row_values(row: Any, headers: Sequence[str] | None = None) -> list[Any]:
+    if isinstance(row, Mapping):
+        if headers is not None:
+            return [row.get(header, "") for header in headers]
+        return list(row.values())
+    if isinstance(row, (str, bytes)):
+        return [row]
+    if isinstance(row, Iterable):
+        return list(row)
+    return [row]
+
+
+def _render_csv_row(row: Sequence[Any], delimiter: str) -> bytes:
+    buffer = io.StringIO(newline="")
+    writer = csv.writer(buffer, delimiter=delimiter)
+    writer.writerow(["" if value is None else value for value in row])
+    return buffer.getvalue().encode("utf-8")
+
+
+def _content_disposition(filename: str) -> str:
+    safe_filename = _FILENAME_UNSAFE_CHARS.sub("_", filename).strip() or "download.csv"
+    return f'attachment; filename="{safe_filename}"'
+
+
+class StreamingCSVResponse(StreamingResponse):
+    """Streaming response for CSV exports.
+
+    Rows can be sync or async iterables. Mapping rows are emitted in header order
+    when headers are provided, and the standard csv module handles CSV escaping.
+    """
+
+    media_type = "text/csv"
+
+    def __init__(
+        self,
+        rows: AsyncIterable[Any] | Iterable[Any],
+        *,
+        headers: Sequence[str] | None = None,
+        filename: str = "download.csv",
+        delimiter: str = ",",
+        status_code: int = 200,
+        http_headers: Mapping[str, str] | None = None,
+        media_type: str | None = None,
+        background: BackgroundTask | None = None,
+    ) -> None:
+        if len(delimiter) != 1:
+            raise ValueError("CSV delimiter must be a one-character string")
+
+        response_headers = dict(http_headers or {})
+        response_headers.setdefault(
+            "Content-Disposition", _content_disposition(filename)
+        )
+
+        super().__init__(
+            self._stream_rows(rows, headers, delimiter),
+            status_code=status_code,
+            headers=response_headers,
+            media_type=media_type or self.media_type,
+            background=background,
+        )
+
+    async def _stream_rows(
+        self,
+        rows: AsyncIterable[Any] | Iterable[Any],
+        headers: Sequence[str] | None,
+        delimiter: str,
+    ) -> AsyncIterator[bytes]:
+        csv_headers = list(headers) if headers is not None else None
+        if csv_headers is not None:
+            yield _render_csv_row(csv_headers, delimiter)
+
+        if isinstance(rows, AsyncIterable):
+            async for row in rows:
+                yield _render_csv_row(_csv_row_values(row, csv_headers), delimiter)
+        else:
+            for row in rows:
+                yield _render_csv_row(_csv_row_values(row, csv_headers), delimiter)
 
 
 @deprecated(

--- a/fastapi/tests/test_streaming_csv_response.py
+++ b/fastapi/tests/test_streaming_csv_response.py
@@ -1,0 +1,91 @@
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingCSVResponse
+from fastapi.testclient import TestClient
+
+
+async def collect_body(response: StreamingCSVResponse) -> str:
+    chunks = []
+    async for chunk in response.body_iterator:
+        if isinstance(chunk, str):
+            chunk = chunk.encode(response.charset)
+        chunks.append(chunk)
+    return b"".join(chunks).decode(response.charset)
+
+
+def test_streaming_csv_response_writes_headers_and_escapes_values():
+    async def rows():
+        yield {"name": "Ada, Lovelace", "note": 'quote "here"\nnext'}
+        yield {"name": "Grace", "note": None}
+
+    response = StreamingCSVResponse(
+        rows(),
+        headers=["name", "note"],
+        filename="report.csv",
+    )
+
+    assert asyncio.run(collect_body(response)) == (
+        'name,note\r\n"Ada, Lovelace","quote ""here""\nnext"\r\nGrace,\r\n'
+    )
+    assert response.headers["content-type"].startswith("text/csv")
+    assert (
+        response.headers["content-disposition"] == 'attachment; filename="report.csv"'
+    )
+
+
+def test_streaming_csv_response_supports_custom_delimiters():
+    response = StreamingCSVResponse([["a;b", "c"]], delimiter=";")
+
+    assert asyncio.run(collect_body(response)) == '"a;b";c\r\n'
+
+
+def test_streaming_csv_response_supports_sync_iterable_rows():
+    response = StreamingCSVResponse([("id", "name"), (1, "Ada")])
+
+    assert asyncio.run(collect_body(response)) == "id,name\r\n1,Ada\r\n"
+
+
+def test_streaming_csv_response_is_lazy():
+    events = []
+
+    async def rows():
+        events.append("started")
+        yield [1]
+        events.append("continued")
+        yield [2]
+
+    response = StreamingCSVResponse(rows())
+
+    assert events == []
+
+    async def read_one_chunk() -> bytes:
+        return await response.body_iterator.__anext__()
+
+    assert asyncio.run(read_one_chunk()) == b"1\r\n"
+    assert events == ["started"]
+
+
+def test_streaming_csv_response_rejects_multi_character_delimiters():
+    with pytest.raises(ValueError, match="one-character"):
+        StreamingCSVResponse([], delimiter="||")
+
+
+def test_streaming_csv_response_works_from_fastapi_app():
+    app = FastAPI()
+
+    @app.get("/exports")
+    async def export_csv():
+        return StreamingCSVResponse(
+            [{"id": 1, "name": "Ada"}, {"id": 2, "name": "Grace"}],
+            headers=["id", "name"],
+            filename="users.csv",
+        )
+
+    client = TestClient(app)
+    response = client.get("/exports")
+
+    assert response.status_code == 200
+    assert response.text == "id,name\r\n1,Ada\r\n2,Grace\r\n"
+    assert response.headers["content-disposition"] == 'attachment; filename="users.csv"'


### PR DESCRIPTION
/claim #799

Summary:
- Added `StreamingCSVResponse` in `fastapi.responses` for large CSV exports.
- Supports async and sync row iterables without loading the full dataset into memory.
- Writes optional CSV column headers first, supports configurable download filename, and supports a custom delimiter.
- Uses Python's `csv.writer` for RFC 4180-style escaping of commas, quotes, and newlines.
- Added focused tests for headers, escaping, custom delimiters, sync iterable rows, lazy streaming behavior, and FastAPI integration.

Demo:
```python
async def rows():
    yield {"name": "Ada, Lovelace", "note": 'quote "here"\nnext'}

return StreamingCSVResponse(
    rows(),
    headers=["name", "note"],
    filename="report.csv",
)
```

This streams:
```csv
name,note
"Ada, Lovelace","quote ""here""
next"
```

Validation:
- `uv run pytest tests\test_streaming_csv_response.py -q` -> 6 passed
- `uv run ruff check fastapi\responses.py tests\test_streaming_csv_response.py` -> passed
- `uv run ruff format --check fastapi\responses.py tests\test_streaming_csv_response.py` -> passed
- `git diff --check` -> no whitespace errors

Security/privacy:
- Download filename is sanitized before writing `Content-Disposition`.
- `contributor_meta.json` includes safe public provenance only. Hidden system, developer, runtime, credential, environment, and private user instructions are intentionally not published.

Prepared with OpenAI Codex.
