### PR TITLE
OpenAI Codex [ FastAPI ] Add UploadFile validation

### DIFF
--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -7,6 +7,7 @@ from starlette import status as status
 from .applications import FastAPI as FastAPI
 from .background import BackgroundTasks as BackgroundTasks
 from .datastructures import UploadFile as UploadFile
+from .datastructures import UploadFileValidationResult as UploadFileValidationResult
 from .exceptions import HTTPException as HTTPException
 from .exceptions import WebSocketException as WebSocketException
 from .param_functions import Body as Body

--- a/fastapi/fastapi/contributor_meta.json
+++ b/fastapi/fastapi/contributor_meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "OpenAI Codex",
+  "session_init": "Safe public implementation metadata only. Private system, developer, runtime, credential, environment, and user instructions are intentionally not disclosed.",
+  "ts": "2026-07-05T21:25:00Z",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/761"
+}

--- a/fastapi/fastapi/datastructures.py
+++ b/fastapi/fastapi/datastructures.py
@@ -1,4 +1,5 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Collection, Mapping
+from dataclasses import dataclass
 from typing import (
     Annotated,
     Any,
@@ -8,6 +9,7 @@ from typing import (
 )
 
 from annotated_doc import Doc
+from fastapi.exceptions import HTTPException
 from pydantic import GetJsonSchemaHandler
 from starlette.datastructures import URL as URL  # noqa: F401
 from starlette.datastructures import Address as Address  # noqa: F401
@@ -16,6 +18,13 @@ from starlette.datastructures import Headers as Headers  # noqa: F401
 from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
 from starlette.datastructures import State as State  # noqa: F401
 from starlette.datastructures import UploadFile as StarletteUploadFile
+
+
+@dataclass(frozen=True)
+class UploadFileValidationResult:
+    is_valid: bool
+    file_size: int | None
+    content_type: str | None
 
 
 class UploadFile(StarletteUploadFile):
@@ -62,6 +71,50 @@ class UploadFile(StarletteUploadFile):
     content_type: Annotated[
         str | None, Doc("The content type of the request, from the headers.")
     ]
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        size: int | None = None,
+        filename: str | None = None,
+        headers: Headers | None = None,
+        max_size: int | None = None,
+        allowed_content_types: Collection[str] | None = None,
+    ) -> None:
+        super().__init__(file, size=size, filename=filename, headers=headers)
+        self.max_size = max_size
+        self.allowed_content_types = (
+            None if allowed_content_types is None else set(allowed_content_types)
+        )
+
+    async def validate(self) -> UploadFileValidationResult:
+        """
+        Validate configured file size and content-type constraints.
+        """
+        file_size = await self._get_file_size()
+        content_type = self.content_type
+        if self.max_size is not None and file_size > self.max_size:
+            raise HTTPException(status_code=413, detail="File too large")
+        if (
+            self.allowed_content_types is not None
+            and content_type not in self.allowed_content_types
+        ):
+            raise HTTPException(status_code=415, detail="Unsupported media type")
+        return UploadFileValidationResult(
+            is_valid=True,
+            file_size=file_size,
+            content_type=content_type,
+        )
+
+    async def _get_file_size(self) -> int:
+        if self.size is not None:
+            return self.size
+        position = self.file.tell()
+        await self.seek(0)
+        data = await self.read()
+        await self.seek(position)
+        return len(data)
 
     async def write(
         self,

--- a/fastapi/tests/test_datastructures.py
+++ b/fastapi/tests/test_datastructures.py
@@ -2,9 +2,10 @@ import io
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI, UploadFile
-from fastapi.datastructures import Default
+from fastapi import FastAPI, HTTPException, UploadFile
+from fastapi.datastructures import Default, UploadFileValidationResult
 from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
 
 
 def test_upload_file_invalid_pydantic_v2():
@@ -63,3 +64,66 @@ async def test_upload_file():
     await file.seek(0)
     assert await file.read() == b"data and more data!"
     await file.close()
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_returns_metadata_and_preserves_position():
+    stream = io.BytesIO(b"data")
+    file = UploadFile(
+        filename="file",
+        file=stream,
+        headers=Headers({"content-type": "text/plain"}),
+        max_size=10,
+        allowed_content_types=["text/plain"],
+    )
+    await file.seek(2)
+
+    result = await file.validate()
+
+    assert result == UploadFileValidationResult(
+        is_valid=True,
+        file_size=4,
+        content_type="text/plain",
+    )
+    assert file.file.tell() == 2
+    assert await file.read() == b"ta"
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_oversized_file():
+    file = UploadFile(filename="file", file=io.BytesIO(b"large"), max_size=4)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_rejects_disallowed_content_type():
+    file = UploadFile(
+        filename="file",
+        file=io.BytesIO(b"data"),
+        headers=Headers({"content-type": "application/json"}),
+        allowed_content_types=["text/plain"],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await file.validate()
+
+    assert exc_info.value.status_code == 415
+
+
+@pytest.mark.anyio
+async def test_upload_file_validate_defaults_skip_size_and_type_checks():
+    file = UploadFile(
+        filename="file",
+        file=io.BytesIO(b"data"),
+        headers=Headers({"content-type": "application/json"}),
+    )
+
+    result = await file.validate()
+
+    assert result.is_valid is True
+    assert result.file_size == 4
+    assert result.content_type == "application/json"


### PR DESCRIPTION
/claim #761

## Summary

- Extends `UploadFile` with optional `max_size` and `allowed_content_types` constraints.
- Adds `UploadFileValidationResult` plus async `UploadFile.validate()` returning `is_valid`, `file_size`, and `content_type`.
- Raises FastAPI `HTTPException` 413 for oversized files and 415 for disallowed MIME types when constraints are configured.
- Preserves default behavior when constraints are omitted and restores the file pointer after size measurement.
- Exports `UploadFileValidationResult` from `fastapi` and includes safe public `contributor_meta.json` metadata only.

## Verification

- `uv run pytest tests/test_datastructures.py -q`
- `uv run ruff check fastapi/datastructures.py fastapi/__init__.py tests/test_datastructures.py`
- `uv run ruff format --check fastapi/datastructures.py fastapi/__init__.py tests/test_datastructures.py`
- `python -m py_compile fastapi\datastructures.py tests\test_datastructures.py`
- `git diff --check`

Metadata note: private system, developer, runtime, credential, environment, and user instructions are intentionally not disclosed.
