### PR TITLE
OpenAI Codex [ FastAPI ] Add OAuth2 refresh-token helpers

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .security import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
+from .security import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/security/.provenance.json
+++ b/fastapi/fastapi/security/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Public provenance only. Private system, developer, runtime, and user instructions are not disclosed in repository files. Work performed for UnsafeLabs/Bounty-Hunters issue #758: add OAuth2 refresh-token helpers with focused tests.",
+  "created": "2026-07-05T14:58:44.7995628-05:00"
+}

--- a/fastapi/fastapi/security/__init__.py
+++ b/fastapi/fastapi/security/__init__.py
@@ -9,7 +9,9 @@ from .http import HTTPDigest as HTTPDigest
 from .oauth2 import OAuth2 as OAuth2
 from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
 from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordBearerWithRefresh as OAuth2PasswordBearerWithRefresh
 from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
 from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import OAuth2RefreshRequestForm as OAuth2RefreshRequestForm
 from .oauth2 import SecurityScopes as SecurityScopes
 from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/fastapi/fastapi/security/oauth2.py
+++ b/fastapi/fastapi/security/oauth2.py
@@ -327,6 +327,72 @@ class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
         )
 
 
+class OAuth2RefreshRequestForm:
+    """
+    This is a dependency class to collect a refresh token request as form data.
+
+    OAuth2 refresh-token grants require ``grant_type=refresh_token`` and a
+    ``refresh_token`` form field. The optional scope and client credentials follow
+    the same shape as ``OAuth2PasswordRequestForm``.
+    """
+
+    def __init__(
+        self,
+        *,
+        grant_type: Annotated[
+            str,
+            Form(pattern="^refresh_token$"),
+            Doc(
+                """
+                The OAuth2 spec requires refresh-token requests to send the fixed
+                grant type "refresh_token".
+                """
+            ),
+        ],
+        refresh_token: Annotated[
+            str,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                The refresh token previously issued by the authorization server.
+                """
+            ),
+        ],
+        scope: Annotated[
+            str,
+            Form(),
+            Doc(
+                """
+                A single string with several scopes separated by spaces.
+                """
+            ),
+        ] = "",
+        client_id: Annotated[
+            str | None,
+            Form(),
+            Doc(
+                """
+                Optional OAuth2 client identifier.
+                """
+            ),
+        ] = None,
+        client_secret: Annotated[
+            str | None,
+            Form(json_schema_extra={"format": "password"}),
+            Doc(
+                """
+                Optional OAuth2 client secret.
+                """
+            ),
+        ] = None,
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 class OAuth2(SecurityBase):
     """
     This is the base class for OAuth2 authentication, an instance of it would be used
@@ -542,6 +608,78 @@ class OAuth2PasswordBearer(OAuth2):
             else:
                 return None
         return param
+
+
+class OAuth2PasswordBearerWithRefresh(OAuth2PasswordBearer):
+    """
+    OAuth2 password bearer flow with explicit refresh-token endpoint metadata.
+
+    This is a drop-in replacement for ``OAuth2PasswordBearer`` that accepts a
+    ``refresh_url`` argument and exposes it as ``refreshUrl`` in OpenAPI.
+    """
+
+    def __init__(
+        self,
+        tokenUrl: Annotated[
+            str,
+            Doc(
+                """
+                The URL to obtain the OAuth2 token.
+                """
+            ),
+        ],
+        *,
+        refresh_url: Annotated[
+            str,
+            Doc(
+                """
+                The URL to refresh the token and obtain a new access token.
+                """
+            ),
+        ],
+        scheme_name: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme name.
+                """
+            ),
+        ] = None,
+        scopes: Annotated[
+            dict[str, str] | None,
+            Doc(
+                """
+                OAuth2 scopes required by path operations using this dependency.
+                """
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Doc(
+                """
+                Security scheme description.
+                """
+            ),
+        ] = None,
+        auto_error: Annotated[
+            bool,
+            Doc(
+                """
+                Whether to automatically error when the Authorization header is
+                missing or not a bearer token.
+                """
+            ),
+        ] = True,
+    ):
+        self.refresh_url = refresh_url
+        super().__init__(
+            tokenUrl=tokenUrl,
+            scheme_name=scheme_name,
+            scopes=scopes,
+            description=description,
+            auto_error=auto_error,
+            refreshUrl=refresh_url,
+        )
 
 
 class OAuth2AuthorizationCodeBearer(OAuth2):

--- a/fastapi/tests/test_oauth2_refresh_flow.py
+++ b/fastapi/tests/test_oauth2_refresh_flow.py
@@ -1,0 +1,99 @@
+from fastapi import (
+    Depends,
+    FastAPI,
+    OAuth2PasswordBearerWithRefresh,
+    OAuth2RefreshRequestForm,
+    Security,
+)
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+oauth2_scheme = OAuth2PasswordBearerWithRefresh(
+    tokenUrl="/token",
+    refresh_url="/refresh",
+    scopes={"items:read": "Read items"},
+    auto_error=False,
+)
+
+
+@app.get("/items/")
+async def read_items(token: str | None = Security(oauth2_scheme)):
+    if token is None:
+        return {"token": None}
+    return {"token": token}
+
+
+@app.post("/refresh")
+async def refresh_token(form_data: OAuth2RefreshRequestForm = Depends()):
+    return {
+        "grant_type": form_data.grant_type,
+        "refresh_token": form_data.refresh_token,
+        "scopes": form_data.scopes,
+        "client_id": form_data.client_id,
+        "client_secret": form_data.client_secret,
+    }
+
+
+client = TestClient(app)
+
+
+def test_oauth2_password_bearer_with_refresh_is_drop_in_bearer():
+    response = client.get("/items/", headers={"Authorization": "Bearer access-token"})
+
+    assert response.status_code == 200
+    assert response.json() == {"token": "access-token"}
+
+
+def test_oauth2_password_bearer_with_refresh_can_be_optional():
+    response = client.get("/items/")
+
+    assert response.status_code == 200
+    assert response.json() == {"token": None}
+
+
+def test_oauth2_password_bearer_with_refresh_openapi_schema():
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200, response.text
+    security_scheme = response.json()["components"]["securitySchemes"][
+        "OAuth2PasswordBearerWithRefresh"
+    ]
+    assert security_scheme["type"] == "oauth2"
+    assert security_scheme["flows"]["password"] == {
+        "refreshUrl": "/refresh",
+        "scopes": {"items:read": "Read items"},
+        "tokenUrl": "/token",
+    }
+
+
+def test_oauth2_refresh_request_form_parses_refresh_token_request():
+    response = client.post(
+        "/refresh",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-token",
+            "scope": "items:read items:write",
+            "client_id": "client-a",
+            "client_secret": "secret-a",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh-token",
+        "scopes": ["items:read", "items:write"],
+        "client_id": "client-a",
+        "client_secret": "secret-a",
+    }
+
+
+def test_oauth2_refresh_request_form_rejects_wrong_grant_type():
+    response = client.post(
+        "/refresh",
+        data={"grant_type": "password", "refresh_token": "refresh-token"},
+    )
+
+    assert response.status_code == 422
+    assert "refresh_token" in response.text


### PR DESCRIPTION
/claim #758

## Summary
- Adds `OAuth2RefreshRequestForm` for refresh-token form submissions with strict `grant_type=refresh_token` validation.
- Adds `OAuth2PasswordBearerWithRefresh`, a drop-in bearer dependency that accepts `refresh_url` and exposes it as OpenAPI `refreshUrl`.
- Exports the new helpers from `fastapi.security` and top-level `fastapi`.
- Includes safe public provenance metadata only; private runtime/system instructions are intentionally not disclosed.

## Validation
- `uv run pytest tests/test_oauth2_refresh_flow.py tests/test_security_oauth2.py tests/test_security_oauth2_password_bearer_optional.py -q`
- `uv run ruff check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_oauth2_refresh_flow.py`
- `uv run ruff format --check fastapi/security/oauth2.py fastapi/security/__init__.py fastapi/__init__.py tests/test_oauth2_refresh_flow.py`
- `python -m py_compile fastapi\fastapi\security\oauth2.py fastapi\tests\test_oauth2_refresh_flow.py`
- `git diff --check`

Demo evidence: the focused test file exercises the token bearer path, optional auth path, generated OpenAPI `refreshUrl`, valid refresh-token requests, and invalid grant-type rejection.
