### PR TITLE
OpenAI Codex [ T3 Code ] Add HTTP response compression

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Public submission metadata only. Private system, developer, user, runtime, connector, credential, and hidden instruction content is intentionally not disclosed.",
+  "timestamp": "2026-07-05T10:50:01.9402859-05:00",
+  "issue": "UnsafeLabs/Bounty-Hunters#863"
+}

--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { brotliCompressSync, brotliDecompressSync, gunzipSync, gzipSync } from "node:zlib";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import {
+  HTTP_COMPRESSION_LEVEL_ENV,
+  HTTP_COMPRESSION_MIN_BYTES,
+  compressResponseBody,
+  isLoopbackHostname,
+  parseRequestJsonBody,
+  resolveAcceptedCompressionEncoding,
+  resolveCompressedResponse,
+  resolveDevRedirectUrl,
+  resolveHttpCompressionLevel,
+  resolveRequestContentEncoding,
+  shouldSkipCompressionForContentType,
+} from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +36,93 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("http compression", () => {
+  const largeJson = new TextEncoder().encode(
+    JSON.stringify({
+      messages: Array.from({ length: 120 }, (_, index) => ({
+        id: `message-${index}`,
+        body: "Repeated chat history payload ".repeat(8),
+      })),
+    }),
+  );
+
+  it("prefers brotli over gzip when both are accepted", () => {
+    expect(resolveAcceptedCompressionEncoding({ "accept-encoding": "gzip, br" })).toBe("br");
+  });
+
+  it("falls back to gzip when brotli is explicitly disabled", () => {
+    expect(resolveAcceptedCompressionEncoding({ "accept-encoding": "br;q=0, gzip;q=1" })).toBe(
+      "gzip",
+    );
+  });
+
+  it("skips compression for small responses", () => {
+    const body = new TextEncoder().encode("small");
+    const response = resolveCompressedResponse({
+      body,
+      contentType: "application/json",
+      requestHeaders: { "accept-encoding": "br, gzip" },
+    });
+
+    expect(response.encoding).toBeNull();
+    expect(response.body).toBe(body);
+    expect(response.headers["Content-Encoding"]).toBeUndefined();
+  });
+
+  it("skips image and archive content types", () => {
+    expect(shouldSkipCompressionForContentType("image/png")).toBe(true);
+    expect(shouldSkipCompressionForContentType("application/zip")).toBe(true);
+    expect(shouldSkipCompressionForContentType("application/json; charset=utf-8")).toBe(false);
+  });
+
+  it("sets compression headers and produces a brotli body for large JSON responses", () => {
+    const response = resolveCompressedResponse({
+      body: largeJson,
+      contentType: "application/json",
+      requestHeaders: { "accept-encoding": "gzip, br" },
+      responseHeaders: { Vary: "Origin" },
+    });
+
+    expect(largeJson.byteLength).toBeGreaterThan(HTTP_COMPRESSION_MIN_BYTES);
+    expect(response.encoding).toBe("br");
+    expect(response.headers["Content-Encoding"]).toBe("br");
+    expect(response.headers.Vary).toBe("Origin, Accept-Encoding");
+    expect(brotliDecompressSync(response.body).toString()).toBe(Buffer.from(largeJson).toString());
+  });
+
+  it("uses gzip when gzip is the selected encoding", () => {
+    const compressed = compressResponseBody(largeJson, "gzip", 6);
+
+    expect(gunzipSync(compressed).toString()).toBe(Buffer.from(largeJson).toString());
+  });
+
+  it("parses and clamps the configurable compression level", () => {
+    expect(resolveHttpCompressionLevel(undefined)).toBe(6);
+    expect(resolveHttpCompressionLevel("2")).toBe(2);
+    expect(resolveHttpCompressionLevel("99")).toBe(11);
+    expect(resolveHttpCompressionLevel("not-a-number")).toBe(6);
+    expect(HTTP_COMPRESSION_LEVEL_ENV).toBe("T3_HTTP_COMPRESSION_LEVEL");
+  });
+});
+
+describe("compressed request bodies", () => {
+  const payload = { traceId: "abc123", spans: [{ name: "chat-history-load" }] };
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(payload));
+
+  it("detects supported request content encodings", () => {
+    expect(resolveRequestContentEncoding({ "content-encoding": "gzip" })).toBe("gzip");
+    expect(resolveRequestContentEncoding({ "content-encoding": "br" })).toBe("br");
+    expect(resolveRequestContentEncoding({ "content-encoding": "deflate" })).toBeNull();
+  });
+
+  it("decompresses gzip JSON request bodies before parsing", () => {
+    expect(parseRequestJsonBody(gzipSync(payloadBytes), "gzip")).toEqual(payload);
+  });
+
+  it("decompresses brotli JSON request bodies before parsing", () => {
+    expect(parseRequestJsonBody(brotliCompressSync(payloadBytes), "br")).toEqual(payload);
   });
 });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,5 +1,6 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
+import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -7,6 +8,14 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import { cast } from "effect/Function";
 import {
+  brotliCompressSync,
+  brotliDecompressSync,
+  constants as ZlibConstants,
+  gunzipSync,
+  gzipSync,
+} from "node:zlib";
+import {
+  HttpServerError,
   HttpBody,
   HttpClient,
   HttpClientResponse,
@@ -38,6 +47,31 @@ const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
+export const HTTP_COMPRESSION_MIN_BYTES = 1024;
+export const HTTP_COMPRESSION_LEVEL_ENV = "T3_HTTP_COMPRESSION_LEVEL";
+const DEFAULT_HTTP_COMPRESSION_LEVEL = 6;
+const COMPRESSED_CONTENT_TYPES = new Set([
+  "application/gzip",
+  "application/pdf",
+  "application/vnd.rar",
+  "application/wasm",
+  "application/x-7z-compressed",
+  "application/x-bzip2",
+  "application/x-gzip",
+  "application/x-rar-compressed",
+  "application/x-tar",
+  "application/zip",
+  "application/zstd",
+]);
+const jsonTextDecoder = new TextDecoder();
+
+export type HttpCompressionEncoding = "br" | "gzip";
+
+export interface CompressedResponseDecision {
+  readonly body: Uint8Array;
+  readonly encoding: HttpCompressionEncoding | null;
+  readonly headers: Record<string, string>;
+}
 
 export const browserApiCorsLayer = HttpRouter.cors({
   allowedMethods: [...browserApiCorsAllowedMethods],
@@ -60,6 +94,231 @@ export function resolveDevRedirectUrl(devUrl: URL, requestUrl: URL): string {
   redirectUrl.hash = requestUrl.hash;
   return redirectUrl.toString();
 }
+
+function getHeaderValue(
+  headers: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string | undefined {
+  return (
+    headers[name] ??
+    headers[name.toLowerCase()] ??
+    headers[name.toUpperCase()] ??
+    Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1]
+  );
+}
+
+function mergeVaryAcceptEncoding(value: string | undefined): string {
+  if (!value) {
+    return "Accept-Encoding";
+  }
+  const entries = value.split(",").map((entry) => entry.trim());
+  return entries.some((entry) => entry.toLowerCase() === "accept-encoding")
+    ? value
+    : `${value}, Accept-Encoding`;
+}
+
+function parseAcceptEncodingQuality(value: string | undefined): Map<string, number> {
+  const qualities = new Map<string, number>();
+  if (!value) {
+    return qualities;
+  }
+
+  for (const rawEntry of value.split(",")) {
+    const [rawEncoding, ...rawParameters] = rawEntry.split(";");
+    const encoding = rawEncoding?.trim().toLowerCase();
+    if (!encoding) {
+      continue;
+    }
+    const qualityParameter = rawParameters
+      .map((parameter) => parameter.trim().toLowerCase())
+      .find((parameter) => parameter.startsWith("q="));
+    const quality =
+      qualityParameter === undefined ? 1 : Number(qualityParameter.slice("q=".length));
+    qualities.set(encoding, Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0);
+  }
+  return qualities;
+}
+
+export function resolveAcceptedCompressionEncoding(
+  headers: Readonly<Record<string, string | undefined>>,
+): HttpCompressionEncoding | null {
+  const qualities = parseAcceptEncodingQuality(getHeaderValue(headers, "accept-encoding"));
+  const wildcardQuality = qualities.get("*") ?? 0;
+  const brotliQuality = qualities.get("br") ?? wildcardQuality;
+  const gzipQuality = qualities.get("gzip") ?? wildcardQuality;
+  if (brotliQuality > 0) {
+    return "br";
+  }
+  return gzipQuality > 0 ? "gzip" : null;
+}
+
+export function shouldSkipCompressionForContentType(contentType: string): boolean {
+  const normalizedContentType = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (!normalizedContentType) {
+    return false;
+  }
+  return (
+    normalizedContentType.startsWith("audio/") ||
+    normalizedContentType.startsWith("font/") ||
+    normalizedContentType.startsWith("image/") ||
+    normalizedContentType.startsWith("video/") ||
+    normalizedContentType.endsWith("+zip") ||
+    COMPRESSED_CONTENT_TYPES.has(normalizedContentType)
+  );
+}
+
+export function resolveHttpCompressionLevel(
+  value: string | undefined = process.env[HTTP_COMPRESSION_LEVEL_ENV],
+): number {
+  if (value === undefined || value.trim() === "") {
+    return DEFAULT_HTTP_COMPRESSION_LEVEL;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    return DEFAULT_HTTP_COMPRESSION_LEVEL;
+  }
+  return Math.min(11, Math.max(0, parsed));
+}
+
+export function compressResponseBody(
+  body: Uint8Array,
+  encoding: HttpCompressionEncoding,
+  level = resolveHttpCompressionLevel(),
+): Uint8Array {
+  if (encoding === "br") {
+    return brotliCompressSync(body, {
+      params: {
+        [ZlibConstants.BROTLI_PARAM_QUALITY]: level,
+      },
+    });
+  }
+  return gzipSync(body, { level: Math.min(9, level) });
+}
+
+export function resolveCompressedResponse(input: {
+  readonly body: Uint8Array;
+  readonly contentType: string;
+  readonly requestHeaders: Readonly<Record<string, string | undefined>>;
+  readonly responseHeaders?: Readonly<Record<string, string | undefined>>;
+}): CompressedResponseDecision {
+  const responseHeaders = { ...(input.responseHeaders ?? {}) };
+  if (
+    input.body.byteLength <= HTTP_COMPRESSION_MIN_BYTES ||
+    shouldSkipCompressionForContentType(input.contentType)
+  ) {
+    return { body: input.body, encoding: null, headers: responseHeaders as Record<string, string> };
+  }
+
+  const encoding = resolveAcceptedCompressionEncoding(input.requestHeaders);
+  if (!encoding) {
+    return { body: input.body, encoding: null, headers: responseHeaders as Record<string, string> };
+  }
+
+  return {
+    body: compressResponseBody(input.body, encoding),
+    encoding,
+    headers: {
+      ...responseHeaders,
+      "Content-Encoding": encoding,
+      Vary: mergeVaryAcceptEncoding(responseHeaders.Vary ?? responseHeaders.vary),
+    },
+  };
+}
+
+export function resolveRequestContentEncoding(
+  headers: Readonly<Record<string, string | undefined>>,
+): HttpCompressionEncoding | null {
+  const encoding = getHeaderValue(headers, "content-encoding")?.split(",")[0]?.trim().toLowerCase();
+  return encoding === "br" || encoding === "gzip" ? encoding : null;
+}
+
+export function decompressRequestBody(
+  body: Uint8Array,
+  encoding: HttpCompressionEncoding | null,
+): Uint8Array {
+  if (encoding === "br") {
+    return brotliDecompressSync(body);
+  }
+  if (encoding === "gzip") {
+    return gunzipSync(body);
+  }
+  return body;
+}
+
+export function parseRequestJsonBody(
+  body: Uint8Array,
+  encoding: HttpCompressionEncoding | null,
+): unknown {
+  return JSON.parse(jsonTextDecoder.decode(decompressRequestBody(body, encoding)));
+}
+
+function readJsonRequestBody(request: HttpServerRequest.HttpServerRequest) {
+  const encoding = resolveRequestContentEncoding(request.headers);
+  if (!encoding) {
+    return request.json;
+  }
+
+  return Effect.flatMap(request.arrayBuffer, (body) =>
+    Effect.try({
+      try: () => parseRequestJsonBody(new Uint8Array(body), encoding),
+      catch: (cause) =>
+        new HttpServerError.RequestParseError({
+          request,
+          description: `Failed to decode ${encoding} request body`,
+          cause,
+        }),
+    }),
+  );
+}
+
+export function compressHttpServerResponse(
+  request: HttpServerRequest.HttpServerRequest,
+  response: HttpServerResponse.HttpServerResponse,
+): HttpServerResponse.HttpServerResponse {
+  if (
+    request.method === "HEAD" ||
+    response.status === 204 ||
+    response.status === 304 ||
+    getHeaderValue(response.headers, "content-encoding") !== undefined ||
+    response.body._tag !== "Uint8Array"
+  ) {
+    return response;
+  }
+
+  const compressedResponse = resolveCompressedResponse({
+    body: response.body.body,
+    contentType: response.body.contentType,
+    requestHeaders: request.headers,
+    responseHeaders: response.headers,
+  });
+  if (!compressedResponse.encoding) {
+    return response;
+  }
+
+  return HttpServerResponse.uint8Array(compressedResponse.body, {
+    status: response.status,
+    statusText: response.statusText,
+    contentType: response.body.contentType,
+    headers: compressedResponse.headers,
+    cookies: response.cookies,
+  });
+}
+
+export const httpCompressionMiddleware = <E, R>(
+  httpApp: Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>,
+): Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  E,
+  R | HttpServerRequest.HttpServerRequest
+> =>
+  Effect.withFiber((fiber) => {
+    const request = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest);
+    return Effect.map(httpApp, (response) => compressHttpServerResponse(request, response));
+  });
+
+export const compressionRouteLayer = HttpRouter.middleware(httpCompressionMiddleware, {
+  global: true,
+});
 
 const requireAuthenticatedRequest = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
@@ -96,7 +355,7 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
     const otlpTracesUrl = config.otlpTracesUrl;
     const browserTraceCollector = yield* BrowserTraceCollector;
     const httpClient = yield* HttpClient.HttpClient;
-    const bodyJson = cast<unknown, OtlpTracer.TraceData>(yield* request.json);
+    const bodyJson = cast<unknown, OtlpTracer.TraceData>(yield* readJsonRequestBody(request));
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),
@@ -302,9 +561,15 @@ export const staticAndDevRouteLayer = HttpRouter.add(
       if (!indexData) {
         return HttpServerResponse.text("Not Found", { status: 404 });
       }
-      return HttpServerResponse.uint8Array(indexData, {
+      const compressedIndex = resolveCompressedResponse({
+        body: indexData,
+        contentType: "text/html; charset=utf-8",
+        requestHeaders: request.headers,
+      });
+      return HttpServerResponse.uint8Array(compressedIndex.body, {
         status: 200,
         contentType: "text/html; charset=utf-8",
+        headers: compressedIndex.headers,
       });
     }
 
@@ -316,9 +581,15 @@ export const staticAndDevRouteLayer = HttpRouter.add(
       return HttpServerResponse.text("Internal Server Error", { status: 500 });
     }
 
-    return HttpServerResponse.uint8Array(data, {
+    const compressedResponse = resolveCompressedResponse({
+      body: data,
+      contentType,
+      requestHeaders: request.headers,
+    });
+    return HttpServerResponse.uint8Array(compressedResponse.body, {
       status: 200,
       contentType,
+      headers: compressedResponse.headers,
     });
   }),
 );

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -5,6 +5,7 @@ import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 import { ServerConfig } from "./config.ts";
 import {
   attachmentsRouteLayer,
+  compressionRouteLayer,
   otlpTracesProxyRouteLayer,
   projectFaviconRouteLayer,
   serverEnvironmentRouteLayer,
@@ -312,6 +313,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
+  compressionRouteLayer,
 ).pipe(Layer.provide(browserApiCorsLayer));
 
 export const makeServerLayer = Layer.unwrap(


### PR DESCRIPTION
/claim #863

## Summary

- Add HTTP response compression negotiation for in-memory server responses, with Brotli preferred over gzip when both are accepted.
- Skip compression for small responses and already-compressed media/archive content types.
- Decode gzip/Brotli OTLP JSON request bodies before handler processing.
- Add route-global compression middleware and keep direct static file compression support.
- Add safe public `_provenance.json` metadata only.

## Verification

- `bun run --cwd apps/server test src/http.test.ts`
- `bun run --cwd apps/server typecheck`
- `bun run fmt:check apps/server/src/http.ts apps/server/src/http.test.ts apps/server/src/server.ts apps/server/src/_provenance.json`
- `node --check apps\server\src\http.ts`
- `git diff --check`

Note: `git diff --check` only emitted the repository's Windows line-ending warnings for touched TypeScript files.
