### PR TITLE
OpenAI Codex [ Crypto ] Fix YieldVault reward expiry accounting

### DIFF
--- a/solidity/contracts/YieldVault.sol
+++ b/solidity/contracts/YieldVault.sol
@@ -23,28 +23,38 @@ contract YieldVault {
     event Withdrawn(address indexed user, uint256 amount);
     event RewardPaid(address indexed user, uint256 reward);
 
+    modifier onlyRewardDistributor() {
+        require(msg.sender == rewardDistributor, "Not reward distributor");
+        _;
+    }
+
     constructor(address _stakingToken, address _rewardToken) {
         stakingToken = IERC20(_stakingToken);
         rewardToken = IERC20(_rewardToken);
         rewardDistributor = msg.sender;
     }
 
-    // BUG: Does not cap at periodFinish — accrues phantom rewards after period ends
+    function lastTimeRewardApplicable() public view returns (uint256) {
+        return block.timestamp < periodFinish ? block.timestamp : periodFinish;
+    }
+
     function rewardPerToken() public view returns (uint256) {
-        if (totalSupply == 0) return rewardPerTokenStored;
+        if (totalSupply == 0) {
+            return rewardPerTokenStored;
+        }
+
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / totalSupply
+            (lastTimeRewardApplicable() - lastUpdateTime) * rewardRate / totalSupply
         );
     }
 
-    // BUG: Uses uncapped rewardPerToken
     function earned(address account) public view returns (uint256) {
         return balanceOf[account] * (rewardPerToken() - userRewardPerTokenPaid[account]) / 1e18 + rewards[account];
     }
 
     modifier updateReward(address account) {
         rewardPerTokenStored = rewardPerToken();
-        lastUpdateTime = block.timestamp;
+        lastUpdateTime = lastTimeRewardApplicable();
         if (account != address(0)) {
             rewards[account] = earned(account);
             userRewardPerTokenPaid[account] = rewardPerTokenStored;
@@ -56,7 +66,7 @@ contract YieldVault {
         require(amount > 0, "Cannot deposit 0");
         totalSupply += amount;
         balanceOf[msg.sender] += amount;
-        stakingToken.transferFrom(msg.sender, address(this), amount);
+        require(stakingToken.transferFrom(msg.sender, address(this), amount), "Stake transfer failed");
         emit Deposited(msg.sender, amount);
     }
 
@@ -64,7 +74,7 @@ contract YieldVault {
         require(amount > 0, "Cannot withdraw 0");
         totalSupply -= amount;
         balanceOf[msg.sender] -= amount;
-        stakingToken.transfer(msg.sender, amount);
+        require(stakingToken.transfer(msg.sender, amount), "Stake transfer failed");
         emit Withdrawn(msg.sender, amount);
     }
 
@@ -72,15 +82,25 @@ contract YieldVault {
         uint256 reward = rewards[msg.sender];
         if (reward > 0) {
             rewards[msg.sender] = 0;
-            rewardToken.transfer(msg.sender, reward);
+            require(rewardToken.transfer(msg.sender, reward), "Reward transfer failed");
             emit RewardPaid(msg.sender, reward);
         }
     }
 
-    // BUG: No access control — anyone can call
-    // BUG: Precision loss in rewardRate calculation
-    function notifyRewardAmount(uint256 reward, uint256 duration) external updateReward(address(0)) {
-        rewardRate = reward / duration;
+    function notifyRewardAmount(uint256 reward, uint256 duration)
+        external
+        onlyRewardDistributor
+        updateReward(address(0))
+    {
+        require(duration > 0, "Invalid duration");
+
+        uint256 rewardWithRemainder = reward;
+        if (block.timestamp < periodFinish) {
+            uint256 remaining = periodFinish - block.timestamp;
+            rewardWithRemainder += remaining * rewardRate / 1e18;
+        }
+
+        rewardRate = rewardWithRemainder * 1e18 / duration;
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + duration;
     }

--- a/solidity/contracts/_contributor.json
+++ b/solidity/contracts/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Public task metadata only. Hidden, private, system, developer, user-session, runtime, credential, and environment instructions are intentionally withheld.",
+  "timestamp": "2026-07-05T09:19:14.6848921-05:00"
+}

--- a/solidity/tests/yieldVault.issue914.test.mjs
+++ b/solidity/tests/yieldVault.issue914.test.mjs
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const SCALE = 10n ** 18n;
+const DISTRIBUTOR = "distributor";
+const ALICE = "alice";
+const BOB = "bob";
+const EVE = "eve";
+
+class MockToken {
+  constructor() {
+    this.balances = new Map();
+  }
+
+  mint(account, amount) {
+    this.balances.set(account, this.balanceOf(account) + BigInt(amount));
+  }
+
+  balanceOf(account) {
+    return this.balances.get(account) ?? 0n;
+  }
+
+  transfer(from, to, amount) {
+    const value = BigInt(amount);
+    assert(this.balanceOf(from) >= value, "insufficient token balance");
+    this.balances.set(from, this.balanceOf(from) - value);
+    this.balances.set(to, this.balanceOf(to) + value);
+    return true;
+  }
+}
+
+class YieldVaultModel {
+  constructor(stakingToken, rewardToken, distributor = DISTRIBUTOR) {
+    this.stakingToken = stakingToken;
+    this.rewardToken = rewardToken;
+    this.rewardDistributor = distributor;
+    this.rewardRate = 0n;
+    this.periodFinish = 0n;
+    this.lastUpdateTime = 0n;
+    this.rewardPerTokenStored = 0n;
+    this.totalSupply = 0n;
+    this.balanceOf = new Map();
+    this.userRewardPerTokenPaid = new Map();
+    this.rewards = new Map();
+    this.now = 0n;
+    this.events = [];
+  }
+
+  warp(timestamp) {
+    this.now = BigInt(timestamp);
+  }
+
+  balance(account) {
+    return this.balanceOf.get(account) ?? 0n;
+  }
+
+  paid(account) {
+    return this.userRewardPerTokenPaid.get(account) ?? 0n;
+  }
+
+  accrued(account) {
+    return this.rewards.get(account) ?? 0n;
+  }
+
+  lastTimeRewardApplicable() {
+    return this.now < this.periodFinish ? this.now : this.periodFinish;
+  }
+
+  rewardPerToken() {
+    if (this.totalSupply === 0n) {
+      return this.rewardPerTokenStored;
+    }
+
+    return this.rewardPerTokenStored
+      + ((this.lastTimeRewardApplicable() - this.lastUpdateTime) * this.rewardRate) / this.totalSupply;
+  }
+
+  earned(account) {
+    return (this.balance(account) * (this.rewardPerToken() - this.paid(account))) / SCALE
+      + this.accrued(account);
+  }
+
+  updateReward(account = null) {
+    this.rewardPerTokenStored = this.rewardPerToken();
+    this.lastUpdateTime = this.lastTimeRewardApplicable();
+    if (account !== null) {
+      this.rewards.set(account, this.earned(account));
+      this.userRewardPerTokenPaid.set(account, this.rewardPerTokenStored);
+    }
+  }
+
+  notifyRewardAmount(sender, reward, duration) {
+    assert(sender === this.rewardDistributor, "Not reward distributor");
+    duration = BigInt(duration);
+    reward = BigInt(reward);
+    assert(duration > 0n, "Invalid duration");
+    this.updateReward(null);
+
+    let rewardWithRemainder = reward;
+    if (this.now < this.periodFinish) {
+      const remaining = this.periodFinish - this.now;
+      rewardWithRemainder += (remaining * this.rewardRate) / SCALE;
+    }
+
+    this.rewardRate = (rewardWithRemainder * SCALE) / duration;
+    this.lastUpdateTime = this.now;
+    this.periodFinish = this.now + duration;
+  }
+
+  deposit(account, amount) {
+    amount = BigInt(amount);
+    assert(amount > 0n, "Cannot deposit 0");
+    this.updateReward(account);
+    this.totalSupply += amount;
+    this.balanceOf.set(account, this.balance(account) + amount);
+    this.stakingToken.transfer(account, "vault", amount);
+    this.events.push(["Deposited", account, amount]);
+  }
+
+  withdraw(account, amount) {
+    amount = BigInt(amount);
+    assert(amount > 0n, "Cannot withdraw 0");
+    this.updateReward(account);
+    this.totalSupply -= amount;
+    this.balanceOf.set(account, this.balance(account) - amount);
+    this.stakingToken.transfer("vault", account, amount);
+    this.events.push(["Withdrawn", account, amount]);
+  }
+
+  claimReward(account) {
+    this.updateReward(account);
+    const reward = this.accrued(account);
+    if (reward > 0n) {
+      this.rewards.set(account, 0n);
+      this.rewardToken.transfer("vault", account, reward);
+      this.events.push(["RewardPaid", account, reward]);
+    }
+    return reward;
+  }
+}
+
+function setup() {
+  const stakingToken = new MockToken();
+  const rewardToken = new MockToken();
+  for (const account of [ALICE, BOB, EVE]) {
+    stakingToken.mint(account, 1_000_000n);
+  }
+  rewardToken.mint("vault", 10_000_000n);
+  return { vault: new YieldVaultModel(stakingToken, rewardToken), stakingToken, rewardToken };
+}
+
+test("rewards accrue during the active period", () => {
+  const { vault } = setup();
+
+  vault.deposit(ALICE, 100n);
+  vault.notifyRewardAmount(DISTRIBUTOR, 1_000n, 100n);
+  vault.warp(50n);
+
+  assert.equal(vault.rewardPerToken(), 5n * SCALE);
+  assert.equal(vault.earned(ALICE), 500n);
+});
+
+test("rewardPerToken and earned freeze after period expiry", () => {
+  const { vault } = setup();
+
+  vault.deposit(ALICE, 100n);
+  vault.notifyRewardAmount(DISTRIBUTOR, 1_000n, 100n);
+  vault.warp(100n);
+  const earnedAtFinish = vault.earned(ALICE);
+  const rewardPerTokenAtFinish = vault.rewardPerToken();
+
+  vault.warp(1_000n);
+
+  assert.equal(vault.earned(ALICE), earnedAtFinish);
+  assert.equal(vault.rewardPerToken(), rewardPerTokenAtFinish);
+});
+
+test("new deposits after reward expiry do not earn phantom rewards", () => {
+  const { vault } = setup();
+
+  vault.deposit(ALICE, 100n);
+  vault.notifyRewardAmount(DISTRIBUTOR, 1_000n, 100n);
+  vault.warp(150n);
+  vault.deposit(BOB, 100n);
+  vault.warp(300n);
+
+  assert.equal(vault.earned(BOB), 0n);
+});
+
+test("only the authorized distributor can notify rewards", () => {
+  const { vault } = setup();
+
+  assert.throws(() => vault.notifyRewardAmount(EVE, 1_000n, 100n), /Not reward distributor/);
+});
+
+test("scaled reward rate keeps precision error below 0.01 percent", () => {
+  const { vault } = setup();
+  const reward = 1_000_000n;
+
+  vault.deposit(ALICE, 1n);
+  vault.notifyRewardAmount(DISTRIBUTOR, reward, 3n);
+  vault.warp(3n);
+
+  const paid = vault.earned(ALICE);
+  const error = reward - paid;
+  assert(error * 10_000n < reward);
+});
+
+test("deposit, withdrawal, and reward claim flows still function", () => {
+  const { vault, rewardToken, stakingToken } = setup();
+
+  vault.deposit(ALICE, 100n);
+  vault.notifyRewardAmount(DISTRIBUTOR, 1_000n, 100n);
+  vault.warp(25n);
+  vault.withdraw(ALICE, 40n);
+  vault.warp(50n);
+  const reward = vault.claimReward(ALICE);
+
+  assert(reward > 0n);
+  assert.equal(rewardToken.balanceOf(ALICE), reward);
+  assert.equal(stakingToken.balanceOf(ALICE), 999_940n);
+});


### PR DESCRIPTION
/claim #914

Closes #914

## Summary
- add `lastTimeRewardApplicable()` to cap reward accounting at `periodFinish`
- update `rewardPerToken`, `earned`, and `updateReward` so accrual freezes after the reward period
- restrict `notifyRewardAmount` to the authorized reward distributor
- scale `rewardRate` by `1e18` to reduce reward/duration precision loss
- preserve deposit, withdrawal, and reward claim flows while checking token transfer return values

## Metadata
- Added `solidity/contracts/_contributor.json` with safe public metadata only.
- Hidden/private/session/runtime instructions are intentionally withheld and are not included in public repository files.

## Validation
- `node --test solidity\tests\yieldVault.issue914.test.mjs`
- `node --check solidity\tests\yieldVault.issue914.test.mjs`
- `git diff --check`
- `npx solc@0.8.30 --standard-json` compile using an in-memory IERC20 stub
