### PR TITLE
OpenAI Codex [ T3 Code ] Enable SQLite WAL pooling

### DIFF
--- a/t3code/apps/server/src/persistence/.attribution.json
+++ b/t3code/apps/server/src/persistence/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Safe public metadata only. Private system, developer, user, runtime, credential, and session initialization instructions are not published.",
+  "date": "2026-07-05T19:05:00Z"
+}

--- a/t3code/apps/server/src/persistence/BunSqliteClient.ts
+++ b/t3code/apps/server/src/persistence/BunSqliteClient.ts
@@ -1,0 +1,279 @@
+/**
+ * Local Bun SQLite client with pooled connections for the server persistence layer.
+ *
+ * @module BunSqliteClient
+ */
+import { Database } from "bun:sqlite";
+
+import * as Config from "effect/Config";
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import { identity } from "effect/Function";
+import * as Layer from "effect/Layer";
+import * as Pool from "effect/Pool";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import * as Reactivity from "effect/unstable/reactivity/Reactivity";
+import * as Client from "effect/unstable/sql/SqlClient";
+import type { Connection } from "effect/unstable/sql/SqlConnection";
+import { SqlError, classifySqliteError, isSqlError } from "effect/unstable/sql/SqlError";
+import * as Statement from "effect/unstable/sql/Statement";
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name";
+const DEFAULT_BUSY_TIMEOUT_MS = 5000;
+const DEFAULT_POOL_MIN_SIZE = 1;
+const DEFAULT_POOL_MAX_SIZE = 5;
+const DEFAULT_POOL_ACQUIRE_TIMEOUT = Duration.seconds(10);
+const DEFAULT_POOL_TTL = Duration.minutes(10);
+
+export const TypeId: TypeId = "~local/sqlite-bun/SqliteClient";
+export type TypeId = "~local/sqlite-bun/SqliteClient";
+
+export interface SqliteClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId;
+  readonly config: SqliteClientConfig;
+  readonly export: Effect.Effect<Uint8Array, SqlError>;
+  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>;
+  readonly updateValues: never;
+}
+
+export const SqliteClient = Context.Service<SqliteClient>("t3/persistence/BunSqliteClient");
+
+export interface SqliteClientConfig {
+  readonly filename: string;
+  readonly readonly?: boolean | undefined;
+  readonly create?: boolean | undefined;
+  readonly readwrite?: boolean | undefined;
+  readonly disableWAL?: boolean | undefined;
+  readonly busyTimeoutMs?: number | undefined;
+  readonly poolMinSize?: number | undefined;
+  readonly poolMaxSize?: number | undefined;
+  readonly poolAcquireTimeout?: Duration.Input | undefined;
+  readonly spanAttributes?: Record<string, unknown> | undefined;
+  readonly transformResultNames?: ((str: string) => string) | undefined;
+  readonly transformQueryNames?: ((str: string) => string) | undefined;
+}
+
+interface SqliteConnection extends Connection {
+  readonly export: Effect.Effect<Uint8Array, SqlError>;
+  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>;
+}
+
+interface ManagedConnection extends SqliteConnection {
+  readonly db: Database;
+}
+
+const isMemoryFilename = (filename: string): boolean => filename === ":memory:";
+
+const normalizedPoolSize = (value: number | undefined, fallback: number): number =>
+  Math.max(1, Math.trunc(value ?? fallback));
+
+const sqliteError = (cause: unknown, message: string, operation: string) =>
+  new SqlError({
+    reason: classifySqliteError(cause, {
+      message,
+      operation,
+    }),
+  });
+
+const configureConnection = (db: Database, options: SqliteClientConfig) =>
+  Effect.try({
+    try: () => {
+      const busyTimeoutMs = Math.max(
+        0,
+        Math.trunc(options.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS),
+      );
+      db.run(`PRAGMA busy_timeout = ${busyTimeoutMs};`);
+      db.run("PRAGMA synchronous = NORMAL;");
+      db.run("PRAGMA foreign_keys = ON;");
+
+      if (
+        options.disableWAL !== true &&
+        !isMemoryFilename(options.filename) &&
+        options.readonly !== true
+      ) {
+        const row = db.query("PRAGMA journal_mode = WAL;").get() as
+          | { readonly journal_mode?: unknown }
+          | undefined;
+        const journalMode = String(row?.journal_mode ?? "").toLowerCase();
+        if (journalMode !== "wal") {
+          throw new Error(
+            `SQLite did not enter WAL journal mode; received ${journalMode || "unknown"}`,
+          );
+        }
+      }
+    },
+    catch: (cause) => sqliteError(cause, "Failed to configure sqlite connection", "configure"),
+  });
+
+const resetConnection = (db: Database, options: SqliteClientConfig) =>
+  Effect.sync(() => {
+    try {
+      const busyTimeoutMs = Math.max(
+        0,
+        Math.trunc(options.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS),
+      );
+      db.run("PRAGMA reset;");
+      db.run(`PRAGMA busy_timeout = ${busyTimeoutMs};`);
+      db.run("PRAGMA synchronous = NORMAL;");
+      db.run("PRAGMA foreign_keys = ON;");
+    } catch {
+      // Pool release finalization is best-effort.
+    }
+  });
+
+const closeDatabase = (db: Database) =>
+  Effect.sync(() => {
+    try {
+      db.close();
+    } catch {
+      // Closing is best-effort during scope finalization.
+    }
+  });
+
+export const make = (
+  options: SqliteClientConfig,
+): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function* () {
+    const compiler = Statement.makeCompilerSqlite(options.transformQueryNames);
+    const transformRows = options.transformResultNames
+      ? Statement.defaultTransforms(options.transformResultNames).array
+      : undefined;
+
+    const makeConnection = Effect.gen(function* () {
+      const db = yield* Effect.try({
+        try: () =>
+          new Database(options.filename, {
+            readonly: options.readonly,
+            readwrite: options.readwrite ?? true,
+            create: options.create ?? true,
+          } as any),
+        catch: (cause) => sqliteError(cause, "Failed to open sqlite database", "connect"),
+      });
+      yield* Effect.addFinalizer(() => closeDatabase(db));
+      yield* configureConnection(db, options);
+
+      const run = (sql: string, params: ReadonlyArray<unknown> = []) =>
+        Effect.withFiber<Array<any>, SqlError>((fiber) => {
+          const statement = db.query(sql);
+          const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers);
+          // @ts-expect-error bun-types missing safeIntegers method, fixed in newer Bun releases.
+          statement.safeIntegers(useSafeIntegers);
+          try {
+            return Effect.succeed((statement.all(...(params as any)) ?? []) as Array<any>);
+          } catch (cause) {
+            return Effect.fail(sqliteError(cause, "Failed to execute statement", "execute"));
+          }
+        });
+
+      const runValues = (sql: string, params: ReadonlyArray<unknown> = []) =>
+        Effect.withFiber<Array<any>, SqlError>((fiber) => {
+          const statement = db.query(sql);
+          const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers);
+          // @ts-expect-error bun-types missing safeIntegers method, fixed in newer Bun releases.
+          statement.safeIntegers(useSafeIntegers);
+          try {
+            return Effect.succeed((statement.values(...(params as any)) ?? []) as Array<any>);
+          } catch (cause) {
+            return Effect.fail(sqliteError(cause, "Failed to execute statement", "execute"));
+          }
+        });
+
+      return identity<ManagedConnection>({
+        db,
+        execute(sql, params, rowTransform) {
+          return rowTransform ? Effect.map(run(sql, params), rowTransform) : run(sql, params);
+        },
+        executeRaw(sql, params) {
+          return run(sql, params);
+        },
+        executeValues(sql, params) {
+          return runValues(sql, params);
+        },
+        executeUnprepared(sql, params, rowTransform) {
+          return this.execute(sql, params, rowTransform);
+        },
+        executeStream(_sql, _params) {
+          return Stream.die("executeStream not implemented");
+        },
+        export: Effect.try({
+          try: () => db.serialize(),
+          catch: (cause) => sqliteError(cause, "Failed to export database", "export"),
+        }),
+        loadExtension: (path) =>
+          Effect.try({
+            try: () => db.loadExtension(path),
+            catch: (cause) => sqliteError(cause, "Failed to load extension", "loadExtension"),
+          }),
+      });
+    });
+
+    const minSize = isMemoryFilename(options.filename)
+      ? 1
+      : normalizedPoolSize(options.poolMinSize, DEFAULT_POOL_MIN_SIZE);
+    const maxSize = isMemoryFilename(options.filename)
+      ? 1
+      : Math.max(minSize, normalizedPoolSize(options.poolMaxSize, DEFAULT_POOL_MAX_SIZE));
+    const acquireTimeout = options.poolAcquireTimeout ?? DEFAULT_POOL_ACQUIRE_TIMEOUT;
+
+    const connectionPool = yield* Pool.makeWithTTL({
+      acquire: makeConnection,
+      min: minSize,
+      max: maxSize,
+      timeToLive: DEFAULT_POOL_TTL,
+    });
+
+    const acquireManagedConnection = Pool.get(connectionPool).pipe(
+      Effect.timeout(acquireTimeout),
+      Effect.mapError((cause) =>
+        isSqlError(cause)
+          ? cause
+          : sqliteError(cause, "Timed out acquiring sqlite connection from pool", "acquire"),
+      ),
+    );
+
+    const acquirer = Effect.acquireRelease(acquireManagedConnection, (managed) =>
+      resetConnection(managed.db, options),
+    );
+
+    return Object.assign(
+      (yield* Client.make({
+        acquirer,
+        compiler,
+        spanAttributes: [
+          ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+          [ATTR_DB_SYSTEM_NAME, "sqlite"],
+        ],
+        transformRows,
+      })) as SqliteClient,
+      {
+        [TypeId]: TypeId as TypeId,
+        config: options,
+        export: Effect.scoped(Effect.flatMap(acquirer, (_) => _.export)),
+        loadExtension: (path: string) =>
+          Effect.scoped(Effect.flatMap(acquirer, (_) => _.loadExtension(path))),
+      },
+    );
+  });
+
+export const layerConfig = (
+  config: Config.Wrap<SqliteClientConfig>,
+): Layer.Layer<SqliteClient | Client.SqlClient, Config.ConfigError> =>
+  Layer.effectContext(
+    Config.unwrap(config)
+      .asEffect()
+      .pipe(
+        Effect.flatMap(make),
+        Effect.map((client) =>
+          Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
+        ),
+      ),
+  ).pipe(Layer.provide(Reactivity.layer));
+
+export const layer = (config: SqliteClientConfig): Layer.Layer<SqliteClient | Client.SqlClient> =>
+  Layer.effectContext(
+    Effect.map(make(config), (client) =>
+      Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
+    ),
+  ).pipe(Layer.provide(Reactivity.layer));

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -16,7 +16,7 @@ type Loader = {
   layer: (config: RuntimeSqliteLayerConfig) => Layer.Layer<SqlClient.SqlClient>;
 };
 const defaultSqliteClientLoaders = {
-  bun: () => import("@effect/sql-sqlite-bun/SqliteClient"),
+  bun: () => import("../BunSqliteClient.ts"),
   node: () => import("../NodeSqliteClient.ts"),
 } satisfies Record<string, () => Promise<Loader>>;
 
@@ -29,14 +29,7 @@ const makeRuntimeSqliteLayer = Effect.fn("makeRuntimeSqliteLayer")(function* (
   return clientModule.layer(config);
 }, Layer.unwrap);
 
-const setup = Layer.effectDiscard(
-  Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-    yield* sql`PRAGMA journal_mode = WAL;`;
-    yield* sql`PRAGMA foreign_keys = ON;`;
-    yield* runMigrations();
-  }),
-);
+const setup = Layer.effectDiscard(runMigrations());
 
 export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(function* (
   dbPath: string,
@@ -65,3 +58,5 @@ export const SqlitePersistenceMemory = Layer.provideMerge(
 export const layerConfig = Layer.unwrap(
   Effect.map(Effect.service(ServerConfig), ({ dbPath }) => makeSqlitePersistenceLive(dbPath)),
 );
+
+export { sqliteHealthCheck } from "../sqliteHealthCheck.ts";

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -1,8 +1,14 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Exit from "effect/Exit";
+import * as Path from "effect/Path";
+import * as Scope from "effect/Scope";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import * as SqliteClient from "./NodeSqliteClient.ts";
+import { sqliteHealthCheck } from "./sqliteHealthCheck.ts";
 
 const layer = it.layer(SqliteClient.layerMemory());
 
@@ -28,3 +34,121 @@ layer("NodeSqliteClient", (it) => {
     }),
   );
 });
+
+const makeTempDbPath = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-node-sqlite-" });
+  return path.join(directory, "state.sqlite");
+});
+
+const withFileSqlite = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  config: Omit<SqliteClient.SqliteClientConfig, "filename"> = {},
+) =>
+  Effect.gen(function* () {
+    const filename = yield* makeTempDbPath;
+    return yield* effect.pipe(
+      Effect.provide(
+        SqliteClient.layer({
+          ...config,
+          filename,
+        }),
+      ),
+    );
+  }).pipe(Effect.provide(NodeServices.layer), Effect.scoped);
+
+it.effect(
+  "enables WAL, busy timeout, synchronous normal, and health checks for file databases",
+  () =>
+    withFileSqlite(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+
+        const journalMode = yield* sql<{ readonly journal_mode: string }>`PRAGMA journal_mode`;
+        assert.equal(journalMode[0]?.journal_mode.toLowerCase(), "wal");
+
+        const busyTimeout = yield* sql<{ readonly timeout: number }>`PRAGMA busy_timeout`;
+        assert.equal(Number(busyTimeout[0]?.timeout), 5000);
+
+        const synchronous = yield* sql<{ readonly synchronous: number }>`PRAGMA synchronous`;
+        assert.equal(Number(synchronous[0]?.synchronous), 1);
+
+        const health = yield* sqliteHealthCheck();
+        assert.deepStrictEqual(health, { ok: true, details: ["ok"] });
+      }),
+    ),
+);
+
+it.effect("supports concurrent file-backed writes through the connection pool", () =>
+  withFileSqlite(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`CREATE TABLE pooled_entries(id INTEGER PRIMARY KEY, name TEXT NOT NULL)`;
+      yield* Effect.all(
+        Array.from(
+          { length: 20 },
+          (_, index) => sql`INSERT INTO pooled_entries(name) VALUES (${`entry-${index}`})`,
+        ),
+        { concurrency: "unbounded", discard: true },
+      );
+
+      const rows = yield* sql<{
+        readonly count: number;
+      }>`SELECT COUNT(*) AS count FROM pooled_entries`;
+      assert.equal(Number(rows[0]?.count), 20);
+    }),
+  ),
+);
+
+it.effect("keeps transactions scoped to one pooled file connection", () =>
+  withFileSqlite(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`CREATE TABLE transactional_entries(id INTEGER PRIMARY KEY, name TEXT NOT NULL)`;
+      yield* sql.withTransaction(
+        sql`INSERT INTO transactional_entries(name) VALUES (${"committed"})`,
+      );
+
+      const rollbackExit = yield* Effect.exit(
+        sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`INSERT INTO transactional_entries(name) VALUES (${"rolled-back"})`;
+            return yield* Effect.fail("rollback");
+          }),
+        ),
+      );
+      assert.equal(Exit.isFailure(rollbackExit), true);
+
+      const rows = yield* sql<{
+        readonly name: string;
+      }>`SELECT name FROM transactional_entries ORDER BY id`;
+      assert.deepStrictEqual(
+        rows.map((row) => row.name),
+        ["committed"],
+      );
+    }),
+  ),
+);
+
+it.effect(
+  "supports multiple scoped reservations when the file-backed pool is configured above one",
+  () =>
+    withFileSqlite(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const firstScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+          Scope.close(scope, Exit.void).pipe(Effect.ignore),
+        );
+        const secondScope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+          Scope.close(scope, Exit.void).pipe(Effect.ignore),
+        );
+
+        yield* Scope.provide(sql.reserve, firstScope);
+        yield* Scope.provide(sql.reserve, secondScope);
+      }),
+      { poolMaxSize: 2 },
+    ),
+);

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.ts
@@ -10,20 +10,24 @@ import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
-import * as Fiber from "effect/Fiber";
 import { identity } from "effect/Function";
 import * as Layer from "effect/Layer";
+import * as Pool from "effect/Pool";
 import * as Scope from "effect/Scope";
-import * as Semaphore from "effect/Semaphore";
 import * as Context from "effect/Context";
 import * as Stream from "effect/Stream";
 import * as Reactivity from "effect/unstable/reactivity/Reactivity";
 import * as Client from "effect/unstable/sql/SqlClient";
 import type { Connection } from "effect/unstable/sql/SqlConnection";
-import { SqlError, classifySqliteError } from "effect/unstable/sql/SqlError";
+import { SqlError, classifySqliteError, isSqlError } from "effect/unstable/sql/SqlError";
 import * as Statement from "effect/unstable/sql/Statement";
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name";
+const DEFAULT_BUSY_TIMEOUT_MS = 5000;
+const DEFAULT_POOL_MIN_SIZE = 1;
+const DEFAULT_POOL_MAX_SIZE = 5;
+const DEFAULT_POOL_ACQUIRE_TIMEOUT = Duration.seconds(10);
+const DEFAULT_POOL_TTL = Duration.minutes(10);
 
 export const TypeId: TypeId = "~local/sqlite-node/SqliteClient";
 
@@ -38,6 +42,10 @@ export interface SqliteClientConfig {
   readonly filename: string;
   readonly readonly?: boolean | undefined;
   readonly allowExtension?: boolean | undefined;
+  readonly busyTimeoutMs?: number | undefined;
+  readonly poolMinSize?: number | undefined;
+  readonly poolMaxSize?: number | undefined;
+  readonly poolAcquireTimeout?: Duration.Input | undefined;
   readonly prepareCacheSize?: number | undefined;
   readonly prepareCacheTTL?: Duration.Input | undefined;
   readonly spanAttributes?: Record<string, unknown> | undefined;
@@ -72,6 +80,75 @@ const checkNodeSqliteCompat = () => {
   return Effect.void;
 };
 
+interface ManagedConnection {
+  readonly db: DatabaseSync;
+  readonly connection: Connection;
+}
+
+const isMemoryFilename = (filename: string): boolean => filename === ":memory:";
+
+const normalizedPoolSize = (value: number | undefined, fallback: number): number =>
+  Math.max(1, Math.trunc(value ?? fallback));
+
+const sqliteError = (cause: unknown, message: string, operation: string) =>
+  new SqlError({
+    reason: classifySqliteError(cause, {
+      message,
+      operation,
+    }),
+  });
+
+const configureConnection = (db: DatabaseSync, options: SqliteClientConfig) =>
+  Effect.try({
+    try: () => {
+      const busyTimeoutMs = Math.max(
+        0,
+        Math.trunc(options.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS),
+      );
+      db.exec(`PRAGMA busy_timeout = ${busyTimeoutMs};`);
+      db.exec("PRAGMA synchronous = NORMAL;");
+      db.exec("PRAGMA foreign_keys = ON;");
+
+      if (!isMemoryFilename(options.filename) && options.readonly !== true) {
+        const row = db.prepare("PRAGMA journal_mode = WAL;").get() as
+          | { readonly journal_mode?: unknown }
+          | undefined;
+        const journalMode = String(row?.journal_mode ?? "").toLowerCase();
+        if (journalMode !== "wal") {
+          throw new Error(
+            `SQLite did not enter WAL journal mode; received ${journalMode || "unknown"}`,
+          );
+        }
+      }
+    },
+    catch: (cause) => sqliteError(cause, "Failed to configure sqlite connection", "configure"),
+  });
+
+const resetConnection = (db: DatabaseSync, options: SqliteClientConfig) =>
+  Effect.sync(() => {
+    try {
+      const busyTimeoutMs = Math.max(
+        0,
+        Math.trunc(options.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS),
+      );
+      db.exec("PRAGMA reset;");
+      db.exec(`PRAGMA busy_timeout = ${busyTimeoutMs};`);
+      db.exec("PRAGMA synchronous = NORMAL;");
+      db.exec("PRAGMA foreign_keys = ON;");
+    } catch {
+      // Pool release finalization is best-effort.
+    }
+  });
+
+const closeDatabase = (db: DatabaseSync) =>
+  Effect.sync(() => {
+    try {
+      db.close();
+    } catch {
+      // Closing is best-effort during scope finalization.
+    }
+  });
+
 const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
   options: SqliteClientConfig,
   openDatabase: () => DatabaseSync,
@@ -85,11 +162,12 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
 
   const makeConnection = Effect.gen(function* () {
     const scope = yield* Effect.scope;
-    const db = openDatabase();
-    yield* Scope.addFinalizer(
-      scope,
-      Effect.sync(() => db.close()),
-    );
+    const db = yield* Effect.try({
+      try: openDatabase,
+      catch: (cause) => sqliteError(cause, "Failed to open sqlite database", "connect"),
+    });
+    yield* configureConnection(db, options);
+    yield* Scope.addFinalizer(scope, closeDatabase(db));
 
     const statementReaderCache = new WeakMap<StatementSync, boolean>();
     const hasRows = (statement: StatementSync): boolean => {
@@ -174,7 +252,7 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
           }),
       );
 
-    return identity<Connection>({
+    const connection = identity<Connection>({
       execute(sql, params, rowTransform) {
         return rowTransform ? Effect.map(run(sql, params), rowTransform) : run(sql, params);
       },
@@ -192,25 +270,44 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
         return Stream.die("executeStream not implemented");
       },
     });
-  });
 
-  const semaphore = yield* Semaphore.make(1);
-  const connection = yield* makeConnection;
-
-  const acquirer = semaphore.withPermits(1)(Effect.succeed(connection));
-  const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
-    const fiber = Fiber.getCurrent()!;
-    const scope = Context.getUnsafe(fiber.context, Scope.Scope);
-    return Effect.as(
-      Effect.tap(restore(semaphore.take(1)), () => Scope.addFinalizer(scope, semaphore.release(1))),
+    return identity<ManagedConnection>({
+      db,
       connection,
-    );
+    });
   });
+
+  const minSize = isMemoryFilename(options.filename)
+    ? 1
+    : normalizedPoolSize(options.poolMinSize, DEFAULT_POOL_MIN_SIZE);
+  const maxSize = isMemoryFilename(options.filename)
+    ? 1
+    : Math.max(minSize, normalizedPoolSize(options.poolMaxSize, DEFAULT_POOL_MAX_SIZE));
+  const acquireTimeout = options.poolAcquireTimeout ?? DEFAULT_POOL_ACQUIRE_TIMEOUT;
+
+  const connectionPool = yield* Pool.makeWithTTL({
+    acquire: makeConnection,
+    min: minSize,
+    max: maxSize,
+    timeToLive: DEFAULT_POOL_TTL,
+  });
+
+  const acquireManagedConnection = Pool.get(connectionPool).pipe(
+    Effect.timeout(acquireTimeout),
+    Effect.mapError((cause) =>
+      isSqlError(cause)
+        ? cause
+        : sqliteError(cause, "Timed out acquiring sqlite connection from pool", "acquire"),
+    ),
+  );
+
+  const acquirer = Effect.acquireRelease(acquireManagedConnection, (managed) =>
+    resetConnection(managed.db, options),
+  ).pipe(Effect.map((managed) => managed.connection));
 
   return yield* Client.make({
     acquirer,
     compiler,
-    transactionAcquirer,
     spanAttributes: [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
       [ATTR_DB_SYSTEM_NAME, "sqlite"],

--- a/t3code/apps/server/src/persistence/sqliteHealthCheck.ts
+++ b/t3code/apps/server/src/persistence/sqliteHealthCheck.ts
@@ -1,0 +1,17 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export interface SqliteHealthCheckResult {
+  readonly ok: boolean;
+  readonly details: ReadonlyArray<string>;
+}
+
+export const sqliteHealthCheck = Effect.fn("sqliteHealthCheck")(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const rows = yield* sql<Readonly<Record<string, unknown>>>`PRAGMA integrity_check`;
+  const details = rows.map((row) => String(Object.values(row)[0] ?? ""));
+  return {
+    ok: details.length > 0 && details.every((detail) => detail.toLowerCase() === "ok"),
+    details,
+  } satisfies SqliteHealthCheckResult;
+});


### PR DESCRIPTION
/claim #858

## Summary

- Configured SQLite connections with `PRAGMA busy_timeout=5000`, `PRAGMA synchronous=NORMAL`, `PRAGMA foreign_keys=ON`, and verified WAL mode for file-backed writable databases.
- Replaced the Node SQLite single-connection semaphore with an `Effect.Pool` connection pool, defaulting to min 1 / max 5, while keeping `:memory:` databases single-connection to avoid state splits.
- Added a local Bun SQLite client with the same pool and PRAGMA behavior so runtime persistence no longer falls back to an unpooled upstream client.
- Exposed `sqliteHealthCheck` using `PRAGMA integrity_check`.
- Added safe public `.attribution.json` metadata only.

## Verification

```text
bun run --cwd apps/server test src/persistence/NodeSqliteClient.test.ts
bun run --cwd apps/server typecheck
bun run fmt:check apps\server\src\persistence\NodeSqliteClient.ts apps\server\src\persistence\BunSqliteClient.ts apps\server\src\persistence\sqliteHealthCheck.ts apps\server\src\persistence\Layers\Sqlite.ts apps\server\src\persistence\NodeSqliteClient.test.ts apps\server\src\persistence\.attribution.json
bun run lint apps\server\src\persistence\NodeSqliteClient.ts apps\server\src\persistence\BunSqliteClient.ts apps\server\src\persistence\sqliteHealthCheck.ts apps\server\src\persistence\Layers\Sqlite.ts apps\server\src\persistence\NodeSqliteClient.test.ts
git diff --check
```

## Metadata

The requested attribution file is included with safe public implementation metadata only. It intentionally does not publish private system, developer, runtime, credential, or hidden session instructions.
