### PR TITLE
[FhiPunkVn] [ FastAPI ] Fix validation error handler missing request context and body redaction

### DIFF
--- a/fastapi/fastapi/_meta.json
+++ b/fastapi/fastapi/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "FhiPunkVn",
+  "generation_context": "Grok continuous OSS bounty coding session for FhiPunkVn. BOUNTY_VERIFIED only; Algora /bounty $40 on UnsafeLabs/Bounty-Hunters#757. Payment: USDC Base 0xfd3600efdfcd6f02c515f93237e2caaff293769f. MAX_ACTIVE_CODING=1; sole-lane preferred; implement real FastAPI exception_handlers fix. Task: Fix validation error handler missing request context and add body redaction. Include path/method always; echo redacted body only in debug mode; redact password/secret/token/api_key nested fields.",
+  "completed_at": "2026-07-11T10:16:00.000Z"
+}

--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
 from fastapi.utils import is_body_allowed_for_status_code
@@ -6,6 +8,27 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
+
+# Field names redacted when echoing validation request bodies in debug mode.
+_SENSITIVE_FIELD_NAMES = frozenset({"password", "secret", "token", "api_key"})
+_REDACTED = "***REDACTED***"
+
+
+def redact_sensitive_fields(value: Any) -> Any:
+    """Recursively redact sensitive keys from nested request body payloads."""
+    if isinstance(value, dict):
+        redacted: dict[Any, Any] = {}
+        for key, item in value.items():
+            if isinstance(key, str) and key.lower() in _SENSITIVE_FIELD_NAMES:
+                redacted[key] = _REDACTED
+            else:
+                redacted[key] = redact_sensitive_fields(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_sensitive_fields(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_sensitive_fields(item) for item in value)
+    return value
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
@@ -20,10 +43,15 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    return JSONResponse(
-        status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
-    )
+    content: dict[str, Any] = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+    # Echo redacted body only when the app is in debug mode.
+    if getattr(request.app, "debug", False):
+        content["body"] = jsonable_encoder(redact_sensitive_fields(exc.body))
+    return JSONResponse(status_code=422, content=content)
 
 
 async def websocket_request_validation_exception_handler(

--- a/fastapi/tests/test_validation_error_body_redaction.py
+++ b/fastapi/tests/test_validation_error_body_redaction.py
@@ -1,0 +1,138 @@
+"""Tests for validation error request context + sensitive body redaction."""
+
+from typing import Optional
+
+from fastapi import FastAPI
+from fastapi.exception_handlers import redact_sensitive_fields
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class LoginBody(BaseModel):
+    username: str
+    password: str
+    token: Optional[str] = None
+
+
+class NestedSecrets(BaseModel):
+    name: str
+    credentials: dict
+
+
+def test_redact_sensitive_fields_nested():
+    payload = {
+        "username": "alice",
+        "password": "s3cret",
+        "nested": {
+            "api_key": "abc123",
+            "token": "tok",
+            "ok": True,
+            "list": [{"secret": "x"}, {"value": 1}],
+        },
+    }
+    redacted = redact_sensitive_fields(payload)
+    assert redacted["username"] == "alice"
+    assert redacted["password"] == "***REDACTED***"
+    assert redacted["nested"]["api_key"] == "***REDACTED***"
+    assert redacted["nested"]["token"] == "***REDACTED***"
+    assert redacted["nested"]["ok"] is True
+    assert redacted["nested"]["list"][0]["secret"] == "***REDACTED***"
+    assert redacted["nested"]["list"][1]["value"] == 1
+
+
+def test_validation_error_includes_path_and_method_non_debug():
+    app = FastAPI(debug=False)
+
+    @app.post("/login")
+    def login(body: LoginBody):
+        return body
+
+    client = TestClient(app)
+    response = client.post("/login", json={"username": "alice"})
+    assert response.status_code == 422
+    data = response.json()
+    assert "detail" in data
+    assert data["path"] == "/login"
+    assert data["method"] == "POST"
+    assert "body" not in data
+
+
+def test_validation_error_includes_redacted_body_in_debug():
+    app = FastAPI(debug=True)
+
+    @app.post("/login")
+    def login(body: LoginBody):
+        return body
+
+    client = TestClient(app)
+    response = client.post(
+        "/login",
+        json={"username": "alice", "password": "hunter2", "token": "t"},
+    )
+    # password + token present but username valid; still may pass validation
+    # Force validation failure by omitting username type
+    response = client.post(
+        "/login",
+        json={"username": 123, "password": "hunter2", "token": "t"},
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/login"
+    assert data["method"] == "POST"
+    assert "body" in data
+    assert data["body"]["username"] == 123
+    assert data["body"]["password"] == "***REDACTED***"
+    assert data["body"]["token"] == "***REDACTED***"
+
+
+def test_validation_error_redacts_nested_sensitive_keys_in_debug():
+    app = FastAPI(debug=True)
+
+    @app.post("/nested")
+    def nested(body: NestedSecrets):
+        return body
+
+    client = TestClient(app)
+    # missing required `name` forces validation error while credentials present
+    response = client.post(
+        "/nested",
+        json={
+            "credentials": {
+                "api_key": "k",
+                "password": "p",
+                "secret": "s",
+                "token": "t",
+                "public": "ok",
+            }
+        },
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/nested"
+    assert data["method"] == "POST"
+    body = data["body"]
+    creds = body["credentials"]
+    assert creds["api_key"] == "***REDACTED***"
+    assert creds["password"] == "***REDACTED***"
+    assert creds["secret"] == "***REDACTED***"
+    assert creds["token"] == "***REDACTED***"
+    assert creds["public"] == "ok"
+
+
+def test_non_debug_never_includes_body_even_with_sensitive_payload():
+    app = FastAPI(debug=False)
+
+    @app.post("/login")
+    def login(body: LoginBody):
+        return body
+
+    client = TestClient(app)
+    response = client.post(
+        "/login",
+        json={"username": 1, "password": "x", "token": "y", "api_key": "z"},
+    )
+    assert response.status_code == 422
+    data = response.json()
+    assert data["path"] == "/login"
+    assert data["method"] == "POST"
+    assert "body" not in data


### PR DESCRIPTION
## Issue
Closes #757
/claim #757

## Summary
`request_validation_exception_handler` now returns request **path** and **method** on every 422 validation error. When the app is in **debug** mode it also echoes the received request **body** with sensitive fields redacted.

### Changes
- `fastapi/exception_handlers.py`
  - Always include `path` + `method` in validation error JSON
  - Debug-only `body` field via `exc.body`
  - `redact_sensitive_fields()` recursively redacts `password`, `secret`, `token`, `api_key` → `***REDACTED***`
- Tests: `tests/test_validation_error_body_redaction.py` (nested redaction, debug vs non-debug)
- `_meta.json` contributor metadata

## Test plan
- [x] `pytest tests/test_validation_error_body_redaction.py` — 5 passed
- [x] `pytest tests/test_exception_handlers.py` — still green

## Payment
USDC Base: `0xfd3600efdfcd6f02c515f93237e2caaff293769f`