### PR TITLE
[FhiPunkVn] [ T3 Code ] Fix ProviderModelPicker persistence across reloads

### DIFF
--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -3,7 +3,7 @@ import {
   type ProviderDriverKind,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
@@ -17,6 +17,13 @@ import {
   getTriggerDisplayModelLabel,
   getTriggerDisplayModelName,
 } from "./providerIconUtils";
+import {
+  PROVIDER_MODEL_PICKER_STORAGE_KEY,
+  clearPersistedProviderModelSelection,
+  readPersistedProviderModelSelection,
+  resolveProviderModelSelection,
+  writePersistedProviderModelSelection,
+} from "./providerModelPickerPersistence";
 import { setModelPickerOpen } from "../../modelPickerOpenState";
 import type { ProviderInstanceEntry } from "../../providerInstances";
 
@@ -86,9 +93,89 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     };
   }, [isMenuOpen]);
 
+  // Restore last selection from localStorage once instances/models are ready.
+  // Empty storage leaves parent-controlled props unchanged.
+  const didRestoreRef = useRef(false);
+  useEffect(() => {
+    if (didRestoreRef.current || props.disabled) return;
+    if (props.instanceEntries.length === 0) return;
+    const persisted = readPersistedProviderModelSelection();
+    if (!persisted) {
+      didRestoreRef.current = true;
+      return;
+    }
+    const resolved = resolveProviderModelSelection(
+      persisted,
+      props.instanceEntries,
+      props.modelOptionsByInstance,
+    );
+    didRestoreRef.current = true;
+    if (!resolved || !resolved.model) return;
+    if (
+      resolved.instanceId === props.activeInstanceId &&
+      resolved.model === props.model
+    ) {
+      return;
+    }
+    props.onInstanceModelChange(resolved.instanceId, resolved.model);
+  }, [
+    props.activeInstanceId,
+    props.disabled,
+    props.instanceEntries,
+    props.model,
+    props.modelOptionsByInstance,
+    props.onInstanceModelChange,
+  ]);
+
+  // Cross-tab sync: when another tab updates the namespaced key, apply it.
+  useEffect(() => {
+    if (props.disabled) return;
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== PROVIDER_MODEL_PICKER_STORAGE_KEY) return;
+      const persisted = readPersistedProviderModelSelection();
+      const resolved = resolveProviderModelSelection(
+        persisted,
+        props.instanceEntries,
+        props.modelOptionsByInstance,
+      );
+      if (!resolved || !resolved.model) return;
+      if (
+        resolved.instanceId === props.activeInstanceId &&
+        resolved.model === props.model
+      ) {
+        return;
+      }
+      props.onInstanceModelChange(resolved.instanceId, resolved.model);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [
+    props.activeInstanceId,
+    props.disabled,
+    props.instanceEntries,
+    props.model,
+    props.modelOptionsByInstance,
+    props.onInstanceModelChange,
+  ]);
+
   const handleInstanceModelChange = (instanceId: ProviderInstanceId, model: string) => {
     if (props.disabled) return;
+    writePersistedProviderModelSelection({ instanceId, model });
     props.onInstanceModelChange(instanceId, model);
+    setIsMenuOpen(false);
+  };
+
+  const handleResetToDefault = () => {
+    if (props.disabled) return;
+    clearPersistedProviderModelSelection();
+    const fallback = resolveProviderModelSelection(
+      null,
+      props.instanceEntries,
+      props.modelOptionsByInstance,
+    );
+    if (fallback && fallback.model) {
+      props.onInstanceModelChange(fallback.instanceId, fallback.model);
+    }
     setIsMenuOpen(false);
   };
 
@@ -169,18 +256,33 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
         align="start"
         className="border-0 bg-transparent p-0 shadow-none before:hidden [--viewport-inline-padding:0] *:data-[slot=popover-viewport]:p-0"
       >
-        <ModelPickerContent
-          activeInstanceId={activeInstanceId}
-          model={props.model}
-          lockedProvider={props.lockedProvider}
-          lockedContinuationGroupKey={props.lockedContinuationGroupKey ?? null}
-          instanceEntries={props.instanceEntries}
-          {...(props.keybindings ? { keybindings: props.keybindings } : {})}
-          modelOptionsByInstance={props.modelOptionsByInstance}
-          terminalOpen={props.terminalOpen ?? false}
-          onRequestClose={() => setIsMenuOpen(false)}
-          onInstanceModelChange={handleInstanceModelChange}
-        />
+        <div className="flex flex-col">
+          <ModelPickerContent
+            activeInstanceId={activeInstanceId}
+            model={props.model}
+            lockedProvider={props.lockedProvider}
+            lockedContinuationGroupKey={props.lockedContinuationGroupKey ?? null}
+            instanceEntries={props.instanceEntries}
+            {...(props.keybindings ? { keybindings: props.keybindings } : {})}
+            modelOptionsByInstance={props.modelOptionsByInstance}
+            terminalOpen={props.terminalOpen ?? false}
+            onRequestClose={() => setIsMenuOpen(false)}
+            onInstanceModelChange={handleInstanceModelChange}
+          />
+          <div className="border-border/60 bg-popover border-t px-2 py-1.5">
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-8 w-full justify-start px-2 text-xs text-muted-foreground hover:text-foreground"
+              data-provider-model-picker-reset="true"
+              disabled={props.disabled}
+              onClick={handleResetToDefault}
+            >
+              Reset to default
+            </Button>
+          </div>
+        </div>
       </PopoverPopup>
     </Popover>
   );

--- a/t3code/apps/web/src/components/chat/_generation.json
+++ b/t3code/apps/web/src/components/chat/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "FhiPunkVn",
+  "pre_task_context": "Grok continuous OSS bounty coding session. BOUNTY_VERIFIED only; Algora /bounty $40 on UnsafeLabs/Bounty-Hunters#834 ProviderModelPicker localStorage persistence. Payment USDC Base 0xfd3600efdfcd6f02c515f93237e2caaff293769f. Prior shipped #757 FastAPI validation handler PR #7568. MAX_ACTIVE_CODING=1 sole-lane. Task: persist provider+model selection across reloads with namespaced keys, invalid fallback, Reset to default, multi-tab storage events.",
+  "timestamp": "2026-07-11T10:18:00.000Z"
+}

--- a/t3code/apps/web/src/components/chat/providerModelPickerPersistence.test.ts
+++ b/t3code/apps/web/src/components/chat/providerModelPickerPersistence.test.ts
@@ -1,0 +1,105 @@
+import { ProviderInstanceId } from "@t3tools/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ProviderInstanceEntry } from "../../providerInstances";
+import type { ModelEsque } from "./providerIconUtils";
+import {
+  PROVIDER_MODEL_PICKER_STORAGE_KEY,
+  clearPersistedProviderModelSelection,
+  readPersistedProviderModelSelection,
+  resolveProviderModelSelection,
+  writePersistedProviderModelSelection,
+} from "./providerModelPickerPersistence";
+
+const codexId = ProviderInstanceId.make("codex");
+const claudeId = ProviderInstanceId.make("claudeAgent");
+
+const entries: ReadonlyArray<ProviderInstanceEntry> = [
+  {
+    instanceId: codexId,
+    driverKind: "codex" as ProviderInstanceEntry["driverKind"],
+    displayName: "Codex",
+  },
+  {
+    instanceId: claudeId,
+    driverKind: "claudeAgent" as ProviderInstanceEntry["driverKind"],
+    displayName: "Claude",
+  },
+];
+
+const models = new Map<ProviderInstanceId, ReadonlyArray<ModelEsque>>([
+  [codexId, [{ slug: "gpt-5-codex", name: "GPT-5 Codex" }]],
+  [
+    claudeId,
+    [
+      { slug: "claude-opus-4-6", name: "Claude Opus 4.6" },
+      { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    ],
+  ],
+]);
+
+afterEach(() => {
+  clearPersistedProviderModelSelection();
+});
+
+describe("providerModelPickerPersistence", () => {
+  it("uses a namespaced storage key", () => {
+    expect(PROVIDER_MODEL_PICKER_STORAGE_KEY.startsWith("t3code:")).toBe(true);
+  });
+
+  it("returns null when storage is empty", () => {
+    expect(readPersistedProviderModelSelection()).toBeNull();
+  });
+
+  it("round-trips provider and model", () => {
+    writePersistedProviderModelSelection({
+      instanceId: claudeId,
+      model: "claude-sonnet-4-6",
+    });
+    expect(readPersistedProviderModelSelection()).toEqual({
+      instanceId: claudeId,
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  it("clears persisted preference", () => {
+    writePersistedProviderModelSelection({
+      instanceId: codexId,
+      model: "gpt-5-codex",
+    });
+    clearPersistedProviderModelSelection();
+    expect(readPersistedProviderModelSelection()).toBeNull();
+  });
+
+  it("falls back to first available when preferred provider is gone", () => {
+    const resolved = resolveProviderModelSelection(
+      { instanceId: "missing-provider", model: "x" },
+      entries,
+      models,
+    );
+    expect(resolved).toEqual({ instanceId: codexId, model: "gpt-5-codex" });
+  });
+
+  it("falls back to first model when preferred model is gone but provider remains", () => {
+    const resolved = resolveProviderModelSelection(
+      { instanceId: claudeId, model: "deleted-model" },
+      entries,
+      models,
+    );
+    expect(resolved).toEqual({ instanceId: claudeId, model: "claude-opus-4-6" });
+  });
+
+  it("returns preferred pair when still available", () => {
+    const resolved = resolveProviderModelSelection(
+      { instanceId: claudeId, model: "claude-sonnet-4-6" },
+      entries,
+      models,
+    );
+    expect(resolved).toEqual({ instanceId: claudeId, model: "claude-sonnet-4-6" });
+  });
+
+  it("empty preferred resolves to first provider first model", () => {
+    const resolved = resolveProviderModelSelection(null, entries, models);
+    expect(resolved).toEqual({ instanceId: codexId, model: "gpt-5-codex" });
+  });
+});

--- a/t3code/apps/web/src/components/chat/providerModelPickerPersistence.ts
+++ b/t3code/apps/web/src/components/chat/providerModelPickerPersistence.ts
@@ -1,0 +1,106 @@
+import type { ProviderInstanceId } from "@t3tools/contracts";
+import type { ProviderInstanceEntry } from "../../providerInstances";
+import type { ModelEsque } from "./providerIconUtils";
+
+/** Namespaced localStorage key for last selected provider + model. */
+export const PROVIDER_MODEL_PICKER_STORAGE_KEY = "t3code:provider-model-picker:v1";
+
+export type PersistedProviderModelSelection = {
+  instanceId: string;
+  model: string;
+};
+
+export type ResolvedProviderModelSelection = {
+  instanceId: ProviderInstanceId;
+  model: string;
+};
+
+const memoryStore = new Map<string, string>();
+
+function getStorage(): Storage | { getItem: (k: string) => string | null; setItem: (k: string, v: string) => void; removeItem: (k: string) => void } {
+  if (typeof window !== "undefined" && typeof window.localStorage !== "undefined") {
+    return window.localStorage;
+  }
+  return {
+    getItem: (k) => memoryStore.get(k) ?? null,
+    setItem: (k, v) => {
+      memoryStore.set(k, v);
+    },
+    removeItem: (k) => {
+      memoryStore.delete(k);
+    },
+  };
+}
+
+export function readPersistedProviderModelSelection(): PersistedProviderModelSelection | null {
+  try {
+    const raw = getStorage().getItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedProviderModelSelection>;
+    if (
+      typeof parsed?.instanceId !== "string" ||
+      parsed.instanceId.length === 0 ||
+      typeof parsed?.model !== "string" ||
+      parsed.model.length === 0
+    ) {
+      return null;
+    }
+    return { instanceId: parsed.instanceId, model: parsed.model };
+  } catch {
+    return null;
+  }
+}
+
+export function writePersistedProviderModelSelection(
+  selection: PersistedProviderModelSelection,
+): void {
+  try {
+    getStorage().setItem(PROVIDER_MODEL_PICKER_STORAGE_KEY, JSON.stringify(selection));
+  } catch {
+    // Quota / private mode — ignore.
+  }
+}
+
+export function clearPersistedProviderModelSelection(): void {
+  try {
+    getStorage().removeItem(PROVIDER_MODEL_PICKER_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Resolve a preferred selection against currently available instances/models.
+ * Falls back to the first available instance + its first model when the
+ * preferred pair is missing or incomplete.
+ */
+export function resolveProviderModelSelection(
+  preferred: PersistedProviderModelSelection | null | undefined,
+  instanceEntries: ReadonlyArray<ProviderInstanceEntry>,
+  modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>,
+): ResolvedProviderModelSelection | null {
+  if (instanceEntries.length === 0) return null;
+
+  if (preferred) {
+    const preferredEntry = instanceEntries.find(
+      (entry) => entry.instanceId === preferred.instanceId,
+    );
+    if (preferredEntry) {
+      const options = modelOptionsByInstance.get(preferredEntry.instanceId) ?? [];
+      const modelMatch = options.find((option) => option.slug === preferred.model);
+      if (modelMatch) {
+        return { instanceId: preferredEntry.instanceId, model: modelMatch.slug };
+      }
+      if (options[0]) {
+        return { instanceId: preferredEntry.instanceId, model: options[0].slug };
+      }
+    }
+  }
+
+  const firstEntry = instanceEntries[0]!;
+  const firstOptions = modelOptionsByInstance.get(firstEntry.instanceId) ?? [];
+  if (!firstOptions[0]) {
+    return { instanceId: firstEntry.instanceId, model: "" };
+  }
+  return { instanceId: firstEntry.instanceId, model: firstOptions[0].slug };
+}


### PR DESCRIPTION
## Issue
Closes #834
/claim #834

## Summary
`ProviderModelPicker` now remembers the last selected provider instance + model across reloads via a namespaced localStorage key (`t3code:provider-model-picker:v1`).

### Behavior
- On selection: write `{ instanceId, model }` to localStorage
- On mount: restore when valid; if provider missing → first available; if model missing → first model of that provider
- Empty storage: existing parent-controlled behavior unchanged
- **Reset to default** footer action clears storage and applies first provider/model
- Cross-tab sync via `storage` events

### Files
- `providerModelPickerPersistence.ts` + unit tests (8)
- `ProviderModelPicker.tsx` restore/persist/reset
- `_generation.json`

## Test plan
- [x] `vitest run src/components/chat/providerModelPickerPersistence.test.ts` — 8 passed

## Payment
USDC Base: `0xfd3600efdfcd6f02c515f93237e2caaff293769f`