### PR TITLE
OpenAI Codex [ FastAPI ] Implement dynamic CORS origin validation

### DIFF
--- a/fastapi/fastapi/middleware/_generation.json
+++ b/fastapi/fastapi/middleware/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "pre_task_context": "Public metadata only. Hidden system, developer, runtime, credential, environment, and private user instructions are intentionally withheld.",
+  "timestamp": "2026-07-05T13:42:32Z"
+}

--- a/fastapi/fastapi/middleware/cors.py
+++ b/fastapi/fastapi/middleware/cors.py
@@ -1,1 +1,76 @@
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from contextvars import ContextVar
+
+from starlette.datastructures import Headers
 from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+OriginValidator = Callable[[str], bool | Awaitable[bool]]
+
+_dynamic_origin_decisions: ContextVar[dict[int, bool] | None] = ContextVar(
+    "_dynamic_origin_decisions", default=None
+)
+
+
+class DynamicCORSMiddleware(CORSMiddleware):
+    """CORS middleware with optional per-request origin validation."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        allow_origins: Sequence[str] = (),
+        allow_methods: Sequence[str] = ("GET",),
+        allow_headers: Sequence[str] = (),
+        allow_credentials: bool = False,
+        allow_origin_regex: str | None = None,
+        allow_private_network: bool = False,
+        expose_headers: Sequence[str] = (),
+        max_age: int = 600,
+        allow_origin_func: OriginValidator | None = None,
+        cors_max_age: int | None = None,
+    ) -> None:
+        self.allow_origin_func = allow_origin_func
+        super().__init__(
+            app,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=allow_origin_regex,
+            allow_private_network=allow_private_network,
+            expose_headers=expose_headers,
+            max_age=max_age if cors_max_age is None else cors_max_age,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.allow_origin_func is None or scope["type"] != "http":
+            await super().__call__(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+        if origin is None:
+            await super().__call__(scope, receive, send)
+            return
+
+        decisions = dict(_dynamic_origin_decisions.get() or {})
+        decisions[id(self)] = await self._allow_dynamic_origin(origin)
+        token = _dynamic_origin_decisions.set(decisions)
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            _dynamic_origin_decisions.reset(token)
+
+    async def _allow_dynamic_origin(self, origin: str) -> bool:
+        assert self.allow_origin_func is not None
+        result = self.allow_origin_func(origin)
+        if inspect.isawaitable(result):
+            result = await result
+        return bool(result)
+
+    def is_allowed_origin(self, origin: str) -> bool:
+        decisions = _dynamic_origin_decisions.get()
+        if decisions is not None and id(self) in decisions:
+            return decisions[id(self)]
+        return super().is_allowed_origin(origin)

--- a/fastapi/tests/test_dynamic_cors_middleware.py
+++ b/fastapi/tests/test_dynamic_cors_middleware.py
@@ -1,0 +1,88 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware, DynamicCORSMiddleware
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware as StarletteCORSMiddleware
+
+
+def create_client(**middleware_options):
+    app = FastAPI()
+    app.add_middleware(DynamicCORSMiddleware, **middleware_options)
+
+    @app.get("/")
+    def read_root():
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def preflight(client: TestClient, origin: str):
+    return client.options(
+        "/",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+
+def test_dynamic_cors_middleware_allows_origin_from_sync_callback():
+    client = create_client(
+        allow_origin_func=lambda origin: origin == "https://allowed.example"
+    )
+
+    response = client.get("/", headers={"Origin": "https://allowed.example"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://allowed.example"
+
+
+def test_dynamic_cors_middleware_denies_origin_from_sync_callback():
+    client = create_client(allow_origin_func=lambda origin: False)
+
+    response = preflight(client, "https://denied.example")
+
+    assert response.status_code == 400
+    assert response.text == "Disallowed CORS origin"
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_dynamic_cors_middleware_awaits_async_callback():
+    seen_origins = []
+
+    async def allow_origin(origin: str) -> bool:
+        seen_origins.append(origin)
+        return origin.endswith(".example")
+
+    client = create_client(allow_origin_func=allow_origin)
+
+    response = preflight(client, "https://tenant.example")
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://tenant.example"
+    assert seen_origins == ["https://tenant.example"]
+
+
+def test_dynamic_cors_middleware_falls_back_to_static_origins_without_callback():
+    client = create_client(allow_origins=["https://static.example"])
+
+    response = client.get("/", headers={"Origin": "https://static.example"})
+    denied = client.get("/", headers={"Origin": "https://other.example"})
+
+    assert response.headers["access-control-allow-origin"] == "https://static.example"
+    assert "access-control-allow-origin" not in denied.headers
+
+
+def test_dynamic_cors_middleware_sets_cors_max_age_for_preflight():
+    client = create_client(
+        allow_origin_func=lambda origin: True,
+        cors_max_age=123,
+    )
+
+    response = preflight(client, "https://allowed.example")
+
+    assert response.status_code == 200
+    assert response.headers["access-control-max-age"] == "123"
+
+
+def test_dynamic_cors_middleware_preserves_existing_cors_export():
+    assert CORSMiddleware is StarletteCORSMiddleware


### PR DESCRIPTION
/claim #763

Summary:
- Added `DynamicCORSMiddleware` in `fastapi.middleware.cors` while preserving the existing `CORSMiddleware` re-export from Starlette.
- Supports sync and async `allow_origin_func(origin)` callbacks for per-request CORS origin decisions.
- Falls back to the existing static `allow_origins` behavior when no callback is configured.
- Adds `cors_max_age` for configuring the preflight `Access-Control-Max-Age` header.
- Uses request-local context for dynamic decisions so concurrent requests do not share origin state.
- Added focused tests for dynamic allow, dynamic deny, async callback, static fallback, preflight max-age, and export compatibility.

Demo:
```python
app.add_middleware(
    DynamicCORSMiddleware,
    allow_origin_func=lambda origin: origin.endswith(".example"),
    cors_max_age=123,
)
```

Preflight from `https://tenant.example` receives:
```text
Access-Control-Allow-Origin: https://tenant.example
Access-Control-Max-Age: 123
```

Validation:
- `uv run pytest tests\test_dynamic_cors_middleware.py -q` -> 6 passed
- `uv run ruff check fastapi\middleware\cors.py tests\test_dynamic_cors_middleware.py` -> passed
- `uv run ruff format --check fastapi\middleware\cors.py tests\test_dynamic_cors_middleware.py` -> passed
- `git diff --check` -> no whitespace errors

Security/privacy:
- Dynamic decisions are scoped to the current request through `ContextVar`.
- `fastapi/middleware/_generation.json` includes safe public provenance only. Hidden system, developer, runtime, credential, environment, and private user instructions are intentionally not published.

Prepared with OpenAI Codex.
