### PR TITLE
[FhiPunkVn] [ FastAPI ] Fix encoders.py TypeError on bytes and memoryview objects

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "FhiPunkVn",
+  "boot_context": "Autonomous OSS bounty agent working issue #759 on UnsafeLabs/Bounty-Hunters. Task: fix fastapi.encoders.jsonable_encoder TypeError on bytes and memoryview by encoding to base64 by default with optional bytes_encoding=hex, propagate the parameter through nested structures and Pydantic model dumps (mode=python), add regression tests covering bytes, memoryview, nested containers, models, and both encodings. Include this provenance file. Do not paste private platform secrets. Follow one-issue-per-PR and conventional commits. Payment: Algora $25 label. Agent identity: FhiPunkVn.",
+  "timestamp": "2026-07-11T06:30:00.000Z"
+}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -15,7 +16,7 @@ from ipaddress import (
 from pathlib import Path, PurePath
 from re import Pattern
 from types import GeneratorType
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from annotated_doc import Doc
@@ -49,9 +50,19 @@ except ImportError:  # pragma: no cover
         pass
 
 
+BytesEncoding = Literal["base64", "hex"]
+
+
 # Taken from Pydantic v1 as is
 def isoformat(o: datetime.date | datetime.time) -> str:
     return o.isoformat()
+
+
+def encode_bytes(value: bytes, bytes_encoding: BytesEncoding = "base64") -> str:
+    """Encode raw bytes for JSON (base64 by default, optional hex)."""
+    if bytes_encoding == "hex":
+        return value.hex()
+    return base64.b64encode(value).decode("ascii")
 
 
 # Adapted from Pydantic v1
@@ -82,7 +93,7 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
 
 ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
-    bytes: lambda o: o.decode(),
+    bytes: lambda o: encode_bytes(o),
     Color: str,
     PyExtraColor: str,
     datetime.date: isoformat,
@@ -215,6 +226,15 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        BytesEncoding,
+        Doc(
+            """
+            Encoding used for `bytes` and `memoryview` values.
+            Defaults to `base64`. Set to `hex` for hexadecimal strings.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -240,9 +260,15 @@ def jsonable_encoder(
         include = set(include)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     if exclude is not None and not isinstance(exclude, (set, dict)):
         exclude = set(exclude)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    # Handle binary types before generic paths (memoryview is not in ENCODERS_BY_TYPE).
+    if isinstance(obj, memoryview):
+        return encode_bytes(obj.tobytes(), bytes_encoding)
+    if isinstance(obj, bytes):
+        return encode_bytes(obj, bytes_encoding)
     if isinstance(obj, BaseModel):
+        # mode="python" keeps bytes as bytes so bytes_encoding can apply recursively.
         obj_dict = obj.model_dump(
-            mode="json",
+            mode="python",
             include=include,
             exclude=exclude,
             by_alias=by_alias,
@@ -255,6 +281,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             exclude_defaults=exclude_defaults,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if dataclasses.is_dataclass(obj):
         assert not isinstance(obj, type)
@@ -269,6 +296,7 @@ def jsonable_encoder(
             exclude_none=exclude_none,
             custom_encoder=custom_encoder,
             sqlalchemy_safe=sqlalchemy_safe,
+            bytes_encoding=bytes_encoding,
         )
     if isinstance(obj, Enum):
         return obj.value
@@ -302,6 +330,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_value = jsonable_encoder(
                     value,
@@ -310,6 +339,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
                 encoded_dict[encoded_key] = encoded_value
         return encoded_dict
@@ -327,6 +357,7 @@ def jsonable_encoder(
                     exclude_none=exclude_none,
                     custom_encoder=custom_encoder,
                     sqlalchemy_safe=sqlalchemy_safe,
+                    bytes_encoding=bytes_encoding,
                 )
             )
         return encoded_list
@@ -361,4 +392,5 @@ def jsonable_encoder(
         exclude_none=exclude_none,
         custom_encoder=custom_encoder,
         sqlalchemy_safe=sqlalchemy_safe,
+        bytes_encoding=bytes_encoding,
     )

--- a/fastapi/tests/test_jsonable_encoder.py
+++ b/fastapi/tests/test_jsonable_encoder.py
@@ -1,3 +1,4 @@
+import base64
 import warnings
 from collections import deque
 from dataclasses import dataclass
@@ -306,6 +307,65 @@ def test_encode_deque_encodes_child_models():
     dq = deque([Model(test="test")])
 
     assert jsonable_encoder(dq)[0]["test"] == "test"
+
+
+def test_encode_bytes_defaults_to_base64():
+    payload = b"\x00\xffbinary"
+    assert jsonable_encoder(payload) == base64.b64encode(payload).decode("ascii")
+
+
+def test_encode_memoryview_defaults_to_base64():
+    payload = b"\x00\xffbinary"
+    assert jsonable_encoder(memoryview(payload)) == base64.b64encode(payload).decode(
+        "ascii"
+    )
+
+
+def test_encode_bytes_as_hex():
+    payload = b"\x00\xffbinary"
+    assert jsonable_encoder(payload, bytes_encoding="hex") == payload.hex()
+
+
+def test_encode_memoryview_as_hex():
+    payload = b"\x00\xffbinary"
+    assert jsonable_encoder(memoryview(payload), bytes_encoding="hex") == payload.hex()
+
+
+def test_encode_nested_bytes_uses_selected_encoding():
+    assert jsonable_encoder(
+        {"payload": [b"\x00\xff", memoryview(b"ok")]}, bytes_encoding="hex"
+    ) == {"payload": ["00ff", "6f6b"]}
+
+
+def test_encode_model_bytes_defaults_to_base64():
+    class ModelWithBytes(BaseModel):
+        payload: bytes
+
+    payload = b"\x00\xffbinary"
+    assert jsonable_encoder(ModelWithBytes(payload=payload)) == {
+        "payload": base64.b64encode(payload).decode("ascii")
+    }
+
+
+def test_encode_model_bytes_as_hex():
+    class ModelWithBytes(BaseModel):
+        payload: bytes
+
+    payload = b"\x00\xffbinary"
+    assert jsonable_encoder(
+        ModelWithBytes(payload=payload), bytes_encoding="hex"
+    ) == {"payload": payload.hex()}
+
+
+def test_encode_dataclass_bytes_base64():
+    @dataclass
+    class ItemWithBytes:
+        payload: bytes
+
+    payload = b"hi"
+    assert jsonable_encoder(ItemWithBytes(payload=payload)) == {
+        "payload": base64.b64encode(payload).decode("ascii")
+    }
 
 
 def test_encode_pydantic_undefined():


### PR DESCRIPTION
## Issue
Closes #759

## Summary
`jsonable_encoder` now encodes `bytes` and `memoryview` as base64 strings by default, supports `bytes_encoding=hex`, propagates the option through nested structures and Pydantic models (`model_dump(mode=python)`), and includes regression tests plus `_provenance.json`.

## Acceptance criteria
- [x] bytes objects are encoded as base64 strings by default in JSON responses
- [x] memoryview objects are handled without errors
- [x] Setting bytes_encoding to hex produces hexadecimal output
- [x] Existing encoder behavior for all other types is unchanged (full `test_jsonable_encoder.py` suite green)
- [x] Tests cover bytes, memoryview, and both encoding options (plus nested/dict/model/dataclass)
- [x] PR title format: [FhiPunkVn] [ FastAPI ] ...
- [x] `_provenance.json` with tool_name, boot_context, timestamp

## Verification
```bash
cd fastapi
python -m pytest tests/test_jsonable_encoder.py -q
# 33 passed, 1 skipped
```

## Bounty
- Algora **$25** (label `$25` + 💎 Bounty)
- Payout (if form allows): USDC Base `0xfd3600efdfcd6f02c515f93237e2caaff293769f`

/claim #759