### PR TITLE
OpenAI Codex [ T3 Code ] Standardize server error types

### DIFF
--- a/t3code/apps/server/src/_meta.json
+++ b/t3code/apps/server/src/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "OpenAI Codex",
+  "generation_context": "Public implementation metadata only. Private system, developer, runtime, environment, credentials, and hidden session instructions are intentionally not included.",
+  "completed_at": "2026-07-05T18:42:00.000Z"
+}

--- a/t3code/apps/server/src/bootstrap.ts
+++ b/t3code/apps/server/src/bootstrap.ts
@@ -4,7 +4,6 @@ import * as Net from "node:net";
 import * as readline from "node:readline";
 import type { Readable } from "node:stream";
 
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
@@ -12,10 +11,8 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
-class BootstrapError extends Data.TaggedError("BootstrapError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+import { ConfigError } from "./errors.ts";
+import type { ConfigError as BootstrapError } from "./errors.ts";
 
 export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function* <A, I>(
   schema: Schema.Codec<A, I>,
@@ -52,7 +49,7 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       }
       resume(
         Effect.fail(
-          new BootstrapError({
+          ConfigError({
             message: "Failed to read bootstrap envelope.",
             cause: error,
           }),
@@ -67,7 +64,7 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       } else {
         resume(
           Effect.fail(
-            new BootstrapError({
+            ConfigError({
               message: "Failed to decode bootstrap envelope.",
               cause: parsed.failure,
             }),
@@ -97,7 +94,7 @@ const isFdReady = (fd: number) =>
   Effect.try({
     try: () => NFS.fstatSync(fd),
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to stat bootstrap fd.",
         cause: error,
       }),
@@ -136,7 +133,7 @@ const makeBootstrapInputStream = (fd: number) =>
       }
     },
     catch: (error) =>
-      new BootstrapError({
+      ConfigError({
         message: "Failed to duplicate bootstrap fd.",
         cause: error,
       }),

--- a/t3code/apps/server/src/errors.test.ts
+++ b/t3code/apps/server/src/errors.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import * as Match from "effect/Match";
+
+import {
+  AuthError,
+  ConfigError,
+  DatabaseError,
+  GitError,
+  NetworkError,
+  type ServerError,
+  ValidationError,
+  errorToLog,
+  errorToResponse,
+} from "./errors.ts";
+
+describe("server errors", () => {
+  it("maps canonical tags to HTTP responses", () => {
+    const timestamp = "2026-07-05T00:00:00.000Z";
+
+    expect(errorToResponse(AuthError({ message: "auth", timestamp })).status).toBe(401);
+    expect(errorToResponse(ValidationError({ message: "validation", timestamp })).status).toBe(400);
+    expect(errorToResponse(DatabaseError({ message: "database", timestamp })).status).toBe(500);
+    expect(errorToResponse(NetworkError({ message: "network", timestamp })).status).toBe(502);
+    expect(errorToResponse(ConfigError({ message: "config", timestamp })).status).toBe(500);
+    expect(errorToResponse(GitError({ message: "git", timestamp })).status).toBe(422);
+  });
+
+  it("preserves cause chains for structured logs", () => {
+    const root = new Error("disk unavailable");
+    const wrapped = new Error("settings load failed");
+    Object.assign(wrapped, { cause: root });
+
+    const log = errorToLog(
+      DatabaseError({
+        message: "database open failed",
+        cause: wrapped,
+        timestamp: "2026-07-05T00:00:00.000Z",
+      }),
+    );
+
+    expect(log).toMatchObject({
+      tag: "DatabaseError",
+      message: "database open failed",
+      timestamp: "2026-07-05T00:00:00.000Z",
+    });
+    expect(log.stack).toContain("settings load failed");
+    expect(log.causeChain.map((cause) => cause.message)).toEqual([
+      "settings load failed",
+      "disk unavailable",
+    ]);
+  });
+
+  it("supports Effect Match tag pattern matching", () => {
+    const classify = Match.typeTags<ServerError, string>()({
+      AuthError: () => "auth",
+      ValidationError: () => "client",
+      DatabaseError: () => "server",
+      NetworkError: () => "upstream",
+      ConfigError: () => "server",
+      GitError: () => "git",
+    });
+
+    expect(classify(GitError({ message: "bad ref", timestamp: "2026-07-05T00:00:00.000Z" }))).toBe(
+      "git",
+    );
+  });
+});

--- a/t3code/apps/server/src/errors.ts
+++ b/t3code/apps/server/src/errors.ts
@@ -1,0 +1,139 @@
+import * as Data from "effect/Data";
+import * as DateTime from "effect/DateTime";
+import * as Match from "effect/Match";
+
+export interface ServerErrorInput {
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly timestamp?: string;
+}
+
+export interface ServerErrorFields {
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly timestamp: string;
+}
+
+export type ServerError = Data.TaggedEnum<{
+  readonly NetworkError: ServerErrorFields;
+  readonly DatabaseError: ServerErrorFields;
+  readonly AuthError: ServerErrorFields;
+  readonly GitError: ServerErrorFields;
+  readonly ConfigError: ServerErrorFields;
+  readonly ValidationError: ServerErrorFields;
+}>;
+
+export type NetworkError = Extract<ServerError, { readonly _tag: "NetworkError" }>;
+export type DatabaseError = Extract<ServerError, { readonly _tag: "DatabaseError" }>;
+export type AuthError = Extract<ServerError, { readonly _tag: "AuthError" }>;
+export type GitError = Extract<ServerError, { readonly _tag: "GitError" }>;
+export type ConfigError = Extract<ServerError, { readonly _tag: "ConfigError" }>;
+export type ValidationError = Extract<ServerError, { readonly _tag: "ValidationError" }>;
+
+const ServerErrors = Data.taggedEnum<ServerError>();
+
+const timestampNow = () => DateTime.formatIso(DateTime.nowUnsafe());
+
+const withTimestamp = (input: ServerErrorInput): ServerErrorFields => ({
+  message: input.message,
+  timestamp: input.timestamp ?? timestampNow(),
+  ...(input.cause === undefined ? {} : { cause: input.cause }),
+});
+
+export const NetworkError = (input: ServerErrorInput): NetworkError =>
+  ServerErrors.NetworkError(withTimestamp(input));
+export const DatabaseError = (input: ServerErrorInput): DatabaseError =>
+  ServerErrors.DatabaseError(withTimestamp(input));
+export const AuthError = (input: ServerErrorInput): AuthError =>
+  ServerErrors.AuthError(withTimestamp(input));
+export const GitError = (input: ServerErrorInput): GitError =>
+  ServerErrors.GitError(withTimestamp(input));
+export const ConfigError = (input: ServerErrorInput): ConfigError =>
+  ServerErrors.ConfigError(withTimestamp(input));
+export const ValidationError = (input: ServerErrorInput): ValidationError =>
+  ServerErrors.ValidationError(withTimestamp(input));
+
+export interface ServerErrorResponse {
+  readonly status: 400 | 401 | 422 | 500 | 502;
+  readonly body: {
+    readonly error: string;
+  };
+}
+
+export const errorToResponse = Match.typeTags<ServerError, ServerErrorResponse>()({
+  AuthError: (error) => ({ status: 401, body: { error: error.message } }),
+  ValidationError: (error) => ({ status: 400, body: { error: error.message } }),
+  DatabaseError: (error) => ({ status: 500, body: { error: error.message } }),
+  NetworkError: (error) => ({ status: 502, body: { error: error.message } }),
+  ConfigError: (error) => ({ status: 500, body: { error: error.message } }),
+  GitError: (error) => ({ status: 422, body: { error: error.message } }),
+});
+
+export interface ServerErrorCauseLog {
+  readonly tag?: string;
+  readonly message: string;
+  readonly stack?: string;
+}
+
+export interface ServerErrorLog {
+  readonly tag: ServerError["_tag"];
+  readonly message: string;
+  readonly timestamp: string;
+  readonly stack: string;
+  readonly causeChain: ReadonlyArray<ServerErrorCauseLog>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const causeMessage = (cause: unknown): string => {
+  if (cause instanceof Error) return cause.message;
+  if (isRecord(cause) && typeof cause.message === "string") return cause.message;
+  return String(cause);
+};
+
+const causeStack = (cause: unknown): string | undefined => {
+  if (cause instanceof Error) return cause.stack;
+  if (isRecord(cause) && typeof cause.stack === "string") return cause.stack;
+  return undefined;
+};
+
+const causeTag = (cause: unknown): string | undefined =>
+  isRecord(cause) && typeof cause._tag === "string" ? cause._tag : undefined;
+
+const nestedCause = (cause: unknown): unknown =>
+  isRecord(cause) && "cause" in cause ? cause.cause : undefined;
+
+const collectCauseChain = (cause: unknown): ReadonlyArray<ServerErrorCauseLog> => {
+  const chain: ServerErrorCauseLog[] = [];
+  let current = cause;
+  const seen = new Set<unknown>();
+
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const stack = causeStack(current);
+    const tag = causeTag(current);
+    chain.push({
+      message: causeMessage(current),
+      ...(tag ? { tag } : {}),
+      ...(stack ? { stack } : {}),
+    });
+    current = nestedCause(current);
+  }
+
+  return chain;
+};
+
+export function errorToLog(error: ServerError): ServerErrorLog {
+  const causeChain = collectCauseChain(error.cause);
+  return {
+    tag: error._tag,
+    message: error.message,
+    timestamp: error.timestamp,
+    stack:
+      causeChain.find((cause) => cause.stack !== undefined)?.stack ??
+      new Error(error.message).stack ??
+      "",
+    causeChain,
+  };
+}

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,6 +1,5 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -27,6 +26,7 @@ import { BrowserTraceCollector } from "./observability/Services/BrowserTraceColl
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
+import { ValidationError } from "./errors.ts";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
 import {
   browserApiCorsAllowedHeaders,
@@ -81,11 +81,6 @@ export const serverEnvironmentRouteLayer = HttpRouter.add(
   }),
 );
 
-class DecodeOtlpTraceRecordsError extends Data.TaggedError("DecodeOtlpTraceRecordsError")<{
-  readonly cause: unknown;
-  readonly bodyJson: OtlpTracer.TraceData;
-}> {}
-
 export const otlpTracesProxyRouteLayer = HttpRouter.add(
   "POST",
   OTLP_TRACES_PROXY_PATH,
@@ -100,7 +95,11 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),
-      catch: (cause) => new DecodeOtlpTraceRecordsError({ cause, bodyJson }),
+      catch: (cause) =>
+        ValidationError({
+          message: "Failed to decode browser OTLP traces.",
+          cause: { cause, bodyJson },
+        }),
     }).pipe(
       Effect.flatMap((records) => browserTraceCollector.record(records)),
       Effect.catch((cause) =>

--- a/t3code/apps/server/src/serverRuntimeStartup.test.ts
+++ b/t3code/apps/server/src/serverRuntimeStartup.test.ts
@@ -64,7 +64,7 @@ it.effect("enqueueCommand fails queued work when readiness fails", () =>
         .pipe(Effect.forkScoped);
 
       yield* commandGate.failCommandReady(
-        new ServerRuntimeStartupError({
+        ServerRuntimeStartupError({
           message: "startup failed",
         }),
       );

--- a/t3code/apps/server/src/serverRuntimeStartup.ts
+++ b/t3code/apps/server/src/serverRuntimeStartup.ts
@@ -7,7 +7,6 @@ import {
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
-import * as Data from "effect/Data";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -32,6 +31,8 @@ import { ServerSettingsService } from "./serverSettings.ts";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
+import { ConfigError } from "./errors.ts";
+import type { ConfigError as ServerRuntimeStartupError } from "./errors.ts";
 import { ProviderSessionReaper } from "./provider/Services/ProviderSessionReaper.ts";
 import {
   formatHeadlessServeOutput,
@@ -40,10 +41,7 @@ import {
   issueHeadlessServeAccessInfo,
 } from "./startupAccess.ts";
 
-export class ServerRuntimeStartupError extends Data.TaggedError("ServerRuntimeStartupError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export { ConfigError as ServerRuntimeStartupError };
 
 export interface ServerRuntimeStartupShape {
   readonly awaitCommandReady: Effect.Effect<void, ServerRuntimeStartupError>;
@@ -106,7 +104,7 @@ export const makeCommandGate = Effect.gen(function* () {
           return yield* effect;
         }
         if (readinessState !== "pending") {
-          return yield* readinessState;
+          return yield* Effect.fail(readinessState);
         }
 
         const result = yield* Deferred.make<A, E | ServerRuntimeStartupError>();
@@ -402,7 +400,7 @@ export const makeServerRuntimeStartup = Effect.gen(function* () {
     Effect.gen(function* () {
       const startupExit = yield* Effect.exit(startup);
       if (Exit.isFailure(startupExit)) {
-        const error = new ServerRuntimeStartupError({
+        const error = ConfigError({
           message: "Server runtime startup failed before command readiness.",
           cause: startupExit.cause,
         });


### PR DESCRIPTION
/claim #861

## Summary

- Added `apps/server/src/errors.ts` with canonical `Effect.Data.TaggedEnum` server errors for `AuthError`, `ValidationError`, `DatabaseError`, `NetworkError`, `ConfigError`, and `GitError`.
- Added `errorToResponse` mappings and `errorToLog` structured serialization with timestamp, stack, and cause-chain preservation.
- Migrated focused existing error handling paths in `bootstrap.ts`, `http.ts`, and `serverRuntimeStartup.ts` to use the centralized tagged errors.
- Added tests for every status mapping, cause-chain logging, and Effect `Match.typeTags` pattern matching.

## Metadata

The requested `_meta.json` is included with safe public implementation metadata only. It intentionally does not include private system, developer, runtime, credential, or hidden session instructions.

## Verification

```text
bun run --cwd apps/server test src/errors.test.ts src/serverRuntimeStartup.test.ts src/http.test.ts
bun run --cwd apps/server typecheck
bun run fmt:check apps\server\src\errors.ts apps\server\src\errors.test.ts apps\server\src\bootstrap.ts apps\server\src\http.ts apps\server\src\serverRuntimeStartup.ts apps\server\src\serverRuntimeStartup.test.ts apps\server\src\_meta.json
bun run lint apps\server\src\errors.ts apps\server\src\errors.test.ts apps\server\src\bootstrap.ts apps\server\src\http.ts apps\server\src\serverRuntimeStartup.ts apps\server\src\serverRuntimeStartup.test.ts
git diff --cached --check
```

## Note

`src/bootstrap.test.ts` has existing Windows-only harness failures for `/dev/null`, `mkfifo`, and fd ownership; I did not change those platform assumptions. The focused server tests, full server typecheck, formatter, linter, and whitespace checks pass.
