### PR TITLE
g0spel [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -16,6 +16,7 @@ contract LiquidityPool is ERC20 {
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,8 +28,9 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            // Lock MINIMUM_LIQUIDITY to zero address to prevent first-depositor manipulation
+            lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
+            _mint(address(0), MINIMUM_LIQUIDITY);
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,17 +46,13 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // Use internal reserves instead of balanceOf to prevent manipulation via direct transfer
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 
@@ -65,6 +63,13 @@ contract LiquidityPool is ERC20 {
         reserveB -= amountB;
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    /// @notice Updates internal reserves to match actual contract balances — recovers from donation attacks
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/contracts/_generation.json
+++ b/solidity/contracts/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "g0spel",
+  "pre_task_context": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.\n\nHost: Linux (7.1.2-3-cachyos)\nUser home directory: /home/ss\nCurrent working directory: /home/ss\n\nPython toolchain: python3=3.11.15 (no pip module), pip→python3.14 (mismatch), PEP 668=yes (use venv or uv), uv=installed.\n\nActive Hermes profile: default.\n\nConversation started: Monday, July 06, 2026\nModel: deepseek-v4-flash\nProvider: custom\n\nYou are a focused subagent working on a specific delegated task.\n\nYOUR TASK:\nSubmit fix for UnsafeLabs/Bounty-Hunters issue #918 ($600): First-depositor price manipulation in LiquidityPool.",
+  "timestamp": "2026-07-06T00:00:00Z"
+}


### PR DESCRIPTION
Fixes #918

## Changes

### LiquidityPool.sol
1. **MINIMUM_LIQUIDITY lock**: On first deposit (totalSupply == 0), mint 1000 LP tokens to address(0) and subtract them from the user's mint. This prevents the classic Uniswap V2 first-depositor price manipulation attack.

2. **removeLiquidity uses internal reserves**: Replaced `tokenA.balanceOf(address(this))`/`tokenB.balanceOf(address(this))` with `reserveA`/`reserveB` to prevent manipulation via direct token transfers to the pool.

3. **Added sync() function**: Updates internal reserves to match actual contract balances, allowing recovery from donation attacks. Emits a new `Sync` event.

### _generation.json
- Added per issue requirements for AI-generated submissions.

## Acceptance Criteria
- [x] First deposit locks MINIMUM_LIQUIDITY tokens at address(0)
- [x] First depositor receives LP tokens minus the locked amount
- [x] Subsequent deposits use the correct proportional formula
- [x] removeLiquidity uses internal reserves, not balanceOf
- [x] sync function updates reserves and emits a Sync event
- [x] Direct token transfers to the pool do not affect LP token pricing

/bounty 00