### PR TITLE
OpenAI Codex [ Crypto ] Fix zero-fee flash loans and pool drainage

### DIFF
--- a/solidity/contracts/.contributor.json
+++ b/solidity/contracts/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Public metadata only. Hidden system, developer, runtime, credential, environment, and private user instructions are intentionally withheld.",
+  "timestamp": "2026-07-05T13:49:15Z"
+}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -11,55 +11,96 @@ contract FlashLoan {
     IERC20 public loanToken;
     uint256 public feeBPS; // fee in basis points
     uint256 public totalFees;
+    uint256 public poolBalance;
     address public owner;
     bool public paused;
+    bool private loanActive;
+
+    uint256 public constant BPS_DENOMINATOR = 10000;
+    uint256 public constant MAX_LOAN_BPS = 5000;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event PoolDeposit(address indexed depositor, uint256 amount);
+    event FeesWithdrawn(address indexed owner, uint256 amount);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier nonReentrant() {
+        require(!loanActive, "Loan active");
+        loanActive = true;
+        _;
+        loanActive = false;
+    }
 
     constructor(address _loanToken, uint256 _feeBPS) {
+        require(_loanToken != address(0), "Invalid token");
+        require(_feeBPS <= BPS_DENOMINATOR, "Invalid fee");
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
-    function flashLoan(uint256 amount, bytes calldata data) external {
+    function flashLoan(uint256 amount, bytes calldata data) external nonReentrant {
         require(!paused, "Paused");
         require(amount > 0, "Amount must be > 0");
+        require(poolBalance >= amount, "Insufficient pool balance");
+        require(amount <= poolBalance * MAX_LOAN_BPS / BPS_DENOMINATOR, "Loan cap exceeded");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
+        uint256 fee = calculateFee(amount);
+        uint256 repayment = amount + fee;
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
-
-        loanToken.transfer(msg.sender, amount);
+        poolBalance -= amount;
+        require(loanToken.transfer(msg.sender, amount), "Loan transfer failed");
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        require(loanToken.transferFrom(msg.sender, address(this), repayment), "Loan not repaid");
 
+        poolBalance += repayment;
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
+    function calculateFee(uint256 amount) public view returns (uint256) {
+        uint256 fee = amount * feeBPS / BPS_DENOMINATOR;
+        if (fee == 0 && amount > 0) {
+            return 1;
+        }
+        return fee;
+    }
+
     function depositToPool(uint256 amount) external {
-        loanToken.transferFrom(msg.sender, address(this), amount);
+        require(amount > 0, "Amount must be > 0");
+        require(loanToken.transferFrom(msg.sender, address(this), amount), "Deposit failed");
+        poolBalance += amount;
+        emit PoolDeposit(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
+        require(fees > 0, "No fees");
         totalFees = 0;
-        loanToken.transfer(owner, fees);
+        poolBalance -= fees;
+        require(loanToken.transfer(owner, fees), "Fee transfer failed");
+        emit FeesWithdrawn(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolBalance;
     }
 }

--- a/solidity/tests/flashLoan.issue919.test.mjs
+++ b/solidity/tests/flashLoan.issue919.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("../contracts/FlashLoan.sol", import.meta.url), "utf8");
+
+class FlashLoanModel {
+  constructor(feeBPS) {
+    this.feeBPS = BigInt(feeBPS);
+    this.poolBalance = 0n;
+    this.totalFees = 0n;
+    this.paused = false;
+    this.externalTokenBalance = 0n;
+  }
+
+  calculateFee(amount) {
+    amount = BigInt(amount);
+    const fee = (amount * this.feeBPS) / 10_000n;
+    return fee === 0n && amount > 0n ? 1n : fee;
+  }
+
+  deposit(amount) {
+    amount = BigInt(amount);
+    this.poolBalance += amount;
+    this.externalTokenBalance += amount;
+  }
+
+  flashLoan(amount, repayAmount, { externalBalanceDelta = 0n } = {}) {
+    amount = BigInt(amount);
+    repayAmount = BigInt(repayAmount);
+    externalBalanceDelta = BigInt(externalBalanceDelta);
+    const snapshot = {
+      poolBalance: this.poolBalance,
+      totalFees: this.totalFees,
+      externalTokenBalance: this.externalTokenBalance,
+    };
+
+    try {
+      assert.equal(this.paused, false, "Paused");
+      assert(amount > 0n, "Amount must be > 0");
+      assert(this.poolBalance >= amount, "Insufficient pool balance");
+      assert(amount <= (this.poolBalance * 5_000n) / 10_000n, "Loan cap exceeded");
+
+      const fee = this.calculateFee(amount);
+      const repayment = amount + fee;
+
+      this.poolBalance -= amount;
+      this.externalTokenBalance -= amount;
+
+      this.externalTokenBalance += externalBalanceDelta;
+      assert(repayAmount >= repayment, "Loan not repaid");
+
+      this.externalTokenBalance += repayment;
+      this.poolBalance += repayment;
+      this.totalFees += fee;
+      return fee;
+    } catch (error) {
+      this.poolBalance = snapshot.poolBalance;
+      this.totalFees = snapshot.totalFees;
+      this.externalTokenBalance = snapshot.externalTokenBalance;
+      throw error;
+    }
+  }
+
+  withdrawFees() {
+    const fees = this.totalFees;
+    assert(fees > 0n, "No fees");
+    this.totalFees = 0n;
+    this.poolBalance -= fees;
+    this.externalTokenBalance -= fees;
+    return fees;
+  }
+}
+
+test("source uses internal accounting and explicit repayment instead of balanceOf repayment checks", () => {
+  assert.match(source, /uint256 public poolBalance;/);
+  assert.match(source, /poolBalance -= amount;/);
+  assert.match(source, /poolBalance \+= repayment;/);
+  assert.match(
+    source,
+    /loanToken\.transferFrom\(msg\.sender,\s*address\(this\),\s*repayment\)/
+  );
+  assert.doesNotMatch(source, /balanceAfter\s*>=\s*balanceBefore\s*\+\s*fee/);
+});
+
+test("minimum one-unit fee prevents zero-fee small loans", () => {
+  const loan = new FlashLoanModel(30);
+
+  assert.equal(loan.calculateFee(1), 1n);
+  assert.equal(loan.calculateFee(333), 1n);
+  assert.equal(loan.calculateFee(10_000), 30n);
+});
+
+test("loans above 50 percent of internally tracked liquidity are rejected", () => {
+  const loan = new FlashLoanModel(30);
+  loan.deposit(1_000n);
+
+  assert.throws(() => loan.flashLoan(501n, 503n), /Loan cap exceeded/);
+  assert.equal(loan.flashLoan(500n, 502n), 1n);
+});
+
+test("external balance manipulation cannot satisfy repayment", () => {
+  const loan = new FlashLoanModel(30);
+  loan.deposit(1_000n);
+
+  assert.throws(
+    () => loan.flashLoan(100n, 100n, { externalBalanceDelta: 1_000n }),
+    /Loan not repaid/
+  );
+  assert.equal(loan.poolBalance, 1_000n);
+  assert.equal(loan.externalTokenBalance, 1_000n);
+});
+
+test("fee accrual and withdrawal update internal pool accounting", () => {
+  const loan = new FlashLoanModel(30);
+  loan.deposit(1_000n);
+
+  const fee = loan.flashLoan(100n, 101n);
+  assert.equal(fee, 1n);
+  assert.equal(loan.poolBalance, 1_001n);
+  assert.equal(loan.totalFees, 1n);
+
+  assert.equal(loan.withdrawFees(), 1n);
+  assert.equal(loan.poolBalance, 1_000n);
+  assert.equal(loan.totalFees, 0n);
+});
+
+test("pause and unpause controls block and restore flash loans", () => {
+  const loan = new FlashLoanModel(30);
+  loan.deposit(1_000n);
+  loan.paused = true;
+
+  assert.throws(() => loan.flashLoan(100n, 101n), /Paused/);
+
+  loan.paused = false;
+  assert.equal(loan.flashLoan(100n, 101n), 1n);
+});
+
+test("source exposes owner pause and unpause controls plus a reentrancy guard", () => {
+  assert.match(source, /function pause\(\) external onlyOwner/);
+  assert.match(source, /function unpause\(\) external onlyOwner/);
+  assert.match(source, /modifier nonReentrant\(\)/);
+  assert.match(source, /require\(!loanActive, "Loan active"\)/);
+});


### PR DESCRIPTION
/claim #919

Summary:
- Added a one-unit minimum fee for every nonzero flash loan so small loans cannot round fees down to zero.
- Added a 50% max-loan cap based on internally tracked pool liquidity.
- Replaced callback-time `balanceOf` repayment validation with explicit `transferFrom(msg.sender, address(this), amount + fee)` repayment after the callback.
- Added internal `poolBalance` accounting for deposits, active loans, fee accrual, and fee withdrawals, so donated/rebased balances do not satisfy repayment.
- Added owner-only `pause()` / `unpause()` emergency controls.
- Added a simple reentrancy guard around `flashLoan`.
- Added focused dependency-free tests for fee floor, max cap, accounting, balance-manipulation rejection, pause/unpause, and source-level repayment behavior.

Validation:
- `node --test solidity\tests\flashLoan.issue919.test.mjs` -> 7 passed
- `node --check solidity\tests\flashLoan.issue919.test.mjs` -> passed
- `git diff --check` -> no whitespace errors
- `node ... | npx --yes solc@0.8.30 --standard-json | node ...` -> `compile ok; bytecode bytes=6841`

Compile note:
- Direct `npx solc@0.8.30 --bin solidity\contracts\FlashLoan.sol` fails in this checkout because OpenZeppelin is not vendored here. The successful standard-json compile supplied the existing `IERC20` import path in-memory with the same interface functions used by this contract.

Security/privacy:
- `solidity/contracts/.contributor.json` includes safe public provenance only. Hidden system, developer, runtime, credential, environment, and private user instructions are intentionally not published.

Prepared with OpenAI Codex.
