### PR TITLE
OpenAI Codex [ T3 Code ] Add sliding window metrics aggregation

### DIFF
--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -24,6 +24,10 @@ import {
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
 import { resolveStaticDir, ServerConfig } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
+import {
+  AGGREGATED_METRICS_PATH,
+  MetricsAggregator,
+} from "./observability/Services/MetricsAggregator.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
@@ -132,6 +136,21 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
           Effect.succeed(HttpServerResponse.text("Trace export failed.", { status: 502 })),
         ),
       );
+  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+);
+
+export const aggregatedMetricsRouteLayer = HttpRouter.add(
+  "GET",
+  AGGREGATED_METRICS_PATH,
+  Effect.gen(function* () {
+    yield* requireAuthenticatedRequest;
+    const metricsAggregator = yield* MetricsAggregator;
+    const windows = yield* metricsAggregator.getWindows;
+
+    return HttpServerResponse.jsonUnsafe(windows, {
+      status: 200,
+      headers: browserApiCorsHeaders,
+    });
   }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
 );
 

--- a/t3code/apps/server/src/observability/.generation_meta.json
+++ b/t3code/apps/server/src/observability/.generation_meta.json
@@ -1,0 +1,17 @@
+{
+  "generated_by": "OpenAI Codex",
+  "generated_at_utc": "2026-07-05T18:13:00.1322805Z",
+  "public_task": "UnsafeLabs/Bounty-Hunters issue #856: Add sliding window metrics aggregation with Effect.Stream",
+  "private_instructions_included": false,
+  "files_added": [
+    "apps/server/src/observability/Services/MetricsAggregator.ts",
+    "apps/server/src/observability/Services/MetricsAggregator.test.ts"
+  ],
+  "files_updated": [
+    "apps/server/src/observability/RpcInstrumentation.ts",
+    "apps/server/src/observability/Layers/Observability.ts",
+    "apps/server/src/http.ts",
+    "apps/server/src/server.ts",
+    "apps/server/src/server.test.ts"
+  ]
+}

--- a/t3code/apps/server/src/observability/Layers/Observability.ts
+++ b/t3code/apps/server/src/observability/Layers/Observability.ts
@@ -8,6 +8,7 @@ import { OtlpMetrics, OtlpSerialization, OtlpTracer } from "effect/unstable/obse
 import { ServerConfig } from "../../config.ts";
 import { ServerLoggerLive } from "../../serverLogger.ts";
 import { BrowserTraceCollector } from "../Services/BrowserTraceCollector.ts";
+import { MetricsAggregatorLive } from "../Services/MetricsAggregator.ts";
 
 const otlpSerializationLayer = OtlpSerialization.layerJson;
 
@@ -81,6 +82,12 @@ export const ObservabilityLive = Layer.unwrap(
             },
           }).pipe(Layer.provideMerge(otlpSerializationLayer));
 
-    return Layer.mergeAll(ServerLoggerLive, traceReferencesLayer, tracerLayer, metricsLayer);
+    return Layer.mergeAll(
+      ServerLoggerLive,
+      traceReferencesLayer,
+      tracerLayer,
+      metricsLayer,
+      MetricsAggregatorLive,
+    );
   }),
 );

--- a/t3code/apps/server/src/observability/RpcInstrumentation.test.ts
+++ b/t3code/apps/server/src/observability/RpcInstrumentation.test.ts
@@ -14,6 +14,7 @@ import {
   observeRpcStream,
   observeRpcStreamEffect,
 } from "./RpcInstrumentation.ts";
+import { makeMetricsAggregatorLive, MetricsAggregator } from "./Services/MetricsAggregator.ts";
 
 const hasMetricSnapshot = (
   snapshots: ReadonlyArray<Metric.Metric.Snapshot>,
@@ -87,6 +88,24 @@ describe("RpcInstrumentation", () => {
         true,
       );
     }),
+  );
+
+  it.effect("records aggregate metrics when the MetricsAggregator service is present", () =>
+    Effect.gen(function* () {
+      const aggregator = yield* MetricsAggregator;
+
+      yield* observeRpcEffect("rpc.instrumentation.aggregate", Effect.succeed("ok"), {
+        "rpc.aggregate": "test",
+      });
+
+      const windows = yield* aggregator.getWindows;
+      const aggregate = windows
+        .flatMap((window) => window.methods)
+        .find((method) => method.method === "rpc.instrumentation.aggregate");
+
+      assert.equal(aggregate?.requestCount, 1);
+      assert.equal(aggregate?.successCount, 1);
+    }).pipe(Effect.provide(makeMetricsAggregatorLive({ autoRotate: false }))),
   );
 
   it.effect("records failure outcomes for unary RPC handlers", () =>

--- a/t3code/apps/server/src/observability/RpcInstrumentation.ts
+++ b/t3code/apps/server/src/observability/RpcInstrumentation.ts
@@ -4,11 +4,13 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Metric from "effect/Metric";
+import * as Option from "effect/Option";
 import * as References from "effect/References";
 import * as Stream from "effect/Stream";
 
-import { outcomeFromExit } from "./Attributes.ts";
+import { outcomeFromExit, type ObservabilityOutcome } from "./Attributes.ts";
 import { metricAttributes, rpcRequestDuration, rpcRequestsTotal, withMetrics } from "./Metrics.ts";
+import { MetricsAggregator } from "./Services/MetricsAggregator.ts";
 
 const RPC_SPAN_PREFIX = "ws.rpc";
 const DEFAULT_RPC_SPAN_ATTRIBUTES = {
@@ -61,6 +63,46 @@ const withRpcStreamTracing = <A, E, R>(
       )
     : stream.pipe(Stream.provideService(References.TracerEnabled, false));
 
+const nanosToMillis = (elapsedNanos: bigint): number => Number(elapsedNanos) / 1_000_000;
+
+const recordRpcAggregateObservation = (
+  method: string,
+  elapsedNanos: bigint,
+  outcome: ObservabilityOutcome,
+): Effect.Effect<void, never, never> =>
+  Effect.serviceOption(MetricsAggregator).pipe(
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.void,
+        onSome: (aggregator) =>
+          aggregator.recordRpc({
+            method,
+            outcome,
+            durationMs: nanosToMillis(elapsedNanos),
+          }),
+      }),
+    ),
+    Effect.ignore,
+  );
+
+const withRpcAggregateMetrics = <A, E, R>(
+  method: string,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.gen(function* () {
+    const startedAt = yield* Clock.currentTimeNanos;
+    const exit = yield* Effect.exit(effect);
+    const endedAt = yield* Clock.currentTimeNanos;
+    const elapsedNanos = endedAt > startedAt ? endedAt - startedAt : 0n;
+
+    yield* recordRpcAggregateObservation(method, elapsedNanos, outcomeFromExit(exit));
+
+    if (Exit.isSuccess(exit)) {
+      return exit.value;
+    }
+    return yield* Effect.failCause(exit.cause);
+  });
+
 const recordRpcStreamMetrics = <E>(
   method: string,
   startedAt: bigint,
@@ -84,6 +126,7 @@ const recordRpcStreamMetrics = <E>(
       ),
       1,
     );
+    yield* recordRpcAggregateObservation(method, elapsedNanos, outcomeFromExit(exit));
   });
 
 export const observeRpcEffect = <A, E, R>(
@@ -99,6 +142,7 @@ export const observeRpcEffect = <A, E, R>(
         method,
       },
     }),
+    (instrumentedEffect) => withRpcAggregateMetrics(method, instrumentedEffect),
   );
 
   return withRpcEffectTracing(method, instrumented, traceAttributes);

--- a/t3code/apps/server/src/observability/Services/MetricsAggregator.test.ts
+++ b/t3code/apps/server/src/observability/Services/MetricsAggregator.test.ts
@@ -1,0 +1,122 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+
+import {
+  calculatePercentile,
+  makeMetricsAggregator,
+  selectSlidingWindowBuffer,
+  type AggregatedMetricsWindow,
+} from "./MetricsAggregator.ts";
+
+const getMethod = (windows: ReadonlyArray<AggregatedMetricsWindow>, method: string) =>
+  windows.flatMap((window) => window.methods).find((entry) => entry.method === method);
+
+const makeTestAggregator = (options?: Parameters<typeof makeMetricsAggregator>[0]) =>
+  makeMetricsAggregator({
+    autoRotate: false,
+    ...options,
+  }).pipe(Effect.scoped, Effect.provide(TestClock.layer()));
+
+describe("MetricsAggregator", () => {
+  it("calculates nearest-rank percentiles from a sorted array", () => {
+    const sortedValues = [10, 20, 30, 40, 100];
+
+    assert.equal(calculatePercentile(sortedValues, 50), 30);
+    assert.equal(calculatePercentile(sortedValues, 95), 100);
+    assert.equal(calculatePercentile(sortedValues, 99), 100);
+  });
+
+  it.effect("aggregates latency percentiles, error rate, and throughput per method", () =>
+    Effect.gen(function* () {
+      const aggregator = yield* makeTestAggregator();
+
+      for (const durationMs of [10, 20, 30, 40, 100]) {
+        yield* aggregator.recordRpc({
+          method: "rpc.metrics.aggregate",
+          outcome: durationMs === 100 ? "failure" : "success",
+          durationMs,
+          observedAtMs: 1_000,
+        });
+      }
+
+      const windows = yield* aggregator.snapshotAt(1_000);
+      const method = getMethod(windows, "rpc.metrics.aggregate");
+
+      assert.equal(method?.requestCount, 5);
+      assert.equal(method?.successCount, 4);
+      assert.equal(method?.failureCount, 1);
+      assert.equal(method?.errorRate, 20);
+      assert.equal(method?.throughput, 5 / 60);
+      assert.deepStrictEqual(method?.latencyMs, {
+        p50: 30,
+        p95: 100,
+        p99: 100,
+      });
+    }),
+  );
+
+  it.effect("rotates windows and returns the latest bounded sliding buffer", () =>
+    Effect.gen(function* () {
+      const aggregator = yield* makeTestAggregator({
+        windowMs: 1_000,
+        windowCount: 3,
+      });
+
+      for (const observedAtMs of [0, 1_000, 2_000, 3_000, 4_000]) {
+        yield* aggregator.recordRpc({
+          method: "rpc.metrics.rotate",
+          outcome: "success",
+          durationMs: observedAtMs / 1_000 + 1,
+          observedAtMs,
+        });
+      }
+
+      const windows = yield* aggregator.snapshotAt(4_000);
+
+      assert.equal(windows.length, 3);
+      assert.deepStrictEqual(
+        windows.map((window) => window.startMs),
+        [2_000, 3_000, 4_000],
+      );
+      assert.equal(windows[2]?.methods[0]?.requestCount, 1);
+      assert.equal(windows[2]?.startedAt, "1970-01-01T00:00:04.000Z");
+    }),
+  );
+
+  it.effect("keeps request counts while bounding retained latency samples", () =>
+    Effect.gen(function* () {
+      const aggregator = yield* makeTestAggregator({
+        maxLatencySamplesPerMethod: 3,
+      });
+
+      for (const durationMs of [10, 20, 30, 40, 50]) {
+        yield* aggregator.recordRpc({
+          method: "rpc.metrics.samples",
+          outcome: "success",
+          durationMs,
+          observedAtMs: 500,
+        });
+      }
+
+      const windows = yield* aggregator.snapshotAt(500);
+      const method = getMethod(windows, "rpc.metrics.samples");
+
+      assert.equal(method?.requestCount, 5);
+      assert.equal(method?.retainedSampleCount, 3);
+      assert.deepStrictEqual(method?.latencyMs, {
+        p50: 40,
+        p95: 50,
+        p99: 50,
+      });
+    }),
+  );
+
+  it.effect("uses Effect.Stream.sliding to select overlapping window slices", () =>
+    Effect.gen(function* () {
+      const latest = yield* selectSlidingWindowBuffer([1, 2, 3, 4, 5], 3);
+
+      assert.deepStrictEqual(latest, [3, 4, 5]);
+    }),
+  );
+});

--- a/t3code/apps/server/src/observability/Services/MetricsAggregator.ts
+++ b/t3code/apps/server/src/observability/Services/MetricsAggregator.ts
@@ -1,0 +1,370 @@
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
+import type * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+
+import type { ObservabilityOutcome } from "../Attributes.ts";
+
+export const AGGREGATED_METRICS_PATH = "/metrics/aggregated";
+export const METRICS_AGGREGATION_WINDOW_MS = 60_000;
+export const METRICS_AGGREGATION_WINDOW_COUNT = 60;
+export const METRICS_AGGREGATION_MAX_LATENCY_SAMPLES_PER_METHOD = 10_000;
+
+export interface RpcMetricObservation {
+  readonly method: string;
+  readonly outcome: ObservabilityOutcome;
+  readonly durationMs: number;
+  readonly observedAtMs?: number;
+}
+
+export interface AggregatedMethodMetrics {
+  readonly method: string;
+  readonly requestCount: number;
+  readonly successCount: number;
+  readonly failureCount: number;
+  readonly interruptCount: number;
+  readonly errorRate: number;
+  readonly throughput: number;
+  readonly latencyMs: {
+    readonly p50: number;
+    readonly p95: number;
+    readonly p99: number;
+  };
+  readonly retainedSampleCount: number;
+}
+
+export interface AggregatedMetricsWindow {
+  readonly startedAt: string;
+  readonly endedAt: string;
+  readonly startMs: number;
+  readonly endMs: number;
+  readonly durationMs: number;
+  readonly methods: ReadonlyArray<AggregatedMethodMetrics>;
+}
+
+export interface MetricsAggregatorOptions {
+  readonly windowMs?: number;
+  readonly windowCount?: number;
+  readonly maxLatencySamplesPerMethod?: number;
+  readonly autoRotate?: boolean;
+}
+
+export interface MetricsAggregatorShape {
+  readonly recordRpc: (observation: RpcMetricObservation) => Effect.Effect<void>;
+  readonly getWindows: Effect.Effect<ReadonlyArray<AggregatedMetricsWindow>>;
+  readonly snapshotAt: (nowMs: number) => Effect.Effect<ReadonlyArray<AggregatedMetricsWindow>>;
+}
+
+export class MetricsAggregator extends Context.Service<MetricsAggregator, MetricsAggregatorShape>()(
+  "t3/observability/Services/MetricsAggregator",
+) {}
+
+interface ResolvedMetricsAggregatorOptions {
+  readonly windowMs: number;
+  readonly windowCount: number;
+  readonly maxLatencySamplesPerMethod: number;
+  readonly autoRotate: boolean;
+}
+
+interface MethodAccumulator {
+  readonly requestCount: number;
+  readonly successCount: number;
+  readonly failureCount: number;
+  readonly interruptCount: number;
+  readonly latencySamplesMs: ReadonlyArray<number>;
+}
+
+interface MetricsAggregatorState {
+  readonly currentWindowStartMs: number;
+  readonly current: Readonly<Record<string, MethodAccumulator>>;
+  readonly completedWindows: ReadonlyArray<AggregatedMetricsWindow>;
+}
+
+const emptyAccumulators: Readonly<Record<string, MethodAccumulator>> = {};
+
+const positiveIntegerOrDefault = (value: number | undefined, fallback: number): number =>
+  value === undefined || !Number.isFinite(value) ? fallback : Math.max(1, Math.floor(value));
+
+const resolveOptions = (options?: MetricsAggregatorOptions): ResolvedMetricsAggregatorOptions => ({
+  windowMs: positiveIntegerOrDefault(options?.windowMs, METRICS_AGGREGATION_WINDOW_MS),
+  windowCount: positiveIntegerOrDefault(options?.windowCount, METRICS_AGGREGATION_WINDOW_COUNT),
+  maxLatencySamplesPerMethod: positiveIntegerOrDefault(
+    options?.maxLatencySamplesPerMethod,
+    METRICS_AGGREGATION_MAX_LATENCY_SAMPLES_PER_METHOD,
+  ),
+  autoRotate: options?.autoRotate ?? true,
+});
+
+const normalizeTimestampMs = (value: number): number =>
+  Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+
+const normalizeDurationMs = (value: number): number =>
+  Number.isFinite(value) ? Math.max(0, value) : 0;
+
+const windowStartFor = (timestampMs: number, windowMs: number): number =>
+  Math.floor(normalizeTimestampMs(timestampMs) / windowMs) * windowMs;
+
+const formatTimestampIso = (timestampMs: number): string =>
+  DateTime.formatIso(DateTime.makeUnsafe(timestampMs));
+
+const makeInitialState = (
+  nowMs: number,
+  options: ResolvedMetricsAggregatorOptions,
+): MetricsAggregatorState => ({
+  currentWindowStartMs: windowStartFor(nowMs, options.windowMs),
+  current: emptyAccumulators,
+  completedWindows: [],
+});
+
+export function calculatePercentile(
+  sortedValues: ReadonlyArray<number>,
+  percentile: number,
+): number {
+  if (sortedValues.length === 0) {
+    return 0;
+  }
+
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil((percentile / 100) * sortedValues.length) - 1),
+  );
+  return sortedValues[index] ?? 0;
+}
+
+const appendWindow = (
+  windows: ReadonlyArray<AggregatedMetricsWindow>,
+  window: AggregatedMetricsWindow,
+  windowCount: number,
+): ReadonlyArray<AggregatedMetricsWindow> => {
+  const next = [...windows, window];
+  return next.length <= windowCount ? next : next.slice(next.length - windowCount);
+};
+
+export const selectSlidingWindowBuffer = <A>(
+  windows: ReadonlyArray<A>,
+  windowCount: number,
+): Effect.Effect<ReadonlyArray<A>> => {
+  const boundedWindowCount = positiveIntegerOrDefault(
+    windowCount,
+    METRICS_AGGREGATION_WINDOW_COUNT,
+  );
+  if (windows.length <= boundedWindowCount) {
+    return Effect.succeed(windows);
+  }
+
+  return Stream.fromIterable(windows).pipe(
+    Stream.sliding(boundedWindowCount),
+    Stream.runLast,
+    Effect.map((lastWindow) =>
+      Array.from(Option.getOrElse(lastWindow, (): ReadonlyArray<A> => [])),
+    ),
+  );
+};
+
+const aggregateMethod = (
+  method: string,
+  accumulator: MethodAccumulator,
+  durationMs: number,
+): AggregatedMethodMetrics => {
+  const sortedLatencySamples = accumulator.latencySamplesMs.toSorted((left, right) => left - right);
+  const errorCount = accumulator.failureCount + accumulator.interruptCount;
+
+  return {
+    method,
+    requestCount: accumulator.requestCount,
+    successCount: accumulator.successCount,
+    failureCount: accumulator.failureCount,
+    interruptCount: accumulator.interruptCount,
+    errorRate: accumulator.requestCount === 0 ? 0 : (errorCount / accumulator.requestCount) * 100,
+    throughput: durationMs <= 0 ? 0 : accumulator.requestCount / (durationMs / 1000),
+    latencyMs: {
+      p50: calculatePercentile(sortedLatencySamples, 50),
+      p95: calculatePercentile(sortedLatencySamples, 95),
+      p99: calculatePercentile(sortedLatencySamples, 99),
+    },
+    retainedSampleCount: accumulator.latencySamplesMs.length,
+  };
+};
+
+const buildWindowSnapshot = (
+  startMs: number,
+  endMs: number,
+  accumulators: Readonly<Record<string, MethodAccumulator>>,
+): AggregatedMetricsWindow => {
+  const durationMs = Math.max(0, endMs - startMs);
+
+  return {
+    startedAt: formatTimestampIso(startMs),
+    endedAt: formatTimestampIso(endMs),
+    startMs,
+    endMs,
+    durationMs,
+    methods: Object.entries(accumulators)
+      .map(([method, accumulator]) => aggregateMethod(method, accumulator, durationMs))
+      .toSorted((left, right) => left.method.localeCompare(right.method)),
+  };
+};
+
+const rollStateForward = (
+  state: MetricsAggregatorState,
+  nowMs: number,
+  options: ResolvedMetricsAggregatorOptions,
+): MetricsAggregatorState => {
+  const targetWindowStartMs = windowStartFor(nowMs, options.windowMs);
+  if (targetWindowStartMs <= state.currentWindowStartMs) {
+    return state;
+  }
+
+  const elapsedWindows = Math.floor(
+    (targetWindowStartMs - state.currentWindowStartMs) / options.windowMs,
+  );
+  const droppedAllKnownWindows = elapsedWindows > options.windowCount;
+  const firstWindowStartMs = droppedAllKnownWindows
+    ? targetWindowStartMs - options.windowCount * options.windowMs
+    : state.currentWindowStartMs;
+
+  let completedWindows: ReadonlyArray<AggregatedMetricsWindow> = droppedAllKnownWindows
+    ? []
+    : [...state.completedWindows];
+  for (
+    let windowStartMs = firstWindowStartMs;
+    windowStartMs < targetWindowStartMs;
+    windowStartMs += options.windowMs
+  ) {
+    const accumulators =
+      windowStartMs === state.currentWindowStartMs ? state.current : emptyAccumulators;
+    completedWindows = appendWindow(
+      completedWindows,
+      buildWindowSnapshot(windowStartMs, windowStartMs + options.windowMs, accumulators),
+      options.windowCount,
+    );
+  }
+
+  return {
+    currentWindowStartMs: targetWindowStartMs,
+    current: emptyAccumulators,
+    completedWindows,
+  };
+};
+
+const emptyAccumulator: MethodAccumulator = {
+  requestCount: 0,
+  successCount: 0,
+  failureCount: 0,
+  interruptCount: 0,
+  latencySamplesMs: [],
+};
+
+const recordObservation = (
+  state: MetricsAggregatorState,
+  observation: Required<RpcMetricObservation>,
+  options: ResolvedMetricsAggregatorOptions,
+): MetricsAggregatorState => {
+  const rolledState = rollStateForward(state, observation.observedAtMs, options);
+  const currentAccumulator = rolledState.current[observation.method] ?? emptyAccumulator;
+  const nextLatencySamples = [
+    ...currentAccumulator.latencySamplesMs,
+    normalizeDurationMs(observation.durationMs),
+  ].slice(-options.maxLatencySamplesPerMethod);
+
+  const nextAccumulator: MethodAccumulator = {
+    requestCount: currentAccumulator.requestCount + 1,
+    successCount: currentAccumulator.successCount + (observation.outcome === "success" ? 1 : 0),
+    failureCount: currentAccumulator.failureCount + (observation.outcome === "failure" ? 1 : 0),
+    interruptCount:
+      currentAccumulator.interruptCount + (observation.outcome === "interrupt" ? 1 : 0),
+    latencySamplesMs: nextLatencySamples,
+  };
+
+  return {
+    ...rolledState,
+    current: {
+      ...rolledState.current,
+      [observation.method]: nextAccumulator,
+    },
+  };
+};
+
+const snapshotState = (
+  state: MetricsAggregatorState,
+  options: ResolvedMetricsAggregatorOptions,
+): ReadonlyArray<AggregatedMetricsWindow> => [
+  ...state.completedWindows,
+  buildWindowSnapshot(
+    state.currentWindowStartMs,
+    state.currentWindowStartMs + options.windowMs,
+    state.current,
+  ),
+];
+
+export const makeMetricsAggregator = (
+  options?: MetricsAggregatorOptions,
+): Effect.Effect<MetricsAggregatorShape, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const resolvedOptions = resolveOptions(options);
+    const nowMs = yield* Clock.currentTimeMillis;
+    const stateRef = yield* Ref.make(makeInitialState(nowMs, resolvedOptions));
+
+    const snapshotAt: MetricsAggregatorShape["snapshotAt"] = (snapshotNowMs) =>
+      Ref.updateAndGet(stateRef, (state) =>
+        rollStateForward(state, snapshotNowMs, resolvedOptions),
+      ).pipe(
+        Effect.flatMap((state) =>
+          selectSlidingWindowBuffer(
+            snapshotState(state, resolvedOptions),
+            resolvedOptions.windowCount,
+          ),
+        ),
+      );
+
+    const rotate = Clock.currentTimeMillis.pipe(
+      Effect.flatMap((rotationNowMs) =>
+        Ref.update(stateRef, (state) => rollStateForward(state, rotationNowMs, resolvedOptions)),
+      ),
+    );
+
+    if (resolvedOptions.autoRotate) {
+      yield* Effect.forkScoped(
+        rotate.pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("metrics.aggregator.rotate-failed", { cause }),
+          ),
+          Effect.repeat(Schedule.spaced(Duration.millis(resolvedOptions.windowMs))),
+        ),
+      );
+    }
+
+    return {
+      recordRpc: (observation) =>
+        Effect.gen(function* () {
+          const observedAtMs =
+            observation.observedAtMs === undefined
+              ? yield* Clock.currentTimeMillis
+              : normalizeTimestampMs(observation.observedAtMs);
+          yield* Ref.update(stateRef, (state) =>
+            recordObservation(
+              state,
+              {
+                ...observation,
+                observedAtMs,
+              },
+              resolvedOptions,
+            ),
+          );
+        }),
+      getWindows: Clock.currentTimeMillis.pipe(Effect.flatMap(snapshotAt)),
+      snapshotAt,
+    } satisfies MetricsAggregatorShape;
+  });
+
+export const makeMetricsAggregatorLive = (options?: MetricsAggregatorOptions) =>
+  Layer.effect(MetricsAggregator, makeMetricsAggregator(options));
+
+export const MetricsAggregatorLive = makeMetricsAggregatorLive();

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -88,6 +88,10 @@ import {
   BrowserTraceCollector,
   type BrowserTraceCollectorShape,
 } from "./observability/Services/BrowserTraceCollector.ts";
+import {
+  AGGREGATED_METRICS_PATH,
+  makeMetricsAggregatorLive,
+} from "./observability/Services/MetricsAggregator.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
 import {
   ProjectSetupScriptRunner,
@@ -693,6 +697,7 @@ const buildAppUnderTest = (options?: {
           ...options?.layers?.browserTraceCollector,
         }),
       ),
+      Layer.provide(makeMetricsAggregatorLive({ autoRotate: false })),
       Layer.provide(
         Layer.mock(ServerLifecycleEvents)({
           publish: (event) => Effect.succeed({ ...(event as any), sequence: 1 }),
@@ -1064,6 +1069,36 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(response.status, 200);
       assertBrowserApiCorsHeaders(response.headers);
       assert.deepEqual(body, testEnvironmentDescriptor);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("serves authenticated aggregated metrics as timestamped JSON windows", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const url = yield* getHttpServerUrl(AGGREGATED_METRICS_PATH);
+      const cookie = yield* getAuthenticatedSessionCookieHeader();
+      const response = yield* Effect.promise(() =>
+        fetch(url, {
+          headers: {
+            cookie,
+          },
+        }),
+      );
+      const body = (yield* Effect.promise(() => response.json())) as ReadonlyArray<{
+        readonly startedAt: string;
+        readonly endedAt: string;
+        readonly startMs: number;
+        readonly endMs: number;
+        readonly methods: ReadonlyArray<unknown>;
+      }>;
+
+      assert.equal(response.status, 200);
+      assert.isAtLeast(body.length, 1);
+      assert.match(body[0]?.startedAt ?? "", /^\d{4}-\d{2}-\d{2}T/);
+      assert.match(body[0]?.endedAt ?? "", /^\d{4}-\d{2}-\d{2}T/);
+      assert.isAtLeast(body[0]?.endMs ?? 0, body[0]?.startMs ?? 0);
+      assert.isArray(body[0]?.methods);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -4,6 +4,7 @@ import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 
 import { ServerConfig } from "./config.ts";
 import {
+  aggregatedMetricsRouteLayer,
   attachmentsRouteLayer,
   otlpTracesProxyRouteLayer,
   projectFaviconRouteLayer,
@@ -305,6 +306,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   authSessionRouteLayer,
   authWebSocketTokenRouteLayer,
   attachmentsRouteLayer,
+  aggregatedMetricsRouteLayer,
   orchestrationDispatchRouteLayer,
   orchestrationSnapshotRouteLayer,
   otlpTracesProxyRouteLayer,


### PR DESCRIPTION
## Summary

- Add a `MetricsAggregator` service backed by `Effect.Ref`, scheduled `Effect.Schedule` rotation, and a bounded 60-window buffer.
- Record RPC observations from unary and stream instrumentation, grouped per method with p50/p95/p99 latency, error rate, throughput, and retained sample counts.
- Expose authenticated `GET /metrics/aggregated` JSON windows with timestamps, and add safe public generation metadata for issue #856.

## Tests

- `bun run --cwd apps\server test src\observability\Services\MetricsAggregator.test.ts src\observability\RpcInstrumentation.test.ts`
- `bun run --cwd apps\server test src\server.test.ts -t "serves authenticated aggregated metrics as timestamped JSON windows"`
- `bun run --cwd apps\server typecheck`
- `bun run fmt:check apps\server\src\observability\Services\MetricsAggregator.ts apps\server\src\observability\Services\MetricsAggregator.test.ts apps\server\src\observability\RpcInstrumentation.ts apps\server\src\observability\RpcInstrumentation.test.ts apps\server\src\observability\Layers\Observability.ts apps\server\src\http.ts apps\server\src\server.ts apps\server\src\server.test.ts apps\server\src\observability\.generation_meta.json`
- `bun run lint apps\server\src\observability\Services\MetricsAggregator.ts apps\server\src\observability\Services\MetricsAggregator.test.ts apps\server\src\observability\RpcInstrumentation.ts apps\server\src\observability\RpcInstrumentation.test.ts apps\server\src\observability\Layers\Observability.ts apps\server\src\http.ts apps\server\src\server.ts apps\server\src\server.test.ts`
- `git diff --check` (clean; Git reports Windows CRLF conversion warnings only)
