### PR TITLE
OpenAI Codex [ T3 Code ] Add environment variable validation at startup

### DIFF
--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -9,6 +9,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServer from "effect/unstable/http/HttpServer";
@@ -33,6 +34,7 @@ import {
 import { WorkspacePathsLive } from "./workspace/Layers/WorkspacePaths.ts";
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore.ts";
 import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
+import { ENVIRONMENT_VARIABLE_DEFINITIONS } from "./cli/envValidation.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
@@ -48,6 +50,50 @@ const captureStdout = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
       "";
     return { result, output };
   }).pipe(Effect.provide(Layer.mergeAll(CliRuntimeLayer, TestConsole.layer)));
+
+const captureStdoutExit = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const result = yield* Effect.exit(effect);
+    const output =
+      (yield* TestConsole.logLines).findLast((line): line is string => typeof line === "string") ??
+      "";
+    return { result, output };
+  }).pipe(Effect.provide(Layer.mergeAll(CliRuntimeLayer, TestConsole.layer)));
+
+const withServerEnvironment = <A, E, R>(
+  env: Readonly<Record<string, string | undefined>>,
+  effect: Effect.Effect<A, E, R>,
+) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previousValues = new Map<string, string | undefined>();
+      const names = new Set([
+        ...ENVIRONMENT_VARIABLE_DEFINITIONS.map((definition) => definition.name),
+        ...Object.keys(env),
+      ]);
+      for (const name of names) {
+        previousValues.set(name, process.env[name]);
+        const value = env[name];
+        if (value === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = value;
+        }
+      }
+      return previousValues;
+    }),
+    () => effect,
+    (previousValues) =>
+      Effect.sync(() => {
+        for (const [name, value] of previousValues) {
+          if (value === undefined) {
+            delete process.env[name];
+          } else {
+            process.env[name] = value;
+          }
+        }
+      }),
+  );
 
 const makeCliTestServerConfig = (baseDir: string) =>
   Effect.gen(function* () {
@@ -171,6 +217,36 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
       assert.equal(error.option, "log-level");
       assert.equal(error.value, "Debug");
     }),
+  );
+
+  it.effect("validates config and exits without starting the server", () =>
+    withServerEnvironment(
+      {},
+      Effect.gen(function* () {
+        const { output } = yield* captureStdout(runCli(["--validate-config"]));
+
+        assert.isTrue(output.includes("Environment variable validation passed."));
+        assert.isTrue(output.includes("T3CODE_LOG_LEVEL"));
+        assert.isTrue(output.includes("(default Info)"));
+      }),
+    ),
+  );
+
+  it.effect("prints validation errors for invalid config values", () =>
+    withServerEnvironment(
+      {
+        T3CODE_PORT: "not-a-port",
+      },
+      Effect.gen(function* () {
+        const { result, output } = yield* captureStdoutExit(runCli(["--validate-config"]));
+
+        assert.isTrue(Exit.isFailure(result));
+        assert.isTrue(output.includes("Environment variable validation failed."));
+        assert.isTrue(output.includes("T3CODE_PORT"));
+        assert.isTrue(output.includes("integer port 1-65535"));
+        assert.isTrue(output.includes('"not-a-port"'));
+      }),
+    ),
   );
 
   it.effect("executes auth pairing subcommands and redacts secrets from list output", () =>

--- a/t3code/apps/server/src/cli/_provenance.json
+++ b/t3code/apps/server/src/cli/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Private system, developer, runtime, and session instructions cannot be disclosed. This submission was produced for public UnsafeLabs/Bounty-Hunters issue #853 using only public repository and issue context.",
+  "timestamp": "2026-07-05T12:41:30.0472572-05:00"
+}

--- a/t3code/apps/server/src/cli/config.ts
+++ b/t3code/apps/server/src/cli/config.ts
@@ -80,6 +80,10 @@ export const tailscaleServePortFlag = Flag.integer("tailscale-serve-port").pipe(
   Flag.withDescription("HTTPS port for Tailscale Serve when --tailscale-serve is enabled."),
   Flag.optional,
 );
+export const validateConfigFlag = Flag.boolean("validate-config").pipe(
+  Flag.withDescription("Validate server environment variables and exit without starting."),
+  Flag.optional,
+);
 
 const EnvServerConfig = Config.all({
   logLevel: Config.logLevel("T3CODE_LOG_LEVEL").pipe(Config.withDefault("Info")),
@@ -151,6 +155,7 @@ export interface CliServerFlags {
   readonly logWebSocketEvents: Option.Option<boolean>;
   readonly tailscaleServeEnabled: Option.Option<boolean>;
   readonly tailscaleServePort: Option.Option<number>;
+  readonly validateConfig?: Option.Option<boolean>;
 }
 
 export interface CliAuthLocationFlags {
@@ -185,6 +190,7 @@ export const sharedServerCommandFlags = {
   logWebSocketEvents: logWebSocketEventsFlag,
   tailscaleServeEnabled: tailscaleServeFlag,
   tailscaleServePort: tailscaleServePortFlag,
+  validateConfig: validateConfigFlag,
 } as const;
 
 export const authLocationFlags = sharedServerLocationFlags;

--- a/t3code/apps/server/src/cli/envValidation.test.ts
+++ b/t3code/apps/server/src/cli/envValidation.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from "vitest";
+
+import { formatEnvironmentValidationTable, validateEnvironmentVariables } from "./envValidation.ts";
+
+it("documents optional defaults when no server environment variables are set", () => {
+  const result = validateEnvironmentVariables({});
+  const output = formatEnvironmentValidationTable(result);
+
+  expect(result.ok).toBe(true);
+  expect(output).toContain("Environment variable validation passed.");
+  expect(output).toContain("T3CODE_LOG_LEVEL");
+  expect(output).toContain("(default Info)");
+  expect(output).toContain("T3CODE_PORT");
+  expect(output).toContain("first available at or above 3773");
+});
+
+it("reports invalid values with expected type information and received value", () => {
+  const result = validateEnvironmentVariables({
+    T3CODE_PORT: "not-a-port",
+    T3CODE_NO_BROWSER: "yes",
+    VITE_DEV_SERVER_URL: "not-a-url",
+  });
+  const output = formatEnvironmentValidationTable(result);
+
+  expect(result.ok).toBe(false);
+  expect(output).toContain("Environment variable validation failed.");
+  expect(output).toContain("T3CODE_PORT");
+  expect(output).toContain("integer port 1-65535");
+  expect(output).toContain('"not-a-port"');
+  expect(output).toContain("T3CODE_NO_BROWSER");
+  expect(output).toContain("boolean: true|false");
+  expect(output).toContain('"yes"');
+  expect(output).toContain("VITE_DEV_SERVER_URL");
+  expect(output).toContain("URL");
+});
+
+it("accepts valid typed values", () => {
+  const result = validateEnvironmentVariables({
+    T3CODE_LOG_LEVEL: "Debug",
+    T3CODE_MODE: "desktop",
+    T3CODE_PORT: "4888",
+    T3CODE_NO_BROWSER: "true",
+    VITE_DEV_SERVER_URL: "http://127.0.0.1:5173",
+  });
+
+  expect(result.ok).toBe(true);
+  expect(result.rows.find((row) => row.name === "T3CODE_PORT")?.status).toBe("set");
+});

--- a/t3code/apps/server/src/cli/envValidation.ts
+++ b/t3code/apps/server/src/cli/envValidation.ts
@@ -1,0 +1,388 @@
+import { PortSchema } from "@t3tools/contracts";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import { RuntimeMode } from "../config.ts";
+
+export type EnvironmentValidationStatus = "default" | "invalid" | "missing" | "optional" | "set";
+
+export interface EnvironmentVariableDefinition {
+  readonly name: string;
+  readonly required: boolean;
+  readonly expected: string;
+  readonly description: string;
+  readonly defaultValue?: string;
+  readonly schema: Schema.Decoder<unknown>;
+  readonly decode: (input: unknown) => Exit.Exit<unknown, Schema.SchemaError>;
+}
+
+type EnvironmentVariableDefinitionInput = Omit<EnvironmentVariableDefinition, "decode">;
+
+export interface EnvironmentValidationRow {
+  readonly name: string;
+  readonly required: boolean;
+  readonly expected: string;
+  readonly description: string;
+  readonly defaultValue: string | undefined;
+  readonly status: EnvironmentValidationStatus;
+  readonly receivedValue: string | undefined;
+}
+
+export interface EnvironmentValidationResult {
+  readonly ok: boolean;
+  readonly rows: ReadonlyArray<EnvironmentValidationRow>;
+}
+
+export class EnvironmentValidationError extends Schema.TaggedErrorClass<EnvironmentValidationError>()(
+  "EnvironmentValidationError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+const LogLevelString = Schema.Literals([
+  "All",
+  "Fatal",
+  "Error",
+  "Warn",
+  "Info",
+  "Debug",
+  "Trace",
+  "None",
+  "all",
+  "fatal",
+  "error",
+  "warn",
+  "info",
+  "debug",
+  "trace",
+  "none",
+]);
+
+const BooleanString = Schema.Literals(["true", "false"]);
+const IntegerString = Schema.NumberFromString.check(Schema.isInt());
+const decodePortSchema = Schema.decodeUnknownExit(PortSchema);
+const PortString = Schema.NumberFromString.check(Schema.isInt()).check(
+  Schema.makeFilter((value) =>
+    Exit.isSuccess(decodePortSchema(value))
+      ? undefined
+      : "expected an integer port between 1 and 65535",
+  ),
+);
+
+const ENVIRONMENT_VARIABLE_DEFINITION_INPUTS: ReadonlyArray<EnvironmentVariableDefinitionInput> = [
+  {
+    name: "T3CODE_LOG_LEVEL",
+    required: false,
+    expected: "log level: All|Fatal|Error|Warn|Info|Debug|Trace|None",
+    description: "Server console log level.",
+    defaultValue: "Info",
+    schema: LogLevelString,
+  },
+  {
+    name: "T3CODE_TRACE_MIN_LEVEL",
+    required: false,
+    expected: "log level: All|Fatal|Error|Warn|Info|Debug|Trace|None",
+    description: "Minimum level written to the server trace file.",
+    defaultValue: "Info",
+    schema: LogLevelString,
+  },
+  {
+    name: "T3CODE_TRACE_TIMING_ENABLED",
+    required: false,
+    expected: "boolean: true|false",
+    description: "Enable timing fields in server traces.",
+    defaultValue: "true",
+    schema: BooleanString,
+  },
+  {
+    name: "T3CODE_TRACE_FILE",
+    required: false,
+    expected: "path string",
+    description: "Override the server trace file path.",
+    schema: Schema.String,
+  },
+  {
+    name: "T3CODE_TRACE_MAX_BYTES",
+    required: false,
+    expected: "integer",
+    description: "Maximum trace file size before rotation.",
+    defaultValue: String(10 * 1024 * 1024),
+    schema: IntegerString,
+  },
+  {
+    name: "T3CODE_TRACE_MAX_FILES",
+    required: false,
+    expected: "integer",
+    description: "Maximum number of rotated trace files to keep.",
+    defaultValue: "10",
+    schema: IntegerString,
+  },
+  {
+    name: "T3CODE_TRACE_BATCH_WINDOW_MS",
+    required: false,
+    expected: "integer milliseconds",
+    description: "Trace batching window in milliseconds.",
+    defaultValue: "200",
+    schema: IntegerString,
+  },
+  {
+    name: "T3CODE_OTLP_TRACES_URL",
+    required: false,
+    expected: "URL",
+    description: "OTLP traces collector endpoint.",
+    schema: Schema.URLFromString,
+  },
+  {
+    name: "T3CODE_OTLP_METRICS_URL",
+    required: false,
+    expected: "URL",
+    description: "OTLP metrics collector endpoint.",
+    schema: Schema.URLFromString,
+  },
+  {
+    name: "T3CODE_OTLP_EXPORT_INTERVAL_MS",
+    required: false,
+    expected: "integer milliseconds",
+    description: "OTLP export interval in milliseconds.",
+    defaultValue: "10000",
+    schema: IntegerString,
+  },
+  {
+    name: "T3CODE_OTLP_SERVICE_NAME",
+    required: false,
+    expected: "string",
+    description: "Service name attached to OTLP telemetry.",
+    defaultValue: "t3-server",
+    schema: Schema.String,
+  },
+  {
+    name: "T3CODE_MODE",
+    required: false,
+    expected: "web|desktop",
+    description: "Runtime mode.",
+    defaultValue: "web",
+    schema: RuntimeMode,
+  },
+  {
+    name: "T3CODE_PORT",
+    required: false,
+    expected: "integer port 1-65535",
+    description: "HTTP/WebSocket server port.",
+    defaultValue: "first available at or above 3773",
+    schema: PortString,
+  },
+  {
+    name: "T3CODE_HOST",
+    required: false,
+    expected: "host/interface string",
+    description: "Host/interface for the server listener.",
+    schema: Schema.String,
+  },
+  {
+    name: "T3CODE_HOME",
+    required: false,
+    expected: "path string",
+    description: "Base directory for server state and logs.",
+    defaultValue: "platform default",
+    schema: Schema.String,
+  },
+  {
+    name: "VITE_DEV_SERVER_URL",
+    required: false,
+    expected: "URL",
+    description: "Dev web URL to proxy or redirect to.",
+    schema: Schema.URLFromString,
+  },
+  {
+    name: "T3CODE_NO_BROWSER",
+    required: false,
+    expected: "boolean: true|false",
+    description: "Disable automatic browser opening.",
+    schema: BooleanString,
+  },
+  {
+    name: "T3CODE_BOOTSTRAP_FD",
+    required: false,
+    expected: "integer file descriptor",
+    description: "File descriptor for desktop bootstrap settings.",
+    schema: IntegerString,
+  },
+  {
+    name: "T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD",
+    required: false,
+    expected: "boolean: true|false",
+    description: "Create a project for the current directory on startup.",
+    defaultValue: "true in web mode, false in headless mode",
+    schema: BooleanString,
+  },
+  {
+    name: "T3CODE_LOG_WS_EVENTS",
+    required: false,
+    expected: "boolean: true|false",
+    description: "Emit server-side logs for WebSocket push traffic.",
+    defaultValue: "true when dev URL is configured, otherwise false",
+    schema: BooleanString,
+  },
+  {
+    name: "T3CODE_TAILSCALE_SERVE",
+    required: false,
+    expected: "boolean: true|false",
+    description: "Configure Tailscale Serve for Tailnet HTTPS exposure.",
+    defaultValue: "false",
+    schema: BooleanString,
+  },
+  {
+    name: "T3CODE_TAILSCALE_SERVE_PORT",
+    required: false,
+    expected: "integer port 1-65535",
+    description: "HTTPS port for Tailscale Serve.",
+    defaultValue: "443",
+    schema: PortString,
+  },
+];
+
+export const ENVIRONMENT_VARIABLE_DEFINITIONS: ReadonlyArray<EnvironmentVariableDefinition> =
+  ENVIRONMENT_VARIABLE_DEFINITION_INPUTS.map((definition) =>
+    Object.assign({}, definition, {
+      decode: Schema.decodeUnknownExit(definition.schema),
+    }),
+  );
+
+const validateVariable = (
+  definition: EnvironmentVariableDefinition,
+  env: Readonly<Record<string, string | undefined>>,
+): EnvironmentValidationRow => {
+  const receivedValue = env[definition.name];
+
+  if (receivedValue === undefined) {
+    return {
+      name: definition.name,
+      required: definition.required,
+      expected: definition.expected,
+      description: definition.description,
+      defaultValue: definition.defaultValue,
+      status: definition.required
+        ? "missing"
+        : definition.defaultValue === undefined
+          ? "optional"
+          : "default",
+      receivedValue,
+    };
+  }
+
+  return {
+    name: definition.name,
+    required: definition.required,
+    expected: definition.expected,
+    description: definition.description,
+    defaultValue: definition.defaultValue,
+    status: Exit.isSuccess(definition.decode(receivedValue)) ? "set" : "invalid",
+    receivedValue,
+  };
+};
+
+export const validateEnvironmentVariables = (
+  env: Readonly<Record<string, string | undefined>>,
+): EnvironmentValidationResult => {
+  const rows = ENVIRONMENT_VARIABLE_DEFINITIONS.map((definition) =>
+    validateVariable(definition, env),
+  );
+  const ok = rows.every((row) => row.status !== "invalid" && row.status !== "missing");
+  return { ok, rows };
+};
+
+const quoteValue = (value: string | undefined) => {
+  if (value === undefined) return "(unset)";
+  if (value.length <= 44) return JSON.stringify(value);
+  return JSON.stringify(`${value.slice(0, 41)}...`);
+};
+
+const rowDisplayValue = (row: EnvironmentValidationRow) => {
+  switch (row.status) {
+    case "default":
+      return `(default ${row.defaultValue ?? ""})`;
+    case "optional":
+      return "(optional unset)";
+    case "missing":
+      return "(missing)";
+    case "invalid":
+    case "set":
+      return quoteValue(row.receivedValue);
+  }
+};
+
+const padRight = (value: string, width: number) => value.padEnd(width, " ");
+
+const formatRows = (rows: ReadonlyArray<EnvironmentValidationRow>) => {
+  const tableRows = rows.map((row) => ({
+    name: row.name,
+    required: row.required ? "yes" : "no",
+    expected: row.expected,
+    status: row.status,
+    value: rowDisplayValue(row),
+    description: row.description,
+  }));
+  const headers = {
+    name: "Variable",
+    required: "Required",
+    expected: "Expected",
+    status: "Status",
+    value: "Value",
+    description: "Description",
+  };
+  const widths = {
+    name: Math.max(headers.name.length, ...tableRows.map((row) => row.name.length)),
+    required: Math.max(headers.required.length, ...tableRows.map((row) => row.required.length)),
+    expected: Math.max(headers.expected.length, ...tableRows.map((row) => row.expected.length)),
+    status: Math.max(headers.status.length, ...tableRows.map((row) => row.status.length)),
+    value: Math.max(headers.value.length, ...tableRows.map((row) => row.value.length)),
+  };
+  const renderRow = (row: typeof headers) =>
+    [
+      padRight(row.name, widths.name),
+      padRight(row.required, widths.required),
+      padRight(row.expected, widths.expected),
+      padRight(row.status, widths.status),
+      padRight(row.value, widths.value),
+      row.description,
+    ].join("  ");
+  const header = renderRow(headers);
+  const separator = [
+    "-".repeat(widths.name),
+    "-".repeat(widths.required),
+    "-".repeat(widths.expected),
+    "-".repeat(widths.status),
+    "-".repeat(widths.value),
+    "-".repeat(headers.description.length),
+  ].join("  ");
+  return [header, separator, ...tableRows.map(renderRow)].join("\n");
+};
+
+export const formatEnvironmentValidationTable = (result: EnvironmentValidationResult) =>
+  [
+    result.ok
+      ? "Environment variable validation passed."
+      : "Environment variable validation failed.",
+    "",
+    formatRows(result.rows),
+  ].join("\n");
+
+export const validateEnvironmentForStartup = (options?: { readonly printWhenValid?: boolean }) =>
+  Effect.gen(function* () {
+    const result = validateEnvironmentVariables(process.env);
+    if (!result.ok || options?.printWhenValid === true) {
+      yield* Console.log(formatEnvironmentValidationTable(result));
+    }
+    if (!result.ok) {
+      return yield* new EnvironmentValidationError({
+        message: "Invalid server environment variables.",
+      });
+    }
+  });
+
+export const isValidateConfigEnabled = (value: Option.Option<boolean> | undefined) =>
+  Option.getOrElse(value ?? Option.none(), () => false);

--- a/t3code/apps/server/src/cli/server.ts
+++ b/t3code/apps/server/src/cli/server.ts
@@ -4,6 +4,7 @@ import { Command, GlobalFlag } from "effect/unstable/cli";
 import { ServerConfig, type StartupPresentation } from "../config.ts";
 import { runServer } from "../server.ts";
 import { type CliServerFlags, resolveServerConfig, sharedServerCommandFlags } from "./config.ts";
+import { isValidateConfigEnabled, validateEnvironmentForStartup } from "./envValidation.ts";
 
 export const runServerCommand = (
   flags: CliServerFlags,
@@ -13,6 +14,10 @@ export const runServerCommand = (
   },
 ) =>
   Effect.gen(function* () {
+    const validateConfig = isValidateConfigEnabled(flags.validateConfig);
+    yield* validateEnvironmentForStartup({ printWhenValid: validateConfig });
+    if (validateConfig) return;
+
     const logLevel = yield* GlobalFlag.LogLevel;
     const config = yield* resolveServerConfig(flags, logLevel, options);
     return yield* runServer.pipe(Effect.provideService(ServerConfig, config));


### PR DESCRIPTION
## Summary

- Adds a server environment variable validation catalog backed by Effect Schema decoders.
- Validates provided server env vars before resolving config, creating runtime directories, opening databases, or starting listeners.
- Adds `--validate-config` to `t3`, `t3 start`, and `t3 serve` so users can print the validation/defaults table without starting the server.
- Adds focused pure validation tests and CLI tests for valid and invalid config checks.

## Verification

- `bun run --cwd apps\server test src\cli\envValidation.test.ts src\bin.test.ts`
- `bun run --cwd apps\server typecheck`
- `bun run fmt:check apps\server\src\cli\envValidation.ts apps\server\src\cli\envValidation.test.ts apps\server\src\cli\config.ts apps\server\src\cli\server.ts apps\server\src\bin.test.ts apps\server\src\cli\_provenance.json`
- `bun run lint apps\server\src\cli\envValidation.ts apps\server\src\cli\envValidation.test.ts apps\server\src\cli\config.ts apps\server\src\cli\server.ts apps\server\src\bin.test.ts`
- `git diff --check`

Closes #853
