### PR TITLE
OpenAI Codex [ FastAPI ] Add rate limiting to API key auth

### DIFF
--- a/fastapi/.audit.json
+++ b/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "environment_config": "Private system, developer, user, runtime, credential, and environment instructions are intentionally withheld. This public metadata records only non-sensitive provenance.",
+  "completed_at": "2026-07-05T09:57:00-05:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -1,6 +1,7 @@
 from .api_key import APIKeyCookie as APIKeyCookie
 from .api_key import APIKeyHeader as APIKeyHeader
 from .api_key import APIKeyQuery as APIKeyQuery
+from .api_key import APIKeyWithRateLimit as APIKeyWithRateLimit
 from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
 from .http import HTTPBasic as HTTPBasic
 from .http import HTTPBasicCredentials as HTTPBasicCredentials

--- a/fastapi/fastapi/security/api_key.py
+++ b/fastapi/fastapi/security/api_key.py
@@ -1,3 +1,6 @@
+import math
+import time
+from threading import RLock
 from typing import Annotated
 
 from annotated_doc import Doc
@@ -5,7 +8,8 @@ from fastapi.openapi.models import APIKey, APIKeyIn
 from fastapi.security.base import SecurityBase
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.responses import Response
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_429_TOO_MANY_REQUESTS
 
 
 class APIKeyBase(SecurityBase):
@@ -230,6 +234,151 @@ class APIKeyHeader(APIKeyBase):
     async def __call__(self, request: Request) -> str | None:
         api_key = request.headers.get(self.model.name)
         return self.check_api_key(api_key)
+
+
+class APIKeyWithRateLimit(APIKeyHeader):
+    """
+    API key header authentication with a per-key in-memory rate limit and
+    deprecated key warnings.
+    """
+
+    _RATE_LIMIT_WINDOWS = {
+        "s": 1,
+        "sec": 1,
+        "second": 1,
+        "seconds": 1,
+        "m": 60,
+        "min": 60,
+        "minute": 60,
+        "minutes": 60,
+        "h": 3600,
+        "hr": 3600,
+        "hour": 3600,
+        "hours": 3600,
+        "d": 86400,
+        "day": 86400,
+        "days": 86400,
+    }
+
+    def __init__(
+        self,
+        *,
+        name: Annotated[str, Doc("Header name.")],
+        rate_limit: Annotated[
+            str,
+            Doc(
+                """
+                Rate limit in the form ``<count>/<window>``, for example
+                ``100/minute`` or ``1000/hour``.
+                """
+            ),
+        ],
+        deprecated_keys: Annotated[
+            list[str] | set[str] | tuple[str, ...] | None,
+            Doc(
+                """
+                API keys that remain accepted but emit an HTTP Warning header.
+                """
+            ),
+        ] = None,
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                By default, if the header is not provided, `APIKeyWithRateLimit`
+                will automatically cancel the request and send the client an error.
+                """
+            ),
+        ] = True,
+    ):
+        super().__init__(
+            name=name,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+        self.rate_limit = rate_limit
+        self.rate_limit_count, self.rate_limit_window_seconds = self._parse_rate_limit(
+            rate_limit
+        )
+        self.deprecated_keys = set(deprecated_keys or ())
+        self._requests_by_key: dict[str, list[float]] = {}
+        self._lock = RLock()
+
+    async def __call__(self, request: Request, response: Response) -> str | None:
+        api_key = await super().__call__(request)
+        if api_key is None:
+            return None
+
+        if api_key in self.deprecated_keys:
+            response.headers["Warning"] = (
+                '299 - "API key is deprecated and will be deactivated"'
+            )
+
+        self._check_rate_limit(api_key)
+        return api_key
+
+    @classmethod
+    def _parse_rate_limit(cls, rate_limit: str) -> tuple[int, int]:
+        count_text, separator, window_text = rate_limit.strip().partition("/")
+        if not separator:
+            raise ValueError(
+                "rate_limit must use the '<count>/<window>' format, "
+                "for example '100/minute'"
+            )
+        try:
+            count = int(count_text)
+        except ValueError as exc:
+            raise ValueError("rate_limit count must be an integer") from exc
+        if count < 1:
+            raise ValueError("rate_limit count must be greater than or equal to 1")
+
+        window_seconds = cls._RATE_LIMIT_WINDOWS.get(window_text.strip().lower())
+        if window_seconds is None:
+            raise ValueError(
+                "rate_limit window must be one of second, minute, hour, or day"
+            )
+        return count, window_seconds
+
+    def _check_rate_limit(self, api_key: str) -> None:
+        now = time.monotonic()
+        with self._lock:
+            cutoff = now - self.rate_limit_window_seconds
+            request_times = [
+                request_time
+                for request_time in self._requests_by_key.get(api_key, [])
+                if request_time > cutoff
+            ]
+            if len(request_times) >= self.rate_limit_count:
+                retry_after = max(
+                    1,
+                    math.ceil(request_times[0] + self.rate_limit_window_seconds - now),
+                )
+                self._requests_by_key[api_key] = request_times
+                raise HTTPException(
+                    status_code=HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Rate limit exceeded",
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+            request_times.append(now)
+            self._requests_by_key[api_key] = request_times
 
 
 class APIKeyCookie(APIKeyBase):

--- a/fastapi/tests/test_security_api_key_rate_limit.py
+++ b/fastapi/tests/test_security_api_key_rate_limit.py
@@ -1,0 +1,109 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi import Depends, FastAPI, Security
+from fastapi.security import APIKeyWithRateLimit
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    username: str
+
+
+def make_client(security: APIKeyWithRateLimit) -> TestClient:
+    app = FastAPI()
+
+    def get_current_user(api_key: str = Security(security)) -> User:
+        return User(username=api_key)
+
+    @app.get("/users/me")
+    def read_current_user(current_user: User = Depends(get_current_user)) -> User:
+        return current_user
+
+    return TestClient(app)
+
+
+def test_rate_limit_is_enforced_per_api_key() -> None:
+    client = make_client(APIKeyWithRateLimit(name="key", rate_limit="2/minute"))
+
+    assert client.get("/users/me", headers={"key": "alpha"}).status_code == 200
+    assert client.get("/users/me", headers={"key": "alpha"}).status_code == 200
+
+    response = client.get("/users/me", headers={"key": "alpha"})
+    assert response.status_code == 429, response.text
+    assert response.json() == {"detail": "Rate limit exceeded"}
+    assert int(response.headers["Retry-After"]) > 0
+
+    response = client.get("/users/me", headers={"key": "beta"})
+    assert response.status_code == 200, response.text
+    assert response.json() == {"username": "beta"}
+
+
+def test_rate_limit_window_resets(monkeypatch) -> None:
+    monotonic_now = 100.0
+    monkeypatch.setattr(
+        "fastapi.security.api_key.time.monotonic", lambda: monotonic_now
+    )
+    client = make_client(APIKeyWithRateLimit(name="key", rate_limit="1/second"))
+
+    assert client.get("/users/me", headers={"key": "alpha"}).status_code == 200
+
+    response = client.get("/users/me", headers={"key": "alpha"})
+    assert response.status_code == 429, response.text
+    assert response.headers["Retry-After"] == "1"
+
+    monotonic_now = 102.0
+
+    response = client.get("/users/me", headers={"key": "alpha"})
+    assert response.status_code == 200, response.text
+
+
+def test_deprecated_key_adds_warning_header() -> None:
+    client = make_client(
+        APIKeyWithRateLimit(
+            name="key",
+            rate_limit="10/minute",
+            deprecated_keys={"old-secret"},
+        )
+    )
+
+    response = client.get("/users/me", headers={"key": "old-secret"})
+    assert response.status_code == 200, response.text
+    assert response.headers["Warning"] == (
+        '299 - "API key is deprecated and will be deactivated"'
+    )
+
+    response = client.get("/users/me", headers={"key": "new-secret"})
+    assert response.status_code == 200, response.text
+    assert "Warning" not in response.headers
+
+
+def test_missing_key_uses_existing_api_key_header_behavior() -> None:
+    client = make_client(APIKeyWithRateLimit(name="key", rate_limit="10/minute"))
+
+    response = client.get("/users/me")
+
+    assert response.status_code == 401, response.text
+    assert response.json() == {"detail": "Not authenticated"}
+    assert response.headers["WWW-Authenticate"] == "APIKey"
+
+
+@pytest.mark.parametrize("rate_limit", ["", "abc/minute", "0/minute", "5/month"])
+def test_invalid_rate_limit(rate_limit: str) -> None:
+    with pytest.raises(ValueError):
+        APIKeyWithRateLimit(name="key", rate_limit=rate_limit)
+
+
+def test_store_handles_concurrent_requests() -> None:
+    client = make_client(APIKeyWithRateLimit(name="key", rate_limit="20/minute"))
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        responses = list(
+            executor.map(
+                lambda _: client.get("/users/me", headers={"key": "alpha"}),
+                range(8),
+            )
+        )
+
+    assert {response.status_code for response in responses} == {200}


### PR DESCRIPTION
/claim #768

## Summary

- Added opt-in `APIKeyWithRateLimit` extending `APIKeyHeader` without changing existing API key classes.
- Parses limits such as `100/minute` and `1000/hour`.
- Tracks requests per API key in a thread-safe in-memory sliding window.
- Returns `429 Too Many Requests` with `Retry-After` when a key exceeds its limit.
- Supports `deprecated_keys` that still authenticate while adding an HTTP `Warning` header.
- Exports `APIKeyWithRateLimit` from `fastapi.security`.

## Verification

- `uv run pytest tests\test_security_api_key_rate_limit.py tests\test_security_api_key_header.py tests\test_security_api_key_header_optional.py -q` -> 15 passed
- `uv run ruff check fastapi\security\api_key.py fastapi\security\__init__.py tests\test_security_api_key_rate_limit.py` -> passed
- `uv run ruff format --check fastapi\security\api_key.py fastapi\security\__init__.py tests\test_security_api_key_rate_limit.py` -> passed
- `python -m py_compile fastapi\security\api_key.py tests\test_security_api_key_rate_limit.py` -> passed
- `git diff --check` -> passed with line-ending warnings only

## Security / Metadata

Safe public metadata is included in `fastapi/.audit.json`. Private system, developer, user, runtime, credential, and environment instructions are intentionally not published in repository files or PR text.
