### PR TITLE
OpenAI Codex [ FastAPI ] Add standardized pagination helpers

### DIFF
--- a/fastapi/fastapi/.attribution.json
+++ b/fastapi/fastapi/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "OpenAI Codex",
+  "platform_config": "Safe public metadata only. Private system, developer, runtime, credential, and user-authentication instructions are intentionally not published.",
+  "date": "2026-07-05T20:05:00.000Z"
+}

--- a/fastapi/fastapi/pagination.py
+++ b/fastapi/fastapi/pagination.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Annotated, Generic, TypeVar
+
+from pydantic import BaseModel, Field
+
+from .param_functions import Query
+
+ItemT = TypeVar("ItemT")
+
+DEFAULT_PAGE = 1
+DEFAULT_PAGE_SIZE = 50
+DEFAULT_MAX_PAGE_SIZE = 100
+
+
+class PaginatedResponse(BaseModel, Generic[ItemT]):
+    items: list[ItemT]
+    total: int = Field(ge=0)
+    page: int = Field(ge=1)
+    page_size: int = Field(ge=1)
+    total_pages: int = Field(ge=0)
+    has_next: bool
+    has_previous: bool
+    next_cursor: str | None = None
+    previous_cursor: str | None = None
+
+
+@dataclass(frozen=True)
+class Paginator:
+    page: int = DEFAULT_PAGE
+    page_size: int = DEFAULT_PAGE_SIZE
+    cursor: str | None = None
+    max_page_size: int = DEFAULT_MAX_PAGE_SIZE
+
+    def __post_init__(self) -> None:
+        page = max(self.page, DEFAULT_PAGE)
+        fallback_size = DEFAULT_PAGE_SIZE
+        max_page_size = max(self.max_page_size, 1)
+        page_size = self.page_size if self.page_size > 0 else fallback_size
+        object.__setattr__(self, "page", page)
+        object.__setattr__(self, "max_page_size", max_page_size)
+        object.__setattr__(self, "page_size", min(page_size, max_page_size))
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    @property
+    def limit(self) -> int:
+        return self.page_size
+
+    @property
+    def cursor_offset(self) -> int:
+        if self.cursor is None:
+            return self.offset
+        return self.decode_cursor(self.cursor)
+
+    def offset_slice(self) -> slice:
+        return slice(self.offset, self.offset + self.limit)
+
+    def cursor_slice(self) -> slice:
+        offset = self.cursor_offset
+        return slice(offset, offset + self.limit)
+
+    def apply_to_query(self, query):
+        return query.offset(self.offset).limit(self.limit)
+
+    @staticmethod
+    def encode_cursor(offset: int) -> str:
+        payload = json.dumps({"offset": max(offset, 0)}, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+    @staticmethod
+    def decode_cursor(cursor: str) -> int:
+        try:
+            padded = cursor + "=" * (-len(cursor) % 4)
+            payload = base64.urlsafe_b64decode(padded.encode())
+            decoded = json.loads(payload)
+            offset = int(decoded.get("offset", 0))
+        except (binascii.Error, ValueError, TypeError, json.JSONDecodeError):
+            return 0
+        return max(offset, 0)
+
+    def create_response(
+        self,
+        items: Sequence[ItemT],
+        *,
+        total: int,
+        offset: int | None = None,
+        include_cursors: bool = False,
+    ) -> PaginatedResponse[ItemT]:
+        normalized_total = max(total, 0)
+        current_offset = self.offset if offset is None else max(offset, 0)
+        total_pages = (
+            math.ceil(normalized_total / self.page_size) if normalized_total else 0
+        )
+        page = max((current_offset // self.page_size) + 1, DEFAULT_PAGE)
+        has_previous = current_offset > 0
+        has_next = current_offset + len(items) < normalized_total
+        previous_offset = max(current_offset - self.page_size, 0)
+        next_offset = current_offset + self.page_size
+
+        return PaginatedResponse[ItemT](
+            items=list(items),
+            total=normalized_total,
+            page=page,
+            page_size=self.page_size,
+            total_pages=total_pages,
+            has_next=has_next,
+            has_previous=has_previous,
+            next_cursor=self.encode_cursor(next_offset)
+            if include_cursors and has_next
+            else None,
+            previous_cursor=(
+                self.encode_cursor(previous_offset)
+                if include_cursors and has_previous
+                else None
+            ),
+        )
+
+    def paginate_sequence(self, items: Sequence[ItemT]) -> PaginatedResponse[ItemT]:
+        page_items = items[self.offset_slice()]
+        return self.create_response(page_items, total=len(items))
+
+    def paginate_cursor_sequence(
+        self, items: Sequence[ItemT]
+    ) -> PaginatedResponse[ItemT]:
+        offset = self.cursor_offset
+        page_items = items[self.cursor_slice()]
+        return self.create_response(
+            page_items,
+            total=len(items),
+            offset=offset,
+            include_cursors=True,
+        )
+
+
+def paginate(
+    page: Annotated[
+        int, Query(description="One-based page number for offset pagination")
+    ] = 1,
+    page_size: Annotated[
+        int,
+        Query(description="Number of items per page"),
+    ] = DEFAULT_PAGE_SIZE,
+    cursor: Annotated[
+        str | None,
+        Query(description="Opaque cursor for cursor pagination"),
+    ] = None,
+) -> Paginator:
+    return Paginator(page=page, page_size=page_size, cursor=cursor)

--- a/fastapi/tests/test_pagination.py
+++ b/fastapi/tests/test_pagination.py
@@ -1,0 +1,179 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from fastapi.pagination import PaginatedResponse, Paginator, paginate
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+ITEMS = [Item(id=index, name=f"item-{index}") for index in range(1, 26)]
+
+
+class FakeQuery:
+    def __init__(self):
+        self.offset_value = None
+        self.limit_value = None
+
+    def offset(self, value):
+        self.offset_value = value
+        return self
+
+    def limit(self, value):
+        self.limit_value = value
+        return self
+
+
+def test_offset_pagination_calculates_skip_limit_and_boundaries():
+    paginator = Paginator(page=2, page_size=10)
+    response = paginator.paginate_sequence(ITEMS)
+
+    assert paginator.offset == 10
+    assert paginator.limit == 10
+    assert [item.id for item in response.items] == list(range(11, 21))
+    assert response.total == 25
+    assert response.page == 2
+    assert response.page_size == 10
+    assert response.total_pages == 3
+    assert response.has_next is True
+    assert response.has_previous is True
+
+
+def test_offset_pagination_sets_boundary_flags_on_first_and_last_pages():
+    first = Paginator(page=1, page_size=10).paginate_sequence(ITEMS)
+    last = Paginator(page=3, page_size=10).paginate_sequence(ITEMS)
+
+    assert [item.id for item in first.items] == list(range(1, 11))
+    assert first.has_previous is False
+    assert first.has_next is True
+    assert [item.id for item in last.items] == list(range(21, 26))
+    assert last.has_previous is True
+    assert last.has_next is False
+
+
+def test_offset_pagination_handles_invalid_page_and_page_size_values():
+    paginator = Paginator(page=-5, page_size=0)
+    response = paginator.paginate_sequence(ITEMS)
+
+    assert paginator.page == 1
+    assert paginator.page_size == 50
+    assert [item.id for item in response.items] == list(range(1, 26))
+    assert response.total_pages == 1
+    assert response.has_next is False
+    assert response.has_previous is False
+
+
+def test_offset_pagination_can_be_applied_to_sqlalchemy_style_queries():
+    query = FakeQuery()
+
+    result = Paginator(page=4, page_size=15).apply_to_query(query)
+
+    assert result is query
+    assert query.offset_value == 45
+    assert query.limit_value == 15
+
+
+def test_empty_results_return_zero_total_pages():
+    response = Paginator(page=1, page_size=10).paginate_sequence([])
+
+    assert response.items == []
+    assert response.total == 0
+    assert response.page == 1
+    assert response.total_pages == 0
+    assert response.has_next is False
+    assert response.has_previous is False
+
+
+def test_cursor_pagination_uses_encoded_cursors_for_navigation():
+    first = Paginator(page_size=7).paginate_cursor_sequence(ITEMS)
+    assert [item.id for item in first.items] == list(range(1, 8))
+    assert first.previous_cursor is None
+    assert first.next_cursor is not None
+
+    second = Paginator(page_size=7, cursor=first.next_cursor).paginate_cursor_sequence(
+        ITEMS
+    )
+    assert [item.id for item in second.items] == list(range(8, 15))
+    assert second.page == 2
+    assert second.previous_cursor is not None
+    assert second.next_cursor is not None
+
+    previous = Paginator(
+        page_size=7, cursor=second.previous_cursor
+    ).paginate_cursor_sequence(ITEMS)
+    assert [item.id for item in previous.items] == list(range(1, 8))
+
+
+def test_invalid_cursor_falls_back_to_first_page():
+    response = Paginator(
+        page_size=5, cursor="not-a-valid-cursor"
+    ).paginate_cursor_sequence(ITEMS)
+
+    assert [item.id for item in response.items] == list(range(1, 6))
+    assert response.page == 1
+    assert response.has_previous is False
+    assert response.has_next is True
+
+
+def test_paginated_response_generic_validates_item_type():
+    response = PaginatedResponse[Item](
+        items=[{"id": 1, "name": "parsed"}],
+        total=1,
+        page=1,
+        page_size=10,
+        total_pages=1,
+        has_next=False,
+        has_previous=False,
+    )
+
+    assert response.items == [Item(id=1, name="parsed")]
+
+
+def test_paginate_dependency_reads_query_parameters():
+    app = FastAPI()
+
+    @app.get("/items", response_model=PaginatedResponse[Item])
+    def read_items(paginator: Annotated[Paginator, Depends(paginate)]):
+        return paginator.paginate_sequence(ITEMS)
+
+    client = TestClient(app)
+    response = client.get("/items?page=2&page_size=4")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {"id": 5, "name": "item-5"},
+            {"id": 6, "name": "item-6"},
+            {"id": 7, "name": "item-7"},
+            {"id": 8, "name": "item-8"},
+        ],
+        "total": 25,
+        "page": 2,
+        "page_size": 4,
+        "total_pages": 7,
+        "has_next": True,
+        "has_previous": True,
+        "next_cursor": None,
+        "previous_cursor": None,
+    }
+
+
+def test_paginate_dependency_supports_cursor_parameter():
+    app = FastAPI()
+
+    @app.get("/items")
+    def read_items(paginator: Annotated[Paginator, Depends(paginate)]):
+        return paginator.paginate_cursor_sequence(ITEMS)
+
+    client = TestClient(app)
+    first = client.get("/items?page_size=6").json()
+    second = client.get(f"/items?page_size=6&cursor={first['next_cursor']}").json()
+
+    assert [item["id"] for item in first["items"]] == list(range(1, 7))
+    assert [item["id"] for item in second["items"]] == list(range(7, 13))
+    assert second["page"] == 2
+    assert second["has_previous"] is True


### PR DESCRIPTION
/claim #802

## Summary
- add `fastapi.pagination` with `Paginator`, `PaginatedResponse[T]`, and the injectable `paginate` dependency
- support offset pagination for lists plus SQLAlchemy-style `offset().limit()` query objects
- support cursor pagination with opaque encoded next/previous cursors
- handle page 0/negative page, page_size 0, invalid cursors, and empty result sets
- include safe public `.attribution.json` metadata only

## Verification
- `uv run pytest tests/test_pagination.py -q`
- `uv run ruff check fastapi/pagination.py tests/test_pagination.py`
- `uv run ruff format --check fastapi/pagination.py tests/test_pagination.py`
- `python -m py_compile fastapi/pagination.py tests/test_pagination.py`
- `git diff --check`

## Metadata note
The issue asks for platform configuration metadata. This PR includes only safe public metadata and intentionally does not publish private system, developer, runtime, credential, or user-authentication instructions.
