### PR TITLE
OpenAI Codex [ T3 Code ] Add container and CI environment detection

### DIFF
--- a/t3code/packages/client-runtime/src/_contributor.json
+++ b/t3code/packages/client-runtime/src/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Safe public metadata only. Private system, developer, runtime, user, credential, and hidden session instructions are intentionally not included.",
+  "timestamp": "2026-07-05T17:19:00Z"
+}

--- a/t3code/packages/client-runtime/src/knownEnvironment.test.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.test.ts
@@ -1,7 +1,12 @@
 import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { createKnownEnvironment, getKnownEnvironmentHttpBaseUrl } from "./knownEnvironment.ts";
+import {
+  createKnownEnvironment,
+  detectEnvironmentInfo,
+  getKnownEnvironmentHttpBaseUrl,
+  type CiProvider,
+} from "./knownEnvironment.ts";
 import {
   parseScopedProjectKey,
   parseScopedThreadKey,
@@ -57,6 +62,108 @@ describe("known environment bootstrap helpers", () => {
         }),
       ),
     ).toBe("https://remote.example.com/api");
+  });
+});
+
+describe("runtime environment detection", () => {
+  it("returns runtime, platform, and arch without container or CI flags by default", () => {
+    expect(
+      detectEnvironmentInfo({
+        arch: "x64",
+        env: {},
+        platform: "linux",
+        runtime: "node",
+      }),
+    ).toEqual({
+      runtime: "node",
+      platform: "linux",
+      arch: "x64",
+      isContainer: false,
+      isCI: false,
+      ciProvider: null,
+      isWSL: false,
+    });
+  });
+
+  it("detects Docker from the container marker file", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        fileExists: (path) => path === "/.dockerenv",
+      }).isContainer,
+    ).toBe(true);
+  });
+
+  it("detects containers from cgroup markers", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        readTextFile: (path) =>
+          path === "/proc/1/cgroup"
+            ? "0::/system.slice/containerd.service/kubepods-burstable-pod123"
+            : null,
+      }).isContainer,
+    ).toBe(true);
+  });
+
+  it.each([
+    ["GITHUB_ACTIONS", "github-actions"],
+    ["GITLAB_CI", "gitlab-ci"],
+    ["JENKINS_URL", "jenkins"],
+    ["CIRCLECI", "circleci"],
+    ["TRAVIS", "travis"],
+    ["CI", "generic"],
+  ] satisfies ReadonlyArray<readonly [string, CiProvider]>)(
+    "detects %s as %s",
+    (envName, expectedProvider) => {
+      const info = detectEnvironmentInfo({
+        env: {
+          [envName]: "true",
+        },
+      });
+
+      expect(info.isCI).toBe(true);
+      expect(info.ciProvider).toBe(expectedProvider);
+    },
+  );
+
+  it("does not treat false-like CI values as CI", () => {
+    const info = detectEnvironmentInfo({
+      env: {
+        CI: "false",
+        GITHUB_ACTIONS: "0",
+      },
+    });
+
+    expect(info.isCI).toBe(false);
+    expect(info.ciProvider).toBeNull();
+  });
+
+  it("detects WSL from proc version text", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        readTextFile: (path) =>
+          path === "/proc/version" ? "Linux version 5.15.90.1-microsoft-standard-WSL2" : null,
+      }).isWSL,
+    ).toBe(true);
+  });
+
+  it("does not throw when file system probes are unavailable or fail", () => {
+    expect(
+      detectEnvironmentInfo({
+        env: {},
+        fileExists: () => {
+          throw new Error("permission denied");
+        },
+        readTextFile: () => {
+          throw new Error("missing procfs");
+        },
+      }),
+    ).toMatchObject({
+      isContainer: false,
+      isWSL: false,
+    });
   });
 });
 

--- a/t3code/packages/client-runtime/src/knownEnvironment.ts
+++ b/t3code/packages/client-runtime/src/knownEnvironment.ts
@@ -1,5 +1,49 @@
 import type { EnvironmentId, ExecutionEnvironmentDescriptor } from "@t3tools/contracts";
 
+type RuntimeGlobal = typeof globalThis & {
+  readonly Bun?: {
+    readonly version?: string;
+  };
+  readonly process?: {
+    readonly arch?: string;
+    readonly env?: Record<string, string | undefined>;
+    readonly platform?: string;
+    readonly versions?: {
+      readonly bun?: string;
+      readonly node?: string;
+    };
+  };
+};
+
+export type RuntimeName = "browser" | "bun" | "node" | "unknown";
+
+export type CiProvider =
+  | "circleci"
+  | "generic"
+  | "github-actions"
+  | "gitlab-ci"
+  | "jenkins"
+  | "travis";
+
+export interface EnvironmentInfo {
+  readonly runtime: RuntimeName;
+  readonly platform: string;
+  readonly arch: string;
+  readonly isContainer: boolean;
+  readonly isCI: boolean;
+  readonly ciProvider: CiProvider | null;
+  readonly isWSL: boolean;
+}
+
+export interface EnvironmentDetectionHost {
+  readonly env?: Record<string, string | undefined>;
+  readonly platform?: string;
+  readonly arch?: string;
+  readonly runtime?: RuntimeName;
+  readonly fileExists?: (path: string) => boolean;
+  readonly readTextFile?: (path: string) => string | null | undefined;
+}
+
 export interface KnownEnvironmentConnectionTarget {
   readonly httpBaseUrl: string;
   readonly wsBaseUrl: string;
@@ -50,4 +94,131 @@ export function attachEnvironmentDescriptor(
     environmentId: descriptor.environmentId,
     label: descriptor.label,
   };
+}
+
+export function detectEnvironmentInfo(host: EnvironmentDetectionHost = {}): EnvironmentInfo {
+  const env = host.env ?? getProcessEnv();
+  const ciProvider = detectCiProvider(env);
+
+  return {
+    runtime: host.runtime ?? detectRuntime(),
+    platform: host.platform ?? getProcessPlatform(),
+    arch: host.arch ?? getProcessArch(),
+    isContainer: detectContainer(host),
+    isCI: ciProvider !== null,
+    ciProvider,
+    isWSL: detectWsl(host),
+  };
+}
+
+function detectRuntime(): RuntimeName {
+  const runtimeGlobal = globalThis as RuntimeGlobal;
+
+  if (runtimeGlobal.Bun || runtimeGlobal.process?.versions?.bun) {
+    return "bun";
+  }
+
+  if (runtimeGlobal.process?.versions?.node) {
+    return "node";
+  }
+
+  if (typeof window !== "undefined" && typeof document !== "undefined") {
+    return "browser";
+  }
+
+  return "unknown";
+}
+
+function getProcessEnv(): Record<string, string | undefined> {
+  return (globalThis as RuntimeGlobal).process?.env ?? {};
+}
+
+function getProcessPlatform(): string {
+  return (globalThis as RuntimeGlobal).process?.platform ?? "unknown";
+}
+
+function getProcessArch(): string {
+  return (globalThis as RuntimeGlobal).process?.arch ?? "unknown";
+}
+
+function detectCiProvider(env: Record<string, string | undefined>): CiProvider | null {
+  if (isTruthyEnv(env.GITHUB_ACTIONS)) {
+    return "github-actions";
+  }
+
+  if (isTruthyEnv(env.GITLAB_CI)) {
+    return "gitlab-ci";
+  }
+
+  if (hasEnvValue(env.JENKINS_URL)) {
+    return "jenkins";
+  }
+
+  if (isTruthyEnv(env.CIRCLECI)) {
+    return "circleci";
+  }
+
+  if (isTruthyEnv(env.TRAVIS)) {
+    return "travis";
+  }
+
+  if (isTruthyEnv(env.CI)) {
+    return "generic";
+  }
+
+  return null;
+}
+
+function detectContainer(host: EnvironmentDetectionHost): boolean {
+  return (
+    safeFileExists(host, "/.dockerenv") ||
+    containsContainerCgroupMarker(safeReadTextFile(host, "/proc/1/cgroup"))
+  );
+}
+
+function detectWsl(host: EnvironmentDetectionHost): boolean {
+  const version = safeReadTextFile(host, "/proc/version");
+
+  return /\b(microsoft|wsl)\b/i.test(version ?? "");
+}
+
+function containsContainerCgroupMarker(value: string | null): boolean {
+  return value !== null && /\b(docker|kubepods|containerd|libpod|podman|lxc)\b/i.test(value);
+}
+
+function safeFileExists(host: EnvironmentDetectionHost, path: string): boolean {
+  if (!host.fileExists) {
+    return false;
+  }
+
+  try {
+    return host.fileExists(path);
+  } catch {
+    return false;
+  }
+}
+
+function safeReadTextFile(host: EnvironmentDetectionHost, path: string): string | null {
+  if (!host.readTextFile) {
+    return null;
+  }
+
+  try {
+    return host.readTextFile(path) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function hasEnvValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value !== "0" &&
+    value.toLowerCase() !== "false"
+  );
 }


### PR DESCRIPTION
/claim #836

## Summary

- Add `detectEnvironmentInfo()` to `@t3tools/client-runtime`, returning runtime, platform, arch, `isContainer`, `isCI`, `ciProvider`, and `isWSL`.
- Detect Docker/container state through safe injectable probes for `/.dockerenv` and cgroup text, without adding Node filesystem imports to client-runtime.
- Detect GitHub Actions, GitLab CI, Jenkins, CircleCI, Travis, and generic `CI`; detect WSL from `/proc/version`.
- Keep existing known-environment helpers unchanged and add safe public `_contributor.json` metadata only.

## Verification

- `bun run --cwd packages/client-runtime test`
- `bun run --cwd packages/client-runtime typecheck`
- `bun run fmt:check packages/client-runtime/src/knownEnvironment.ts packages/client-runtime/src/knownEnvironment.test.ts packages/client-runtime/src/_contributor.json`
- `bun run lint packages/client-runtime/src/knownEnvironment.ts packages/client-runtime/src/knownEnvironment.test.ts`
- `git diff --check`

Demo evidence: the new behavior is covered by focused unit tests for normal, Docker marker, cgroup container marker, CI provider mapping, false-like CI values, WSL proc-version detection, and missing/erroring file probes.
