### PR TITLE
OpenAI Codex [ T3 Code ] Add Developer and Git menus to Electron application menu bar

### DIFF
--- a/t3code/.contributor.json
+++ b/t3code/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Safe public metadata only. Private system, developer, runtime, user, credential, and hidden session instructions are intentionally not included.",
+  "timestamp": "2026-07-05T17:12:00Z"
+}

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -4,6 +4,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 
 import type * as Electron from "electron";
 
@@ -11,8 +12,10 @@ import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as DesktopApplicationMenu from "./DesktopApplicationMenu.ts";
+import * as DesktopBackendManager from "../backend/DesktopBackendManager.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopState from "../app/DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 
@@ -63,6 +66,30 @@ const desktopUpdatesLayer = Layer.succeed(DesktopUpdates.DesktopUpdates, {
   install: Effect.die("unexpected install"),
 } satisfies DesktopUpdates.DesktopUpdatesShape);
 
+const desktopBackendManagerLayer = Layer.succeed(DesktopBackendManager.DesktopBackendManager, {
+  start: Effect.void,
+  stop: () => Effect.void,
+  currentConfig: Effect.succeed(Option.none()),
+  snapshot: Effect.succeed({
+    desiredRunning: true,
+    ready: true,
+    activePid: Option.none(),
+    restartAttempt: 0,
+    restartScheduled: false,
+  }),
+} satisfies DesktopBackendManager.DesktopBackendManagerShape);
+
+const makeDesktopStateLayer = (backendReady: boolean) =>
+  Layer.effect(
+    DesktopState.DesktopState,
+    Effect.gen(function* () {
+      return {
+        backendReady: yield* Ref.make(backendReady),
+        quitting: yield* Ref.make(false),
+      } satisfies DesktopState.DesktopStateShape;
+    }),
+  );
+
 const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
   Layer.succeed(DesktopWindow.DesktopWindow, {
     createMain: Effect.die("unexpected createMain"),
@@ -94,12 +121,14 @@ describe("DesktopApplicationMenu", () => {
 
       yield* Effect.gen(function* () {
         const menu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
-        yield* menu.configure;
+        yield* Effect.scoped(menu.configure);
       }).pipe(
         Effect.provide(
           DesktopApplicationMenu.layer.pipe(
             Layer.provideMerge(makeElectronMenuLayer(applicationMenuTemplate)),
             Layer.provideMerge(makeDesktopWindowLayer(selectedAction)),
+            Layer.provideMerge(desktopBackendManagerLayer),
+            Layer.provideMerge(makeDesktopStateLayer(true)),
             Layer.provideMerge(desktopUpdatesLayer),
             Layer.provideMerge(electronDialogLayer),
             Layer.provideMerge(electronAppLayer),
@@ -125,8 +154,72 @@ describe("DesktopApplicationMenu", () => {
         throw new Error("Expected Settings menu item to have a click handler.");
       }
 
+      const developerMenu = template.find((item) => item.label === "Developer");
+      assert.isDefined(developerMenu);
+      if (!Array.isArray(developerMenu.submenu)) {
+        throw new Error("Expected Developer menu submenu to be an array.");
+      }
+      assert.includeMembers(
+        developerMenu.submenu.map((item) => item.label),
+        ["Toggle Terminal", "Clear Terminal", "Restart Backend", "Open DevTools"],
+      );
+
+      const gitMenu = template.find((item) => item.label === "Git");
+      assert.isDefined(gitMenu);
+      if (!Array.isArray(gitMenu.submenu)) {
+        throw new Error("Expected Git menu submenu to be an array.");
+      }
+      assert.includeMembers(
+        gitMenu.submenu.map((item) => item.label),
+        ["Stage All Changes", "Commit", "Push", "Pull", "Create Branch"],
+      );
+
       settingsClick({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
       assert.equal(yield* Deferred.await(selectedAction), "open-settings");
+    }),
+  );
+
+  it.effect("disables backend-dependent menu actions until the backend is ready", () =>
+    Effect.gen(function* () {
+      const selectedAction = yield* Deferred.make<string>();
+      const applicationMenuTemplate =
+        yield* Deferred.make<readonly Electron.MenuItemConstructorOptions[]>();
+
+      yield* Effect.gen(function* () {
+        const menu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
+        yield* Effect.scoped(menu.configure);
+      }).pipe(
+        Effect.provide(
+          DesktopApplicationMenu.layer.pipe(
+            Layer.provideMerge(makeElectronMenuLayer(applicationMenuTemplate)),
+            Layer.provideMerge(makeDesktopWindowLayer(selectedAction)),
+            Layer.provideMerge(desktopBackendManagerLayer),
+            Layer.provideMerge(makeDesktopStateLayer(false)),
+            Layer.provideMerge(desktopUpdatesLayer),
+            Layer.provideMerge(electronDialogLayer),
+            Layer.provideMerge(electronAppLayer),
+            Layer.provideMerge(
+              DesktopEnvironment.layer(environmentInput).pipe(
+                Layer.provide(Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({}))),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      const template = yield* Deferred.await(applicationMenuTemplate);
+      const developerMenu = template.find((item) => item.label === "Developer");
+      const gitMenu = template.find((item) => item.label === "Git");
+      assert.isDefined(developerMenu);
+      assert.isDefined(gitMenu);
+      if (!Array.isArray(developerMenu.submenu) || !Array.isArray(gitMenu.submenu)) {
+        throw new Error("Expected Developer and Git menu submenus to be arrays.");
+      }
+
+      assert.isFalse(
+        developerMenu.submenu.find((item) => item.label === "Toggle Terminal")?.enabled,
+      );
+      assert.isFalse(gitMenu.submenu.find((item) => item.label === "Commit")?.enabled);
     }),
   );
 });

--- a/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/t3code/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -1,8 +1,11 @@
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Scope from "effect/Scope";
 
 import type * as Electron from "electron";
 
@@ -10,12 +13,14 @@ import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
+import * as DesktopBackendManager from "../backend/DesktopBackendManager.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopState from "../app/DesktopState.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 
 export interface DesktopApplicationMenuShape {
-  readonly configure: Effect.Effect<void>;
+  readonly configure: Effect.Effect<void, never, Scope.Scope>;
 }
 
 export class DesktopApplicationMenu extends Context.Service<
@@ -26,7 +31,11 @@ export class DesktopApplicationMenu extends Context.Service<
 type DesktopApplicationMenuRuntimeServices =
   | DesktopUpdates.DesktopUpdates
   | DesktopWindow.DesktopWindow
+  | DesktopBackendManager.DesktopBackendManager
+  | DesktopState.DesktopState
   | ElectronDialog.ElectronDialog;
+
+const BACKEND_MENU_REFRESH_INTERVAL = Duration.seconds(1);
 
 const { logInfo: logUpdaterInfo } = DesktopObservability.makeComponentLogger("desktop-updater");
 
@@ -67,6 +76,16 @@ const checkForUpdatesFromMenu: Effect.Effect<
   }
 }).pipe(Effect.withSpan("desktop.menu.checkForUpdates"));
 
+const restartBackendFromMenu: Effect.Effect<
+  void,
+  never,
+  DesktopBackendManager.DesktopBackendManager
+> = Effect.gen(function* () {
+  const backendManager = yield* DesktopBackendManager.DesktopBackendManager;
+  yield* backendManager.stop({ timeout: Duration.seconds(2) });
+  yield* backendManager.start;
+}).pipe(Effect.withSpan("desktop.menu.restartBackend"));
+
 const handleCheckForUpdatesMenuClick: Effect.Effect<
   void,
   DesktopWindow.DesktopWindowError,
@@ -98,9 +117,11 @@ const make = Effect.gen(function* () {
   const electronApp = yield* ElectronApp.ElectronApp;
   const electronMenu = yield* ElectronMenu.ElectronMenu;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const desktopState = yield* DesktopState.DesktopState;
   const appName = yield* electronApp.name;
   const context = yield* Effect.context<DesktopApplicationMenuRuntimeServices>();
   const runPromise = Effect.runPromiseWith(context);
+  const lastBackendReady = yield* Ref.make<boolean | null>(null);
 
   const runMenuEffect = <E>(
     action: string,
@@ -120,13 +141,19 @@ const make = Effect.gen(function* () {
     );
   };
 
-  const configure = Effect.gen(function* () {
-    const checkForUpdatesClick = () => {
-      runMenuEffect("check-for-updates", handleCheckForUpdatesMenuClick);
-    };
-    const settingsClick = () => {
-      runMenuEffect("open-settings", dispatchMenuAction("open-settings"));
-    };
+  const checkForUpdatesClick = () => {
+    runMenuEffect("check-for-updates", handleCheckForUpdatesMenuClick);
+  };
+  const dispatchRendererMenuActionClick = (action: string) => () => {
+    runMenuEffect(action, dispatchMenuAction(action));
+  };
+  const restartBackendClick = () => {
+    runMenuEffect("restart-backend", restartBackendFromMenu);
+  };
+
+  const buildTemplate = (backendReady: boolean): Electron.MenuItemConstructorOptions[] => {
+    const backendActionEnabled = backendReady;
+    const settingsClick = dispatchRendererMenuActionClick("open-settings");
     const template: Electron.MenuItemConstructorOptions[] = [];
 
     if (environment.platform === "darwin") {
@@ -189,6 +216,69 @@ const make = Effect.gen(function* () {
           { role: "togglefullscreen" },
         ],
       },
+      {
+        label: "Developer",
+        submenu: [
+          {
+            label: "Toggle Terminal",
+            accelerator: "CmdOrCtrl+`",
+            enabled: backendActionEnabled,
+            click: dispatchRendererMenuActionClick("terminal.toggle"),
+          },
+          {
+            label: "Clear Terminal",
+            accelerator: "CmdOrCtrl+Shift+K",
+            enabled: backendActionEnabled,
+            click: dispatchRendererMenuActionClick("terminal.clear"),
+          },
+          {
+            label: "Restart Backend",
+            accelerator: "CmdOrCtrl+Shift+R",
+            click: restartBackendClick,
+          },
+          { type: "separator" },
+          {
+            label: "Open DevTools",
+            accelerator: environment.platform === "darwin" ? "Alt+Command+I" : "Ctrl+Shift+I",
+            role: "toggleDevTools",
+          },
+        ],
+      },
+      {
+        label: "Git",
+        submenu: [
+          {
+            label: "Stage All Changes",
+            accelerator: "CmdOrCtrl+Shift+A",
+            enabled: backendActionEnabled,
+            click: dispatchRendererMenuActionClick("git.stageAll"),
+          },
+          {
+            label: "Commit",
+            accelerator: "CmdOrCtrl+Enter",
+            enabled: backendActionEnabled,
+            click: dispatchRendererMenuActionClick("git.commit"),
+          },
+          {
+            label: "Push",
+            accelerator: "CmdOrCtrl+Shift+P",
+            enabled: backendActionEnabled,
+            click: dispatchRendererMenuActionClick("git.push"),
+          },
+          {
+            label: "Pull",
+            accelerator: "CmdOrCtrl+Shift+U",
+            enabled: backendActionEnabled,
+            click: dispatchRendererMenuActionClick("git.pull"),
+          },
+          {
+            label: "Create Branch",
+            accelerator: "CmdOrCtrl+Shift+B",
+            enabled: backendActionEnabled,
+            click: dispatchRendererMenuActionClick("git.createBranch"),
+          },
+        ],
+      },
       { role: "windowMenu" },
       {
         role: "help",
@@ -201,7 +291,36 @@ const make = Effect.gen(function* () {
       },
     );
 
-    yield* electronMenu.setApplicationMenu(template);
+    return template;
+  };
+
+  const applyMenu = Effect.gen(function* () {
+    const backendReady = yield* Ref.get(desktopState.backendReady);
+    yield* Ref.set(lastBackendReady, backendReady);
+    yield* electronMenu.setApplicationMenu(buildTemplate(backendReady));
+  });
+
+  const refreshBackendMenuState = Effect.gen(function* () {
+    const backendReady = yield* Ref.get(desktopState.backendReady);
+    const previousBackendReady = yield* Ref.get(lastBackendReady);
+    if (previousBackendReady === backendReady) {
+      return;
+    }
+    yield* applyMenu;
+  });
+
+  const configure = Effect.gen(function* () {
+    yield* applyMenu;
+    yield* Effect.forever(
+      refreshBackendMenuState.pipe(
+        Effect.delay(BACKEND_MENU_REFRESH_INTERVAL),
+        Effect.catchCause((cause) =>
+          logMenuError("desktop menu backend readiness refresh failed", {
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      ),
+    ).pipe(Effect.forkScoped, Effect.asVoid);
   }).pipe(Effect.withSpan("desktop.menu.configure"));
 
   return DesktopApplicationMenu.of({

--- a/t3code/apps/server/src/git/GitWorkflowService.ts
+++ b/t3code/apps/server/src/git/GitWorkflowService.ts
@@ -22,6 +22,8 @@ import {
   type GitResolvePullRequestResult,
   type GitRunStackedActionInput,
   type GitRunStackedActionResult,
+  type VcsStageAllInput,
+  type VcsStageAllResult,
   type VcsStatusInput,
   type VcsStatusLocalResult,
   type VcsStatusRemoteResult,
@@ -46,6 +48,7 @@ export interface GitWorkflowServiceShape {
   readonly invalidateRemoteStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly invalidateStatus: (cwd: string) => Effect.Effect<void, never>;
   readonly pullCurrentBranch: (cwd: string) => Effect.Effect<VcsPullResult, GitCommandError>;
+  readonly stageAll: (input: VcsStageAllInput) => Effect.Effect<VcsStageAllResult, GitCommandError>;
   readonly runStackedAction: (
     input: GitRunStackedActionInput,
     options?: GitRunStackedActionOptions,
@@ -271,6 +274,11 @@ export const make = Effect.fn("makeGitWorkflowService")(function* () {
     pullCurrentBranch: (cwd) =>
       ensureGitCommand("GitWorkflowService.pullCurrentBranch", cwd).pipe(
         Effect.andThen(git.pullCurrentBranch(cwd)),
+      ),
+    stageAll: (input) =>
+      ensureGitCommand("GitWorkflowService.stageAll", input.cwd).pipe(
+        Effect.andThen(git.stageAll(input)),
+        Effect.tap(() => gitManager.invalidateStatus(input.cwd)),
       ),
     runStackedAction: (input, options) =>
       ensureGit("GitWorkflowService.runStackedAction", input.cwd).pipe(

--- a/t3code/apps/server/src/vcs/GitVcsDriver.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriver.ts
@@ -23,6 +23,8 @@ import {
   type VcsListRefsResult,
   type VcsPullResult,
   type VcsRemoveWorktreeInput,
+  type VcsStageAllInput,
+  type VcsStageAllResult,
   type VcsStatusInput,
   type VcsStatusResult,
 } from "@t3tools/contracts";
@@ -185,6 +187,7 @@ export interface GitVcsDriverShape {
   ) => Effect.Effect<string | null, GitCommandError>;
   readonly listRefs: (input: VcsListRefsInput) => Effect.Effect<VcsListRefsResult, GitCommandError>;
   readonly pullCurrentBranch: (cwd: string) => Effect.Effect<VcsPullResult, GitCommandError>;
+  readonly stageAll: (input: VcsStageAllInput) => Effect.Effect<VcsStageAllResult, GitCommandError>;
   readonly createWorktree: (
     input: VcsCreateWorktreeInput,
   ) => Effect.Effect<VcsCreateWorktreeResult, GitCommandError>;

--- a/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/t3code/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1586,6 +1586,16 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     };
   });
 
+  const stageAll: GitVcsDriver.GitVcsDriverShape["stageAll"] = Effect.fn("stageAll")(
+    function* (input) {
+      yield* executeGit("GitVcsDriver.stageAll", input.cwd, ["add", "--all"], {
+        timeoutMs: 10_000,
+        fallbackErrorMessage: "git add --all failed",
+      });
+      return { staged: true };
+    },
+  );
+
   const readRangeContext: GitVcsDriver.GitVcsDriverShape["readRangeContext"] = Effect.fn(
     "readRangeContext",
   )(function* (cwd, baseRef) {
@@ -2123,6 +2133,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     commit,
     pushCurrentBranch,
     pullCurrentBranch,
+    stageAll,
     readRangeContext,
     readConfigValue,
     listRefs,

--- a/t3code/apps/server/src/ws.ts
+++ b/t3code/apps/server/src/ws.ts
@@ -1027,6 +1027,12 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             ),
             { "rpc.aggregate": "git" },
           ),
+        [WS_METHODS.vcsStageAll]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsStageAll,
+            gitWorkflow.stageAll(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "vcs" },
+          ),
         [WS_METHODS.gitRunStackedAction]: (input) =>
           observeRpcStream(
             WS_METHODS.gitRunStackedAction,

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -2460,6 +2460,62 @@ export default function ChatView(props: ChatViewProps) {
   }, [activeThreadKey, focusComposer, terminalState.terminalOpen]);
 
   useEffect(() => {
+    const onMenuAction = window.desktopBridge?.onMenuAction;
+    if (typeof onMenuAction !== "function") {
+      return;
+    }
+
+    const unsubscribe = onMenuAction((action) => {
+      if (action === "terminal.toggle") {
+        toggleTerminalVisibility();
+        return;
+      }
+
+      if (action !== "terminal.clear") {
+        return;
+      }
+
+      const api = readEnvironmentApi(environmentId);
+      if (!api || !activeThreadId) {
+        toastManager.add({
+          type: "error",
+          title: "Terminal unavailable",
+          description: "Open a thread with a connected environment before clearing the terminal.",
+        });
+        return;
+      }
+
+      const terminalId =
+        terminalState.activeTerminalId ||
+        terminalState.terminalIds[0] ||
+        DEFAULT_THREAD_TERMINAL_ID;
+      if (!terminalState.terminalOpen) {
+        setTerminalOpen(true);
+      }
+
+      void api.terminal.clear({ threadId: activeThreadId, terminalId }).catch((error: unknown) => {
+        toastManager.add({
+          type: "error",
+          title: "Clear terminal failed",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
+      });
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [
+    activeThreadId,
+    environmentId,
+    setTerminalOpen,
+    terminalState.activeTerminalId,
+    terminalState.terminalIds,
+    terminalState.terminalOpen,
+    toggleTerminalVisibility,
+  ]);
+
+  useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
       if (!activeThreadId || useCommandPaletteStore.getState().open || event.defaultPrevented) {
         return;

--- a/t3code/apps/web/src/components/GitActionsControl.browser.tsx
+++ b/t3code/apps/web/src/components/GitActionsControl.browser.tsx
@@ -103,9 +103,11 @@ vi.mock("~/lib/gitReactQuery", () => ({
     publishRepository: vi.fn(() => ["publish-repository"]),
     pull: vi.fn(() => ["pull"]),
     runStackedAction: vi.fn(() => ["run-stacked-action"]),
+    stageAll: vi.fn(() => ["stage-all"]),
   },
   gitPullMutationOptions: vi.fn(() => ({ __kind: "pull" })),
   gitRunStackedActionMutationOptions: vi.fn(() => ({ __kind: "run-stacked-action" })),
+  gitStageAllMutationOptions: vi.fn(() => ({ __kind: "stage-all" })),
   invalidateGitQueries: invalidateGitQueriesSpy,
   sourceControlPublishRepositoryMutationOptions: vi.fn(() => ({ __kind: "publish-repository" })),
 }));

--- a/t3code/apps/web/src/components/GitActionsControl.tsx
+++ b/t3code/apps/web/src/components/GitActionsControl.tsx
@@ -69,6 +69,7 @@ import {
   gitMutationKeys,
   gitPullMutationOptions,
   gitRunStackedActionMutationOptions,
+  gitStageAllMutationOptions,
   sourceControlPublishRepositoryMutationOptions,
 } from "~/lib/gitReactQuery";
 import { refreshGitStatus, useGitStatus } from "~/lib/gitStatusState";
@@ -1088,6 +1089,9 @@ export default function GitActionsControl({
   const pullMutation = useMutation(
     gitPullMutationOptions({ environmentId: activeEnvironmentId, cwd: gitCwd, queryClient }),
   );
+  const stageAllMutation = useMutation(
+    gitStageAllMutationOptions({ environmentId: activeEnvironmentId, cwd: gitCwd, queryClient }),
+  );
 
   const isRunStackedActionRunning =
     useIsMutating({
@@ -1095,11 +1099,14 @@ export default function GitActionsControl({
     }) > 0;
   const isPullRunning =
     useIsMutating({ mutationKey: gitMutationKeys.pull(activeEnvironmentId, gitCwd) }) > 0;
+  const isStageAllRunning =
+    useIsMutating({ mutationKey: gitMutationKeys.stageAll(activeEnvironmentId, gitCwd) }) > 0;
   const isPublishRunning =
     useIsMutating({
       mutationKey: gitMutationKeys.publishRepository(activeEnvironmentId, gitCwd),
     }) > 0;
-  const isGitActionRunning = isRunStackedActionRunning || isPullRunning || isPublishRunning;
+  const isGitActionRunning =
+    isRunStackedActionRunning || isPullRunning || isStageAllRunning || isPublishRunning;
   const isSelectingWorktreeBase =
     !activeServerThread &&
     activeDraftThread?.envMode === "worktree" &&
@@ -1488,6 +1495,30 @@ export default function GitActionsControl({
     });
   };
 
+  const runPullWithToast = useCallback(() => {
+    const promise = pullMutation.mutateAsync();
+    void toastManager.promise<
+      Awaited<ReturnType<typeof pullMutation.mutateAsync>>,
+      ThreadToastData
+    >(promise, {
+      loading: { title: "Pulling...", data: threadToastData },
+      success: (result) => ({
+        title: result.status === "pulled" ? "Pulled" : "Already up to date",
+        description:
+          result.status === "pulled"
+            ? `Updated ${result.refName} from ${result.upstreamRef ?? "upstream"}`
+            : `${result.refName} is already synchronized.`,
+        data: threadToastData,
+      }),
+      error: (err) => ({
+        title: "Pull failed",
+        description: err instanceof Error ? err.message : "An error occurred.",
+        data: threadToastData,
+      }),
+    });
+    void promise.catch(() => undefined);
+  }, [pullMutation, threadToastData]);
+
   const runDialogActionOnNewBranch = () => {
     if (!isCommitDialogOpen) return;
     const commitMessage = dialogCommitMessage.trim();
@@ -1516,27 +1547,7 @@ export default function GitActionsControl({
       return;
     }
     if (quickAction.kind === "run_pull") {
-      const promise = pullMutation.mutateAsync();
-      void toastManager.promise<
-        Awaited<ReturnType<typeof pullMutation.mutateAsync>>,
-        ThreadToastData
-      >(promise, {
-        loading: { title: "Pulling...", data: threadToastData },
-        success: (result) => ({
-          title: result.status === "pulled" ? "Pulled" : "Already up to date",
-          description:
-            result.status === "pulled"
-              ? `Updated ${result.refName} from ${result.upstreamRef ?? "upstream"}`
-              : `${result.refName} is already synchronized.`,
-          data: threadToastData,
-        }),
-        error: (err) => ({
-          title: "Pull failed",
-          description: err instanceof Error ? err.message : "An error occurred.",
-          data: threadToastData,
-        }),
-      });
-      void promise.catch(() => undefined);
+      runPullWithToast();
       return;
     }
     if (quickAction.kind === "show_hint") {
@@ -1553,24 +1564,27 @@ export default function GitActionsControl({
     }
   };
 
-  const openDialogForMenuItem = (item: GitActionMenuItem) => {
-    if (item.disabled) return;
-    if (item.kind === "open_pr") {
-      void openExistingPr();
-      return;
-    }
-    if (item.dialogAction === "push") {
-      void runGitActionWithToast({ action: "push" });
-      return;
-    }
-    if (item.dialogAction === "create_pr") {
-      void runGitActionWithToast({ action: "create_pr" });
-      return;
-    }
-    setExcludedFiles(new Set());
-    setIsEditingFiles(false);
-    setIsCommitDialogOpen(true);
-  };
+  const openDialogForMenuItem = useCallback(
+    (item: GitActionMenuItem) => {
+      if (item.disabled) return;
+      if (item.kind === "open_pr") {
+        void openExistingPr();
+        return;
+      }
+      if (item.dialogAction === "push") {
+        void runGitActionWithToast({ action: "push" });
+        return;
+      }
+      if (item.dialogAction === "create_pr") {
+        void runGitActionWithToast({ action: "create_pr" });
+        return;
+      }
+      setExcludedFiles(new Set());
+      setIsEditingFiles(false);
+      setIsCommitDialogOpen(true);
+    },
+    [openExistingPr, runGitActionWithToast],
+  );
 
   const runDialogAction = () => {
     if (!isCommitDialogOpen) return;
@@ -1585,6 +1599,136 @@ export default function GitActionsControl({
       ...(!allSelected ? { filePaths: selectedFiles.map((f) => f.path) } : {}),
     });
   };
+
+  useEffect(() => {
+    const onMenuAction = window.desktopBridge?.onMenuAction;
+    if (typeof onMenuAction !== "function") {
+      return;
+    }
+
+    const showUnavailableToast = (title: string, description: string) => {
+      toastManager.add({
+        type: "info",
+        title,
+        description,
+        data: threadToastData,
+      });
+    };
+
+    const runStageAll = () => {
+      if (!gitCwd || !activeEnvironmentId) {
+        showUnavailableToast("Stage All Changes", "Git actions are unavailable.");
+        return;
+      }
+      if (!gitStatusForActions?.hasWorkingTreeChanges) {
+        showUnavailableToast("Stage All Changes", "There are no working tree changes to stage.");
+        return;
+      }
+      if (isGitActionRunning) {
+        showUnavailableToast("Stage All Changes", "Another Git action is already running.");
+        return;
+      }
+
+      const promise = stageAllMutation.mutateAsync();
+      void toastManager.promise<
+        Awaited<ReturnType<typeof stageAllMutation.mutateAsync>>,
+        ThreadToastData
+      >(promise, {
+        loading: { title: "Staging changes...", data: threadToastData },
+        success: () => ({ title: "Changes staged", data: threadToastData }),
+        error: (err) => ({
+          title: "Stage failed",
+          description: err instanceof Error ? err.message : "An error occurred.",
+          data: threadToastData,
+        }),
+      });
+      void promise.catch(() => undefined);
+    };
+
+    const runMenuItem = (itemId: GitActionMenuItem["id"], actionLabel: string) => {
+      const item = gitActionMenuItems.find((entry) => entry.id === itemId);
+      if (!item) {
+        showUnavailableToast(actionLabel, "Git status is unavailable.");
+        return;
+      }
+      if (item.disabled) {
+        showUnavailableToast(
+          actionLabel,
+          getMenuActionDisabledReason({
+            item,
+            gitStatus: gitStatusForActions,
+            isBusy: isGitActionRunning,
+            hasPrimaryRemote,
+          }) ?? "This Git action is currently unavailable.",
+        );
+        return;
+      }
+      openDialogForMenuItem(item);
+    };
+
+    const unsubscribe = onMenuAction((action) => {
+      switch (action) {
+        case "git.stageAll":
+          runStageAll();
+          return;
+        case "git.commit":
+          runMenuItem("commit", "Commit");
+          return;
+        case "git.push":
+          runMenuItem("push", "Push");
+          return;
+        case "git.pull":
+          if (!gitStatusForActions) {
+            showUnavailableToast("Pull", "Git status is unavailable.");
+            return;
+          }
+          if (isGitActionRunning) {
+            showUnavailableToast("Pull", "Another Git action is already running.");
+            return;
+          }
+          if (!gitStatusForActions.refName || !gitStatusForActions.hasUpstream) {
+            showUnavailableToast("Pull", "The current branch has no upstream to pull from.");
+            return;
+          }
+          runPullWithToast();
+          return;
+        case "git.createBranch":
+          if (isGitActionRunning) {
+            showUnavailableToast("Create Branch", "Another Git action is already running.");
+            return;
+          }
+          if (!gitStatusForActions?.hasWorkingTreeChanges) {
+            showUnavailableToast(
+              "Create Branch",
+              "Make working tree changes before creating a feature branch from this menu.",
+            );
+            return;
+          }
+          void runGitActionWithToast({
+            action: "commit",
+            featureBranch: true,
+            skipDefaultBranchPrompt: true,
+          });
+          return;
+      }
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [
+    activeEnvironmentId,
+    gitActionMenuItems,
+    gitCwd,
+    gitStatusForActions,
+    hasPrimaryRemote,
+    isGitActionRunning,
+    openDialogForMenuItem,
+    runGitActionWithToast,
+    runPullWithToast,
+    stageAllMutation,
+    threadToastData,
+  ]);
 
   const openChangedFileInEditor = useCallback(
     (filePath: string) => {

--- a/t3code/apps/web/src/environmentApi.ts
+++ b/t3code/apps/web/src/environmentApi.ts
@@ -38,6 +38,7 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
       createRef: rpcClient.vcs.createRef,
       switchRef: rpcClient.vcs.switchRef,
       init: rpcClient.vcs.init,
+      stageAll: rpcClient.vcs.stageAll,
     },
     git: {
       resolvePullRequest: rpcClient.git.resolvePullRequest,

--- a/t3code/apps/web/src/lib/gitReactQuery.ts
+++ b/t3code/apps/web/src/lib/gitReactQuery.ts
@@ -35,6 +35,8 @@ export const gitMutationKeys = {
     ["git", "mutation", "run-stacked-action", environmentId ?? null, cwd] as const,
   pull: (environmentId: EnvironmentId | null, cwd: string | null) =>
     ["git", "mutation", "pull", environmentId ?? null, cwd] as const,
+  stageAll: (environmentId: EnvironmentId | null, cwd: string | null) =>
+    ["git", "mutation", "stage-all", environmentId ?? null, cwd] as const,
   preparePullRequestThread: (environmentId: EnvironmentId | null, cwd: string | null) =>
     ["git", "mutation", "prepare-pull-request-thread", environmentId ?? null, cwd] as const,
   publishRepository: (environmentId: EnvironmentId | null, cwd: string | null) =>
@@ -224,6 +226,24 @@ export function gitPullMutationOptions(input: {
       if (!input.cwd || !input.environmentId) throw new Error("Git pull is unavailable.");
       const api = ensureEnvironmentApi(input.environmentId);
       return api.vcs.pull({ cwd: input.cwd });
+    },
+    onSuccess: async () => {
+      await invalidateGitBranchQueries(input.queryClient, input.environmentId, input.cwd);
+    },
+  });
+}
+
+export function gitStageAllMutationOptions(input: {
+  environmentId: EnvironmentId | null;
+  cwd: string | null;
+  queryClient: QueryClient;
+}) {
+  return mutationOptions({
+    mutationKey: gitMutationKeys.stageAll(input.environmentId, input.cwd),
+    mutationFn: async () => {
+      if (!input.cwd || !input.environmentId) throw new Error("Git stage all is unavailable.");
+      const api = ensureEnvironmentApi(input.environmentId);
+      return api.vcs.stageAll({ cwd: input.cwd });
     },
     onSuccess: async () => {
       await invalidateGitBranchQueries(input.queryClient, input.environmentId, input.cwd);

--- a/t3code/apps/web/src/rpc/wsRpcClient.ts
+++ b/t3code/apps/web/src/rpc/wsRpcClient.ts
@@ -86,6 +86,7 @@ export interface WsRpcClient {
   };
   readonly vcs: {
     readonly pull: RpcUnaryMethod<typeof WS_METHODS.vcsPull>;
+    readonly stageAll: RpcUnaryMethod<typeof WS_METHODS.vcsStageAll>;
     readonly refreshStatus: RpcUnaryMethod<typeof WS_METHODS.vcsRefreshStatus>;
     readonly onStatus: (
       input: RpcInput<typeof WS_METHODS.subscribeVcsStatus>,
@@ -199,6 +200,7 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
     },
     vcs: {
       pull: (input) => transport.request((client) => client[WS_METHODS.vcsPull](input)),
+      stageAll: (input) => transport.request((client) => client[WS_METHODS.vcsStageAll](input)),
       refreshStatus: (input) =>
         transport.request((client) => client[WS_METHODS.vcsRefreshStatus](input)),
       onStatus: (input, listener, options) => {

--- a/t3code/packages/contracts/src/git.ts
+++ b/t3code/packages/contracts/src/git.ts
@@ -109,6 +109,16 @@ export const VcsPullInput = Schema.Struct({
 });
 export type VcsPullInput = typeof VcsPullInput.Type;
 
+export const VcsStageAllInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type VcsStageAllInput = typeof VcsStageAllInput.Type;
+
+export const VcsStageAllResult = Schema.Struct({
+  staged: Schema.Boolean,
+});
+export type VcsStageAllResult = typeof VcsStageAllResult.Type;
+
 export const GitRunStackedActionInput = Schema.Struct({
   actionId: TrimmedNonEmptyStringSchema,
   cwd: TrimmedNonEmptyStringSchema,

--- a/t3code/packages/contracts/src/ipc.ts
+++ b/t3code/packages/contracts/src/ipc.ts
@@ -12,6 +12,8 @@ import type {
   VcsListRefsResult,
   VcsPullInput,
   VcsPullResult,
+  VcsStageAllInput,
+  VcsStageAllResult,
   VcsRemoveWorktreeInput,
   GitResolvePullRequestResult,
   VcsStatusInput,
@@ -529,6 +531,7 @@ export interface EnvironmentApi {
     switchRef: (input: VcsSwitchRefInput) => Promise<VcsSwitchRefResult>;
     init: (input: VcsInitInput) => Promise<void>;
     pull: (input: VcsPullInput) => Promise<VcsPullResult>;
+    stageAll: (input: VcsStageAllInput) => Promise<VcsStageAllResult>;
     refreshStatus: (input: VcsStatusInput) => Promise<VcsStatusResult>;
     onStatus: (
       input: VcsStatusInput,

--- a/t3code/packages/contracts/src/rpc.ts
+++ b/t3code/packages/contracts/src/rpc.ts
@@ -25,6 +25,8 @@ import {
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
   VcsPullInput,
+  VcsStageAllInput,
+  VcsStageAllResult,
   GitPullRequestRefInput,
   VcsPullResult,
   VcsRemoveWorktreeInput,
@@ -115,6 +117,7 @@ export const WS_METHODS = {
 
   // VCS methods
   vcsPull: "vcs.pull",
+  vcsStageAll: "vcs.stageAll",
   vcsRefreshStatus: "vcs.refreshStatus",
   vcsListRefs: "vcs.listRefs",
   vcsCreateWorktree: "vcs.createWorktree",
@@ -297,6 +300,12 @@ export const WsSubscribeVcsStatusRpc = Rpc.make(WS_METHODS.subscribeVcsStatus, {
 export const WsVcsPullRpc = Rpc.make(WS_METHODS.vcsPull, {
   payload: VcsPullInput,
   success: VcsPullResult,
+  error: GitCommandError,
+});
+
+export const WsVcsStageAllRpc = Rpc.make(WS_METHODS.vcsStageAll, {
+  payload: VcsStageAllInput,
+  success: VcsStageAllResult,
   error: GitCommandError,
 });
 
@@ -494,6 +503,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsFilesystemBrowseRpc,
   WsSubscribeVcsStatusRpc,
   WsVcsPullRpc,
+  WsVcsStageAllRpc,
   WsVcsRefreshStatusRpc,
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,


### PR DESCRIPTION
/claim #831

## Summary

- Adds native Developer and Git application menus to the Electron desktop menu.
- Routes terminal and Git menu selections through the existing desktop menu-action bridge.
- Adds a narrow `vcs.stageAll` RPC backed by `git add --all` so the Git menu can stage changes without faking the operation.
- Handles Restart Backend in the desktop backend manager boundary and refreshes native menu enabled state when backend readiness changes.
- Adds safe public contributor metadata at `t3code/.contributor.json`.

## Verification

- `bun run --cwd apps/desktop test src/window/DesktopApplicationMenu.test.ts`
- `bun run --cwd apps/web test src/lib/gitReactQuery.test.ts src/components/GitActionsControl.browser.tsx`
- `bun run --cwd apps/server test src/vcs/GitVcsDriverCore.test.ts`
- `bun run --cwd packages/contracts test src/git.test.ts`
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/server typecheck`
- `bun run fmt:check ...`
- `bun run lint ...` exits 0; it still reports existing `ChatView` `composerRef.current` dependency warnings unrelated to this menu wiring.
- `git diff --check`

## Privacy note

The requested contributor metadata is intentionally limited to safe public metadata. Private system, developer, runtime, user, credential, and hidden session instructions are not included.
