### PR TITLE
Codex GPT-5 [ T3 Code ] Add SQLite WAL pooling

### DIFF
--- a/t3code/apps/server/src/persistence/.attribution.json
+++ b/t3code/apps/server/src/persistence/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Codex GPT-5",
+  "platform_config": "Public-safe attribution only. Private system, developer, runtime, user, credential, memory, and session instructions are intentionally omitted and are not published.",
+  "date": "2026-07-12T20:34:29.0597072Z"
+}

--- a/t3code/apps/server/src/persistence/BunSqliteClient.ts
+++ b/t3code/apps/server/src/persistence/BunSqliteClient.ts
@@ -1,0 +1,239 @@
+import { Database } from "bun:sqlite";
+
+import * as Config from "effect/Config";
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import { identity } from "effect/Function";
+import * as Layer from "effect/Layer";
+import * as Pool from "effect/Pool";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+import * as Reactivity from "effect/unstable/reactivity/Reactivity";
+import * as Client from "effect/unstable/sql/SqlClient";
+import type { Connection } from "effect/unstable/sql/SqlConnection";
+import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError";
+import * as Statement from "effect/unstable/sql/Statement";
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name";
+const ACQUIRE_TIMEOUT = Duration.seconds(10);
+const POOL_MIN_SIZE = 1;
+const POOL_MAX_SIZE = 5;
+const POOL_TTL = Duration.minutes(10);
+
+const classifyError = (cause: unknown, message: string, operation: string) =>
+  classifySqliteError(cause, { message, operation });
+
+const acquireTimeoutError = (cause: unknown) =>
+  new SqlError({
+    reason: classifyError(cause, "Timed out acquiring sqlite connection", "acquire"),
+  });
+
+export const TypeId: TypeId = "~local/sqlite-bun/SqliteClient";
+
+export type TypeId = "~local/sqlite-bun/SqliteClient";
+
+export interface SqliteClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId;
+  readonly config: SqliteClientConfig;
+  readonly export: Effect.Effect<Uint8Array, SqlError>;
+  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>;
+
+  readonly updateValues: never;
+}
+
+export const SqliteClient = Context.Service<SqliteClient>("t3/persistence/BunSqliteClient");
+
+export interface SqliteClientConfig {
+  readonly filename: string;
+  readonly readonly?: boolean | undefined;
+  readonly create?: boolean | undefined;
+  readonly readwrite?: boolean | undefined;
+  readonly disableWAL?: boolean | undefined;
+
+  readonly spanAttributes?: Record<string, unknown> | undefined;
+
+  readonly transformResultNames?: ((str: string) => string) | undefined;
+  readonly transformQueryNames?: ((str: string) => string) | undefined;
+}
+
+interface SqliteConnection extends Connection {
+  readonly export: Effect.Effect<Uint8Array, SqlError>;
+  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>;
+}
+
+const isMemoryDatabase = (filename: string) => filename === ":memory:";
+
+const configureDatabase = (db: Database, options: SqliteClientConfig) =>
+  Effect.try({
+    try: () => {
+      if (
+        options.disableWAL !== true &&
+        options.readonly !== true &&
+        !isMemoryDatabase(options.filename)
+      ) {
+        db.run("PRAGMA journal_mode = WAL;");
+      }
+      db.run("PRAGMA busy_timeout = 5000;");
+      db.run("PRAGMA synchronous = NORMAL;");
+      db.run("PRAGMA foreign_keys = ON;");
+    },
+    catch: (cause) =>
+      new SqlError({
+        reason: classifyError(cause, "Failed to configure sqlite connection", "configure"),
+      }),
+  });
+
+const resetConnection = (connection: Connection) =>
+  Effect.all(
+    [
+      connection.executeUnprepared("PRAGMA busy_timeout = 5000", [], undefined),
+      connection.executeUnprepared("PRAGMA synchronous = NORMAL", [], undefined),
+      connection.executeUnprepared("PRAGMA foreign_keys = ON", [], undefined),
+    ],
+    { discard: true },
+  );
+
+export const make = (
+  options: SqliteClientConfig,
+): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function* () {
+    const compiler = Statement.makeCompilerSqlite(options.transformQueryNames);
+    const transformRows = options.transformResultNames
+      ? Statement.defaultTransforms(options.transformResultNames).array
+      : undefined;
+
+    const makeConnection = Effect.gen(function* () {
+      const db = new Database(options.filename, {
+        readonly: options.readonly,
+        readwrite: options.readwrite ?? true,
+        create: options.create ?? true,
+      } as any);
+      yield* Effect.addFinalizer(() => Effect.sync(() => db.close()));
+      yield* configureDatabase(db, options);
+
+      const run = (sql: string, params: ReadonlyArray<unknown> = []) =>
+        Effect.withFiber<Array<any>, SqlError>((fiber) => {
+          const statement = db.query(sql);
+          const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers);
+          // @ts-ignore bun-types may lag the safeIntegers API.
+          statement.safeIntegers(useSafeIntegers);
+          try {
+            return Effect.succeed((statement.all(...(params as any)) ?? []) as Array<any>);
+          } catch (cause) {
+            return Effect.fail(
+              new SqlError({
+                reason: classifyError(cause, "Failed to execute statement", "execute"),
+              }),
+            );
+          }
+        });
+
+      const runValues = (sql: string, params: ReadonlyArray<unknown> = []) =>
+        Effect.withFiber<Array<any>, SqlError>((fiber) => {
+          const statement = db.query(sql);
+          const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers);
+          // @ts-ignore bun-types may lag the safeIntegers API.
+          statement.safeIntegers(useSafeIntegers);
+          try {
+            return Effect.succeed((statement.values(...(params as any)) ?? []) as Array<any>);
+          } catch (cause) {
+            return Effect.fail(
+              new SqlError({
+                reason: classifyError(cause, "Failed to execute statement", "execute"),
+              }),
+            );
+          }
+        });
+
+      return identity<SqliteConnection>({
+        execute(sql, params, transformRows) {
+          return transformRows ? Effect.map(run(sql, params), transformRows) : run(sql, params);
+        },
+        executeRaw(sql, params) {
+          return run(sql, params);
+        },
+        executeValues(sql, params) {
+          return runValues(sql, params);
+        },
+        executeUnprepared(sql, params, transformRows) {
+          return this.execute(sql, params, transformRows);
+        },
+        executeStream(_sql, _params) {
+          return Stream.die("executeStream not implemented");
+        },
+        export: Effect.try({
+          try: () => db.serialize(),
+          catch: (cause) =>
+            new SqlError({ reason: classifyError(cause, "Failed to export database", "export") }),
+        }),
+        loadExtension: (path) =>
+          Effect.try({
+            try: () => db.loadExtension(path),
+            catch: (cause) =>
+              new SqlError({
+                reason: classifyError(cause, "Failed to load extension", "loadExtension"),
+              }),
+          }),
+      });
+    });
+
+    const pool = yield* isMemoryDatabase(options.filename)
+      ? Pool.make({
+          acquire: makeConnection,
+          size: 1,
+        })
+      : Pool.makeWithTTL({
+          acquire: makeConnection,
+          min: POOL_MIN_SIZE,
+          max: POOL_MAX_SIZE,
+          timeToLive: POOL_TTL,
+        });
+    const makePooledAcquirer = <A extends Connection>(pool: Pool.Pool<A, SqlError>) =>
+      Effect.acquireRelease(
+        Effect.mapError(Effect.timeout(Pool.get(pool), ACQUIRE_TIMEOUT), acquireTimeoutError),
+        (connection) => Effect.orDie(resetConnection(connection)),
+      );
+    const acquirer = makePooledAcquirer(pool);
+
+    return Object.assign(
+      (yield* Client.make({
+        acquirer,
+        compiler,
+        transactionAcquirer: acquirer,
+        spanAttributes: [
+          ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+          [ATTR_DB_SYSTEM_NAME, "sqlite"],
+        ],
+        transformRows,
+      })) as SqliteClient,
+      {
+        [TypeId]: TypeId as TypeId,
+        config: options,
+        export: Effect.scoped(Effect.flatMap(acquirer, (_) => _.export)),
+        loadExtension: (path: string) =>
+          Effect.scoped(Effect.flatMap(acquirer, (_) => _.loadExtension(path))),
+      },
+    );
+  });
+
+export const layerConfig = (
+  config: Config.Wrap<SqliteClientConfig>,
+): Layer.Layer<SqliteClient | Client.SqlClient, Config.ConfigError> =>
+  Layer.effectContext(
+    Config.unwrap(config)
+      .asEffect()
+      .pipe(
+        Effect.flatMap(make),
+        Effect.map((client) =>
+          Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
+        ),
+      ),
+  ).pipe(Layer.provide(Reactivity.layer));
+
+export const layer = (config: SqliteClientConfig): Layer.Layer<SqliteClient | Client.SqlClient> =>
+  Layer.effectContext(
+    Effect.map(make(config), (client) =>
+      Context.make(SqliteClient, client).pipe(Context.add(Client.SqlClient, client)),
+    ),
+  ).pipe(Layer.provide(Reactivity.layer));

--- a/t3code/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/t3code/apps/server/src/persistence/Layers/Sqlite.ts
@@ -16,7 +16,7 @@ type Loader = {
   layer: (config: RuntimeSqliteLayerConfig) => Layer.Layer<SqlClient.SqlClient>;
 };
 const defaultSqliteClientLoaders = {
-  bun: () => import("@effect/sql-sqlite-bun/SqliteClient"),
+  bun: () => import("../BunSqliteClient.ts"),
   node: () => import("../NodeSqliteClient.ts"),
 } satisfies Record<string, () => Promise<Loader>>;
 
@@ -29,14 +29,40 @@ const makeRuntimeSqliteLayer = Effect.fn("makeRuntimeSqliteLayer")(function* (
   return clientModule.layer(config);
 }, Layer.unwrap);
 
-const setup = Layer.effectDiscard(
-  Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient;
-    yield* sql`PRAGMA journal_mode = WAL;`;
-    yield* sql`PRAGMA foreign_keys = ON;`;
-    yield* runMigrations();
-  }),
-);
+export const sqliteHealthCheck = Effect.fn("sqliteHealthCheck")(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const rows = yield* sql<Record<string, unknown>>`PRAGMA integrity_check;`;
+  const details = rows.map((row) => String(Object.values(row)[0] ?? ""));
+
+  return {
+    ok: details.length === 1 && details[0]?.toLowerCase() === "ok",
+    details,
+  };
+});
+
+const setup = (verifyWal: boolean) =>
+  Layer.effectDiscard(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const journalMode = yield* sql<Record<string, unknown>>`PRAGMA journal_mode = WAL;`;
+      yield* sql`PRAGMA busy_timeout = 5000;`;
+      yield* sql`PRAGMA synchronous = NORMAL;`;
+      yield* sql`PRAGMA foreign_keys = ON;`;
+
+      const mode = String(Object.values(journalMode[0] ?? {})[0] ?? "").toLowerCase();
+      if (verifyWal && mode !== "wal") {
+        return yield* Effect.die(
+          new Error(`SQLite WAL mode verification failed: ${mode || "unknown"}`),
+        );
+      }
+
+      yield* runMigrations();
+    }),
+  );
+
+const isMemoryDatabase = (filename: string) => filename === ":memory:";
+
+const makeSetupLayer = (filename: string) => setup(!isMemoryDatabase(filename));
 
 export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(function* (
   dbPath: string,
@@ -46,7 +72,7 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
   yield* fs.makeDirectory(path.dirname(dbPath), { recursive: true });
 
   return Layer.provideMerge(
-    setup,
+    makeSetupLayer(dbPath),
     makeRuntimeSqliteLayer({
       filename: dbPath,
       spanAttributes: {
@@ -58,7 +84,7 @@ export const makeSqlitePersistenceLive = Effect.fn("makeSqlitePersistenceLive")(
 }, Layer.unwrap);
 
 export const SqlitePersistenceMemory = Layer.provideMerge(
-  setup,
+  makeSetupLayer(":memory:"),
   makeRuntimeSqliteLayer({ filename: ":memory:" }),
 );
 

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -1,7 +1,14 @@
 import { assert, it } from "@effect/vitest";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import type { PlatformError } from "effect/PlatformError";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
+import { sqliteHealthCheck } from "./Layers/Sqlite.ts";
 import * as SqliteClient from "./NodeSqliteClient.ts";
 
 const layer = it.layer(SqliteClient.layerMemory());
@@ -27,4 +34,83 @@ layer("NodeSqliteClient", (it) => {
       assert.equal(values[1]?.[1], "beta");
     }),
   );
+
+  it.effect("keeps a single in-memory database across pooled acquisitions", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`CREATE TABLE memory_entries(id INTEGER PRIMARY KEY, name TEXT NOT NULL)`;
+      yield* sql`INSERT INTO memory_entries(name) VALUES (${"alpha"})`;
+
+      const rows = yield* sql<{ readonly name: string }>`
+        SELECT name FROM memory_entries
+      `;
+
+      assert.deepEqual(rows, [{ name: "alpha" }]);
+    }),
+  );
 });
+
+const withTempSqlite = <A, E>(
+  effect: (dbPath: string) => Effect.Effect<A, E, SqlClient.SqlClient>,
+): Effect.Effect<A, E | PlatformError> => {
+  const nodePlatform = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-sqlite-" });
+      const dbPath = path.join(dir, "state.sqlite");
+
+      return yield* effect(dbPath).pipe(Effect.provide(SqliteClient.layer({ filename: dbPath })));
+    }),
+  ).pipe(Effect.provide(nodePlatform));
+};
+
+it.effect("NodeSqliteClient file databases enable WAL and contention PRAGMAs", () =>
+  withTempSqlite(() =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`CREATE TABLE entries(id INTEGER PRIMARY KEY, name TEXT NOT NULL)`;
+      yield* sql`INSERT INTO entries(name) VALUES (${"alpha"})`;
+
+      const journalMode = yield* sql<Record<string, unknown>>`PRAGMA journal_mode`;
+      const busyTimeout = yield* sql<Record<string, unknown>>`PRAGMA busy_timeout`;
+      const synchronous = yield* sql<Record<string, unknown>>`PRAGMA synchronous`;
+
+      assert.equal(String(Object.values(journalMode[0] ?? {})[0]).toLowerCase(), "wal");
+      assert.equal(Number(Object.values(busyTimeout[0] ?? {})[0]), 5000);
+      assert.equal(Number(Object.values(synchronous[0] ?? {})[0]), 1);
+    }),
+  ),
+);
+
+it.effect("NodeSqliteClient handles concurrent writes through pooled file connections", () =>
+  withTempSqlite(() =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`CREATE TABLE writes(id INTEGER PRIMARY KEY, value INTEGER NOT NULL)`;
+      yield* Effect.all(
+        Array.from({ length: 20 }, (_, index) => sql`INSERT INTO writes(value) VALUES (${index})`),
+        { concurrency: 5, discard: true },
+      );
+
+      const rows = yield* sql<Record<string, unknown>>`SELECT COUNT(*) AS count FROM writes`;
+      assert.equal(Number(Object.values(rows[0] ?? {})[0]), 20);
+    }),
+  ),
+);
+
+it.effect("sqliteHealthCheck reports PRAGMA integrity_check details", () =>
+  withTempSqlite(() =>
+    Effect.gen(function* () {
+      const result = yield* sqliteHealthCheck();
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.details, ["ok"]);
+    }),
+  ),
+);

--- a/t3code/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/t3code/apps/server/src/persistence/NodeSqliteClient.ts
@@ -10,11 +10,10 @@ import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
-import * as Fiber from "effect/Fiber";
 import { identity } from "effect/Function";
 import * as Layer from "effect/Layer";
+import * as Pool from "effect/Pool";
 import * as Scope from "effect/Scope";
-import * as Semaphore from "effect/Semaphore";
 import * as Context from "effect/Context";
 import * as Stream from "effect/Stream";
 import * as Reactivity from "effect/unstable/reactivity/Reactivity";
@@ -24,6 +23,18 @@ import { SqlError, classifySqliteError } from "effect/unstable/sql/SqlError";
 import * as Statement from "effect/unstable/sql/Statement";
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name";
+const ACQUIRE_TIMEOUT = Duration.seconds(10);
+const POOL_MIN_SIZE = 1;
+const POOL_MAX_SIZE = 5;
+const POOL_TTL = Duration.minutes(10);
+
+const classifyError = (cause: unknown, message: string, operation: string) =>
+  classifySqliteError(cause, { message, operation });
+
+const acquireTimeoutError = (cause: unknown) =>
+  new SqlError({
+    reason: classifyError(cause, "Timed out acquiring sqlite connection", "acquire"),
+  });
 
 export const TypeId: TypeId = "~local/sqlite-node/SqliteClient";
 
@@ -38,6 +49,7 @@ export interface SqliteClientConfig {
   readonly filename: string;
   readonly readonly?: boolean | undefined;
   readonly allowExtension?: boolean | undefined;
+  readonly disableWAL?: boolean | undefined;
   readonly prepareCacheSize?: number | undefined;
   readonly prepareCacheTTL?: Duration.Input | undefined;
   readonly spanAttributes?: Record<string, unknown> | undefined;
@@ -72,6 +84,38 @@ const checkNodeSqliteCompat = () => {
   return Effect.void;
 };
 
+const isMemoryDatabase = (filename: string) => filename === ":memory:";
+
+const configureDatabase = (db: DatabaseSync, options: SqliteClientConfig) =>
+  Effect.try({
+    try: () => {
+      if (
+        options.disableWAL !== true &&
+        options.readonly !== true &&
+        !isMemoryDatabase(options.filename)
+      ) {
+        db.prepare("PRAGMA journal_mode = WAL").all();
+      }
+      db.prepare("PRAGMA busy_timeout = 5000").all();
+      db.prepare("PRAGMA synchronous = NORMAL").all();
+      db.prepare("PRAGMA foreign_keys = ON").all();
+    },
+    catch: (cause) =>
+      new SqlError({
+        reason: classifyError(cause, "Failed to configure sqlite connection", "configure"),
+      }),
+  });
+
+const resetConnection = (connection: Connection) =>
+  Effect.all(
+    [
+      connection.executeUnprepared("PRAGMA busy_timeout = 5000", [], undefined),
+      connection.executeUnprepared("PRAGMA synchronous = NORMAL", [], undefined),
+      connection.executeUnprepared("PRAGMA foreign_keys = ON", [], undefined),
+    ],
+    { discard: true },
+  );
+
 const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
   options: SqliteClientConfig,
   openDatabase: () => DatabaseSync,
@@ -90,6 +134,7 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
       scope,
       Effect.sync(() => db.close()),
     );
+    yield* configureDatabase(db, options);
 
     const statementReaderCache = new WeakMap<StatementSync, boolean>();
     const hasRows = (statement: StatementSync): boolean => {
@@ -194,23 +239,29 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
     });
   });
 
-  const semaphore = yield* Semaphore.make(1);
-  const connection = yield* makeConnection;
-
-  const acquirer = semaphore.withPermits(1)(Effect.succeed(connection));
-  const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
-    const fiber = Fiber.getCurrent()!;
-    const scope = Context.getUnsafe(fiber.context, Scope.Scope);
-    return Effect.as(
-      Effect.tap(restore(semaphore.take(1)), () => Scope.addFinalizer(scope, semaphore.release(1))),
-      connection,
+  const makePooledAcquirer = <A extends Connection>(pool: Pool.Pool<A, SqlError>) =>
+    Effect.acquireRelease(
+      Effect.mapError(Effect.timeout(Pool.get(pool), ACQUIRE_TIMEOUT), acquireTimeoutError),
+      (connection) => Effect.orDie(resetConnection(connection)),
     );
-  });
+
+  const pool = yield* isMemoryDatabase(options.filename)
+    ? Pool.make({
+        acquire: makeConnection,
+        size: 1,
+      })
+    : Pool.makeWithTTL({
+        acquire: makeConnection,
+        min: POOL_MIN_SIZE,
+        max: POOL_MAX_SIZE,
+        timeToLive: POOL_TTL,
+      });
+  const acquirer = makePooledAcquirer(pool);
 
   return yield* Client.make({
     acquirer,
     compiler,
-    transactionAcquirer,
+    transactionAcquirer: acquirer,
     spanAttributes: [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
       [ATTR_DB_SYSTEM_NAME, "sqlite"],


### PR DESCRIPTION
/claim #858

## Summary
- Added local Node and Bun SQLite clients backed by Effect.Pool.
- Configured file-backed SQLite connections with WAL, busy_timeout=5000, synchronous=NORMAL, and foreign_keys=ON.
- Kept :memory: databases on a single pooled connection so in-memory state is not split across connections.
- Added sqliteHealthCheck via PRAGMA integrity_check.
- Added focused coverage for WAL/PRAGMAs, in-memory persistence, concurrent writes, and health check.

## Verification
- `bun run test src/persistence/NodeSqliteClient.test.ts` -> 5 tests passed.
- `bun run lint apps/server/src/persistence/NodeSqliteClient.ts apps/server/src/persistence/BunSqliteClient.ts apps/server/src/persistence/Layers/Sqlite.ts apps/server/src/persistence/NodeSqliteClient.test.ts` -> 0 warnings, 0 errors.
- `bun run fmt apps/server/src/persistence/NodeSqliteClient.ts apps/server/src/persistence/BunSqliteClient.ts apps/server/src/persistence/Layers/Sqlite.ts apps/server/src/persistence/NodeSqliteClient.test.ts` -> formatted 4 files.
- Filtered server typecheck for changed files -> no diagnostics for BunSqliteClient, NodeSqliteClient, or Layers/Sqlite.
- `git diff --check` -> no whitespace errors.

## Demo
The focused test run exercises the implementation end-to-end: WAL and PRAGMA configuration, pooled concurrent writes, single-connection memory DB behavior, and integrity_check health reporting.

## Attribution
Includes safe public `.attribution.json` only; private system, developer, runtime, session, user instructions, and credentials are intentionally not published.