### PR TITLE
OpenAI Codex [ T3 Code ] Add Effect.Cache provider response caching

### DIFF
--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -58,6 +58,10 @@ export const providerRuntimeEventsTotal = Metric.counter("t3_provider_runtime_ev
   description: "Total canonical provider runtime events processed.",
 });
 
+export const providerCacheRequestsTotal = Metric.counter("t3_provider_cache_requests_total", {
+  description: "Total provider API response cache requests by cache kind and outcome.",
+});
+
 export const gitCommandsTotal = Metric.counter("t3_git_commands_total", {
   description: "Total git commands executed by the server runtime.",
 });

--- a/t3code/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/t3code/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -43,6 +43,7 @@ import * as Semaphore from "effect/Semaphore";
 import { ServerConfig } from "../../config.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
+import { makeProviderCache } from "../ProviderCache.ts";
 import {
   hydrateCachedProvider,
   isCachedProviderCorrelated,
@@ -278,6 +279,7 @@ export const ProviderRegistryLive = Layer.effect(
     const liveSubsRef = yield* Ref.make<ReadonlyMap<ProviderInstanceId, ProviderInstance>>(
       new Map(),
     );
+    const providerCache = yield* makeProviderCache();
     // Serialize `syncLiveSources` so a rapid burst of reconciles doesn't
     // interleave two passes clobbering each other's fiber bookkeeping.
     const syncSemaphore = yield* Semaphore.make(1);
@@ -430,13 +432,19 @@ export const ProviderRegistryLive = Layer.effect(
     const refreshOneSource = Effect.fn("refreshOneSource")(function* (
       providerSource: ProviderSnapshotSource,
     ) {
-      return yield* providerSource.refresh.pipe(
-        Effect.flatMap((nextProvider) =>
-          correlateSnapshotWithSource(providerSource, nextProvider).pipe(
-            Effect.flatMap(syncProvider),
+      return yield* providerCache
+        .refreshProvider({
+          instanceId: providerSource.instanceId,
+          driver: providerSource.driverKind,
+          refresh: providerSource.refresh,
+        })
+        .pipe(
+          Effect.flatMap((nextProvider) =>
+            correlateSnapshotWithSource(providerSource, nextProvider).pipe(
+              Effect.flatMap(syncProvider),
+            ),
           ),
-        ),
-      );
+        );
     });
 
     const refreshAll = Effect.fn("refreshAll")(function* () {
@@ -542,6 +550,17 @@ export const ProviderRegistryLive = Layer.effect(
           newlyAdded.push([instanceId, instance] as const);
         }
 
+        yield* Effect.forEach(
+          newlyAdded,
+          ([instanceId]) => providerCache.invalidateProvider(instanceId),
+          { concurrency: "unbounded", discard: true },
+        );
+        yield* Effect.forEach(
+          Array.from(previousSubs.keys()).filter((instanceId) => !knownInstanceIds.has(instanceId)),
+          providerCache.invalidateProvider,
+          { concurrency: "unbounded", discard: true },
+        );
+
         // Fork long-lived subscriptions to each new/rebuilt instance's
         // change stream BEFORE kicking off refreshes — if the driver's
         // own initial probe (line 140 in `makeManagedServerProvider`)
@@ -550,7 +569,12 @@ export const ProviderRegistryLive = Layer.effect(
         for (const [, instance] of newlyAdded) {
           const source = buildSnapshotSource(instance);
           yield* Stream.runForEach(source.streamChanges, (provider) =>
-            correlateSnapshotWithSource(source, provider).pipe(Effect.flatMap(syncProvider)),
+            providerCache
+              .rememberProvider(provider)
+              .pipe(
+                Effect.andThen(correlateSnapshotWithSource(source, provider)),
+                Effect.flatMap(syncProvider),
+              ),
           ).pipe(Effect.forkScoped);
         }
 

--- a/t3code/apps/server/src/provider/ProviderCache.test.ts
+++ b/t3code/apps/server/src/provider/ProviderCache.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, assert } from "@effect/vitest";
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Ref from "effect/Ref";
+import * as TestClock from "effect/testing/TestClock";
+
+import { makeProviderCache } from "./ProviderCache.ts";
+
+const driver = ProviderDriverKind.make("codex");
+const instanceId = ProviderInstanceId.make("codex");
+const fastModeCapabilities = createModelCapabilities({
+  optionDescriptors: [
+    {
+      id: "fastMode",
+      label: "Fast Mode",
+      type: "boolean",
+    },
+  ],
+});
+
+const makeProvider = (
+  checkedAt: string,
+  capabilities: ServerProvider["models"][number]["capabilities"] = fastModeCapabilities,
+): ServerProvider => ({
+  instanceId,
+  driver,
+  enabled: true,
+  installed: true,
+  version: "1.0.0",
+  status: "ready",
+  auth: { status: "authenticated" },
+  checkedAt,
+  models: [
+    {
+      slug: "gpt-test",
+      name: "GPT Test",
+      isCustom: false,
+      capabilities,
+    },
+  ],
+  slashCommands: [],
+  skills: [],
+});
+
+describe("ProviderCache", () => {
+  it.effect("caches provider model list refreshes until the model TTL expires", () =>
+    Effect.gen(function* () {
+      const cache = yield* makeProviderCache({
+        modelListTtl: Duration.minutes(5),
+        capabilityTtl: Duration.minutes(15),
+      });
+      const calls = yield* Ref.make(0);
+      const refresh = Ref.updateAndGet(calls, (count) => count + 1).pipe(
+        Effect.map((count) => makeProvider(`2026-07-05T00:00:0${count}.000Z`)),
+      );
+      const input = {
+        instanceId,
+        driver,
+        refresh,
+      };
+
+      const first = yield* cache.refreshProvider(input);
+      const second = yield* cache.refreshProvider(input);
+      yield* TestClock.adjust(Duration.minutes(6));
+      const third = yield* cache.refreshProvider(input);
+      const stats = yield* cache.getStats;
+
+      assert.strictEqual(first.checkedAt, "2026-07-05T00:00:01.000Z");
+      assert.strictEqual(second.checkedAt, "2026-07-05T00:00:01.000Z");
+      assert.strictEqual(third.checkedAt, "2026-07-05T00:00:02.000Z");
+      assert.strictEqual(yield* Ref.get(calls), 2);
+      assert.strictEqual(stats.modelHits, 1);
+      assert.strictEqual(stats.modelMisses, 2);
+    }),
+  );
+
+  it.effect("keeps cached capabilities available after the model-list TTL expires", () =>
+    Effect.gen(function* () {
+      const cache = yield* makeProviderCache({
+        modelListTtl: Duration.minutes(5),
+        capabilityTtl: Duration.minutes(15),
+      });
+      const calls = yield* Ref.make(0);
+      const refresh = Ref.updateAndGet(calls, (count) => count + 1).pipe(
+        Effect.map((count) =>
+          count === 1
+            ? makeProvider("2026-07-05T00:00:01.000Z", fastModeCapabilities)
+            : makeProvider("2026-07-05T00:06:01.000Z", null),
+        ),
+      );
+      const input = {
+        instanceId,
+        driver,
+        refresh,
+      };
+
+      yield* cache.refreshProvider(input);
+      yield* TestClock.adjust(Duration.minutes(6));
+      const refreshed = yield* cache.refreshProvider(input);
+      const stats = yield* cache.getStats;
+
+      assert.strictEqual(refreshed.checkedAt, "2026-07-05T00:06:01.000Z");
+      assert.deepStrictEqual(refreshed.models[0]?.capabilities, fastModeCapabilities);
+      assert.strictEqual(stats.capabilityHits, 1);
+      assert.strictEqual(stats.capabilityMisses, 1);
+    }),
+  );
+
+  it.effect("invalidates cached provider data on demand", () =>
+    Effect.gen(function* () {
+      const cache = yield* makeProviderCache();
+      const calls = yield* Ref.make(0);
+      const refresh = Ref.updateAndGet(calls, (count) => count + 1).pipe(
+        Effect.map((count) => makeProvider(`2026-07-05T00:00:0${count}.000Z`)),
+      );
+      const input = {
+        instanceId,
+        driver,
+        refresh,
+      };
+
+      const first = yield* cache.refreshProvider(input);
+      const cached = yield* cache.refreshProvider(input);
+      yield* cache.invalidateProvider(instanceId);
+      const refreshed = yield* cache.refreshProvider(input);
+      const stats = yield* cache.getStats;
+
+      assert.strictEqual(first.checkedAt, "2026-07-05T00:00:01.000Z");
+      assert.strictEqual(cached.checkedAt, "2026-07-05T00:00:01.000Z");
+      assert.strictEqual(refreshed.checkedAt, "2026-07-05T00:00:02.000Z");
+      assert.strictEqual(stats.invalidations, 1);
+    }),
+  );
+
+  it.effect("remembers streamed provider snapshots as the latest cached value", () =>
+    Effect.gen(function* () {
+      const cache = yield* makeProviderCache();
+      const calls = yield* Ref.make(0);
+      const refresh = Ref.updateAndGet(calls, (count) => count + 1).pipe(
+        Effect.map((count) => makeProvider(`2026-07-05T00:00:0${count}.000Z`)),
+      );
+      const input = {
+        instanceId,
+        driver,
+        refresh,
+      };
+
+      yield* cache.refreshProvider(input);
+      yield* cache.rememberProvider(makeProvider("2026-07-05T00:00:09.000Z"));
+      const cached = yield* cache.refreshProvider(input);
+
+      assert.strictEqual(cached.checkedAt, "2026-07-05T00:00:09.000Z");
+      assert.strictEqual(yield* Ref.get(calls), 1);
+    }),
+  );
+
+  it.effect("deduplicates concurrent cache misses for the same provider instance", () =>
+    Effect.gen(function* () {
+      const cache = yield* makeProviderCache();
+      const calls = yield* Ref.make(0);
+      const release = yield* Deferred.make<void>();
+      const refresh = Ref.update(calls, (count) => count + 1).pipe(
+        Effect.andThen(Deferred.await(release)),
+        Effect.as(makeProvider("2026-07-05T00:00:01.000Z")),
+      );
+      const input = {
+        instanceId,
+        driver,
+        refresh,
+      };
+
+      const fiber = yield* Effect.all(
+        [cache.refreshProvider(input), cache.refreshProvider(input), cache.refreshProvider(input)],
+        { concurrency: "unbounded" },
+      ).pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      assert.strictEqual(yield* Ref.get(calls), 1);
+      yield* Deferred.succeed(release, undefined);
+      const providers = yield* Fiber.join(fiber);
+
+      assert.strictEqual(yield* Ref.get(calls), 1);
+      assert.deepStrictEqual(
+        providers.map((provider) => provider.checkedAt),
+        ["2026-07-05T00:00:01.000Z", "2026-07-05T00:00:01.000Z", "2026-07-05T00:00:01.000Z"],
+      );
+    }),
+  );
+});

--- a/t3code/apps/server/src/provider/ProviderCache.ts
+++ b/t3code/apps/server/src/provider/ProviderCache.ts
@@ -1,0 +1,208 @@
+import {
+  ProviderDriverKind,
+  type ProviderInstanceId,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import * as Cache from "effect/Cache";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+
+import * as Metrics from "../observability/Metrics.ts";
+
+export const DEFAULT_PROVIDER_MODEL_LIST_TTL = Duration.minutes(5);
+export const DEFAULT_PROVIDER_CAPABILITY_TTL = Duration.minutes(15);
+
+export interface ProviderCacheStats {
+  readonly modelHits: number;
+  readonly modelMisses: number;
+  readonly capabilityHits: number;
+  readonly capabilityMisses: number;
+  readonly invalidations: number;
+}
+
+export interface ProviderCacheOptions {
+  readonly capacity?: number;
+  readonly modelListTtl?: Duration.Input;
+  readonly capabilityTtl?: Duration.Input;
+}
+
+export interface ProviderRefreshInput {
+  readonly instanceId: ProviderInstanceId;
+  readonly driver: ProviderDriverKind;
+  readonly refresh: Effect.Effect<ServerProvider>;
+}
+
+type CacheKind = "models" | "capabilities";
+type CacheOutcome = "hit" | "miss";
+type ProviderModel = ServerProvider["models"][number];
+type ModelCapabilities = NonNullable<ProviderModel["capabilities"]>;
+type CapabilityMap = ReadonlyMap<string, ModelCapabilities>;
+
+interface ProviderRefreshLoader {
+  readonly driver: ProviderDriverKind;
+  readonly refresh: Effect.Effect<ServerProvider>;
+}
+
+const initialStats: ProviderCacheStats = {
+  modelHits: 0,
+  modelMisses: 0,
+  capabilityHits: 0,
+  capabilityMisses: 0,
+  invalidations: 0,
+};
+
+const incrementStats = (
+  stats: ProviderCacheStats,
+  kind: CacheKind,
+  outcome: CacheOutcome,
+): ProviderCacheStats => {
+  if (kind === "models") {
+    return outcome === "hit"
+      ? { ...stats, modelHits: stats.modelHits + 1 }
+      : { ...stats, modelMisses: stats.modelMisses + 1 };
+  }
+  return outcome === "hit"
+    ? { ...stats, capabilityHits: stats.capabilityHits + 1 }
+    : { ...stats, capabilityMisses: stats.capabilityMisses + 1 };
+};
+
+const collectCapabilities = (models: ReadonlyArray<ProviderModel>): CapabilityMap => {
+  const capabilities = new Map<string, ModelCapabilities>();
+  for (const model of models) {
+    if (model.capabilities !== null) {
+      capabilities.set(model.slug, model.capabilities);
+    }
+  }
+  return capabilities;
+};
+
+const applyCachedCapabilities = (provider: ServerProvider, capabilities: CapabilityMap) => {
+  if (capabilities.size === 0) {
+    return provider;
+  }
+
+  return {
+    ...provider,
+    models: provider.models.map((model) => {
+      if (model.capabilities !== null) {
+        return model;
+      }
+      const cachedCapabilities = capabilities.get(model.slug);
+      return cachedCapabilities ? { ...model, capabilities: cachedCapabilities } : model;
+    }),
+  } satisfies ServerProvider;
+};
+
+export const makeProviderCache = Effect.fn("makeProviderCache")(function* (
+  options: ProviderCacheOptions = {},
+) {
+  const capacity = options.capacity ?? 64;
+  const modelListTtl = options.modelListTtl ?? DEFAULT_PROVIDER_MODEL_LIST_TTL;
+  const capabilityTtl = options.capabilityTtl ?? DEFAULT_PROVIDER_CAPABILITY_TTL;
+  const loadersRef = yield* Ref.make<ReadonlyMap<ProviderInstanceId, ProviderRefreshLoader>>(
+    new Map(),
+  );
+  const statsRef = yield* Ref.make<ProviderCacheStats>(initialStats);
+
+  const recordAccess = (input: ProviderRefreshInput, kind: CacheKind, outcome: CacheOutcome) =>
+    Ref.update(statsRef, (stats) => incrementStats(stats, kind, outcome)).pipe(
+      Effect.andThen(
+        Metrics.increment(Metrics.providerCacheRequestsTotal, {
+          provider: input.driver,
+          instanceId: input.instanceId,
+          cache: kind,
+          outcome,
+        }),
+      ),
+    );
+
+  const modelListCache = yield* Cache.makeWith<ProviderInstanceId, ServerProvider>(
+    (instanceId) =>
+      Ref.get(loadersRef).pipe(
+        Effect.flatMap((loaders) => {
+          const loader = loaders.get(instanceId);
+          if (!loader) {
+            return Effect.die(
+              new Error(`No provider refresh loader registered for '${instanceId}'.`),
+            );
+          }
+          return loader.refresh;
+        }),
+      ),
+    {
+      capacity,
+      timeToLive: (exit) => (Exit.isSuccess(exit) ? modelListTtl : Duration.zero),
+    },
+  );
+
+  const capabilityCache = yield* Cache.makeWith<ProviderInstanceId, CapabilityMap>(
+    (instanceId) =>
+      Cache.get(modelListCache, instanceId).pipe(
+        Effect.map((provider) => collectCapabilities(provider.models)),
+      ),
+    {
+      capacity,
+      timeToLive: (exit) => (Exit.isSuccess(exit) ? capabilityTtl : Duration.zero),
+    },
+  );
+
+  const refreshProvider = Effect.fn("ProviderCache.refreshProvider")(function* (
+    input: ProviderRefreshInput,
+  ) {
+    yield* Ref.update(loadersRef, (loaders) => {
+      const next = new Map(loaders);
+      next.set(input.instanceId, {
+        driver: input.driver,
+        refresh: input.refresh,
+      });
+      return next;
+    });
+
+    const modelOption = yield* Cache.getOption(modelListCache, input.instanceId);
+    yield* recordAccess(input, "models", Option.isSome(modelOption) ? "hit" : "miss");
+    const provider = yield* Cache.get(modelListCache, input.instanceId);
+
+    const capabilityOption = yield* Cache.getOption(capabilityCache, input.instanceId);
+    yield* recordAccess(input, "capabilities", Option.isSome(capabilityOption) ? "hit" : "miss");
+    const capabilities = yield* Cache.get(capabilityCache, input.instanceId);
+
+    return applyCachedCapabilities(provider, capabilities);
+  });
+
+  const invalidateProvider = Effect.fn("ProviderCache.invalidateProvider")(function* (
+    instanceId: ProviderInstanceId,
+  ) {
+    yield* Cache.invalidate(modelListCache, instanceId);
+    yield* Cache.invalidate(capabilityCache, instanceId);
+    yield* Ref.update(statsRef, (stats) => ({
+      ...stats,
+      invalidations: stats.invalidations + 1,
+    }));
+  });
+
+  const rememberProvider = Effect.fn("ProviderCache.rememberProvider")(function* (
+    provider: ServerProvider,
+  ) {
+    yield* Cache.set(modelListCache, provider.instanceId, provider);
+    const capabilities = collectCapabilities(provider.models);
+    if (capabilities.size > 0) {
+      yield* Cache.set(capabilityCache, provider.instanceId, capabilities);
+    }
+  });
+
+  const invalidateAll = Effect.fn("ProviderCache.invalidateAll")(function* () {
+    const instanceIds = yield* Cache.keys(modelListCache);
+    yield* Effect.forEach(instanceIds, invalidateProvider, { discard: true });
+  });
+
+  return {
+    refreshProvider,
+    rememberProvider,
+    invalidateProvider,
+    invalidateAll,
+    getStats: Ref.get(statsRef),
+  } as const;
+});

--- a/t3code/apps/server/src/provider/contributor_meta.json
+++ b/t3code/apps/server/src/provider/contributor_meta.json
@@ -1,0 +1,6 @@
+{
+  "agent": "OpenAI Codex",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/865",
+  "session_init": "Safe public metadata only. Private system, developer, runtime, and user-authentication instructions are intentionally not published.",
+  "generated_at": "2026-07-05T19:26:00.000Z"
+}


### PR DESCRIPTION
## Summary

- add a registry-level `ProviderCache` using `Effect.Cache`
- cache provider model-list refreshes for 5 minutes and capability data for 15 minutes
- invalidate cache entries when provider instances are added, rebuilt, or removed, and seed cache entries from live provider stream updates
- record provider cache hit/miss metrics through observability
- include safe public contributor metadata without publishing private runtime/session instructions

## Tests

- `bunx vitest run apps/server/src/provider/ProviderCache.test.ts`
- `bun --filter t3 typecheck`
- `bunx oxlint apps/server/src/provider/ProviderCache.ts apps/server/src/provider/ProviderCache.test.ts apps/server/src/provider/Layers/ProviderRegistry.ts apps/server/src/observability/Metrics.ts`

## Notes

`bunx vitest run apps/server/src/provider/Layers/ProviderRegistry.test.ts` was also run on Windows. It had existing environment-sensitive failures in real process-spawn/path assertions unrelated to this cache change: two missing-Codex-binary `installed` assertions and one Claude HOME path normalization assertion.

Closes #865
