### PR TITLE
OpenAI Codex [ FastAPI ] Add router-level middleware support

### DIFF
--- a/fastapi/fastapi/.provenance.json
+++ b/fastapi/fastapi/.provenance.json
@@ -1,0 +1,6 @@
+{
+  "agent_name": "OpenAI Codex",
+  "config_snapshot": "Safe public implementation metadata only. Private system, developer, runtime, credential, environment, and user instructions are intentionally not disclosed.",
+  "created": "2026-07-05T21:02:00Z",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/796"
+}

--- a/fastapi/fastapi/routing.py
+++ b/fastapi/fastapi/routing.py
@@ -78,6 +78,8 @@ from starlette._utils import is_async_callable
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import (
@@ -90,6 +92,31 @@ from starlette.routing import Mount as Mount  # noqa
 from starlette.types import AppType, ASGIApp, Lifespan, Receive, Scope, Send
 from starlette.websockets import WebSocket
 from typing_extensions import deprecated
+
+
+def _normalize_router_middleware(middleware: Sequence[Any] | None) -> list[Middleware]:
+    normalized: list[Middleware] = []
+    for item in middleware or []:
+        if isinstance(item, Middleware):
+            normalized.append(item)
+        elif inspect.isclass(item):
+            normalized.append(Middleware(item))
+        elif callable(item):
+            normalized.append(Middleware(BaseHTTPMiddleware, dispatch=item))
+        else:
+            raise TypeError(
+                "Router middleware must be starlette.middleware.Middleware, "
+                "an ASGI middleware class, or a callable dispatch function"
+            )
+    return normalized
+
+
+def _build_router_middleware_stack(
+    app: ASGIApp, middleware: Sequence[Middleware]
+) -> ASGIApp:
+    for cls, args, kwargs in reversed(middleware):
+        app = cls(app, *args, **kwargs)
+    return app
 
 
 # Copy of starlette.routing.request_response modified to include the
@@ -1122,6 +1149,18 @@ class APIRouter(routing.Router):
                 """
             ),
         ] = None,
+        middleware: Annotated[
+            Sequence[Any] | None,
+            Doc(
+                """
+                A sequence of middleware to apply only to the routes registered on
+                this router.
+
+                Middleware can be Starlette `Middleware` instances, ASGI middleware
+                classes, or callable request dispatch functions.
+                """
+            ),
+        ] = None,
         redirect_slashes: Annotated[
             bool,
             Doc(
@@ -1267,6 +1306,9 @@ class APIRouter(routing.Router):
             ),
         ] = Default(True),
     ) -> None:
+        self.user_middleware: list[Middleware] = _normalize_router_middleware(
+            middleware
+        )
         # Determine the lifespan context to use
         if lifespan is None:
             # Use the default lifespan that runs on_startup/on_shutdown handlers
@@ -1313,6 +1355,44 @@ class APIRouter(routing.Router):
         self.default_response_class = default_response_class
         self.generate_unique_id_function = generate_unique_id_function
         self.strict_content_type = strict_content_type
+        self._refresh_route_middleware()
+
+    def _apply_route_middleware(
+        self, route: BaseRoute, middleware: Sequence[Middleware]
+    ) -> None:
+        app = getattr(route, "app", None)
+        if app is None:
+            return
+        original_app = getattr(route, "_fastapi_router_original_app", None)
+        if original_app is None:
+            original_app = app
+            route._fastapi_router_original_app = original_app  # type: ignore[attr-defined]
+        middleware_list = list(middleware)
+        route._fastapi_router_middleware = middleware_list  # type: ignore[attr-defined]
+        route.app = _build_router_middleware_stack(original_app, middleware_list)  # type: ignore[attr-defined]
+
+    def _append_route(
+        self,
+        route: BaseRoute,
+        route_middleware: Sequence[Middleware] | None = None,
+    ) -> None:
+        child_middleware = list(route_middleware or [])
+        route._fastapi_child_router_middleware = child_middleware  # type: ignore[attr-defined]
+        self._apply_route_middleware(route, [*self.user_middleware, *child_middleware])
+        self.routes.append(route)
+
+    def _refresh_route_middleware(self) -> None:
+        for route in self.routes:
+            child_middleware = getattr(route, "_fastapi_child_router_middleware", [])
+            self._apply_route_middleware(
+                route, [*self.user_middleware, *child_middleware]
+            )
+
+    def add_middleware(
+        self, middleware_class: type[Any], *args: Any, **kwargs: Any
+    ) -> None:
+        self.user_middleware.append(Middleware(middleware_class, *args, **kwargs))
+        self._refresh_route_middleware()
 
     def route(
         self,
@@ -1332,6 +1412,36 @@ class APIRouter(routing.Router):
             return func
 
         return decorator
+
+    def add_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        methods: Collection[str] | None = None,
+        name: str | None = None,
+        include_in_schema: bool = True,
+        *,
+        _route_middleware: Sequence[Middleware] | None = None,
+    ) -> None:
+        route = routing.Route(
+            path,
+            endpoint=endpoint,
+            methods=methods,
+            name=name,
+            include_in_schema=include_in_schema,
+        )
+        self._append_route(route, _route_middleware)
+
+    def add_websocket_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        name: str | None = None,
+        *,
+        _route_middleware: Sequence[Middleware] | None = None,
+    ) -> None:
+        route = routing.WebSocketRoute(path, endpoint=endpoint, name=name)
+        self._append_route(route, _route_middleware)
 
     def add_api_route(
         self,
@@ -1364,6 +1474,7 @@ class APIRouter(routing.Router):
         generate_unique_id_function: Callable[[APIRoute], str]
         | DefaultPlaceholder = Default(generate_unique_id),
         strict_content_type: bool | DefaultPlaceholder = Default(True),
+        _route_middleware: Sequence[Middleware] | None = None,
     ) -> None:
         route_class = route_class_override or self.route_class
         responses = responses or {}
@@ -1414,7 +1525,7 @@ class APIRouter(routing.Router):
                 strict_content_type, self.strict_content_type
             ),
         )
-        self.routes.append(route)
+        self._append_route(route, _route_middleware)
 
     def api_route(
         self,
@@ -1485,6 +1596,7 @@ class APIRouter(routing.Router):
         name: str | None = None,
         *,
         dependencies: Sequence[params.Depends] | None = None,
+        _route_middleware: Sequence[Middleware] | None = None,
     ) -> None:
         current_dependencies = self.dependencies.copy()
         if dependencies:
@@ -1497,7 +1609,7 @@ class APIRouter(routing.Router):
             dependencies=current_dependencies,
             dependency_overrides_provider=self.dependency_overrides_provider,
         )
-        self.routes.append(route)
+        self._append_route(route, _route_middleware)
 
     def websocket(
         self,
@@ -1793,6 +1905,7 @@ class APIRouter(routing.Router):
                         router.strict_content_type,
                         self.strict_content_type,
                     ),
+                    _route_middleware=getattr(route, "_fastapi_router_middleware", []),
                 )
             elif isinstance(route, routing.Route):
                 methods = list(route.methods or [])
@@ -1802,6 +1915,7 @@ class APIRouter(routing.Router):
                     methods=methods,
                     include_in_schema=route.include_in_schema,
                     name=route.name,
+                    _route_middleware=getattr(route, "_fastapi_router_middleware", []),
                 )
             elif isinstance(route, APIWebSocketRoute):
                 current_dependencies = []
@@ -1814,10 +1928,14 @@ class APIRouter(routing.Router):
                     route.endpoint,
                     dependencies=current_dependencies,
                     name=route.name,
+                    _route_middleware=getattr(route, "_fastapi_router_middleware", []),
                 )
             elif isinstance(route, routing.WebSocketRoute):
                 self.add_websocket_route(
-                    prefix + route.path, route.endpoint, name=route.name
+                    prefix + route.path,
+                    route.endpoint,
+                    name=route.name,
+                    _route_middleware=getattr(route, "_fastapi_router_middleware", []),
                 )
         for handler in router.on_startup:
             self.add_event_handler("startup", handler)

--- a/fastapi/tests/test_router_middleware.py
+++ b/fastapi/tests/test_router_middleware.py
@@ -1,0 +1,118 @@
+from collections.abc import Callable
+
+from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi.testclient import TestClient
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+def header_middleware(header: str, value: str) -> Callable:
+    async def middleware(request: Request, call_next: Callable) -> Response:
+        response = await call_next(request)
+        response.headers[header] = value
+        return response
+
+    return middleware
+
+
+def record_middleware(name: str) -> Callable:
+    async def middleware(request: Request, call_next: Callable) -> Response:
+        request.scope.setdefault("router_middleware_order", []).append(name)
+        return await call_next(request)
+
+    return middleware
+
+
+class ClassHeaderMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, *, header: str, value: str) -> None:
+        super().__init__(app)
+        self.header = header
+        self.value = value
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        response = await call_next(request)
+        response.headers[self.header] = self.value
+        return response
+
+
+def test_router_middleware_is_scoped_to_router_routes() -> None:
+    app = FastAPI()
+    router = APIRouter(middleware=[header_middleware("x-router", "scoped")])
+    other_router = APIRouter()
+
+    @router.get("/scoped")
+    async def scoped() -> dict[str, bool]:
+        return {"ok": True}
+
+    @other_router.get("/other")
+    async def other() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/app")
+    async def app_route() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+    app.include_router(other_router)
+
+    client = TestClient(app)
+
+    assert client.get("/scoped").headers["x-router"] == "scoped"
+    assert "x-router" not in client.get("/other").headers
+    assert "x-router" not in client.get("/app").headers
+
+
+def test_router_middleware_order_and_include_router_preservation() -> None:
+    app = FastAPI()
+    parent_router = APIRouter(middleware=[record_middleware("parent")])
+    child_router = APIRouter(middleware=[record_middleware("child")])
+
+    @child_router.get("/leaf")
+    async def leaf(request: Request) -> dict[str, list[str]]:
+        return {"order": request.scope["router_middleware_order"]}
+
+    parent_router.include_router(child_router, prefix="/child")
+    app.include_router(parent_router, prefix="/parent")
+
+    response = TestClient(app).get("/parent/child/leaf")
+
+    assert response.json() == {"order": ["parent", "child"]}
+
+
+def test_router_supports_class_and_callable_middleware() -> None:
+    router = APIRouter(
+        middleware=[
+            Middleware(ClassHeaderMiddleware, header="x-class", value="class"),
+            header_middleware("x-callable", "callable"),
+        ]
+    )
+    app = FastAPI()
+
+    @router.get("/combined")
+    async def combined() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.include_router(router)
+    response = TestClient(app).get("/combined")
+
+    assert response.headers["x-class"] == "class"
+    assert response.headers["x-callable"] == "callable"
+
+
+def test_add_middleware_wraps_existing_router_routes() -> None:
+    router = APIRouter()
+    app = FastAPI()
+
+    @router.get("/late")
+    async def late() -> dict[str, bool]:
+        return {"ok": True}
+
+    router.add_middleware(
+        BaseHTTPMiddleware,
+        dispatch=header_middleware("x-added-after-route", "yes"),
+    )
+    app.include_router(router)
+
+    response = TestClient(app).get("/late")
+
+    assert response.headers["x-added-after-route"] == "yes"


### PR DESCRIPTION
/claim #796

## Summary

- Adds router-scoped middleware support to `APIRouter` through a constructor `middleware` parameter.
- Supports Starlette `Middleware` entries, ASGI middleware classes, and callable request dispatch functions.
- Adds `router.add_middleware()` and rewraps existing router routes when it is called.
- Preserves parent and child router middleware ordering through nested `include_router()` calls.
- Includes safe public `.provenance.json` metadata only; private runtime/system/developer/user instructions are intentionally not disclosed.

## Verification

- `uv run pytest tests/test_router_middleware.py tests/test_include_router_defaults_overrides.py tests/test_custom_route_class.py tests/test_empty_router.py -q`
- `uv run ruff check fastapi/routing.py tests/test_router_middleware.py`
- `uv run ruff format --check fastapi/routing.py tests/test_router_middleware.py`
- `python -m py_compile fastapi\routing.py tests\test_router_middleware.py`
- `git diff --check`

Demo evidence: `tests/test_router_middleware.py` verifies router-only scoping, isolation from other routers/app routes, middleware order, nested include preservation, class-based middleware, callable middleware, and late `add_middleware()` wrapping.
