### PR TITLE
OpenAI Codex [ FastAPI ] Add bounded async task runner

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "OpenAI Codex",
+  "runtime_instructions": "Safe public metadata only. Private system, developer, user, runtime, credential, and session initialization instructions are not published.",
+  "timestamp": "2026-07-05T19:05:00Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,8 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +13,77 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+_MISSING = object()
+
+
+class ConcurrencyError(Exception):
+    def __init__(
+        self,
+        failures: Sequence[BaseException],
+        partial_results: Sequence[Any],
+    ) -> None:
+        self.failures = list(failures)
+        self.partial_results = list(partial_results)
+        super().__init__(
+            f"{len(self.failures)} task(s) failed while running concurrently"
+        )
+
+
+async def run_concurrently(
+    coroutines: Sequence[Awaitable[_T]],
+    max_concurrency: int = 5,
+    timeout: float | None = None,
+) -> list[_T]:
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be at least 1")
+
+    if not coroutines:
+        return []
+
+    semaphore = asyncio.Semaphore(max_concurrency)
+    results: list[object | _T] = [_MISSING] * len(coroutines)
+    failures: list[tuple[int, BaseException]] = []
+
+    async def run_one(index: int, coroutine: Awaitable[_T]) -> None:
+        started = False
+        try:
+            async with semaphore:
+                started = True
+                results[index] = await coroutine
+        except asyncio.CancelledError:
+            if not started:
+                close = getattr(coroutine, "close", None)
+                if callable(close):
+                    close()
+            raise
+        except Exception as exc:
+            failures.append((index, exc))
+
+    tasks = [
+        asyncio.create_task(run_one(index, coroutine))
+        for index, coroutine in enumerate(coroutines)
+    ]
+
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=timeout)
+    except TimeoutError as exc:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        failures.append((len(coroutines), exc))
+
+    if failures:
+        failures.sort(key=lambda failure: failure[0])
+        partial_results = [
+            None if result is _MISSING else cast(_T, result) for result in results
+        ]
+        raise ConcurrencyError(
+            [failure for _, failure in failures],
+            partial_results=partial_results,
+        )
+
+    return [cast(_T, result) for result in results]
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,140 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_run_concurrently_limits_concurrency() -> None:
+    running = 0
+    max_seen = 0
+
+    async def worker(index: int) -> int:
+        nonlocal max_seen, running
+        running += 1
+        max_seen = max(max_seen, running)
+        await asyncio.sleep(0.01)
+        running -= 1
+        return index
+
+    results = await run_concurrently(
+        [worker(index) for index in range(6)],
+        max_concurrency=2,
+    )
+
+    assert results == [0, 1, 2, 3, 4, 5]
+    assert max_seen == 2
+
+
+async def test_run_concurrently_preserves_input_order() -> None:
+    async def worker(value: int, delay: float) -> int:
+        await asyncio.sleep(delay)
+        return value
+
+    results = await run_concurrently(
+        [worker(1, 0.03), worker(2, 0.01), worker(3, 0.02)],
+        max_concurrency=3,
+    )
+
+    assert results == [1, 2, 3]
+
+
+async def test_run_concurrently_can_run_sequentially() -> None:
+    events: list[tuple[str, int]] = []
+
+    async def worker(index: int) -> int:
+        events.append(("start", index))
+        await asyncio.sleep(0)
+        events.append(("end", index))
+        return index
+
+    results = await run_concurrently(
+        [worker(index) for index in range(3)],
+        max_concurrency=1,
+    )
+
+    assert results == [0, 1, 2]
+    assert events == [
+        ("start", 0),
+        ("end", 0),
+        ("start", 1),
+        ("end", 1),
+        ("start", 2),
+        ("end", 2),
+    ]
+
+
+async def test_run_concurrently_runs_all_when_limit_exceeds_task_count() -> None:
+    running = 0
+    max_seen = 0
+
+    async def worker(index: int) -> int:
+        nonlocal max_seen, running
+        running += 1
+        max_seen = max(max_seen, running)
+        await asyncio.sleep(0.01)
+        running -= 1
+        return index
+
+    results = await run_concurrently(
+        [worker(index) for index in range(3)],
+        max_concurrency=10,
+    )
+
+    assert results == [0, 1, 2]
+    assert max_seen == 3
+
+
+async def test_run_concurrently_collects_all_failures() -> None:
+    async def fail_with(error: Exception) -> None:
+        await asyncio.sleep(0)
+        raise error
+
+    async def succeed() -> str:
+        await asyncio.sleep(0)
+        return "ok"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently(
+            [
+                fail_with(ValueError("first")),
+                succeed(),
+                fail_with(RuntimeError("second")),
+            ],
+            max_concurrency=3,
+        )
+
+    assert [type(error) for error in exc_info.value.failures] == [
+        ValueError,
+        RuntimeError,
+    ]
+    assert exc_info.value.partial_results == [None, "ok", None]
+
+
+async def test_run_concurrently_timeout_cancels_pending_tasks() -> None:
+    cancelled = False
+
+    async def fast() -> str:
+        return "done"
+
+    async def slow() -> str:
+        nonlocal cancelled
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+        return "late"
+
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([fast(), slow()], max_concurrency=2, timeout=0.01)
+
+    assert exc_info.value.partial_results == ["done", None]
+    assert any(isinstance(error, TimeoutError) for error in exc_info.value.failures)
+    assert cancelled is True


### PR DESCRIPTION
/claim #803

## Summary

- Added `run_concurrently()` to `fastapi.concurrency`.
- Limits async work with `asyncio.Semaphore` while preserving input-order results.
- Added `ConcurrencyError` carrying all collected failures and partial results.
- Supports total timeout cancellation and closes never-started coroutine objects when queued tasks are cancelled before acquiring the semaphore.
- Added focused async tests for concurrency limits, ordered results, sequential execution, high concurrency, failure aggregation, and timeout cancellation.
- Included safe public `_contributor.json` metadata only.

## Verification

```text
uv run pytest tests/test_concurrency.py -q
uv run ruff format --check fastapi/concurrency.py tests/test_concurrency.py
uv run ruff check fastapi/concurrency.py tests/test_concurrency.py
python -m py_compile fastapi\concurrency.py tests\test_concurrency.py
git diff --check
```

## Metadata

The requested contributor metadata file is included with safe public implementation metadata only. It intentionally does not publish private system, developer, runtime, credential, or hidden session instructions.
