### PR TITLE
OpenAI Codex [ T3 Code ] Add fuzzy search to CommandPalette

### DIFF
--- a/t3code/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/t3code/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,6 +4,7 @@ import type { Thread } from "../types";
 import {
   buildThreadActionItems,
   filterCommandPaletteGroups,
+  matchCommandPaletteSearchField,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -162,5 +163,182 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+describe("filterCommandPaletteGroups", () => {
+  it("fuzzy matches command titles across word boundaries and exposes highlight indexes", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: [
+        {
+          kind: "action",
+          value: "open-file",
+          searchTerms: ["Open File"],
+          title: "Open File",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "ofl",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["open-file"]);
+    expect(groups[0]?.items[0]?.titleMatchIndexes).toEqual([0, 5, 7]);
+  });
+
+  it("sorts better fuzzy title matches ahead of looser matches", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: [
+        {
+          kind: "action",
+          value: "open-folder",
+          searchTerms: ["Open Folder"],
+          title: "Open Folder",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "open-file",
+          searchTerms: ["Open File"],
+          title: "Open File",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "ofl",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["open-file", "open-folder"]);
+  });
+
+  it("keeps empty queries in the default order", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: [
+        {
+          kind: "action",
+          value: "second",
+          searchTerms: ["Second"],
+          title: "Second",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "first",
+          searchTerms: ["First"],
+          title: "First",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["second", "first"]);
+    expect(groups[0]?.items[0]?.titleMatchIndexes).toBeUndefined();
+  });
+
+  it("filters single-character queries", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: [
+        {
+          kind: "action",
+          value: "open-file",
+          searchTerms: ["Open File"],
+          title: "Open File",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "save-file",
+          searchTerms: ["Save File"],
+          title: "Save File",
+          icon: null,
+          run: async () => undefined,
+        },
+        {
+          kind: "action",
+          value: "close-file",
+          searchTerms: ["Close File"],
+          title: "Close File",
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "o",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["open-file", "close-file"]);
+  });
+
+  it("handles 200+ registered commands with linear fuzzy matching", () => {
+    const group: CommandPaletteGroup = {
+      value: "actions",
+      label: "Actions",
+      items: Array.from({ length: 250 }, (_, index) => ({
+        kind: "action" as const,
+        value: `command-${index}`,
+        searchTerms: [`Command ${index.toString().padStart(3, "0")}`],
+        title: `Command ${index.toString().padStart(3, "0")}`,
+        icon: null,
+        run: async () => undefined,
+      })),
+    };
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [group],
+      query: "cmd",
+      isInSubmenu: false,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(groups[0]?.items).toHaveLength(250);
+    expect(groups[0]?.items[0]?.titleMatchIndexes).toEqual([0, 2, 6]);
+  });
+});
+
+describe("matchCommandPaletteSearchField", () => {
+  it("returns null when query characters are missing", () => {
+    expect(matchCommandPaletteSearchField("Open File", "oz")).toBeNull();
   });
 });

--- a/t3code/apps/web/src/components/CommandPalette.logic.ts
+++ b/t3code/apps/web/src/components/CommandPalette.logic.ts
@@ -14,6 +14,7 @@ export interface CommandPaletteItem {
   readonly value: string;
   readonly searchTerms: ReadonlyArray<string>;
   readonly title: ReactNode;
+  readonly titleMatchIndexes?: ReadonlyArray<number>;
   readonly description?: string;
   readonly timestamp?: string;
   readonly icon: ReactNode;
@@ -175,37 +176,115 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
   });
 }
 
-function rankSearchFieldMatch(field: string, normalizedQuery: string): number {
+export interface CommandPaletteFuzzyMatch {
+  readonly matchedIndexes: ReadonlyArray<number>;
+  readonly score: number;
+}
+
+function isAlphaNumeric(value: string): boolean {
+  return /[a-z0-9]/i.test(value);
+}
+
+function isLowercaseAsciiLetter(value: string): boolean {
+  return value >= "a" && value <= "z";
+}
+
+function isUppercaseAsciiLetter(value: string): boolean {
+  return value >= "A" && value <= "Z";
+}
+
+function isWordBoundary(value: string, index: number): boolean {
+  if (index === 0) {
+    return true;
+  }
+
+  const previous = value[index - 1] ?? "";
+  const current = value[index] ?? "";
+  return (
+    !isAlphaNumeric(previous) ||
+    (isLowercaseAsciiLetter(previous) && isUppercaseAsciiLetter(current))
+  );
+}
+
+export function matchCommandPaletteSearchField(
+  field: string,
+  normalizedQuery: string,
+): CommandPaletteFuzzyMatch | null {
+  if (field.length === 0 || normalizedQuery.length === 0) {
+    return null;
+  }
+
+  const lowerField = field.toLowerCase();
+  const lowerQuery = normalizedQuery.toLowerCase();
+  const matchedIndexes: number[] = [];
+  let fieldIndex = 0;
+
+  for (const queryCharacter of lowerQuery) {
+    const nextIndex = lowerField.indexOf(queryCharacter, fieldIndex);
+    if (nextIndex === -1) {
+      return null;
+    }
+
+    matchedIndexes.push(nextIndex);
+    fieldIndex = nextIndex + 1;
+  }
+
   const normalizedField = normalizeSearchText(field);
-  if (normalizedField.length === 0 || !normalizedField.includes(normalizedQuery)) {
-    return Number.NEGATIVE_INFINITY;
-  }
+  let score = 1_000;
+
   if (normalizedField === normalizedQuery) {
-    return 3;
+    score += 500;
+  } else if (normalizedField.startsWith(normalizedQuery)) {
+    score += 250;
   }
-  if (normalizedField.startsWith(normalizedQuery)) {
-    return 2;
+
+  for (let index = 0; index < matchedIndexes.length; index += 1) {
+    const matchedIndex = matchedIndexes[index] ?? 0;
+    score += 20;
+
+    if (isWordBoundary(field, matchedIndex)) {
+      score += 40;
+    }
+
+    if (index > 0 && matchedIndex === (matchedIndexes[index - 1] ?? 0) + 1) {
+      score += 25;
+    }
   }
-  return 1;
+
+  score += Math.max(0, 80 - field.length);
+
+  return { matchedIndexes, score };
 }
 
 function rankCommandPaletteItemMatch(
   item: CommandPaletteActionItem | CommandPaletteSubmenuItem,
   normalizedQuery: string,
-): number {
+): { matchedIndexes: ReadonlyArray<number>; rank: number; termIndex: number } | null {
   const terms = item.searchTerms.filter((term) => term.length > 0);
   if (terms.length === 0) {
-    return 0;
+    return null;
   }
 
+  let bestMatch: { matchedIndexes: ReadonlyArray<number>; rank: number; termIndex: number } | null =
+    null;
   for (const [index, field] of terms.entries()) {
-    const fieldRank = rankSearchFieldMatch(field, normalizedQuery);
-    if (fieldRank !== Number.NEGATIVE_INFINITY) {
-      return 1_000 - index * 100 + fieldRank;
+    const fieldMatch = matchCommandPaletteSearchField(field, normalizedQuery);
+    if (!fieldMatch) {
+      continue;
+    }
+
+    const candidate = {
+      matchedIndexes: fieldMatch.matchedIndexes,
+      rank: 10_000 - index * 1_000 + fieldMatch.score,
+      termIndex: index,
+    };
+
+    if (!bestMatch || candidate.rank > bestMatch.rank) {
+      bestMatch = candidate;
     }
   }
 
-  return 0;
+  return bestMatch;
 }
 
 export function filterCommandPaletteGroups(input: {
@@ -254,15 +333,20 @@ export function filterCommandPaletteGroups(input: {
   return searchableGroups.flatMap((group) => {
     const items = group.items
       .map((item, index) => {
-        const haystack = normalizeSearchText(item.searchTerms.join(" "));
-        if (!haystack.includes(normalizedQuery)) {
+        const match = rankCommandPaletteItemMatch(item, normalizedQuery);
+        if (!match) {
           return null;
         }
 
+        const matchedItem =
+          match.termIndex === 0 && typeof item.title === "string"
+            ? { ...item, titleMatchIndexes: match.matchedIndexes }
+            : item;
+
         return {
-          item,
+          item: matchedItem,
           index,
-          rank: rankCommandPaletteItemMatch(item, normalizedQuery),
+          rank: match.rank,
         };
       })
       .filter(

--- a/t3code/apps/web/src/components/CommandPaletteResults.tsx
+++ b/t3code/apps/web/src/components/CommandPaletteResults.tsx
@@ -73,7 +73,7 @@ function DisabledCommandPaletteResultRow(props: {
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="flex min-w-0 items-center gap-1.5 text-sm text-foreground">
             {props.item.titleLeadingContent}
-            <span className="truncate">{props.item.title}</span>
+            <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
           </span>
           <span className="truncate text-muted-foreground/70 text-xs">
             {props.item.description}
@@ -82,7 +82,7 @@ function DisabledCommandPaletteResultRow(props: {
       ) : (
         <span className="flex min-w-0 flex-1 items-center gap-1.5 text-sm text-foreground">
           {props.item.titleLeadingContent}
-          <span className="truncate">{props.item.title}</span>
+          <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
         </span>
       )}
       {props.item.titleTrailingContent}
@@ -119,7 +119,7 @@ function CommandPaletteResultRow(props: {
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="flex min-w-0 items-center gap-1.5 text-sm text-foreground">
             {props.item.titleLeadingContent}
-            <span className="truncate">{props.item.title}</span>
+            <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
           </span>
           <span className="truncate text-muted-foreground/70 text-xs">
             {props.item.description}
@@ -128,7 +128,7 @@ function CommandPaletteResultRow(props: {
       ) : (
         <span className="flex min-w-0 flex-1 items-center gap-1.5 text-sm text-foreground">
           {props.item.titleLeadingContent}
-          <span className="truncate">{props.item.title}</span>
+          <span className="truncate">{renderCommandPaletteTitle(props.item)}</span>
         </span>
       )}
       {props.item.titleTrailingContent}
@@ -143,4 +143,35 @@ function CommandPaletteResultRow(props: {
       ) : null}
     </CommandItem>
   );
+}
+
+function renderCommandPaletteTitle(item: CommandPaletteActionItem | CommandPaletteSubmenuItem) {
+  if (
+    typeof item.title !== "string" ||
+    !item.titleMatchIndexes ||
+    item.titleMatchIndexes.length === 0
+  ) {
+    return item.title;
+  }
+
+  const highlightedIndexes = new Set(item.titleMatchIndexes);
+  const titleParts = [];
+
+  for (let index = 0; index < item.title.length; index += 1) {
+    const character = item.title[index];
+    titleParts.push(
+      highlightedIndexes.has(index) ? (
+        <span
+          className="command-palette-match-highlight font-semibold text-primary underline decoration-primary/50 underline-offset-2"
+          key={index}
+        >
+          {character}
+        </span>
+      ) : (
+        character
+      ),
+    );
+  }
+
+  return titleParts;
 }

--- a/t3code/apps/web/src/components/_provenance.json
+++ b/t3code/apps/web/src/components/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, runtime, and session instructions are intentionally not disclosed. This submission metadata is limited to safe public context for UnsafeLabs/Bounty-Hunters issue #830.",
+  "timestamp": "2026-07-05T17:29:26.0534578Z"
+}


### PR DESCRIPTION
/claim #830

## Summary

- Replaced CommandPalette's substring/prefix filtering with deterministic fuzzy character matching that allows gaps.
- Scores matches by exact/prefix quality, word-boundary hits, consecutive hits, and shorter command names, then sorts results by score.
- Adds highlighted title characters using `command-palette-match-highlight` spans while preserving existing item values and keyboard navigation.
- Adds focused logic coverage for `ofl` -> `Open File`, match ordering, empty-query ordering, single-character filtering, and 250-command matching.

## Verification

- `bun run --cwd apps\web test src\components\CommandPalette.logic.test.ts`
- `bun run --cwd apps\web typecheck`
- `bun run fmt:check apps\web\src\components\CommandPalette.logic.ts apps\web\src\components\CommandPalette.logic.test.ts apps\web\src\components\CommandPaletteResults.tsx apps\web\src\components\_provenance.json`
- `bun run lint apps\web\src\components\CommandPalette.logic.ts apps\web\src\components\CommandPalette.logic.test.ts apps\web\src\components\CommandPaletteResults.tsx`
- `git diff --check`

## Provenance Note

I included `_provenance.json` with safe public metadata only. I did not publish hidden system, developer, runtime, or session instructions.
