### PR TITLE
OpenAI Codex [ T3 Code ] Add backend health monitoring and auto-restart

### DIFF
--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -23,6 +23,8 @@ import * as DesktopBackendManager from "./DesktopBackendManager.ts";
 import * as DesktopBackendConfiguration from "./DesktopBackendConfiguration.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const decodeDesktopBackendBootstrap = Schema.decodeEffect(
@@ -106,6 +108,8 @@ function makeManagerLayer(input: {
   readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
   readonly backendOutputLog?: Partial<DesktopObservability.DesktopBackendOutputLogShape>;
   readonly desktopState?: DesktopState.DesktopStateShape;
+  readonly electronApp?: Partial<ElectronApp.ElectronAppShape>;
+  readonly electronDialog?: Partial<ElectronDialog.ElectronDialogShape>;
   readonly desktopWindow?: Partial<DesktopWindow.DesktopWindowShape>;
   readonly config?: DesktopBackendManager.DesktopBackendStartConfig;
 }) {
@@ -128,6 +132,36 @@ function makeManagerLayer(input: {
           writeOutputChunk: () => Effect.void,
           ...input.backendOutputLog,
         } satisfies DesktopObservability.DesktopBackendOutputLogShape),
+        Layer.succeed(ElectronApp.ElectronApp, {
+          metadata: Effect.succeed({
+            appVersion: "0.0.0-test",
+            appPath: "/app",
+            isPackaged: false,
+            resourcesPath: "/resources",
+            runningUnderArm64Translation: false,
+          }),
+          name: Effect.succeed("T3 Code"),
+          whenReady: Effect.void,
+          quit: Effect.void,
+          exit: () => Effect.void,
+          relaunch: () => Effect.void,
+          setPath: () => Effect.void,
+          setName: () => Effect.void,
+          setAboutPanelOptions: () => Effect.void,
+          setAppUserModelId: () => Effect.void,
+          setDesktopName: () => Effect.void,
+          setDockIcon: () => Effect.void,
+          appendCommandLineSwitch: () => Effect.void,
+          on: () => Effect.void,
+          ...input.electronApp,
+        } satisfies ElectronApp.ElectronAppShape),
+        Layer.succeed(ElectronDialog.ElectronDialog, {
+          pickFolder: () => Effect.succeed(Option.none()),
+          confirm: () => Effect.succeed(false),
+          showMessageBox: () => Effect.succeed({ response: 0, checkboxChecked: false }),
+          showErrorBox: () => Effect.void,
+          ...input.electronDialog,
+        } satisfies ElectronDialog.ElectronDialogShape),
         Layer.succeed(DesktopWindow.DesktopWindow, {
           createMain: Effect.die("unexpected createMain"),
           ensureMain: Effect.die("unexpected ensureMain"),
@@ -388,6 +422,131 @@ describe("DesktopBackendManager", () => {
         assert.equal(yield* Queue.size(starts), 0);
         yield* TestClock.adjust(Duration.millis(1));
         assert.equal(yield* Queue.take(starts), 3);
+      }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
+    }),
+  );
+
+  it.effect("restarts a ready backend after three failed health checks", () =>
+    Effect.gen(function* () {
+      const starts = yield* Queue.unbounded<number>();
+      const readyEvents = yield* Queue.unbounded<void>();
+      const dialogs = yield* Queue.unbounded<string>();
+      let startCount = 0;
+      let requestCount = 0;
+
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.gen(function* () {
+            const scope = yield* Scope.Scope;
+            const closed = yield* Deferred.make<void>();
+            startCount += 1;
+            yield* Queue.offer(starts, startCount);
+
+            const close = Deferred.succeed(closed, void 0).pipe(Effect.asVoid);
+            yield* Scope.addFinalizer(scope, close);
+            return makeProcess({
+              exitCode: Deferred.await(closed).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
+              kill: () => close,
+            });
+          }),
+        ),
+      );
+
+      const managerLayer = makeManagerLayer({
+        spawnerLayer,
+        httpClientLayer: httpClientLayer((request) =>
+          Effect.sync(() => {
+            requestCount += 1;
+            const status = requestCount === 1 || requestCount >= 5 ? 200 : 503;
+            return responseForRequest(request, status);
+          }),
+        ),
+        desktopWindow: {
+          handleBackendReady: Queue.offer(readyEvents, void 0).pipe(Effect.asVoid),
+        },
+        electronDialog: {
+          showMessageBox: (options) =>
+            Queue.offer(dialogs, options.message).pipe(
+              Effect.as({ response: 0, checkboxChecked: false }),
+            ),
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const manager = yield* DesktopBackendManager.DesktopBackendManager;
+        yield* manager.start;
+        assert.equal(yield* Queue.take(starts), 1);
+        yield* Queue.take(readyEvents);
+        assert.equal((yield* manager.snapshot).ready, true);
+
+        for (let i = 0; i < 3 && (yield* Queue.size(starts)) === 0; i += 1) {
+          yield* TestClock.adjust(Duration.seconds(18));
+          yield* Effect.yieldNow;
+          yield* TestClock.adjust(Duration.millis(500));
+          yield* Effect.yieldNow;
+        }
+
+        assert.equal(yield* Queue.take(starts), 2);
+        yield* Queue.take(readyEvents);
+        assert.equal(yield* Queue.take(dialogs), "T3 Code backend is restarting");
+        assert.isAtLeast(requestCount, 5);
+        assert.equal((yield* manager.snapshot).ready, true);
+      }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
+    }),
+  );
+
+  it.effect("prompts for manual recovery after three failed automatic restarts", () =>
+    Effect.gen(function* () {
+      const starts = yield* Queue.unbounded<number>();
+      const dialogs = yield* Queue.unbounded<string>();
+      const quitCount = yield* Ref.make(0);
+      let startCount = 0;
+
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.sync(() => {
+            startCount += 1;
+            return makeProcess({
+              exitCode: Queue.offer(starts, startCount).pipe(
+                Effect.as(ChildProcessSpawner.ExitCode(1)),
+              ),
+            });
+          }),
+        ),
+      );
+
+      const managerLayer = makeManagerLayer({
+        spawnerLayer,
+        httpClientLayer: httpClientLayer(() => Effect.never),
+        electronApp: {
+          quit: Ref.update(quitCount, (count) => count + 1),
+        },
+        electronDialog: {
+          showMessageBox: (options) =>
+            Queue.offer(dialogs, options.message).pipe(
+              Effect.as({ response: 1, checkboxChecked: false }),
+            ),
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const manager = yield* DesktopBackendManager.DesktopBackendManager;
+        yield* manager.start;
+
+        assert.equal(yield* Queue.take(starts), 1);
+        yield* TestClock.adjust(Duration.millis(500));
+        assert.equal(yield* Queue.take(starts), 2);
+        yield* TestClock.adjust(Duration.seconds(1));
+        assert.equal(yield* Queue.take(starts), 3);
+        yield* TestClock.adjust(Duration.seconds(2));
+        assert.equal(yield* Queue.take(starts), 4);
+        yield* Effect.yieldNow;
+
+        assert.equal(yield* Queue.take(dialogs), "T3 Code backend could not be restarted");
+        assert.equal(yield* Ref.get(quitCount), 1);
+        assert.equal((yield* manager.snapshot).desiredRunning, false);
       }).pipe(Effect.provide(Layer.merge(TestClock.layer(), managerLayer)));
     }),
   );

--- a/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/t3code/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -27,6 +27,8 @@ import {
 import * as DesktopBackendConfiguration from "./DesktopBackendConfiguration.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopState from "../app/DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
 const INITIAL_RESTART_DELAY = Duration.millis(500);
@@ -34,7 +36,10 @@ const MAX_RESTART_DELAY = Duration.seconds(10);
 const DEFAULT_BACKEND_READINESS_TIMEOUT = Duration.minutes(1);
 const DEFAULT_BACKEND_READINESS_INTERVAL = Duration.millis(100);
 const DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT = Duration.seconds(1);
+const DEFAULT_BACKEND_HEALTH_INTERVAL = Duration.seconds(15);
 const DEFAULT_BACKEND_TERMINATE_GRACE = Duration.seconds(2);
+const BACKEND_HEALTH_FAILURE_THRESHOLD = 3;
+const MAX_AUTOMATIC_RESTART_ATTEMPTS = 3;
 const BACKEND_READINESS_PATH = "/.well-known/t3/environment";
 
 type BackendProcessLayerServices = ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient;
@@ -87,10 +92,12 @@ class BackendProcessSpawnError extends Data.TaggedError("BackendProcessSpawnErro
 
 type BackendProcessError = BackendProcessBootstrapEncodeError | BackendProcessSpawnError;
 
+class BackendHealthRestartRequested extends Data.TaggedError("BackendHealthRestartRequested")<{}> {}
+
 interface RunBackendProcessOptions extends DesktopBackendStartConfig {
   readonly readinessTimeout?: Duration.Duration;
   readonly onStarted?: (pid: number) => Effect.Effect<void>;
-  readonly onReady?: () => Effect.Effect<void>;
+  readonly onReady?: () => Effect.Effect<void, never, Scope.Scope>;
   readonly onReadinessFailure?: (error: BackendTimeoutError) => Effect.Effect<void>;
   readonly onOutput?: (
     streamName: BackendProcessOutputStream,
@@ -194,6 +201,25 @@ const waitForHttpReady = Effect.fn("desktop.backendManager.waitForHttpReady")(fu
   );
 });
 
+const healthCheckSchedule = Schedule.spaced(DEFAULT_BACKEND_HEALTH_INTERVAL).pipe(
+  Schedule.jittered,
+);
+
+const probeBackendHealth = Effect.fn("desktop.backendManager.probeBackendHealth")(function* (
+  baseUrl: URL,
+): Effect.fn.Return<void, BackendTimeoutError, HttpClient.HttpClient> {
+  const readinessUrl = new URL(BACKEND_READINESS_PATH, baseUrl);
+  const client = (yield* HttpClient.HttpClient).pipe(
+    HttpClient.filterStatusOk,
+    HttpClient.transformResponse(Effect.timeout(DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT)),
+  );
+
+  yield* client.get(readinessUrl).pipe(
+    Effect.asVoid,
+    Effect.mapError(() => new BackendTimeoutError({ url: readinessUrl })),
+  );
+});
+
 function describeProcessExit(
   result: Result.Result<ChildProcessSpawner.ExitCode, PlatformError.PlatformError>,
 ): BackendProcessExit {
@@ -283,6 +309,8 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
   const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
   const backendOutputLog = yield* DesktopObservability.DesktopBackendOutputLog;
   const desktopState = yield* DesktopState.DesktopState;
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const electronDialog = yield* ElectronDialog.ElectronDialog;
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
@@ -318,6 +346,157 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
       onNone: () => Effect.void,
       onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
     });
+  });
+
+  const notifyBackendRestarting = Effect.fn("desktop.backendManager.notifyBackendRestarting")(
+    function* (reason: string) {
+      yield* electronDialog
+        .showMessageBox({
+          type: "info",
+          buttons: ["OK"],
+          defaultId: 0,
+          cancelId: 0,
+          noLink: true,
+          message: "T3 Code backend is restarting",
+          detail: `The local backend stopped responding and T3 Code is starting it again.\n\nReason: ${reason}`,
+        })
+        .pipe(Effect.ignore);
+    },
+  );
+
+  const promptManualRecovery = Effect.fn("desktop.backendManager.promptManualRecovery")(function* (
+    reason: string,
+  ) {
+    yield* logBackendManagerError("backend automatic restart limit reached", {
+      reason,
+      restartAttempts: MAX_AUTOMATIC_RESTART_ATTEMPTS,
+    });
+
+    const result = yield* electronDialog.showMessageBox({
+      type: "error",
+      buttons: ["Retry", "Quit"],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+      message: "T3 Code backend could not be restarted",
+      detail:
+        "The local backend failed to recover after several automatic restart attempts. Retry starts it again now; Quit closes the app.",
+    });
+
+    if (result.response === 0) {
+      yield* Ref.update(state, (latest) => ({
+        ...latest,
+        desiredRunning: true,
+        restartAttempt: 0,
+        restartFiber: Option.none(),
+      }));
+      yield* start;
+      return;
+    }
+
+    yield* Ref.set(desktopState.quitting, true);
+    yield* electronApp.quit;
+  });
+
+  const restartUnhealthyBackend = Effect.fn("desktop.backendManager.restartUnhealthyBackend")(
+    function* (runId: number, reason: string) {
+      const active = yield* mutex.withPermits(1)(
+        Ref.modify(state, (latest) => {
+          const currentRun = Option.getOrUndefined(latest.active);
+          if (currentRun?.id !== runId || !latest.desiredRunning) {
+            return [Option.none<ActiveBackendRun>(), latest] as const;
+          }
+
+          return [
+            Option.some(currentRun),
+            {
+              ...latest,
+              ready: false,
+            },
+          ] as const;
+        }).pipe(
+          Effect.tap((run) =>
+            Option.isSome(run) ? Ref.set(desktopState.backendReady, false) : Effect.void,
+          ),
+        ),
+      );
+
+      yield* Option.match(active, {
+        onNone: () => Effect.void,
+        onSome: (run) =>
+          notifyBackendRestarting(reason).pipe(
+            Effect.forkIn(parentScope),
+            Effect.andThen(
+              logBackendManagerError("backend health monitor restarting unresponsive backend", {
+                reason,
+                runId,
+              }),
+            ),
+            Effect.andThen(closeRun(run)),
+          ),
+      });
+    },
+  );
+
+  const requestUnhealthyBackendRestart = Effect.fn(
+    "desktop.backendManager.requestUnhealthyBackendRestart",
+  )(function* (runId: number, reason: string) {
+    yield* Effect.forkIn(
+      restartUnhealthyBackend(runId, reason).pipe(
+        Effect.catchCause((cause) =>
+          logBackendManagerError("backend health restart request failed", {
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      ),
+      parentScope,
+    );
+  });
+
+  const startHealthMonitor = Effect.fn("desktop.backendManager.startHealthMonitor")(function* (
+    runId: number,
+    config: DesktopBackendStartConfig,
+  ) {
+    const consecutiveFailures = yield* Ref.make(0);
+
+    const healthCheck = Effect.gen(function* () {
+      const healthExit = yield* Effect.exit(
+        probeBackendHealth(config.httpBaseUrl).pipe(
+          Effect.provideService(HttpClient.HttpClient, httpClient),
+        ),
+      );
+
+      if (Exit.isSuccess(healthExit)) {
+        yield* Ref.set(consecutiveFailures, 0);
+        return;
+      }
+
+      const failureCount = yield* Ref.updateAndGet(consecutiveFailures, (count) => count + 1);
+      yield* logBackendManagerWarning("backend health check failed", {
+        runId,
+        failureCount,
+        failureThreshold: BACKEND_HEALTH_FAILURE_THRESHOLD,
+        url: new URL(BACKEND_READINESS_PATH, config.httpBaseUrl).href,
+      });
+
+      if (failureCount >= BACKEND_HEALTH_FAILURE_THRESHOLD) {
+        const reason = `${failureCount} consecutive backend health checks failed`;
+        yield* requestUnhealthyBackendRestart(runId, reason);
+        return yield* new BackendHealthRestartRequested();
+      }
+    });
+
+    yield* Effect.forkScoped(
+      healthCheck.pipe(
+        Effect.repeat(healthCheckSchedule),
+        Effect.catchTag("BackendHealthRestartRequested", () => Effect.void),
+        Effect.catchCause((cause) =>
+          logBackendManagerError("backend health monitor failed", {
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      ),
+    );
   });
 
   const start: Effect.Effect<void> = Effect.suspend(() =>
@@ -464,6 +643,7 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
                 }),
               ),
             );
+            yield* startHealthMonitor(runId, config);
           }),
           onReadinessFailure: (error) =>
             logBackendManagerWarning("backend readiness check failed during bootstrap", {
@@ -498,6 +678,17 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
         return [Option.none<Duration.Duration>(), latest] as const;
       }
 
+      if (latest.restartAttempt >= MAX_AUTOMATIC_RESTART_ATTEMPTS) {
+        return [
+          Option.none<Duration.Duration>(),
+          {
+            ...latest,
+            desiredRunning: false,
+            restartFiber: Option.none(),
+          },
+        ] as const;
+      }
+
       const delay = calculateRestartDelay(latest.restartAttempt);
       return [
         Option.some(delay),
@@ -509,7 +700,14 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
     });
 
     yield* Option.match(scheduled, {
-      onNone: () => Effect.void,
+      onNone: () =>
+        Ref.get(state).pipe(
+          Effect.flatMap((latest) =>
+            latest.desiredRunning || latest.restartAttempt < MAX_AUTOMATIC_RESTART_ATTEMPTS
+              ? Effect.void
+              : promptManualRecovery(reason).pipe(Effect.forkIn(parentScope), Effect.asVoid),
+          ),
+        ),
       onSome: Effect.fn("desktop.backendManager.scheduleRestartFiber")(function* (delay) {
         yield* logBackendManagerError("backend exited unexpectedly; restart scheduled", {
           reason,

--- a/t3code/apps/desktop/src/backend/_provenance.json
+++ b/t3code/apps/desktop/src/backend/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Safe public metadata only. Private system, developer, runtime, user, credential, and hidden session instructions are intentionally not included.",
+  "timestamp": "2026-07-05T16:33:27Z"
+}


### PR DESCRIPTION
/claim #820

## Summary
- Added post-readiness backend health monitoring in `DesktopBackendManager`.
- Health checks ping the existing readiness endpoint on a 15s `Effect.Schedule.spaced(...).pipe(Schedule.jittered)` schedule.
- Three consecutive health failures mark the backend unready, show a restart notification, close the unhealthy run, and let the existing restart path recover it.
- Automatic restart attempts are capped at 3; after that the app shows a retry-or-quit recovery dialog instead of looping indefinitely.
- Added safe public `_provenance.json` metadata only.

## Verification
- `bun run --cwd apps/desktop test src/backend/DesktopBackendManager.test.ts` -> 8 tests passed
- `bun run --cwd apps/desktop typecheck` -> passed
- `bun run fmt:check apps/desktop/src/backend/DesktopBackendManager.ts apps/desktop/src/backend/DesktopBackendManager.test.ts apps/desktop/src/backend/_provenance.json` -> passed
- `bun run lint apps/desktop/src/backend/DesktopBackendManager.ts apps/desktop/src/backend/DesktopBackendManager.test.ts` -> 0 warnings/errors
- `git diff --check` -> passed with line-ending warnings only

## Safety
- The provenance file intentionally contains safe public metadata only. Private system/developer/runtime/user instructions and credentials are not published.
