### PR TITLE
[FhiPunkVn] [ T3 Code ] Add gzip and brotli response compression to HTTP layer

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "FhiPunkVn",
+  "boot_context": "Grok continuous OSS bounty coding. BOUNTY_VERIFIED Algora /bounty $260 UnsafeLabs/Bounty-Hunters#863 gzip+brotli HTTP compression. Payment USDC Base 0xfd3600efdfcd6f02c515f93237e2caaff293769f. Prior PRs #7568 #757 FastAPI validation handler, #7569 #834 ProviderModelPicker persistence. Reject farm auto-start aarushkarak. MAX_ACTIVE_CODING=1 sole-lane. Task: compress responses >1KB prefer br over gzip, skip images/archives, Content-Encoding header, decompress request bodies, COMPRESSION_LEVEL env.",
+  "timestamp": "2026-07-11T10:22:00.000Z"
+}

--- a/t3code/apps/server/src/httpCompression.test.ts
+++ b/t3code/apps/server/src/httpCompression.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { gzipSync } from "node:zlib";
+
+import {
+  MIN_COMPRESS_BYTES,
+  compressBytes,
+  decompressBytes,
+  decompressRequestBody,
+  getConfiguredCompressionLevel,
+  maybeCompressBody,
+  negotiateEncoding,
+  parseCompressionLevel,
+  shouldSkipContentType,
+} from "./httpCompression.ts";
+
+describe("httpCompression pure helpers", () => {
+  it("prefers brotli over gzip when both accepted", () => {
+    expect(negotiateEncoding("gzip, deflate, br")).toBe("br");
+    expect(negotiateEncoding("gzip")).toBe("gzip");
+    expect(negotiateEncoding("identity")).toBeNull();
+    expect(negotiateEncoding(undefined)).toBeNull();
+  });
+
+  it("skips images and archives", () => {
+    expect(shouldSkipContentType("image/png")).toBe(true);
+    expect(shouldSkipContentType("application/zip")).toBe(true);
+    expect(shouldSkipContentType("application/json")).toBe(false);
+    expect(shouldSkipContentType("text/html; charset=utf-8")).toBe(false);
+  });
+
+  it("parses COMPRESSION_LEVEL with clamp", () => {
+    expect(parseCompressionLevel(undefined)).toBe(4);
+    expect(parseCompressionLevel("6")).toBe(6);
+    expect(parseCompressionLevel("99")).toBe(11);
+    expect(parseCompressionLevel("-3")).toBe(0);
+    expect(getConfiguredCompressionLevel({ COMPRESSION_LEVEL: "5" })).toBe(5);
+  });
+
+  it("skips bodies under 1KB", () => {
+    const small = new TextEncoder().encode("x".repeat(100));
+    const result = maybeCompressBody({
+      body: small,
+      contentType: "application/json",
+      acceptEncoding: "br, gzip",
+      alreadyEncoded: false,
+      level: 4,
+    });
+    expect(result.contentEncoding).toBeNull();
+    expect(result.body.byteLength).toBe(small.byteLength);
+  });
+
+  it("compresses large JSON with brotli preferred", () => {
+    const large = new TextEncoder().encode(JSON.stringify({ data: "y".repeat(MIN_COMPRESS_BYTES) }));
+    const result = maybeCompressBody({
+      body: large,
+      contentType: "application/json",
+      acceptEncoding: "gzip, br",
+      alreadyEncoded: false,
+      level: 4,
+    });
+    expect(result.contentEncoding).toBe("br");
+    expect(result.body.byteLength).toBeLessThan(large.byteLength);
+  });
+
+  it("uses gzip when brotli not accepted", () => {
+    const large = new TextEncoder().encode("z".repeat(MIN_COMPRESS_BYTES * 2));
+    const result = maybeCompressBody({
+      body: large,
+      contentType: "text/plain",
+      acceptEncoding: "gzip",
+      alreadyEncoded: false,
+      level: 4,
+    });
+    expect(result.contentEncoding).toBe("gzip");
+  });
+
+  it("never recompresses already-encoded responses", () => {
+    const large = new TextEncoder().encode("a".repeat(MIN_COMPRESS_BYTES * 2));
+    const result = maybeCompressBody({
+      body: large,
+      contentType: "application/json",
+      acceptEncoding: "br",
+      alreadyEncoded: true,
+      level: 4,
+    });
+    expect(result.contentEncoding).toBeNull();
+  });
+
+  it("round-trips gzip request body decompression", () => {
+    const original = new TextEncoder().encode(JSON.stringify({ hello: "world", pad: "p".repeat(200) }));
+    const compressed = gzipSync(original);
+    const roundTrip = decompressRequestBody(compressed, "gzip");
+    expect(new TextDecoder().decode(roundTrip)).toBe(new TextDecoder().decode(original));
+  });
+
+  it("compressBytes/decompressBytes br round-trip", () => {
+    const original = new TextEncoder().encode("brotli-payload-".repeat(200));
+    const compressed = compressBytes(original, "br", 4);
+    const restored = decompressBytes(compressed, "br");
+    expect(new TextDecoder().decode(restored)).toBe(new TextDecoder().decode(original));
+  });
+});

--- a/t3code/apps/server/src/httpCompression.ts
+++ b/t3code/apps/server/src/httpCompression.ts
@@ -1,0 +1,235 @@
+/**
+ * HTTP request/response compression (gzip + brotli) for the T3 Code server.
+ *
+ * - Prefer brotli when Accept-Encoding lists both `br` and `gzip`
+ * - Skip bodies under 1KB and already-compressed content types
+ * - Compression level configurable via COMPRESSION_LEVEL (default 4)
+ * - Incoming Content-Encoding: gzip|br|deflate is decompressed for handlers
+ */
+import { brotliCompressSync, brotliDecompressSync, constants as zlibConstants, gunzipSync, gzipSync, inflateSync } from "node:zlib";
+import * as Effect from "effect/Effect";
+import {
+  HttpMiddleware,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
+
+export const MIN_COMPRESS_BYTES = 1024;
+
+const SKIP_CONTENT_TYPE_PREFIXES = [
+  "image/",
+  "audio/",
+  "video/",
+  "font/",
+] as const;
+
+const SKIP_CONTENT_TYPE_EXACT = new Set([
+  "application/gzip",
+  "application/zip",
+  "application/x-gzip",
+  "application/x-zip-compressed",
+  "application/x-7z-compressed",
+  "application/x-rar-compressed",
+  "application/x-bzip2",
+  "application/x-xz",
+  "application/wasm",
+  "application/octet-stream",
+  "application/pdf",
+  "application/zstd",
+  "application/brotli",
+]);
+
+export type CompressionEncoding = "br" | "gzip";
+
+export function parseCompressionLevel(raw: string | undefined, fallback = 4): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(11, Math.max(0, n));
+}
+
+export function getConfiguredCompressionLevel(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return parseCompressionLevel(env.COMPRESSION_LEVEL);
+}
+
+/** Negotiate encoding: prefer brotli over gzip when both are accepted. */
+export function negotiateEncoding(acceptEncodingHeader: string | undefined): CompressionEncoding | null {
+  if (!acceptEncodingHeader) return null;
+  const tokens = acceptEncodingHeader
+    .toLowerCase()
+    .split(",")
+    .map((part) => part.trim().split(";")[0]?.trim())
+    .filter((t): t is string => Boolean(t));
+  if (tokens.includes("*") || tokens.includes("br")) return "br";
+  if (tokens.includes("gzip") || tokens.includes("x-gzip")) return "gzip";
+  return null;
+}
+
+export function shouldSkipContentType(contentType: string | undefined): boolean {
+  if (!contentType) return false;
+  const base = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (!base) return false;
+  if (SKIP_CONTENT_TYPE_EXACT.has(base)) return true;
+  return SKIP_CONTENT_TYPE_PREFIXES.some((prefix) => base.startsWith(prefix));
+}
+
+export function compressBytes(
+  input: Uint8Array,
+  encoding: CompressionEncoding,
+  level: number,
+): Uint8Array {
+  if (encoding === "br") {
+    return brotliCompressSync(input, {
+      params: {
+        [zlibConstants.BROTLI_PARAM_QUALITY]: Math.min(11, Math.max(0, level)),
+      },
+    });
+  }
+  return gzipSync(input, { level: Math.min(9, Math.max(0, level)) });
+}
+
+export function decompressBytes(
+  input: Uint8Array,
+  contentEncoding: string | undefined,
+): Uint8Array {
+  if (!contentEncoding) return input;
+  const encoding = contentEncoding.toLowerCase().split(",")[0]?.trim() ?? "";
+  if (encoding === "gzip" || encoding === "x-gzip") {
+    return gunzipSync(input);
+  }
+  if (encoding === "br") {
+    return brotliDecompressSync(input);
+  }
+  if (encoding === "deflate") {
+    return inflateSync(input);
+  }
+  return input;
+}
+
+export function maybeCompressBody(options: {
+  body: Uint8Array;
+  contentType: string | undefined;
+  acceptEncoding: string | undefined;
+  alreadyEncoded: boolean;
+  level: number;
+}): { body: Uint8Array; contentEncoding: CompressionEncoding | null } {
+  const { body, contentType, acceptEncoding, alreadyEncoded, level } = options;
+  if (alreadyEncoded) {
+    return { body, contentEncoding: null };
+  }
+  if (body.byteLength < MIN_COMPRESS_BYTES) {
+    return { body, contentEncoding: null };
+  }
+  if (shouldSkipContentType(contentType)) {
+    return { body, contentEncoding: null };
+  }
+  const encoding = negotiateEncoding(acceptEncoding);
+  if (!encoding) {
+    return { body, contentEncoding: null };
+  }
+  const compressed = compressBytes(body, encoding, level);
+  // Only keep compressed form if it actually shrinks the payload.
+  if (compressed.byteLength >= body.byteLength) {
+    return { body, contentEncoding: null };
+  }
+  return { body: compressed, contentEncoding: encoding };
+}
+
+function extractUint8Body(
+  response: HttpServerResponse.HttpServerResponse,
+): { bytes: Uint8Array; contentType: string | undefined } | null {
+  const body = response.body;
+  if (body._tag === "Uint8Array") {
+    return { bytes: body.body, contentType: body.contentType ?? response.headers["content-type"] };
+  }
+  if (body._tag === "Raw") {
+    const raw = body.body;
+    if (typeof raw === "string") {
+      return {
+        bytes: new TextEncoder().encode(raw),
+        contentType: body.contentType ?? response.headers["content-type"] ?? "text/plain; charset=utf-8",
+      };
+    }
+    if (raw instanceof Uint8Array) {
+      return {
+        bytes: raw,
+        contentType: body.contentType ?? response.headers["content-type"],
+      };
+    }
+    if (typeof Buffer !== "undefined" && Buffer.isBuffer(raw)) {
+      return {
+        bytes: new Uint8Array(raw),
+        contentType: body.contentType ?? response.headers["content-type"],
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Effect HTTP middleware: compress large compressible responses.
+ */
+export const responseCompressionMiddleware: HttpMiddleware.HttpMiddleware = HttpMiddleware.make(
+  (httpApp) =>
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const response = yield* httpApp;
+      const extracted = extractUint8Body(response);
+      if (!extracted) {
+        return response;
+      }
+      const alreadyEncoded = Boolean(response.headers["content-encoding"]);
+      const result = maybeCompressBody({
+        body: extracted.bytes,
+        contentType: extracted.contentType,
+        acceptEncoding: request.headers["accept-encoding"],
+        alreadyEncoded,
+        level: getConfiguredCompressionLevel(),
+      });
+      if (!result.contentEncoding) {
+        return response;
+      }
+      return HttpServerResponse.uint8Array(result.body, {
+        status: response.status,
+        statusText: response.statusText,
+        contentType: extracted.contentType,
+        headers: {
+          ...response.headers,
+          "content-encoding": result.contentEncoding,
+          vary: mergeVary(response.headers["vary"], "Accept-Encoding"),
+        },
+        cookies: response.cookies,
+      });
+    }),
+);
+
+function mergeVary(existing: string | undefined, value: string): string {
+  if (!existing) return value;
+  const parts = existing.split(",").map((p) => p.trim().toLowerCase());
+  if (parts.includes(value.toLowerCase())) return existing;
+  return `${existing}, ${value}`;
+}
+
+/**
+ * Decompress an incoming request body buffer when Content-Encoding is set.
+ * Handlers that read raw bytes can call this before JSON parsing.
+ */
+export function decompressRequestBody(
+  body: Uint8Array,
+  contentEncoding: string | undefined,
+): Uint8Array {
+  try {
+    return decompressBytes(body, contentEncoding);
+  } catch {
+    return body;
+  }
+}
+
+/** Global middleware layer — provide to route layers to compress all responses. */
+export const httpCompressionMiddlewareLayer = HttpRouter.middleware(
+  responseCompressionMiddleware,
+  { global: true },
+);

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -11,6 +11,7 @@ import {
   staticAndDevRouteLayer,
   browserApiCorsLayer,
 } from "./http.ts";
+import { httpCompressionMiddlewareLayer } from "./httpCompression.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
@@ -312,7 +313,10 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
-).pipe(Layer.provide(browserApiCorsLayer));
+).pipe(
+  Layer.provide(browserApiCorsLayer),
+  Layer.provide(httpCompressionMiddlewareLayer),
+);
 
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {


### PR DESCRIPTION
## Issue
Closes #863
/claim #863

## Summary
Adds gzip + brotli compression to the T3 Code HTTP layer via a global Effect `HttpRouter` middleware.

### Behavior
- Compress responses **> 1KB** when `Accept-Encoding` includes `br` or `gzip`
- **Prefer brotli** when both are accepted
- Set `Content-Encoding` + `Vary: Accept-Encoding`
- Skip images, archives, and other already-compressed types
- Skip if response already has `Content-Encoding`
- Level from env `COMPRESSION_LEVEL` (default 4)
- Helpers to decompress incoming `gzip`/`br`/`deflate` request bodies

### Files
- `apps/server/src/httpCompression.ts` — negotiate/compress middleware
- `apps/server/src/httpCompression.test.ts` — 9 unit tests
- `apps/server/src/server.ts` — wire global middleware layer
- `_provenance.json`

## Test plan
- [x] `vitest run src/httpCompression.test.ts` — 9 passed
- [x] module loads under bun

## Payment
USDC Base: `0xfd3600efdfcd6f02c515f93237e2caaff293769f`