### PR TITLE
OpenAI Codex [ T3 Code ] Add runtime provider config validation

### DIFF
--- a/t3code/packages/contracts/src/.attribution.json
+++ b/t3code/packages/contracts/src/.attribution.json
@@ -1,0 +1,8 @@
+{
+  "agent": "OpenAI Codex",
+  "contributor": "nexicturbo",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/825",
+  "summary": "Added runtime validation for provider configuration API key and HTTPS endpoint fields.",
+  "timestamp": "2026-07-05T12:57:43-05:00",
+  "notes": "Public contribution metadata only; private instructions, credentials, and runtime context are intentionally excluded."
+}

--- a/t3code/packages/contracts/src/providerInstance.test.ts
+++ b/t3code/packages/contracts/src/providerInstance.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 
 import {
@@ -7,6 +8,7 @@ import {
   ProviderInstanceConfigMap,
   ProviderInstanceId,
   ProviderInstanceRef,
+  validateProviderConfig,
 } from "./providerInstance.ts";
 
 const decodeProviderDriverKind = Schema.decodeUnknownSync(ProviderDriverKind);
@@ -14,6 +16,16 @@ const decodeProviderInstanceId = Schema.decodeUnknownSync(ProviderInstanceId);
 const decodeProviderInstanceRef = Schema.decodeUnknownSync(ProviderInstanceRef);
 const decodeProviderInstanceConfig = Schema.decodeUnknownSync(ProviderInstanceConfig);
 const decodeProviderInstanceConfigMap = Schema.decodeUnknownSync(ProviderInstanceConfigMap);
+
+const expectProviderConfigErrors = (input: unknown) => {
+  const decoded = decodeProviderInstanceConfig(input);
+  const result = validateProviderConfig(decoded);
+  expect(Result.isFailure(result)).toBe(true);
+  if (!Result.isFailure(result)) {
+    throw new Error("Expected provider config validation to fail");
+  }
+  return result.failure;
+};
 
 describe("provider slug validation (shared by driver + instance ids)", () => {
   const cases = [
@@ -170,6 +182,109 @@ describe("ProviderInstanceConfig", () => {
   it("rejects driver values that do not satisfy the slug pattern", () => {
     expect(() => decodeProviderInstanceConfig({ driver: "" })).toThrow();
     expect(() => decodeProviderInstanceConfig({ driver: "has spaces" })).toThrow();
+  });
+});
+
+describe("validateProviderConfig", () => {
+  it("passes valid provider config API keys and HTTPS endpoints unchanged", () => {
+    const decoded = decodeProviderInstanceConfig({
+      driver: "claudeAgent",
+      environment: [
+        { name: "ANTHROPIC_API_KEY", value: "sk-ant-valid-12345", sensitive: true },
+        { name: "ANTHROPIC_BASE_URL", value: "https://api.anthropic.com", sensitive: false },
+      ],
+      config: {
+        apiKey: "provider-key-12345",
+        endpointUrl: "https://provider.example.com/v1",
+        nested: {
+          baseUrl: "https://nested.example.com",
+        },
+      },
+    });
+
+    const result = validateProviderConfig(decoded);
+
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.success).toBe(decoded);
+    }
+  });
+
+  it("rejects empty API key fields without breaking envelope decoding", () => {
+    const decoded = decodeProviderInstanceConfig({
+      driver: "claudeAgent",
+      environment: [{ name: "ANTHROPIC_API_KEY", value: "", sensitive: true }],
+    });
+
+    expect(decoded.environment?.[0]?.value).toBe("");
+
+    const result = validateProviderConfig(decoded);
+    expect(Result.isFailure(result)).toBe(true);
+    if (Result.isFailure(result)) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]).toMatchObject({
+        _tag: "ProviderConfigError",
+        fieldName: "environment.ANTHROPIC_API_KEY",
+        invalidValue: "",
+        expectedFormat: expect.stringContaining("at least 10"),
+      });
+    }
+  });
+
+  it("rejects API keys shorter than 10 characters", () => {
+    const errors = expectProviderConfigErrors({
+      driver: "codex",
+      config: { apiKey: "short" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      fieldName: "config.apiKey",
+      invalidValue: "short",
+      expectedFormat: expect.stringContaining("at least 10"),
+    });
+  });
+
+  it("rejects HTTP provider endpoint URLs with an HTTPS suggestion", () => {
+    const errors = expectProviderConfigErrors({
+      driver: "codex",
+      environment: [{ name: "OPENAI_BASE_URL", value: "http://api.openai.com" }],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      fieldName: "environment.OPENAI_BASE_URL",
+      invalidValue: "http://api.openai.com",
+      expectedFormat: expect.stringContaining("Use https://"),
+    });
+  });
+
+  it("rejects malformed endpoint URLs", () => {
+    const errors = expectProviderConfigErrors({
+      driver: "codex",
+      config: { endpointUrl: "not-a-url" },
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      fieldName: "config.endpointUrl",
+      invalidValue: "not-a-url",
+      expectedFormat: expect.stringContaining("valid HTTPS URL"),
+    });
+  });
+
+  it("returns all validation errors instead of only the first", () => {
+    const errors = expectProviderConfigErrors({
+      driver: "codex",
+      config: {
+        apiKey: "short",
+        endpointUrl: "http://bad",
+      },
+    });
+
+    expect(errors).toHaveLength(2);
+    expect(errors.map((error) => error.fieldName)).toEqual(["config.apiKey", "config.endpointUrl"]);
+    expect(errors.map((error) => error.invalidValue)).toEqual(["short", "http://bad"]);
   });
 });
 

--- a/t3code/packages/contracts/src/providerInstance.ts
+++ b/t3code/packages/contracts/src/providerInstance.ts
@@ -34,6 +34,7 @@
  * @module providerInstance
  */
 import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 
@@ -49,6 +50,9 @@ const PROVIDER_SLUG_MAX_CHARS = 64;
 const PROVIDER_SLUG_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 const ENVIRONMENT_VARIABLE_NAME_MAX_CHARS = 128;
 const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const PROVIDER_API_KEY_MIN_CHARS = 10;
+const PROVIDER_API_KEY_PATTERN = /^\S+$/;
+const HOSTNAME_PATTERN = /^(?=.{1,253}$)(?!-)(?:[a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,63}$/;
 
 const slugSchema = TrimmedNonEmptyString.check(
   Schema.isMaxLength(PROVIDER_SLUG_MAX_CHARS),
@@ -137,6 +141,201 @@ export type ProviderInstanceConfig = typeof ProviderInstanceConfig.Type;
  */
 export const ProviderInstanceConfigMap = Schema.Record(ProviderInstanceId, ProviderInstanceConfig);
 export type ProviderInstanceConfigMap = typeof ProviderInstanceConfigMap.Type;
+
+export const ProviderApiKey = TrimmedNonEmptyString.check(
+  Schema.isMinLength(PROVIDER_API_KEY_MIN_CHARS, {
+    message: `API keys must be at least ${PROVIDER_API_KEY_MIN_CHARS} characters long.`,
+  }),
+  Schema.isPattern(PROVIDER_API_KEY_PATTERN, {
+    message: "API keys must not contain whitespace.",
+  }),
+);
+export type ProviderApiKey = typeof ProviderApiKey.Type;
+
+export const ProviderHttpsEndpointUrl = Schema.URLFromString;
+export type ProviderHttpsEndpointUrl = typeof ProviderHttpsEndpointUrl.Type;
+
+export class ProviderConfigError extends Schema.TaggedErrorClass<ProviderConfigError>()(
+  "ProviderConfigError",
+  {
+    fieldName: TrimmedNonEmptyString,
+    invalidValue: Schema.String,
+    expectedFormat: TrimmedNonEmptyString,
+  },
+) {
+  override get message(): string {
+    return `${this.fieldName} must be ${this.expectedFormat}; received ${this.invalidValue}`;
+  }
+}
+
+const decodeProviderApiKey = Schema.decodeUnknownSync(ProviderApiKey);
+const decodeProviderHttpsEndpointUrl = Schema.decodeUnknownSync(ProviderHttpsEndpointUrl);
+
+const formatInvalidValue = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "undefined";
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const makeProviderConfigError = (
+  fieldName: string,
+  invalidValue: unknown,
+  expectedFormat: string,
+) =>
+  new ProviderConfigError({
+    fieldName,
+    invalidValue: formatInvalidValue(invalidValue),
+    expectedFormat,
+  });
+
+const normalizeProviderConfigFieldName = (fieldName: string): string =>
+  fieldName
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+
+const isProviderApiKeyField = (fieldName: string): boolean => {
+  const normalized = normalizeProviderConfigFieldName(fieldName);
+  return (
+    normalized === "API_KEY" ||
+    normalized.endsWith("_API_KEY") ||
+    normalized.endsWith("_ACCESS_TOKEN") ||
+    normalized.endsWith("_AUTH_TOKEN") ||
+    normalized.endsWith("_SECRET_KEY")
+  );
+};
+
+const isProviderEndpointField = (fieldName: string): boolean => {
+  const normalized = normalizeProviderConfigFieldName(fieldName);
+  return (
+    normalized === "URL" ||
+    normalized === "ENDPOINT" ||
+    normalized.endsWith("_URL") ||
+    normalized.endsWith("_ENDPOINT") ||
+    normalized.endsWith("_BASE_URL") ||
+    normalized.endsWith("_ENDPOINT_URL") ||
+    normalized.endsWith("_API_URL")
+  );
+};
+
+const hasProviderEndpointHostname = (hostname: string): boolean => HOSTNAME_PATTERN.test(hostname);
+
+const validateProviderApiKeyField = (fieldName: string, value: unknown): ProviderConfigError[] => {
+  try {
+    decodeProviderApiKey(value);
+    return [];
+  } catch {
+    return [
+      makeProviderConfigError(
+        fieldName,
+        value,
+        `an API key string with at least ${PROVIDER_API_KEY_MIN_CHARS} non-whitespace characters`,
+      ),
+    ];
+  }
+};
+
+const validateProviderEndpointField = (
+  fieldName: string,
+  value: unknown,
+): ProviderConfigError[] => {
+  if (typeof value !== "string") {
+    return [makeProviderConfigError(fieldName, value, "a valid HTTPS URL string with a hostname")];
+  }
+
+  let url: URL;
+  try {
+    url = decodeProviderHttpsEndpointUrl(value);
+  } catch {
+    return [makeProviderConfigError(fieldName, value, "a valid HTTPS URL with a hostname")];
+  }
+
+  if (url.protocol !== "https:") {
+    return [
+      makeProviderConfigError(
+        fieldName,
+        value,
+        "an HTTPS URL. Use https:// rather than http:// for provider endpoints",
+      ),
+    ];
+  }
+
+  if (!hasProviderEndpointHostname(url.hostname)) {
+    return [
+      makeProviderConfigError(
+        fieldName,
+        value,
+        "an HTTPS URL with a fully qualified provider hostname",
+      ),
+    ];
+  }
+
+  return [];
+};
+
+const isRecordValue = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const collectProviderConfigValueErrors = (path: string, value: unknown): ProviderConfigError[] => {
+  const fieldName = path.split(".").at(-1) ?? path;
+  const errors: ProviderConfigError[] = [];
+
+  if (isProviderApiKeyField(fieldName)) {
+    errors.push(...validateProviderApiKeyField(path, value));
+  }
+  if (isProviderEndpointField(fieldName)) {
+    errors.push(...validateProviderEndpointField(path, value));
+  }
+
+  if (isRecordValue(value)) {
+    for (const [key, childValue] of Object.entries(value)) {
+      errors.push(...collectProviderConfigValueErrors(`${path}.${key}`, childValue));
+    }
+  }
+
+  return errors;
+};
+
+export const collectProviderConfigErrors = (
+  config: ProviderInstanceConfig,
+): ReadonlyArray<ProviderConfigError> => {
+  const errors: ProviderConfigError[] = [];
+
+  for (const environmentVariable of config.environment ?? []) {
+    const fieldName = `environment.${environmentVariable.name}`;
+    if (isProviderApiKeyField(environmentVariable.name)) {
+      errors.push(...validateProviderApiKeyField(fieldName, environmentVariable.value));
+    }
+    if (isProviderEndpointField(environmentVariable.name)) {
+      errors.push(...validateProviderEndpointField(fieldName, environmentVariable.value));
+    }
+  }
+
+  if (isRecordValue(config.config)) {
+    for (const [fieldName, value] of Object.entries(config.config)) {
+      errors.push(...collectProviderConfigValueErrors(`config.${fieldName}`, value));
+    }
+  }
+
+  return errors;
+};
+
+export const validateProviderConfig = (
+  config: ProviderInstanceConfig,
+): Result.Result<ProviderInstanceConfig, ReadonlyArray<ProviderConfigError>> => {
+  const errors = collectProviderConfigErrors(config);
+  return errors.length === 0 ? Result.succeed(config) : Result.fail(errors);
+};
+
+export const validateProviderConfigEffect = (
+  config: ProviderInstanceConfig,
+): Effect.Effect<Result.Result<ProviderInstanceConfig, ReadonlyArray<ProviderConfigError>>> =>
+  Effect.succeed(validateProviderConfig(config));
 
 /**
  * Construct the canonical `ProviderInstanceId` used as a back-compat default


### PR DESCRIPTION
Closes #825

## Summary

- Adds schema-backed provider API key and HTTPS endpoint validation helpers in the contracts package.
- Introduces `ProviderConfigError` with `fieldName`, `invalidValue`, and `expectedFormat` fields.
- Adds `collectProviderConfigErrors`, `validateProviderConfig`, and an Effect wrapper that return all validation failures in one pass.
- Preserves the existing opaque provider config envelope decode path so current persisted configs still load unchanged.
- Includes safe public `.attribution.json` metadata only; private instructions, credentials, and runtime context are intentionally excluded.

## Validation Behavior

- API key-like fields reject empty values, whitespace-containing values, and strings shorter than 10 characters.
- Endpoint/base URL fields must parse as URLs, use `https://`, and include a fully qualified provider hostname.
- HTTP URLs return a clear expected-format message suggesting `https://`.
- Environment entries and nested `config` object fields are both inspected.

## Verification

- `bun run --cwd packages\contracts test src\providerInstance.test.ts`
- `bun run --cwd packages\contracts typecheck`
- `bun run fmt:check packages\contracts\src\providerInstance.ts packages\contracts\src\providerInstance.test.ts packages\contracts\src\.attribution.json`
- `bun run lint packages\contracts\src\providerInstance.ts packages\contracts\src\providerInstance.test.ts`
- `git diff --check`
