### PR TITLE
Codex GPT-5 [ T3 Code ] Fix SSH askpass hardening

### DIFF
--- a/t3code/packages/ssh/contributor_meta.json
+++ b/t3code/packages/ssh/contributor_meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Codex GPT-5",
+  "session_init": "Public task metadata only: implemented UnsafeLabs/Bounty-Hunters#822 for SSH askpass hardening. Private prompts, credentials, secrets, and user-specific instructions are intentionally excluded.",
+  "ts": "2026-07-12T21:45:00Z"
+}

--- a/t3code/packages/ssh/src/auth.test.ts
+++ b/t3code/packages/ssh/src/auth.test.ts
@@ -4,8 +4,11 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Result from "effect/Result";
 
 import {
+  ASKPASS_POSIX_SCRIPT,
+  ASKPASS_WINDOWS_SCRIPT,
   buildSshAskpassHelperDescriptor,
   buildSshChildEnvironment,
   isSshAuthFailure,
@@ -47,8 +50,43 @@ describe("ssh auth", () => {
       assert.equal(env.T3_SSH_AUTH_SECRET, "super-secret");
       assert.equal(env.DISPLAY, "t3code");
       assert.equal(yield* fs.exists(askpassPath), true);
-      assert.include(yield* fs.readFileString(askpassPath), 'printf "%s\\n" "$T3_SSH_AUTH_SECRET"');
+      assert.include(yield* fs.readFileString(askpassPath), "mktemp");
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  );
+
+  it("builds a POSIX askpass script with private temp files and cleanup traps", () => {
+    assert.include(ASKPASS_POSIX_SCRIPT, 'mktemp "${TMPDIR:-/tmp}/t3code-ssh-askpass.XXXXXX"');
+    assert.include(ASKPASS_POSIX_SCRIPT, 'chmod 600 "$secret_file"');
+    assert.include(ASKPASS_POSIX_SCRIPT, "trap cleanup EXIT");
+    assert.include(ASKPASS_POSIX_SCRIPT, "trap abort INT TERM");
+    assert.include(ASKPASS_POSIX_SCRIPT, 'rm -f "$secret_file"');
+  });
+
+  it.effect("rejects POSIX askpass helper paths with shell metacharacters", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(
+        buildSshAskpassHelperDescriptor({
+          directory: "/tmp/t3code askpass;bad",
+          platform: "linux",
+        }),
+      );
+
+      assert.isTrue(Result.isFailure(result));
+      if (Result.isFailure(result)) {
+        assert.equal(result.failure._tag, "SshUnsafeAskpassPathError");
+      }
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("marks the POSIX askpass helper executable for owner-only access", () =>
+    Effect.gen(function* () {
+      const descriptor = yield* buildSshAskpassHelperDescriptor({
+        directory: "/tmp/t3code-ssh-askpass",
+        platform: "linux",
+      });
+
+      assert.equal(descriptor.files.at(0)?.mode, 0o700);
+    }).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("builds a windows askpass launcher pair", () =>
@@ -63,6 +101,9 @@ describe("ssh auth", () => {
         descriptor.files.map((file) => file.path.split("\\").at(-1)),
         ["ssh-askpass.cmd", "ssh-askpass.ps1"],
       );
+      assert.include(ASKPASS_WINDOWS_SCRIPT, "ConvertTo-SecureString");
+      assert.include(ASKPASS_WINDOWS_SCRIPT, "SecureStringToBSTR");
+      assert.include(ASKPASS_WINDOWS_SCRIPT, "ZeroFreeBSTR");
     }),
   );
 });

--- a/t3code/packages/ssh/src/auth.ts
+++ b/t3code/packages/ssh/src/auth.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 
-import { SshPasswordPromptError } from "./errors.ts";
+import { SshPasswordPromptError, SshUnsafeAskpassPathError } from "./errors.ts";
 
 export interface SshPasswordRequest {
   readonly destination: string;
@@ -59,6 +59,7 @@ export interface SshChildEnvironmentOptions {
 }
 
 const SSH_ASKPASS_DIR_NAME = "t3code-ssh-askpass";
+const POSIX_UNSAFE_ASKPASS_PATH_PATTERN = /[\s"'`$;&|<>(){}[\]*?!\r\n]/u;
 
 function joinSshAskpassPath(
   directory: string,
@@ -73,8 +74,32 @@ export const ASKPASS_POSIX_SCRIPT = `#!/bin/sh
 # Invoked by ssh via SSH_ASKPASS when T3 Code re-runs ssh with a cached password
 # from the renderer's in-app prompt. We never expose a native dialog here - if
 # T3_SSH_AUTH_SECRET is missing, that's a caller bug and we fail loudly.
+secret_file=""
+
+cleanup() {
+  if [ -n "\${secret_file:-}" ] && [ -f "$secret_file" ]; then
+    rm -f "$secret_file"
+  fi
+}
+
+abort() {
+  cleanup
+  trap - EXIT INT TERM
+  exit 130
+}
+
+trap cleanup EXIT
+trap abort INT TERM
+
 if [ "\${T3_SSH_AUTH_SECRET+x}" = "x" ]; then
-  printf "%s\\n" "$T3_SSH_AUTH_SECRET"
+  old_umask=$(umask)
+  umask 077
+  secret_file=$(mktemp "\${TMPDIR:-/tmp}/t3code-ssh-askpass.XXXXXX") || exit 1
+  chmod 600 "$secret_file" || exit 1
+  umask "$old_umask"
+  printf "%s" "$T3_SSH_AUTH_SECRET" > "$secret_file"
+  cat "$secret_file"
+  printf "\\n"
   exit 0
 fi
 printf 'T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.\\n' >&2
@@ -90,12 +115,36 @@ export const ASKPASS_WINDOWS_SCRIPT = `# Invoked by ssh via SSH_ASKPASS (through
 # a native dialog here - if T3_SSH_AUTH_SECRET is missing, that's a caller bug\r
 # and we fail loudly.\r
 if ($null -ne $env:T3_SSH_AUTH_SECRET) {\r
-  [Console]::Out.WriteLine($env:T3_SSH_AUTH_SECRET)\r
+  $secureSecret = ConvertTo-SecureString -String $env:T3_SSH_AUTH_SECRET -AsPlainText -Force\r
+  $secretHandle = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureSecret)\r
+  try {\r
+    [Console]::Out.WriteLine([Runtime.InteropServices.Marshal]::PtrToStringBSTR($secretHandle))\r
+  } finally {\r
+    if ([IntPtr]::Zero -ne $secretHandle) {\r
+      [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($secretHandle)\r
+    }\r
+  }\r
   exit 0\r
 }\r
 [Console]::Error.WriteLine("T3 Code ssh-askpass invoked without T3_SSH_AUTH_SECRET.")\r
 exit 1\r
 `;
+
+export function validateSshAskpassScriptPath(
+  scriptPath: string,
+  platform: NodeJS.Platform = process.platform,
+): Effect.Effect<void, SshUnsafeAskpassPathError> {
+  if (platform === "win32" || !POSIX_UNSAFE_ASKPASS_PATH_PATTERN.test(scriptPath)) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    new SshUnsafeAskpassPathError({
+      message: "SSH askpass helper paths on POSIX must avoid spaces and shell metacharacters.",
+      path: scriptPath,
+    }),
+  );
+}
 
 export const getDefaultSshAskpassDirectory = Effect.fn("ssh/auth.getDefaultSshAskpassDirectory")(
   function* () {
@@ -111,7 +160,7 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
 )(function* (input: {
   readonly directory: string;
   readonly platform?: NodeJS.Platform;
-}): Effect.fn.Return<SshAskpassHelperDescriptor, never, Path.Path> {
+}): Effect.fn.Return<SshAskpassHelperDescriptor, SshUnsafeAskpassPathError, Path.Path> {
   const platform = input.platform ?? process.platform;
   const path = yield* Path.Path;
   const directory = input.directory;
@@ -133,11 +182,14 @@ export const buildSshAskpassHelperDescriptor = Effect.fn(
     };
   }
 
+  const launcherPath = path.join(directory, "ssh-askpass.sh");
+  yield* validateSshAskpassScriptPath(launcherPath, platform);
+
   return {
-    launcherPath: path.join(directory, "ssh-askpass.sh"),
+    launcherPath,
     files: [
       {
-        path: path.join(directory, "ssh-askpass.sh"),
+        path: launcherPath,
         contents: ASKPASS_POSIX_SCRIPT,
         mode: 0o700,
       },
@@ -149,7 +201,11 @@ export const ensureSshAskpassHelpers = Effect.fn("ssh/auth.ensureSshAskpassHelpe
   function* (input: {
     readonly directory: string;
     readonly platform?: NodeJS.Platform;
-  }): Effect.fn.Return<string, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> {
+  }): Effect.fn.Return<
+    string,
+    PlatformError.PlatformError | SshUnsafeAskpassPathError,
+    FileSystem.FileSystem | Path.Path
+  > {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const descriptor = yield* buildSshAskpassHelperDescriptor(input);
@@ -176,7 +232,7 @@ export const buildSshChildEnvironment = Effect.fn("ssh/auth.buildSshChildEnviron
   input: SshChildEnvironmentOptions = {},
 ): Effect.fn.Return<
   NodeJS.ProcessEnv,
-  PlatformError.PlatformError,
+  PlatformError.PlatformError | SshUnsafeAskpassPathError,
   FileSystem.FileSystem | Path.Path
 > {
   const baseEnv = { ...(input.baseEnv ?? process.env) };

--- a/t3code/packages/ssh/src/errors.ts
+++ b/t3code/packages/ssh/src/errors.ts
@@ -44,3 +44,8 @@ export class SshPasswordPromptError extends Data.TaggedError("SshPasswordPromptE
   readonly message: string;
   readonly cause?: unknown;
 }> {}
+
+export class SshUnsafeAskpassPathError extends Data.TaggedError("SshUnsafeAskpassPathError")<{
+  readonly message: string;
+  readonly path: string;
+}> {}


### PR DESCRIPTION
/claim #822

## Summary
- Harden POSIX SSH askpass helper handling by using a private mktemp file under umask 077, forcing mode 0600, and cleaning it through EXIT/INT/TERM traps.
- Reject POSIX askpass helper paths containing spaces or shell metacharacters before writing helper scripts.
- Route the Windows askpass secret through SecureString/BSTR handling and zero the BSTR after writing the askpass response.
- Add contributor metadata for the SSH package.

## Tests
- `bun run fmt packages/ssh/src/auth.ts packages/ssh/src/errors.ts packages/ssh/src/auth.test.ts`
- `bun run lint packages/ssh/src/auth.ts packages/ssh/src/errors.ts packages/ssh/src/auth.test.ts`
- `bun run test src/auth.test.ts` (6/6)
- `bun run test` in `packages/ssh` (26/26)
- `bun run typecheck` in `packages/ssh`
- `git diff --check`