### PR TITLE
OpenAI Codex [ FastAPI ] Add HTTPBasic brute force protection

### DIFF
--- a/fastapi/.generation_meta.json
+++ b/fastapi/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initial_directives": "Private system, developer, user, runtime, credential, and environment instructions are intentionally withheld. This public metadata records only non-sensitive provenance.",
+  "date": "2026-07-05T09:47:00-05:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -4,6 +4,7 @@ from .api_key import APIKeyQuery as APIKeyQuery
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBasicWithProtection as HTTPBasicWithProtection
 from .http import HTTPBearer as HTTPBearer
 from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2

--- a/fastapi/fastapi/security/http.py
+++ b/fastapi/fastapi/security/http.py
@@ -1,5 +1,12 @@
 import binascii
-from base64 import b64decode
+import hashlib
+import inspect
+import math
+import os
+import secrets
+import time
+from base64 import b64decode, b64encode
+from collections.abc import Awaitable, Callable
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -10,7 +17,7 @@ from fastapi.security.base import SecurityBase
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class HTTPBasicCredentials(BaseModel):
@@ -217,6 +224,194 @@ class HTTPBasic(HTTPBase):
         if not separator:
             raise self.make_not_authenticated_error()
         return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBasicWithProtection(HTTPBasic):
+    """
+    HTTP Basic authentication with optional credential verification and per-IP
+    brute force protection.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_attempts: Annotated[
+            int,
+            Doc(
+                """
+                Number of failed credential checks allowed per client IP before
+                requests are temporarily rejected.
+                """
+            ),
+        ] = 5,
+        window_seconds: Annotated[
+            float,
+            Doc(
+                """
+                Number of seconds in the rolling failure window.
+                """
+            ),
+        ] = 300.0,
+        password_verifier: Annotated[
+            Callable[[HTTPBasicCredentials], bool | Awaitable[bool]] | None,
+            Doc(
+                """
+                Optional callback used to validate parsed Basic credentials.
+                Returning ``False`` records a failed attempt for the client IP.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        realm: Annotated[
+            str | None,
+            Doc(
+                """
+                HTTP Basic authentication realm.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                If ``False``, missing Basic credentials return ``None`` instead of
+                raising an HTTP error. Invalid credentials still count as failed
+                login attempts when a verifier is configured.
+                """
+            ),
+        ] = True,
+    ):
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be greater than or equal to 1")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be greater than 0")
+        super().__init__(
+            scheme_name=scheme_name,
+            realm=realm,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self.password_verifier = password_verifier
+        self._failed_attempts: dict[str, list[float]] = {}
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> HTTPBasicCredentials | None:
+        client_ip = self._client_ip(request)
+        now = time.monotonic()
+        if self._is_locked(client_ip, now):
+            raise self._too_many_attempts_error(client_ip, now)
+
+        credentials = await super().__call__(request)
+        if credentials is None or self.password_verifier is None:
+            return credentials
+
+        verifier_result = self.password_verifier(credentials)
+        if inspect.isawaitable(verifier_result):
+            verifier_result = await verifier_result
+        if verifier_result:
+            self._failed_attempts.pop(client_ip, None)
+            return credentials
+
+        self._record_failure(client_ip, now)
+        raise self.make_not_authenticated_error()
+
+    @staticmethod
+    def hash_password(
+        password: str,
+        *,
+        salt: bytes | None = None,
+        iterations: int = 600_000,
+    ) -> str:
+        if iterations < 1:
+            raise ValueError("iterations must be greater than or equal to 1")
+        if salt is None:
+            salt = os.urandom(16)
+        digest = hashlib.pbkdf2_hmac(
+            "sha256", password.encode("utf-8"), salt, iterations
+        )
+        return "pbkdf2_sha256${}${}${}".format(
+            iterations,
+            b64encode(salt).decode("ascii"),
+            b64encode(digest).decode("ascii"),
+        )
+
+    @staticmethod
+    def verify_password(password: str, expected_password: str) -> bool:
+        hash_parts = expected_password.split("$", 3)
+        if len(hash_parts) == 4 and hash_parts[0] == "pbkdf2_sha256":
+            _, iteration_text, salt_text, expected_digest_text = hash_parts
+            try:
+                iterations = int(iteration_text)
+                salt = b64decode(salt_text.encode("ascii"), validate=True)
+                expected_digest = b64decode(
+                    expected_digest_text.encode("ascii"), validate=True
+                )
+            except (ValueError, binascii.Error):
+                return False
+            digest = hashlib.pbkdf2_hmac(
+                "sha256", password.encode("utf-8"), salt, iterations
+            )
+            return secrets.compare_digest(digest, expected_digest)
+
+        password_digest = hashlib.sha256(password.encode("utf-8")).digest()
+        expected_digest = hashlib.sha256(expected_password.encode("utf-8")).digest()
+        return secrets.compare_digest(password_digest, expected_digest)
+
+    def _client_ip(self, request: Request) -> str:
+        if request.client is None:
+            return "unknown"
+        return request.client.host
+
+    def _active_attempts(self, client_ip: str, now: float) -> list[float]:
+        cutoff = now - self.window_seconds
+        attempts = [
+            attempt_time
+            for attempt_time in self._failed_attempts.get(client_ip, [])
+            if attempt_time > cutoff
+        ]
+        if attempts:
+            self._failed_attempts[client_ip] = attempts
+        else:
+            self._failed_attempts.pop(client_ip, None)
+        return attempts
+
+    def _is_locked(self, client_ip: str, now: float) -> bool:
+        return len(self._active_attempts(client_ip, now)) >= self.max_attempts
+
+    def _record_failure(self, client_ip: str, now: float) -> None:
+        attempts = self._active_attempts(client_ip, now)
+        attempts.append(now)
+        self._failed_attempts[client_ip] = attempts
+
+    def _too_many_attempts_error(self, client_ip: str, now: float) -> HTTPException:
+        attempts = self._active_attempts(client_ip, now)
+        retry_after = 1
+        if attempts:
+            lockout_expires_at = attempts[0] + self.window_seconds
+            retry_after = max(1, math.ceil(lockout_expires_at - now))
+        return HTTPException(
+            status_code=HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many authentication attempts",
+            headers={"Retry-After": str(retry_after)},
+        )
 
 
 class HTTPBearer(HTTPBase):

--- a/fastapi/tests/test_security_http_basic_protection.py
+++ b/fastapi/tests/test_security_http_basic_protection.py
@@ -1,0 +1,130 @@
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBasicCredentials, HTTPBasicWithProtection
+from fastapi.testclient import TestClient
+
+PASSWORD_HASH = HTTPBasicWithProtection.hash_password(
+    "secret", salt=b"fastapi-test-salt", iterations=1_000
+)
+
+
+def make_security(
+    max_attempts: int = 2, window_seconds: float = 60
+) -> HTTPBasicWithProtection:
+    def verify(credentials: HTTPBasicCredentials) -> bool:
+        return (
+            credentials.username == "alice"
+            and HTTPBasicWithProtection.verify_password(
+                credentials.password, PASSWORD_HASH
+            )
+        )
+
+    return HTTPBasicWithProtection(
+        max_attempts=max_attempts,
+        window_seconds=window_seconds,
+        password_verifier=verify,
+    )
+
+
+def make_client(
+    security: HTTPBasicWithProtection, client_host: str = "testclient"
+) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/users/me")
+    def read_current_user(
+        credentials: HTTPBasicCredentials = Security(security),
+    ) -> dict[str, str]:
+        return {"username": credentials.username}
+
+    return TestClient(app, client=(client_host, 50000))
+
+
+def test_failed_attempts_lock_client_ip() -> None:
+    client = make_client(make_security(max_attempts=2))
+
+    response = client.get("/users/me", auth=("alice", "wrong"))
+    assert response.status_code == 401, response.text
+
+    response = client.get("/users/me", auth=("alice", "also-wrong"))
+    assert response.status_code == 401, response.text
+
+    response = client.get("/users/me", auth=("alice", "secret"))
+    assert response.status_code == 429, response.text
+    assert response.json() == {"detail": "Too many authentication attempts"}
+    assert int(response.headers["Retry-After"]) > 0
+
+
+def test_successful_authentication_resets_attempt_counter() -> None:
+    security = make_security(max_attempts=2)
+    client = make_client(security)
+
+    response = client.get("/users/me", auth=("alice", "wrong"))
+    assert response.status_code == 401, response.text
+
+    response = client.get("/users/me", auth=("alice", "secret"))
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "alice"}
+
+    response = client.get("/users/me", auth=("alice", "wrong"))
+    assert response.status_code == 401, response.text
+
+    response = client.get("/users/me", auth=("alice", "also-wrong"))
+    assert response.status_code == 401, response.text
+
+
+def test_failed_attempts_are_scoped_by_client_ip() -> None:
+    security = make_security(max_attempts=1)
+    locked_client = make_client(security, "198.51.100.10")
+    other_client = make_client(security, "203.0.113.20")
+
+    response = locked_client.get("/users/me", auth=("alice", "wrong"))
+    assert response.status_code == 401, response.text
+
+    response = locked_client.get("/users/me", auth=("alice", "secret"))
+    assert response.status_code == 429, response.text
+
+    response = other_client.get("/users/me", auth=("alice", "secret"))
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "alice"}
+
+
+def test_failed_attempt_window_expires(monkeypatch) -> None:
+    monotonic_now = 100.0
+    monkeypatch.setattr("fastapi.security.http.time.monotonic", lambda: monotonic_now)
+    security = make_security(max_attempts=1, window_seconds=10)
+    client = make_client(security)
+
+    response = client.get("/users/me", auth=("alice", "wrong"))
+    assert response.status_code == 401, response.text
+
+    response = client.get("/users/me", auth=("alice", "secret"))
+    assert response.status_code == 429, response.text
+
+    monotonic_now = 111.0
+
+    response = client.get("/users/me", auth=("alice", "secret"))
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "alice"}
+
+
+def test_verify_password_uses_constant_time_comparison(monkeypatch) -> None:
+    compare_calls: list[tuple[bytes, bytes]] = []
+
+    def compare_digest(left: bytes, right: bytes) -> bool:
+        compare_calls.append((left, right))
+        return left == right
+
+    monkeypatch.setattr("fastapi.security.http.secrets.compare_digest", compare_digest)
+
+    assert HTTPBasicWithProtection.verify_password("secret", PASSWORD_HASH)
+    assert not HTTPBasicWithProtection.verify_password("wrong", PASSWORD_HASH)
+    assert len(compare_calls) == 2
+
+
+def test_existing_httpbasic_without_verifier_still_returns_credentials() -> None:
+    client = make_client(HTTPBasicWithProtection())
+
+    response = client.get("/users/me", auth=("alice", "anything"))
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "alice"}


### PR DESCRIPTION
/claim #800

## Summary

- Added opt-in `HTTPBasicWithProtection` extending `HTTPBasic` without changing existing `HTTPBasic` behavior.
- Tracks failed credential-verifier attempts per client IP in a configurable rolling window and returns `429 Too Many Requests` with `Retry-After` while locked out.
- Resets the failed-attempt counter after successful authentication.
- Adds stdlib PBKDF2 password hashing plus constant-time password verification helpers.
- Exports `HTTPBasicWithProtection` from `fastapi.security`.

## Verification

- `uv run pytest tests\test_security_http_basic_protection.py tests\test_security_http_basic_realm.py tests\test_security_http_basic_optional.py -q` -> 16 passed
- `uv run ruff check fastapi\security\http.py fastapi\security\__init__.py tests\test_security_http_basic_protection.py` -> passed
- `uv run ruff format --check fastapi\security\http.py fastapi\security\__init__.py tests\test_security_http_basic_protection.py` -> passed
- `python -m py_compile fastapi\security\http.py tests\test_security_http_basic_protection.py` -> passed
- `git diff --check` -> passed with line-ending warning only

## Security / Metadata

Safe public metadata is included in `fastapi/.generation_meta.json`. Private system, developer, user, runtime, credential, and environment instructions are intentionally not published in repository files or PR text.
