### PR TITLE
OpenAI Codex [ FastAPI ] Add SSE manager

### DIFF
--- a/fastapi/fastapi/.contributor.json
+++ b/fastapi/fastapi/.contributor.json
@@ -1,0 +1,6 @@
+{
+  "agent": "OpenAI Codex",
+  "initialized_with": "Safe public implementation metadata only. Private system, developer, runtime, credential, environment, and user instructions are intentionally not disclosed.",
+  "timestamp": "2026-07-05T21:45:00Z",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/798"
+}

--- a/fastapi/fastapi/__init__.py
+++ b/fastapi/fastapi/__init__.py
@@ -21,5 +21,7 @@ from .param_functions import Security as Security
 from .requests import Request as Request
 from .responses import Response as Response
 from .routing import APIRouter as APIRouter
+from .sse import ServerSentEvent as ServerSentEvent
+from .sse import SSEManager as SSEManager
 from .websockets import WebSocket as WebSocket
 from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/fastapi/fastapi/responses.py
+++ b/fastapi/fastapi/responses.py
@@ -3,6 +3,8 @@ from typing import Any, Protocol, cast
 
 from fastapi.exceptions import FastAPIDeprecationWarning
 from fastapi.sse import EventSourceResponse as EventSourceResponse  # noqa
+from fastapi.sse import ServerSentEvent as ServerSentEvent  # noqa
+from fastapi.sse import SSEManager as SSEManager  # noqa
 from starlette.responses import FileResponse as FileResponse  # noqa
 from starlette.responses import HTMLResponse as HTMLResponse  # noqa
 from starlette.responses import JSONResponse as JSONResponse  # noqa

--- a/fastapi/fastapi/sse.py
+++ b/fastapi/fastapi/sse.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
+import anyio
 from annotated_doc import Doc
 from pydantic import AfterValidator, BaseModel, Field, model_validator
 from starlette.responses import StreamingResponse
@@ -31,6 +36,28 @@ class EventSourceResponse(StreamingResponse):
     """
 
     media_type = "text/event-stream"
+
+
+class _SSESubscriber:
+    def __init__(self, event_type: str | None, max_queue_size: int) -> None:
+        self.event_type = event_type
+        self.send_stream, self.receive_stream = anyio.create_memory_object_stream[
+            ServerSentEvent
+        ](max_queue_size)
+
+    def accepts(self, event: ServerSentEvent) -> bool:
+        return self.event_type is None or event.event == self.event_type
+
+    def put_nowait(self, event: ServerSentEvent) -> None:
+        try:
+            self.send_stream.send_nowait(event)
+        except anyio.WouldBlock:
+            self.receive_stream.receive_nowait()
+            self.send_stream.send_nowait(event)
+
+    async def close(self) -> None:
+        await self.send_stream.aclose()
+        await self.receive_stream.aclose()
 
 
 def _check_id_no_null(v: str | None) -> str | None:
@@ -133,7 +160,7 @@ class ServerSentEvent(BaseModel):
     ] = None
 
     @model_validator(mode="after")
-    def _check_data_exclusive(self) -> "ServerSentEvent":
+    def _check_data_exclusive(self) -> ServerSentEvent:
         if self.data is not None and self.raw_data is not None:
             raise ValueError(
                 "Cannot set both 'data' and 'raw_data' on the same "
@@ -141,6 +168,162 @@ class ServerSentEvent(BaseModel):
                 "or 'raw_data' for pre-formatted strings."
             )
         return self
+
+
+class SSEManager:
+    """Manage broadcast-based Server-Sent Event streams.
+
+    `SSEManager.stream()` returns an async iterator of `ServerSentEvent` objects
+    that can be returned from an endpoint using `response_class=EventSourceResponse`.
+    """
+
+    def __init__(
+        self,
+        *,
+        history_size: int = 100,
+        retry: int | None = None,
+        max_queue_size: int = 100,
+        disconnect_poll_interval: float = 0.1,
+    ) -> None:
+        self.history: deque[ServerSentEvent] = deque(maxlen=history_size)
+        self.retry = retry
+        self.max_queue_size = max_queue_size
+        self.disconnect_poll_interval = disconnect_poll_interval
+        self._subscribers: set[_SSESubscriber] = set()
+        self._next_id = 1
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._subscribers)
+
+    async def broadcast(
+        self,
+        event: ServerSentEvent | None = None,
+        *,
+        data: Any = None,
+        raw_data: str | None = None,
+        event_type: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        comment: str | None = None,
+    ) -> ServerSentEvent:
+        if event is None:
+            event = ServerSentEvent(
+                data=data,
+                raw_data=raw_data,
+                event=event_type,
+                id=id or self._make_event_id(),
+                retry=retry,
+                comment=comment,
+            )
+        elif event.id is None:
+            event = event.model_copy(update={"id": self._make_event_id()})
+        event = self._with_default_retry(event)
+        self.history.append(event)
+        for subscriber in list(self._subscribers):
+            if subscriber.accepts(event):
+                subscriber.put_nowait(event)
+        return event
+
+    async def broadcast_to(
+        self,
+        event_type: str,
+        data: Any = None,
+        *,
+        raw_data: str | None = None,
+        id: str | None = None,
+        retry: int | None = None,
+        comment: str | None = None,
+    ) -> ServerSentEvent:
+        return await self.broadcast(
+            data=data,
+            raw_data=raw_data,
+            event_type=event_type,
+            id=id,
+            retry=retry,
+            comment=comment,
+        )
+
+    async def stream(
+        self,
+        request: Any | None = None,
+        *,
+        event_type: str | None = None,
+        last_event_id: str | None = None,
+        retry: int | None = None,
+    ) -> AsyncIterator[ServerSentEvent]:
+        selected_event_type = self._get_event_type(request, event_type)
+        selected_last_event_id = self._get_last_event_id(request, last_event_id)
+        default_retry = retry if retry is not None else self.retry
+
+        for event in self._replay_events(selected_last_event_id, selected_event_type):
+            yield self._with_default_retry(event, default_retry)
+
+        subscriber = _SSESubscriber(selected_event_type, self.max_queue_size)
+        self._subscribers.add(subscriber)
+        try:
+            async with subscriber.receive_stream:
+                while True:
+                    if await self._is_disconnected(request):
+                        break
+                    event = None
+                    with anyio.move_on_after(self.disconnect_poll_interval):
+                        event = await subscriber.receive_stream.receive()
+                    if event is None:
+                        continue
+                    yield self._with_default_retry(event, default_retry)
+        except anyio.EndOfStream:
+            pass
+        finally:
+            self._subscribers.discard(subscriber)
+            await subscriber.close()
+
+    def _make_event_id(self) -> str:
+        event_id = str(self._next_id)
+        self._next_id += 1
+        return event_id
+
+    def _replay_events(
+        self, last_event_id: str | None, event_type: str | None
+    ) -> list[ServerSentEvent]:
+        events = list(self.history)
+        if last_event_id is not None:
+            for index, event in enumerate(events):
+                if event.id == last_event_id:
+                    events = events[index + 1 :]
+                    break
+        return [
+            event for event in events if event_type is None or event.event == event_type
+        ]
+
+    def _with_default_retry(
+        self, event: ServerSentEvent, retry: int | None = None
+    ) -> ServerSentEvent:
+        default_retry = retry if retry is not None else self.retry
+        if default_retry is not None and event.retry is None:
+            return event.model_copy(update={"retry": default_retry})
+        return event
+
+    def _get_event_type(
+        self, request: Any | None, event_type: str | None
+    ) -> str | None:
+        if event_type is not None or request is None:
+            return event_type
+        query_params = getattr(request, "query_params", {})
+        return query_params.get("event_type")
+
+    def _get_last_event_id(
+        self, request: Any | None, last_event_id: str | None
+    ) -> str | None:
+        if last_event_id is not None or request is None:
+            return last_event_id
+        headers = getattr(request, "headers", {})
+        return headers.get("last-event-id") or headers.get("Last-Event-ID")
+
+    async def _is_disconnected(self, request: Any | None) -> bool:
+        if request is None or not hasattr(request, "is_disconnected"):
+            return False
+        return bool(await request.is_disconnected())
 
 
 def format_sse_event(

--- a/fastapi/tests/test_sse.py
+++ b/fastapi/tests/test_sse.py
@@ -2,11 +2,12 @@ import asyncio
 import time
 from collections.abc import AsyncIterable, Iterable
 
+import anyio
 import fastapi.routing
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.responses import EventSourceResponse
-from fastapi.sse import ServerSentEvent
+from fastapi.sse import ServerSentEvent, SSEManager
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
@@ -316,3 +317,125 @@ def test_no_keepalive_when_fast(client: TestClient):
     assert response.status_code == 200
     # KEEPALIVE_COMMENT is ": ping\n\n".
     assert ": ping\n" not in response.text
+
+
+class FakeSSERequest:
+    def __init__(
+        self,
+        *,
+        query_params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        disconnect_after: int | None = None,
+    ) -> None:
+        self.query_params = query_params or {}
+        self.headers = headers or {}
+        self.disconnect_after = disconnect_after
+        self.disconnect_checks = 0
+
+    async def is_disconnected(self) -> bool:
+        if self.disconnect_after is None:
+            return False
+        self.disconnect_checks += 1
+        return self.disconnect_checks >= self.disconnect_after
+
+
+async def store_next_event(stream, results: dict[str, ServerSentEvent], key: str):
+    results[key] = await anext(stream)
+
+
+@pytest.mark.anyio
+async def test_sse_manager_broadcasts_to_all_and_filtered_clients():
+    manager = SSEManager(disconnect_poll_interval=0.01)
+    all_stream = manager.stream()
+    alert_stream = manager.stream(event_type="alerts")
+    results: dict[str, ServerSentEvent] = {}
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(store_next_event, all_stream, results, "all")
+        task_group.start_soon(store_next_event, alert_stream, results, "alert")
+        await anyio.sleep(0)
+
+        await manager.broadcast_to("alerts", {"message": "ready"}, id="alert-1")
+
+        with anyio.fail_after(1):
+            while set(results) != {"all", "alert"}:
+                await anyio.sleep(0)
+        assert manager.connection_count == 2
+        task_group.cancel_scope.cancel()
+
+    all_event = results["all"]
+    alert_event = results["alert"]
+    assert all_event.event == "alerts"
+    assert all_event.data == {"message": "ready"}
+    assert alert_event.event == "alerts"
+
+    await all_stream.aclose()
+    await alert_stream.aclose()
+    assert manager.connection_count == 0
+
+
+@pytest.mark.anyio
+async def test_sse_manager_filter_skips_non_matching_events():
+    manager = SSEManager(disconnect_poll_interval=0.01)
+    alert_stream = manager.stream(event_type="alerts")
+    results: dict[str, ServerSentEvent] = {}
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(store_next_event, alert_stream, results, "alert")
+        await anyio.sleep(0)
+
+        await manager.broadcast_to("metrics", {"load": 0.5}, id="metric-1")
+        await anyio.sleep(0.03)
+
+        assert "alert" not in results
+
+        await manager.broadcast_to("alerts", {"message": "wake"}, id="alert-1")
+
+        with anyio.fail_after(1):
+            while "alert" not in results:
+                await anyio.sleep(0)
+        task_group.cancel_scope.cancel()
+
+    alert_event = results["alert"]
+    assert alert_event.event == "alerts"
+    assert alert_event.id == "alert-1"
+
+    await alert_stream.aclose()
+
+
+@pytest.mark.anyio
+async def test_sse_manager_replays_since_last_event_id_with_retry():
+    manager = SSEManager(retry=2500)
+    await manager.broadcast_to("metrics", {"load": 0.5}, id="1")
+    await manager.broadcast_to("alerts", {"message": "first"}, id="2")
+    await manager.broadcast_to("alerts", {"message": "second"}, id="3")
+
+    request = FakeSSERequest(
+        query_params={"event_type": "alerts"},
+        headers={"last-event-id": "1"},
+    )
+    replay_stream = manager.stream(request)
+
+    first_event = await anext(replay_stream)
+    second_event = await anext(replay_stream)
+
+    assert first_event.id == "2"
+    assert first_event.retry == 2500
+    assert second_event.id == "3"
+    assert second_event.retry == 2500
+
+    await replay_stream.aclose()
+
+
+@pytest.mark.anyio
+async def test_sse_manager_cleans_up_on_disconnect():
+    manager = SSEManager(disconnect_poll_interval=0.01)
+    request = FakeSSERequest(disconnect_after=2)
+    stream = manager.stream(request)
+
+    with pytest.raises(StopAsyncIteration):
+        with anyio.fail_after(1):
+            await anext(stream)
+
+    assert request.disconnect_checks >= 2
+    assert manager.connection_count == 0


### PR DESCRIPTION
/claim #798

## Summary

- Adds `SSEManager` for broadcast-based Server-Sent Events with per-subscriber bounded queues.
- Supports broadcasting to all subscribers or to a named `event_type` group via `broadcast()` and `broadcast_to()`.
- Reads stream filters from explicit arguments or the request `event_type` query parameter.
- Replays retained history after an explicit or header-derived `Last-Event-ID`.
- Detects disconnects through `request.is_disconnected()` and cleans up subscriber state.
- Applies configurable default `retry` fields and exports `SSEManager` from `fastapi` and `fastapi.responses`.
- Includes safe public `.contributor.json` metadata only.

## Verification

- `uv run pytest tests/test_sse.py -q`
- `uv run ruff check fastapi/sse.py fastapi/__init__.py fastapi/responses.py tests/test_sse.py`
- `uv run ruff format --check fastapi/sse.py fastapi/__init__.py fastapi/responses.py tests/test_sse.py`
- `python -m py_compile fastapi\sse.py tests\test_sse.py`
- `git diff --check`

Metadata note: private system, developer, runtime, credential, environment, and user instructions are intentionally not disclosed.
