### PR TITLE
Codex GPT-5 [ T3 Code ] Add ACP automatic auth refresh

### DIFF
--- a/t3code/packages/effect-acp/.provenance.json
+++ b/t3code/packages/effect-acp/.provenance.json
@@ -1,0 +1,15 @@
+{
+  "agent": "Codex GPT-5",
+  "created_at": "2026-07-12T21:31:00Z",
+  "issue": "UnsafeLabs/Bounty-Hunters#829",
+  "config_snapshot": {
+    "task": "Implement automatic ACP client token refresh with a single Effect retry, typed authentication failures, session-expiration callback, refresh-token tracking, cleanup before re-authentication, and queued concurrent request replay.",
+    "privacy": "This provenance file intentionally contains only public task metadata and validation notes. It does not include private prompts, credentials, environment secrets, or user-specific instructions.",
+    "validation": [
+      "bun run fmt packages/effect-acp/src/client.ts packages/effect-acp/src/errors.ts packages/effect-acp/src/client.test.ts packages/effect-acp/test/fixtures/acp-mock-peer.ts",
+      "bun run lint packages/effect-acp/src/client.ts packages/effect-acp/src/errors.ts packages/effect-acp/src/client.test.ts packages/effect-acp/test/fixtures/acp-mock-peer.ts",
+      "bun run test src/client.test.ts",
+      "bun run typecheck"
+    ]
+  }
+}

--- a/t3code/packages/effect-acp/src/client.test.ts
+++ b/t3code/packages/effect-acp/src/client.test.ts
@@ -146,6 +146,235 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
     }),
   );
 
+  it.effect("refreshes authentication once when the active session expires", () =>
+    Effect.gen(function* () {
+      const expiredSessions = yield* Ref.make<Array<string>>([]);
+      const handle = yield* makeHandle({ ACP_MOCK_PROMPT_EXPIRES_ONCE: "1" });
+      const scope = yield* Scope.make();
+      const acpLayer = AcpClient.layerChildProcess(handle, {
+        onSessionExpired: (sessionId) =>
+          Ref.update(expiredSessions, (current) => [...current, sessionId]),
+      });
+      const context = yield* Layer.buildWithScope(acpLayer, scope);
+
+      yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.AcpClient;
+
+        yield* acp.handleRequestPermission(() =>
+          Effect.succeed({
+            outcome: {
+              outcome: "selected",
+              optionId: "allow",
+            },
+          }),
+        );
+        yield* acp.handleElicitation(() =>
+          Effect.succeed({
+            action: {
+              action: "accept",
+              content: {
+                approved: true,
+              },
+            },
+          }),
+        );
+        yield* acp.handleExtRequest(
+          "x/typed_request",
+          Schema.Struct({ message: Schema.String }),
+          () => Effect.succeed({ ok: true }),
+        );
+        yield* acp.handleExtNotification(
+          "x/typed_notification",
+          Schema.Struct({ count: Schema.Number }),
+          () => Effect.void,
+        );
+
+        yield* acp.agent.initialize({
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: false, writeTextFile: false },
+            terminal: false,
+          },
+          clientInfo: {
+            name: "effect-acp-test",
+            version: "0.0.0",
+          },
+        });
+
+        yield* acp.agent.authenticate({
+          methodId: "cursor_login",
+          _meta: {
+            accessToken: "request-access-token",
+            refreshToken: "request-refresh-token",
+          },
+        });
+
+        const session = yield* acp.agent.createSession({
+          cwd: process.cwd(),
+          mcpServers: [],
+        });
+        const prompt = yield* acp.agent.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hello" }],
+        });
+        assert.equal(prompt.stopReason, "end_turn");
+        assert.deepEqual(yield* Ref.get(expiredSessions), [session.sessionId]);
+
+        const authState = (yield* acp.raw.request("x/auth_state", {})) as {
+          readonly authenticateCount: number;
+          readonly lastRefreshToken: unknown;
+          readonly logoutCount: number;
+          readonly promptCount: number;
+        };
+        assert.equal(authState.authenticateCount, 2);
+        assert.equal(authState.logoutCount, 1);
+        assert.equal(authState.promptCount, 2);
+        assert.equal(authState.lastRefreshToken, "refresh-token-1");
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+    }),
+  );
+
+  it.effect("coalesces concurrent authentication refresh and replays queued prompts", () =>
+    Effect.gen(function* () {
+      const expiredSessions = yield* Ref.make<Array<string>>([]);
+      const handle = yield* makeHandle({ ACP_MOCK_CONCURRENT_PROMPT_EXPIRES: "1" });
+      const scope = yield* Scope.make();
+      const acpLayer = AcpClient.layerChildProcess(handle, {
+        onSessionExpired: (sessionId) =>
+          Ref.update(expiredSessions, (current) => [...current, sessionId]),
+      });
+      const context = yield* Layer.buildWithScope(acpLayer, scope);
+
+      yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.AcpClient;
+
+        yield* acp.handleRequestPermission(() =>
+          Effect.succeed({
+            outcome: {
+              outcome: "selected",
+              optionId: "allow",
+            },
+          }),
+        );
+        yield* acp.handleElicitation(() =>
+          Effect.succeed({
+            action: {
+              action: "accept",
+              content: {
+                approved: true,
+              },
+            },
+          }),
+        );
+        yield* acp.handleExtRequest(
+          "x/typed_request",
+          Schema.Struct({ message: Schema.String }),
+          () => Effect.succeed({ ok: true }),
+        );
+        yield* acp.handleExtNotification(
+          "x/typed_notification",
+          Schema.Struct({ count: Schema.Number }),
+          () => Effect.void,
+        );
+
+        yield* acp.agent.initialize({
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: false, writeTextFile: false },
+            terminal: false,
+          },
+          clientInfo: {
+            name: "effect-acp-test",
+            version: "0.0.0",
+          },
+        });
+        yield* acp.agent.authenticate({ methodId: "cursor_login" });
+
+        const session = yield* acp.agent.createSession({
+          cwd: process.cwd(),
+          mcpServers: [],
+        });
+
+        const prompts = yield* Effect.all(
+          [
+            acp.agent.prompt({
+              sessionId: session.sessionId,
+              prompt: [{ type: "text", text: "one" }],
+            }),
+            acp.agent.prompt({
+              sessionId: session.sessionId,
+              prompt: [{ type: "text", text: "two" }],
+            }),
+          ],
+          { concurrency: 2 },
+        );
+        assert.deepEqual(
+          prompts.map((prompt) => prompt.stopReason),
+          ["end_turn", "end_turn"],
+        );
+
+        const authState = (yield* acp.raw.request("x/auth_state", {})) as {
+          readonly authenticateCount: number;
+          readonly logoutCount: number;
+          readonly promptCount: number;
+        };
+        assert.equal(authState.authenticateCount, 2);
+        assert.equal(authState.logoutCount, 1);
+        assert.equal(authState.promptCount, 4);
+        assert.deepEqual(yield* Ref.get(expiredSessions), [session.sessionId]);
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+    }),
+  );
+
+  it.effect("fails expired requests with a typed authentication error when refresh fails", () =>
+    Effect.gen(function* () {
+      const handle = yield* makeHandle({
+        ACP_MOCK_PROMPT_EXPIRES_ONCE: "1",
+        ACP_MOCK_REFRESH_FAIL: "1",
+      });
+      const scope = yield* Scope.make();
+      const acpLayer = AcpClient.layerChildProcess(handle);
+      const context = yield* Layer.buildWithScope(acpLayer, scope);
+
+      const result = yield* Effect.gen(function* () {
+        const acp = yield* AcpClient.AcpClient;
+
+        yield* acp.agent.initialize({
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: false, writeTextFile: false },
+            terminal: false,
+          },
+          clientInfo: {
+            name: "effect-acp-test",
+            version: "0.0.0",
+          },
+        });
+        yield* acp.agent.authenticate({ methodId: "cursor_login" });
+
+        const session = yield* acp.agent.createSession({
+          cwd: process.cwd(),
+          mcpServers: [],
+        });
+
+        return yield* Effect.exit(
+          acp.agent.prompt({
+            sessionId: session.sessionId,
+            prompt: [{ type: "text", text: "hello" }],
+          }),
+        );
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+      if (result._tag !== "Failure") {
+        assert.fail("Expected prompt to fail when refresh fails");
+      }
+      const rendered = Cause.pretty(result.cause);
+      assert.include(rendered, "AcpAuthenticationError");
+      assert.include(rendered, "ACP re-authentication failed");
+      assert.include(rendered, "mock-session-1");
+    }),
+  );
+
   it.effect(
     "returns formatted invalid params when a typed extension request payload is wrong",
     () =>

--- a/t3code/packages/effect-acp/src/client.ts
+++ b/t3code/packages/effect-acp/src/client.ts
@@ -2,8 +2,10 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Stdio from "effect/Stdio";
 import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import * as RpcServer from "effect/unstable/rpc/RpcServer";
@@ -26,6 +28,7 @@ export interface AcpClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
+  readonly onSessionExpired?: (sessionId: string) => Effect.Effect<void, AcpError.AcpError>;
 }
 
 type AcpClientRaw = {
@@ -306,6 +309,41 @@ interface BufferedNotificationHandler<A> {
   readonly pending: Array<A>;
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readMeta = (value: { readonly _meta?: { readonly [x: string]: unknown } | null }) =>
+  isRecord(value._meta) ? value._meta : undefined;
+
+const pickToken = (meta: Record<string, unknown> | undefined, names: ReadonlyArray<string>) => {
+  if (!meta) {
+    return undefined;
+  }
+  for (const name of names) {
+    if (meta[name] !== undefined) {
+      return meta[name];
+    }
+  }
+  return undefined;
+};
+
+const extractSessionId = (value: unknown) =>
+  isRecord(value) && typeof value.sessionId === "string" ? value.sessionId : undefined;
+
+const isUnauthorizedData = (data: unknown): boolean =>
+  isRecord(data) &&
+  (data.status === 401 ||
+    data.statusCode === 401 ||
+    data.code === 401 ||
+    data.httpStatus === 401 ||
+    data.error === "Unauthorized");
+
+const isAuthenticationExpiredError = (error: AcpError.AcpError) =>
+  error._tag === "AcpRequestError" &&
+  (error.code === -32000 ||
+    isUnauthorizedData(error.data) ||
+    /\b(401|unauthorized|auth(?:entication)?\s*(?:required|expired))\b/i.test(error.errorMessage));
+
 export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpClientOptions = {},
@@ -456,6 +494,166 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
     generateRequestId: () => nextRpcRequestId++ as never,
   }).pipe(Effect.provideService(RpcClient.Protocol, transport.clientProtocol));
 
+  let lastAuthenticatePayload: AcpSchema.AuthenticateRequest | undefined;
+  let authenticationTokens: {
+    readonly accessToken?: unknown;
+    readonly refreshToken?: unknown;
+  } = {};
+  let activeSessionId: string | undefined;
+  let authEpoch = 0;
+  const authRefreshSemaphore = yield* Semaphore.make(1);
+  const authRefreshRetrySchedule = Schedule.recurs(1);
+
+  const rememberAuthentication = (
+    payload: AcpSchema.AuthenticateRequest,
+    response: AcpSchema.AuthenticateResponse,
+  ) =>
+    Effect.sync(() => {
+      const requestMeta = readMeta(payload);
+      const responseMeta = readMeta(response);
+      lastAuthenticatePayload = payload;
+      authenticationTokens = {
+        accessToken:
+          pickToken(responseMeta, ["accessToken", "access_token", "token"]) ??
+          pickToken(requestMeta, ["accessToken", "access_token", "token"]),
+        refreshToken:
+          pickToken(responseMeta, ["refreshToken", "refresh_token"]) ??
+          pickToken(requestMeta, ["refreshToken", "refresh_token"]),
+      };
+      authEpoch++;
+    });
+
+  const clearAuthentication = Effect.sync(() => {
+    lastAuthenticatePayload = undefined;
+    authenticationTokens = {};
+    authEpoch++;
+  });
+
+  const reauthenticationPayload = () => {
+    if (!lastAuthenticatePayload || authenticationTokens.refreshToken === undefined) {
+      return lastAuthenticatePayload;
+    }
+
+    return {
+      ...lastAuthenticatePayload,
+      _meta: {
+        ...readMeta(lastAuthenticatePayload),
+        refreshToken: authenticationTokens.refreshToken,
+      },
+    };
+  };
+
+  const rawInitialize = (payload: AcpSchema.InitializeRequest) =>
+    callRpc(rpc[AGENT_METHODS.initialize](payload));
+  const rawAuthenticate = (payload: AcpSchema.AuthenticateRequest) =>
+    callRpc(rpc[AGENT_METHODS.authenticate](payload));
+  const rawLogout = (payload: AcpSchema.LogoutRequest) =>
+    callRpc(rpc[AGENT_METHODS.logout](payload));
+  const rawCreateSession = (payload: AcpSchema.NewSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_new](payload));
+  const rawLoadSession = (payload: AcpSchema.LoadSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_load](payload));
+  const rawListSessions = (payload: AcpSchema.ListSessionsRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_list](payload));
+  const rawForkSession = (payload: AcpSchema.ForkSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_fork](payload));
+  const rawResumeSession = (payload: AcpSchema.ResumeSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_resume](payload));
+  const rawCloseSession = (payload: AcpSchema.CloseSessionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_close](payload));
+  const rawSetSessionModel = (payload: AcpSchema.SetSessionModelRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_set_model](payload));
+  const rawSetSessionConfigOption = (payload: AcpSchema.SetSessionConfigOptionRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_set_config_option](payload));
+  const rawPrompt = (payload: AcpSchema.PromptRequest) =>
+    callRpc(rpc[AGENT_METHODS.session_prompt](payload));
+
+  const trackSessionId = <A>(response: A) =>
+    Effect.sync(() => {
+      const sessionId = extractSessionId(response);
+      if (sessionId) {
+        activeSessionId = sessionId;
+      }
+    });
+
+  const refreshAuthentication = (expiredSessionId: string | undefined, observedAuthEpoch: number) =>
+    authRefreshSemaphore
+      .withPermits(1)(
+        Effect.gen(function* () {
+          if (authEpoch !== observedAuthEpoch) {
+            return;
+          }
+
+          const payload = reauthenticationPayload();
+          if (!payload) {
+            return yield* new AcpError.AcpAuthenticationError({
+              detail: "Cannot refresh ACP authentication before authenticate has been called",
+              ...(expiredSessionId ? { expiredSessionId } : {}),
+            });
+          }
+
+          if (expiredSessionId && options.onSessionExpired) {
+            yield* options.onSessionExpired(expiredSessionId);
+          }
+
+          yield* Effect.scoped(
+            Effect.acquireRelease(
+              rawLogout({}).pipe(Effect.catch(() => Effect.void)),
+              () => Effect.void,
+            ),
+          );
+          const response = yield* rawAuthenticate(payload);
+          yield* rememberAuthentication(payload, response);
+        }),
+      )
+      .pipe(
+        Effect.mapError((cause) =>
+          cause._tag === "AcpAuthenticationError"
+            ? cause
+            : new AcpError.AcpAuthenticationError({
+                detail: "ACP re-authentication failed",
+                ...(expiredSessionId ? { expiredSessionId } : {}),
+                cause,
+              }),
+        ),
+      );
+
+  const withAuthenticationRefresh = <A>(
+    request: () => Effect.Effect<A, AcpError.AcpError>,
+    payload?: unknown,
+  ) =>
+    Effect.suspend(() => {
+      const expiredSessionId = extractSessionId(payload) ?? activeSessionId;
+      const observedAuthEpoch = authEpoch;
+      let refreshStarted = false;
+
+      return request().pipe(
+        Effect.tapError((error) => {
+          if (!isAuthenticationExpiredError(error) || refreshStarted) {
+            return Effect.void;
+          }
+          refreshStarted = true;
+          return refreshAuthentication(expiredSessionId, observedAuthEpoch);
+        }),
+        Effect.retry({
+          schedule: authRefreshRetrySchedule,
+          times: 1,
+          while: isAuthenticationExpiredError,
+        }),
+        Effect.catchIf(
+          (error) => refreshStarted && isAuthenticationExpiredError(error),
+          (error) =>
+            Effect.fail(
+              new AcpError.AcpAuthenticationError({
+                detail: "ACP request failed after one re-authentication attempt",
+                ...(expiredSessionId ? { expiredSessionId } : {}),
+                cause: error,
+              }),
+            ),
+        ),
+      );
+    });
+
   return AcpClient.of({
     raw: {
       notifications: transport.incoming,
@@ -463,19 +661,44 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
       notify: transport.notify,
     },
     agent: {
-      initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
-      authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
-      logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
-      closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      initialize: rawInitialize,
+      authenticate: (payload) =>
+        rawAuthenticate(payload).pipe(
+          Effect.tap((response) => rememberAuthentication(payload, response)),
+        ),
+      logout: (payload) => rawLogout(payload).pipe(Effect.tap(() => clearAuthentication)),
+      createSession: (payload) =>
+        withAuthenticationRefresh(() => rawCreateSession(payload), payload).pipe(
+          Effect.tap(trackSessionId),
+        ),
+      loadSession: (payload) =>
+        withAuthenticationRefresh(() => rawLoadSession(payload), payload).pipe(
+          Effect.tap(trackSessionId),
+        ),
+      listSessions: (payload) => withAuthenticationRefresh(() => rawListSessions(payload), payload),
+      forkSession: (payload) =>
+        withAuthenticationRefresh(() => rawForkSession(payload), payload).pipe(
+          Effect.tap(trackSessionId),
+        ),
+      resumeSession: (payload) =>
+        withAuthenticationRefresh(() => rawResumeSession(payload), payload).pipe(
+          Effect.tap(trackSessionId),
+        ),
+      closeSession: (payload) =>
+        withAuthenticationRefresh(() => rawCloseSession(payload), payload).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              if (activeSessionId === payload.sessionId) {
+                activeSessionId = undefined;
+              }
+            }),
+          ),
+        ),
+      setSessionModel: (payload) =>
+        withAuthenticationRefresh(() => rawSetSessionModel(payload), payload),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        withAuthenticationRefresh(() => rawSetSessionConfigOption(payload), payload),
+      prompt: (payload) => withAuthenticationRefresh(() => rawPrompt(payload), payload),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>

--- a/t3code/packages/effect-acp/src/errors.ts
+++ b/t3code/packages/effect-acp/src/errors.ts
@@ -128,8 +128,24 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
   }
 }
 
+export class AcpAuthenticationError extends Schema.TaggedErrorClass<AcpAuthenticationError>()(
+  "AcpAuthenticationError",
+  {
+    detail: Schema.String,
+    expiredSessionId: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect),
+  },
+) {
+  override get message() {
+    return this.expiredSessionId
+      ? `${this.detail} (session: ${this.expiredSessionId})`
+      : this.detail;
+  }
+}
+
 export const AcpError = Schema.Union([
   AcpRequestError,
+  AcpAuthenticationError,
   AcpSpawnError,
   AcpProcessExitedError,
   AcpProtocolParseError,

--- a/t3code/packages/effect-acp/test/fixtures/acp-mock-peer.ts
+++ b/t3code/packages/effect-acp/test/fixtures/acp-mock-peer.ts
@@ -5,6 +5,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 
 import * as AcpAgent from "../../src/agent.ts";
+import * as AcpError from "../../src/errors.ts";
 
 if (process.env.ACP_MOCK_MALFORMED_OUTPUT === "1") {
   process.stdout.write("{not-json}\n");
@@ -16,6 +17,16 @@ if (process.env.ACP_MOCK_EXIT_IMMEDIATELY_CODE !== undefined) {
 }
 
 const sessionId = "mock-session-1";
+let authenticateCount = 0;
+let logoutCount = 0;
+let promptCount = 0;
+let lastRefreshToken: unknown = null;
+
+const authExpired = () =>
+  AcpError.AcpRequestError.authRequired("Session authentication expired", {
+    status: 401,
+    sessionId,
+  });
 
 const program = Effect.gen(function* () {
   const agent = yield* AcpAgent.AcpAgent;
@@ -35,8 +46,35 @@ const program = Effect.gen(function* () {
     }),
   );
 
-  yield* agent.handleAuthenticate(() => Effect.succeed({}));
-  yield* agent.handleLogout(() => Effect.succeed({}));
+  yield* agent.handleAuthenticate((request) =>
+    Effect.gen(function* () {
+      const meta =
+        request._meta && typeof request._meta === "object" && !Array.isArray(request._meta)
+          ? request._meta
+          : undefined;
+      lastRefreshToken = meta?.refreshToken ?? null;
+      authenticateCount++;
+      if (process.env.ACP_MOCK_REFRESH_FAIL === "1" && authenticateCount > 1) {
+        return yield* AcpError.AcpRequestError.authRequired("Refresh failed", {
+          status: 401,
+          sessionId,
+        });
+      }
+
+      return {
+        _meta: {
+          accessToken: `access-token-${authenticateCount}`,
+          refreshToken: `refresh-token-${authenticateCount}`,
+        },
+      };
+    }),
+  );
+  yield* agent.handleLogout(() =>
+    Effect.sync(() => {
+      logoutCount++;
+      return {};
+    }),
+  );
   yield* agent.handleCreateSession(() =>
     Effect.succeed({
       sessionId,
@@ -56,6 +94,15 @@ const program = Effect.gen(function* () {
 
   yield* agent.handlePrompt(() =>
     Effect.gen(function* () {
+      promptCount++;
+      if (process.env.ACP_MOCK_PROMPT_EXPIRES_ONCE === "1" && promptCount === 1) {
+        return yield* authExpired();
+      }
+      if (process.env.ACP_MOCK_CONCURRENT_PROMPT_EXPIRES === "1" && promptCount <= 2) {
+        yield* Effect.sleep("50 millis");
+        return yield* authExpired();
+      }
+
       yield* agent.client.requestPermission({
         sessionId,
         options: [
@@ -120,12 +167,20 @@ const program = Effect.gen(function* () {
     }),
   );
 
-  yield* agent.handleUnknownExtRequest((method, params) =>
-    Effect.succeed({
+  yield* agent.handleUnknownExtRequest((method, params) => {
+    if (method === "x/auth_state") {
+      return Effect.succeed({
+        authenticateCount,
+        logoutCount,
+        lastRefreshToken,
+        promptCount,
+      });
+    }
+    return Effect.succeed({
       echoedMethod: method,
       echoedParams: params ?? null,
-    }),
-  );
+    });
+  });
 
   return yield* Effect.never;
 });


### PR DESCRIPTION
/claim #829

## Summary
- Add ACP client auth-expiry detection for 401/auth-required request failures.
- Store refresh-token metadata separately from access-token metadata and reuse the saved refresh token for re-auth.
- Serialize re-auth behind a semaphore so concurrent expired requests wait for one refresh, then replay once.
- Fire `onSessionExpired` before re-auth and wrap failed refresh/replay paths in typed `AcpAuthenticationError`.
- Add safe public `.provenance.json` metadata without private prompts, credentials, or secrets.

## Demo
The focused mock-peer tests demonstrate the full flow:
- expired session -> `onSessionExpired` -> cleanup -> re-auth -> replay -> success
- two concurrent expired prompts -> one refresh -> both replay successfully
- refresh failure -> typed `AcpAuthenticationError`

## Validation
- `bun run fmt packages/effect-acp/src/client.ts packages/effect-acp/src/errors.ts packages/effect-acp/src/client.test.ts packages/effect-acp/test/fixtures/acp-mock-peer.ts`
- `bun run lint packages/effect-acp/src/client.ts packages/effect-acp/src/errors.ts packages/effect-acp/src/client.test.ts packages/effect-acp/test/fixtures/acp-mock-peer.ts`
- `bun run test src/client.test.ts` (8 tests passed)
- `bun run typecheck`
- `git diff --check`