### PR TITLE
OpenAI Codex [ FastAPI ] Add request ID middleware

### DIFF
--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,32 @@
 import logging
+from contextvars import ContextVar, Token
 
 logger = logging.getLogger("fastapi")
+
+_request_id_context: ContextVar[str | None] = ContextVar(
+    "fastapi_request_id",
+    default=None,
+)
+
+
+def get_request_id() -> str | None:
+    return _request_id_context.get()
+
+
+def set_request_id(request_id: str) -> Token[str | None]:
+    return _request_id_context.set(request_id)
+
+
+def reset_request_id(token: Token[str | None]) -> None:
+    _request_id_context.reset(token)
+
+
+class RequestIDFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "request_id"):
+            record.request_id = get_request_id() or "-"
+        return True
+
+
+if not any(isinstance(existing, RequestIDFilter) for existing in logger.filters):
+    logger.addFilter(RequestIDFilter())

--- a/fastapi/fastapi/middleware/_provenance.json
+++ b/fastapi/fastapi/middleware/_provenance.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "OpenAI Codex",
+  "boot_context": "Safe public implementation metadata only. Private system, developer, runtime, credential, environment, and user instructions are intentionally not disclosed.",
+  "timestamp": "2026-07-05T20:50:00Z",
+  "issue": "https://github.com/UnsafeLabs/Bounty-Hunters/issues/797"
+}

--- a/fastapi/fastapi/middleware/requestid.py
+++ b/fastapi/fastapi/middleware/requestid.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.logger import reset_request_id, set_request_id
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class RequestIDMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        header_name: str = "X-Request-ID",
+    ) -> None:
+        self.app = app
+        self.header_name = header_name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        request_id = headers.get(self.header_name) or str(uuid4())
+        scope.setdefault("state", {})["request_id"] = request_id
+        token = set_request_id(request_id)
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                response_headers = MutableHeaders(scope=message)
+                response_headers[self.header_name] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            reset_request_id(token)

--- a/fastapi/tests/test_request_id_middleware.py
+++ b/fastapi/tests/test_request_id_middleware.py
@@ -1,0 +1,125 @@
+import logging
+import re
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+from fastapi import FastAPI, Request
+from fastapi.logger import get_request_id, logger
+from fastapi.middleware.requestid import RequestIDMiddleware
+from fastapi.testclient import TestClient
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/request-id")
+    async def read_request_id(request: Request):
+        logger.info("request id seen")
+        return {
+            "request_id": request.state.request_id,
+            "context_request_id": get_request_id(),
+        }
+
+    return app
+
+
+def test_request_id_middleware_generates_uuid_header():
+    client = TestClient(make_app())
+
+    response = client.get("/request-id")
+
+    assert response.status_code == 200
+    request_id = response.headers["x-request-id"]
+    assert UUID_RE.match(request_id)
+    assert response.json() == {
+        "request_id": request_id,
+        "context_request_id": request_id,
+    }
+
+
+def test_request_id_middleware_preserves_client_header():
+    client = TestClient(make_app())
+
+    response = client.get("/request-id", headers={"X-Request-ID": "client-id-123"})
+
+    assert response.status_code == 200
+    assert response.headers["x-request-id"] == "client-id-123"
+    assert response.json() == {
+        "request_id": "client-id-123",
+        "context_request_id": "client-id-123",
+    }
+
+
+def test_request_id_is_added_to_log_records(caplog):
+    client = TestClient(make_app())
+
+    with caplog.at_level(logging.INFO, logger="fastapi"):
+        response = client.get("/request-id", headers={"X-Request-ID": "log-id"})
+
+    assert response.status_code == 200
+    matching_records = [
+        record for record in caplog.records if record.message == "request id seen"
+    ]
+    assert matching_records
+    assert matching_records[-1].request_id == "log-id"
+
+
+def test_logger_keeps_default_behavior_without_middleware(caplog):
+    app = FastAPI()
+
+    @app.get("/plain")
+    async def plain():
+        logger.info("plain request")
+        return {"context_request_id": get_request_id()}
+
+    client = TestClient(app)
+
+    with caplog.at_level(logging.INFO, logger="fastapi"):
+        response = client.get("/plain")
+
+    assert response.status_code == 200
+    assert response.json() == {"context_request_id": None}
+    matching_records = [
+        record for record in caplog.records if record.message == "plain request"
+    ]
+    assert matching_records
+    assert matching_records[-1].request_id == "-"
+
+
+def test_request_ids_do_not_leak_between_concurrent_requests():
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+    barrier = Barrier(2)
+
+    @app.get("/parallel")
+    async def parallel(request: Request):
+        barrier.wait(timeout=2)
+        return {
+            "request_id": request.state.request_id,
+            "context_request_id": get_request_id(),
+        }
+
+    client = TestClient(app)
+
+    def get_with_request_id(request_id: str):
+        response = client.get("/parallel", headers={"X-Request-ID": request_id})
+        assert response.status_code == 200
+        return response.json()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(get_with_request_id, "parallel-a")
+        second = executor.submit(get_with_request_id, "parallel-b")
+
+    assert first.result() == {
+        "request_id": "parallel-a",
+        "context_request_id": "parallel-a",
+    }
+    assert second.result() == {
+        "request_id": "parallel-b",
+        "context_request_id": "parallel-b",
+    }


### PR DESCRIPTION
/claim #797

## Summary

- Adds `fastapi.middleware.requestid.RequestIDMiddleware`.
- Preserves a client `X-Request-ID` header or generates a UUID for each HTTP request.
- Stores the value on `request.state.request_id` and echoes it in the response `X-Request-ID` header.
- Adds request-scoped logging context for FastAPI log records through `fastapi.logger`.
- Keeps middleware-free logger behavior usable by falling back to `request_id="-"`.
- Covers generated IDs, client-supplied IDs, logging correlation, no-middleware behavior, and concurrent request isolation.
- Includes safe public `_provenance.json` metadata only.

## Verification

- `uv run pytest tests/test_request_id_middleware.py -q`
- `uv run ruff check fastapi/logger.py fastapi/middleware/requestid.py tests/test_request_id_middleware.py`
- `uv run ruff format --check fastapi/logger.py fastapi/middleware/requestid.py tests/test_request_id_middleware.py`
- `python -m py_compile fastapi\logger.py fastapi\middleware\requestid.py tests\test_request_id_middleware.py`
- `git diff --check`

Metadata note: private system, developer, runtime, credential, environment, and user instructions are intentionally not disclosed.
