### PR TITLE
Codex [ T3 Code ] Add sliding window metrics aggregation

### DIFF
--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -24,6 +24,7 @@ import {
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
 import { resolveStaticDir, ServerConfig } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
+import { MetricsAggregator } from "./observability/Services/MetricsAggregator.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
@@ -36,6 +37,7 @@ import {
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
+const AGGREGATED_METRICS_PATH = "/metrics/aggregated";
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 
@@ -132,6 +134,20 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
           Effect.succeed(HttpServerResponse.text("Trace export failed.", { status: 502 })),
         ),
       );
+  }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
+);
+
+export const aggregatedMetricsRouteLayer = HttpRouter.add(
+  "GET",
+  AGGREGATED_METRICS_PATH,
+  Effect.gen(function* () {
+    yield* requireAuthenticatedRequest;
+    const metricsAggregator = yield* MetricsAggregator;
+    const windows = yield* metricsAggregator.snapshot();
+    return HttpServerResponse.jsonUnsafe(windows, {
+      status: 200,
+      headers: browserApiCorsHeaders,
+    });
   }).pipe(Effect.catchTag("AuthError", respondToAuthError)),
 );
 

--- a/t3code/apps/server/src/observability/.generation_meta.json
+++ b/t3code/apps/server/src/observability/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Codex",
+  "initial_directives": "Private system, developer, tool, and user-environment instructions are not reproduced here. Public task context: implement UnsafeLabs/Bounty-Hunters issue #856 for T3 Code by adding a MetricsAggregator service with sliding-window RPC metrics aggregation, JSON endpoint, bounded memory, and tests.",
+  "date": "2026-07-12T22:20:00.000Z"
+}

--- a/t3code/apps/server/src/observability/Layers/Observability.ts
+++ b/t3code/apps/server/src/observability/Layers/Observability.ts
@@ -8,6 +8,7 @@ import { OtlpMetrics, OtlpSerialization, OtlpTracer } from "effect/unstable/obse
 import { ServerConfig } from "../../config.ts";
 import { ServerLoggerLive } from "../../serverLogger.ts";
 import { BrowserTraceCollector } from "../Services/BrowserTraceCollector.ts";
+import { MetricsAggregatorLive } from "../Services/MetricsAggregator.ts";
 
 const otlpSerializationLayer = OtlpSerialization.layerJson;
 
@@ -81,6 +82,12 @@ export const ObservabilityLive = Layer.unwrap(
             },
           }).pipe(Layer.provideMerge(otlpSerializationLayer));
 
-    return Layer.mergeAll(ServerLoggerLive, traceReferencesLayer, tracerLayer, metricsLayer);
+    return Layer.mergeAll(
+      ServerLoggerLive,
+      traceReferencesLayer,
+      tracerLayer,
+      metricsLayer,
+      MetricsAggregatorLive,
+    );
   }),
 );

--- a/t3code/apps/server/src/observability/Metrics.ts
+++ b/t3code/apps/server/src/observability/Metrics.ts
@@ -3,13 +3,16 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Metric from "effect/Metric";
+import * as Option from "effect/Option";
 import { dual } from "effect/Function";
 
 import {
   compactMetricAttributes,
   normalizeModelMetricLabel,
   outcomeFromExit,
+  type ObservabilityOutcome,
 } from "./Attributes.ts";
+import { MetricsAggregator } from "./Services/MetricsAggregator.ts";
 
 export const rpcRequestsTotal = Metric.counter("t3_rpc_requests_total", {
   description: "Total RPC requests handled by the websocket RPC server.",
@@ -87,6 +90,7 @@ export const increment = (
 export interface WithMetricsOptions {
   readonly counter?: Metric.Metric<number, unknown>;
   readonly timer?: Metric.Metric<Duration.Duration, unknown>;
+  readonly rpcMethod?: string;
   readonly attributes?:
     | Readonly<Record<string, unknown>>
     | (() => Readonly<Record<string, unknown>>);
@@ -94,6 +98,33 @@ export interface WithMetricsOptions {
     outcome: ReturnType<typeof outcomeFromExit>,
   ) => Readonly<Record<string, unknown>>;
 }
+
+export interface RpcAggregateMetricSampleInput {
+  readonly method: string;
+  readonly outcome: ObservabilityOutcome;
+  readonly durationMs: number;
+  readonly timestampMs?: number;
+}
+
+export const recordRpcAggregateSample = (
+  input: RpcAggregateMetricSampleInput,
+): Effect.Effect<void, never, never> =>
+  Effect.gen(function* () {
+    const metricsAggregator = yield* Effect.serviceOption(MetricsAggregator);
+    if (Option.isNone(metricsAggregator)) {
+      return;
+    }
+
+    const timestampMs = input.timestampMs ?? (yield* Clock.currentTimeMillis);
+    yield* metricsAggregator.value
+      .recordRpcSample({
+        method: input.method,
+        outcome: input.outcome,
+        durationMs: input.durationMs,
+        timestampMs,
+      })
+      .pipe(Effect.ignoreCause({ log: true }));
+  });
 
 const withMetricsImpl = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
@@ -107,6 +138,7 @@ const withMetricsImpl = <A, E, R>(
     const duration = Duration.nanos(elapsedNanos);
     const baseAttributes =
       typeof options.attributes === "function" ? options.attributes() : (options.attributes ?? {});
+    const outcome = outcomeFromExit(exit);
 
     if (options.timer) {
       yield* Metric.update(
@@ -116,7 +148,6 @@ const withMetricsImpl = <A, E, R>(
     }
 
     if (options.counter) {
-      const outcome = outcomeFromExit(exit);
       yield* Metric.update(
         Metric.withAttributes(
           options.counter,
@@ -128,6 +159,14 @@ const withMetricsImpl = <A, E, R>(
         ),
         1,
       );
+    }
+
+    if (options.rpcMethod) {
+      yield* recordRpcAggregateSample({
+        method: options.rpcMethod,
+        outcome,
+        durationMs: Number(elapsedNanos) / 1_000_000,
+      });
     }
 
     if (Exit.isSuccess(exit)) {

--- a/t3code/apps/server/src/observability/MetricsAggregator.test.ts
+++ b/t3code/apps/server/src/observability/MetricsAggregator.test.ts
@@ -1,0 +1,158 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import {
+  aggregateRpcMetricSamples,
+  makeMetricsAggregatorLive,
+  MetricsAggregator,
+} from "./Services/MetricsAggregator.ts";
+
+describe("MetricsAggregator", () => {
+  it.effect("calculates per-method percentiles, error rate, and throughput", () =>
+    Effect.gen(function* () {
+      const windows = yield* aggregateRpcMetricSamples(
+        [
+          {
+            method: "server.echo",
+            outcome: "success",
+            durationMs: 10,
+            timestampMs: 60_000,
+          },
+          {
+            method: "server.echo",
+            outcome: "failure",
+            durationMs: 20,
+            timestampMs: 61_000,
+          },
+          {
+            method: "server.echo",
+            outcome: "success",
+            durationMs: 30,
+            timestampMs: 62_000,
+          },
+          {
+            method: "server.echo",
+            outcome: "success",
+            durationMs: 40,
+            timestampMs: 63_000,
+          },
+          {
+            method: "server.echo",
+            outcome: "success",
+            durationMs: 50,
+            timestampMs: 64_000,
+          },
+        ],
+        {
+          nowMs: 120_000,
+          windowCount: 1,
+          windowSizeMs: 60_000,
+          windowStepMs: 60_000,
+        },
+      );
+
+      const methodMetrics = windows[0]?.methods[0];
+      assert.equal(windows.length, 1);
+      assert.equal(windows[0]?.sampleCount, 5);
+      assert.equal(methodMetrics?.method, "server.echo");
+      assert.equal(methodMetrics?.requestCount, 5);
+      assert.equal(methodMetrics?.errorCount, 1);
+      assert.equal(methodMetrics?.errorRate, 20);
+      assert.equal(methodMetrics?.throughputPerSecond, 5 / 60);
+      assert.equal(methodMetrics?.p50Ms, 30);
+      assert.equal(methodMetrics?.p95Ms, 50);
+      assert.equal(methodMetrics?.p99Ms, 50);
+    }),
+  );
+
+  it.effect("uses Effect.Stream.sliding to build overlapping windows", () =>
+    Effect.gen(function* () {
+      const windows = yield* aggregateRpcMetricSamples(
+        [
+          {
+            method: "server.first",
+            outcome: "success",
+            durationMs: 10,
+            timestampMs: 60_000,
+          },
+          {
+            method: "server.second",
+            outcome: "success",
+            durationMs: 20,
+            timestampMs: 90_000,
+          },
+        ],
+        {
+          nowMs: 120_000,
+          windowCount: 3,
+          windowSizeMs: 60_000,
+          windowStepMs: 30_000,
+        },
+      );
+
+      assert.equal(windows.length, 3);
+      assert.deepEqual(
+        windows.map((window) => [window.startedAtMs, window.endedAtMs, window.sampleCount]),
+        [
+          [0, 60_000, 0],
+          [30_000, 90_000, 1],
+          [60_000, 120_000, 2],
+        ],
+      );
+    }),
+  );
+
+  it.effect("retains exactly the configured number of windows", () =>
+    Effect.gen(function* () {
+      const windows = yield* aggregateRpcMetricSamples(
+        Array.from({ length: 120 }, (_, index) => ({
+          method: "server.rotate",
+          outcome: "success" as const,
+          durationMs: index,
+          timestampMs: index * 60_000,
+        })),
+        {
+          nowMs: 120 * 60_000,
+          windowCount: 60,
+          windowSizeMs: 60_000,
+          windowStepMs: 60_000,
+        },
+      );
+
+      assert.equal(windows.length, 60);
+      assert.equal(windows[0]?.startedAtMs, 60 * 60_000);
+      assert.equal(windows[59]?.endedAtMs, 120 * 60_000);
+    }),
+  );
+
+  it.effect("bounds retained samples regardless of request volume", () =>
+    Effect.gen(function* () {
+      const metricsAggregator = yield* MetricsAggregator;
+
+      for (let index = 0; index < 10; index += 1) {
+        yield* metricsAggregator.recordRpcSample({
+          method: "server.bounded",
+          outcome: "success",
+          durationMs: index,
+          timestampMs: index * 1_000,
+        });
+      }
+
+      const windows = yield* metricsAggregator.snapshot(10_000);
+      const retainedSampleCount = windows.reduce((count, window) => count + window.sampleCount, 0);
+
+      assert.equal(windows.length, 2);
+      assert.isAtMost(retainedSampleCount, 3);
+    }).pipe(
+      Effect.provide(
+        makeMetricsAggregatorLive({
+          maxSamples: 3,
+          pruneIntervalMs: 60_000,
+          windowCount: 2,
+          windowSizeMs: 10_000,
+          windowStepMs: 10_000,
+        }),
+      ),
+    ),
+  );
+});

--- a/t3code/apps/server/src/observability/RpcInstrumentation.ts
+++ b/t3code/apps/server/src/observability/RpcInstrumentation.ts
@@ -8,7 +8,13 @@ import * as References from "effect/References";
 import * as Stream from "effect/Stream";
 
 import { outcomeFromExit } from "./Attributes.ts";
-import { metricAttributes, rpcRequestDuration, rpcRequestsTotal, withMetrics } from "./Metrics.ts";
+import {
+  metricAttributes,
+  recordRpcAggregateSample,
+  rpcRequestDuration,
+  rpcRequestsTotal,
+  withMetrics,
+} from "./Metrics.ts";
 
 const RPC_SPAN_PREFIX = "ws.rpc";
 const DEFAULT_RPC_SPAN_ATTRIBUTES = {
@@ -69,6 +75,7 @@ const recordRpcStreamMetrics = <E>(
   Effect.gen(function* () {
     const endedAt = yield* Clock.currentTimeNanos;
     const elapsedNanos = endedAt > startedAt ? endedAt - startedAt : 0n;
+    const outcome = outcomeFromExit(exit);
 
     yield* Metric.update(
       Metric.withAttributes(rpcRequestDuration, metricAttributes({ method })),
@@ -79,11 +86,16 @@ const recordRpcStreamMetrics = <E>(
         rpcRequestsTotal,
         metricAttributes({
           method,
-          outcome: outcomeFromExit(exit),
+          outcome,
         }),
       ),
       1,
     );
+    yield* recordRpcAggregateSample({
+      method,
+      outcome,
+      durationMs: Number(elapsedNanos) / 1_000_000,
+    });
   });
 
 export const observeRpcEffect = <A, E, R>(
@@ -95,6 +107,7 @@ export const observeRpcEffect = <A, E, R>(
     withMetrics({
       counter: rpcRequestsTotal,
       timer: rpcRequestDuration,
+      rpcMethod: method,
       attributes: {
         method,
       },

--- a/t3code/apps/server/src/observability/Services/MetricsAggregator.ts
+++ b/t3code/apps/server/src/observability/Services/MetricsAggregator.ts
@@ -1,0 +1,285 @@
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+
+import type { ObservabilityOutcome } from "../Attributes.ts";
+
+const DEFAULT_WINDOW_SIZE_MS = 60_000;
+const DEFAULT_WINDOW_STEP_MS = 60_000;
+const DEFAULT_WINDOW_COUNT = 60;
+const DEFAULT_MAX_SAMPLES = 100_000;
+const DEFAULT_PRUNE_INTERVAL_MS = 60_000;
+
+export interface RpcMetricSample {
+  readonly method: string;
+  readonly outcome: ObservabilityOutcome;
+  readonly durationMs: number;
+  readonly timestampMs: number;
+}
+
+export interface AggregatedMethodMetrics {
+  readonly method: string;
+  readonly requestCount: number;
+  readonly errorCount: number;
+  readonly errorRate: number;
+  readonly throughputPerSecond: number;
+  readonly p50Ms: number;
+  readonly p95Ms: number;
+  readonly p99Ms: number;
+}
+
+export interface AggregatedMetricWindow {
+  readonly startedAt: string;
+  readonly endedAt: string;
+  readonly startedAtMs: number;
+  readonly endedAtMs: number;
+  readonly sampleCount: number;
+  readonly methods: ReadonlyArray<AggregatedMethodMetrics>;
+}
+
+export interface MetricsAggregationOptions {
+  readonly nowMs: number;
+  readonly windowSizeMs?: number;
+  readonly windowStepMs?: number;
+  readonly windowCount?: number;
+}
+
+export interface MetricsAggregatorLiveOptions extends Omit<MetricsAggregationOptions, "nowMs"> {
+  readonly maxSamples?: number;
+  readonly pruneIntervalMs?: number;
+}
+
+interface NormalizedMetricsAggregationOptions {
+  readonly nowMs: number;
+  readonly windowSizeMs: number;
+  readonly windowStepMs: number;
+  readonly windowCount: number;
+  readonly slicesPerWindow: number;
+}
+
+export interface MetricsAggregatorShape {
+  readonly recordRpcSample: (sample: RpcMetricSample) => Effect.Effect<void>;
+  readonly snapshot: (nowMs?: number) => Effect.Effect<ReadonlyArray<AggregatedMetricWindow>>;
+  readonly prune: (nowMs?: number) => Effect.Effect<void>;
+}
+
+export class MetricsAggregator extends Context.Service<MetricsAggregator, MetricsAggregatorShape>()(
+  "t3/observability/Services/MetricsAggregator",
+) {}
+
+const finitePositiveInteger = (value: number | undefined, fallback: number): number => {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.trunc(value));
+};
+
+const aggregationOptionsFromLiveOptions = (
+  nowMs: number,
+  options: MetricsAggregatorLiveOptions,
+): MetricsAggregationOptions => ({
+  nowMs,
+  ...(options.windowCount !== undefined ? { windowCount: options.windowCount } : {}),
+  ...(options.windowSizeMs !== undefined ? { windowSizeMs: options.windowSizeMs } : {}),
+  ...(options.windowStepMs !== undefined ? { windowStepMs: options.windowStepMs } : {}),
+});
+
+const formatTimestamp = (epochMillis: number): string =>
+  DateTime.formatIso(DateTime.makeUnsafe(epochMillis));
+
+const normalizeOptions = (
+  options: MetricsAggregationOptions,
+): NormalizedMetricsAggregationOptions => {
+  const nowMs = finitePositiveInteger(options.nowMs, 0);
+  const windowSizeMs = finitePositiveInteger(options.windowSizeMs, DEFAULT_WINDOW_SIZE_MS);
+  const rawWindowStepMs = finitePositiveInteger(options.windowStepMs, DEFAULT_WINDOW_STEP_MS);
+  const windowStepMs = Math.min(rawWindowStepMs, windowSizeMs);
+  const windowCount = finitePositiveInteger(options.windowCount, DEFAULT_WINDOW_COUNT);
+  const slicesPerWindow = Math.max(1, Math.ceil(windowSizeMs / windowStepMs));
+
+  return {
+    nowMs,
+    windowSizeMs: slicesPerWindow * windowStepMs,
+    windowStepMs,
+    windowCount,
+    slicesPerWindow,
+  };
+};
+
+const normalizeSample = (sample: RpcMetricSample): RpcMetricSample => ({
+  method: sample.method.trim() || "unknown",
+  outcome: sample.outcome,
+  durationMs: Number.isFinite(sample.durationMs) ? Math.max(0, sample.durationMs) : 0,
+  timestampMs: Number.isFinite(sample.timestampMs) ? Math.trunc(sample.timestampMs) : 0,
+});
+
+const percentile = (values: ReadonlyArray<number>, percentileRank: number): number => {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = values.toSorted((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileRank / 100) * sorted.length) - 1),
+  );
+  return sorted[index] ?? 0;
+};
+
+const aggregateMethodMetrics = (
+  samples: ReadonlyArray<RpcMetricSample>,
+  windowDurationMs: number,
+): ReadonlyArray<AggregatedMethodMetrics> => {
+  const samplesByMethod = new Map<string, Array<RpcMetricSample>>();
+  for (const sample of samples) {
+    const existing = samplesByMethod.get(sample.method);
+    if (existing) {
+      existing.push(sample);
+    } else {
+      samplesByMethod.set(sample.method, [sample]);
+    }
+  }
+
+  const windowDurationSeconds = Math.max(1, windowDurationMs / 1_000);
+  return [...samplesByMethod.entries()]
+    .map(([method, methodSamples]) => {
+      const durations = methodSamples.map((sample) => sample.durationMs);
+      const errorCount = methodSamples.filter((sample) => sample.outcome !== "success").length;
+      return {
+        method,
+        requestCount: methodSamples.length,
+        errorCount,
+        errorRate: (errorCount / methodSamples.length) * 100,
+        throughputPerSecond: methodSamples.length / windowDurationSeconds,
+        p50Ms: percentile(durations, 50),
+        p95Ms: percentile(durations, 95),
+        p99Ms: percentile(durations, 99),
+      } satisfies AggregatedMethodMetrics;
+    })
+    .toSorted((left, right) => left.method.localeCompare(right.method));
+};
+
+const makeTimeSlices = (
+  options: NormalizedMetricsAggregationOptions,
+): ReadonlyArray<{ readonly startedAtMs: number; readonly endedAtMs: number }> => {
+  const latestClosedWindowEndMs =
+    Math.floor(options.nowMs / options.windowStepMs) * options.windowStepMs;
+  const latestWindowEndMs =
+    latestClosedWindowEndMs === options.nowMs
+      ? latestClosedWindowEndMs
+      : latestClosedWindowEndMs + options.windowStepMs;
+  const sliceCount = options.windowCount + options.slicesPerWindow - 1;
+  const earliestSliceStartMs = latestWindowEndMs - sliceCount * options.windowStepMs;
+
+  return Array.from({ length: sliceCount }, (_, index) => {
+    const startedAtMs = earliestSliceStartMs + index * options.windowStepMs;
+    return {
+      startedAtMs,
+      endedAtMs: startedAtMs + options.windowStepMs,
+    };
+  });
+};
+
+export const aggregateRpcMetricSamples = (
+  samples: ReadonlyArray<RpcMetricSample>,
+  options: MetricsAggregationOptions,
+): Effect.Effect<ReadonlyArray<AggregatedMetricWindow>> =>
+  Effect.gen(function* () {
+    const normalizedOptions = normalizeOptions(options);
+    const normalizedSamples = samples.map(normalizeSample);
+    const slices = makeTimeSlices(normalizedOptions);
+    const slidingSlices = yield* Stream.runCollect(
+      Stream.fromIterable(slices).pipe(Stream.sliding(normalizedOptions.slicesPerWindow)),
+    );
+
+    return Array.from(slidingSlices, (sliceGroup) => {
+      const group = Array.from(sliceGroup);
+      const firstSlice = group[0] ?? slices[0];
+      const lastSlice = group[group.length - 1] ?? slices[slices.length - 1];
+      const startedAtMs = firstSlice?.startedAtMs ?? 0;
+      const endedAtMs = lastSlice?.endedAtMs ?? startedAtMs + normalizedOptions.windowSizeMs;
+      const windowSamples = normalizedSamples.filter(
+        (sample) => sample.timestampMs >= startedAtMs && sample.timestampMs < endedAtMs,
+      );
+
+      return {
+        startedAt: formatTimestamp(startedAtMs),
+        endedAt: formatTimestamp(endedAtMs),
+        startedAtMs,
+        endedAtMs,
+        sampleCount: windowSamples.length,
+        methods: aggregateMethodMetrics(windowSamples, endedAtMs - startedAtMs),
+      } satisfies AggregatedMetricWindow;
+    }).slice(-normalizedOptions.windowCount);
+  });
+
+const retentionMsFor = (options: MetricsAggregatorLiveOptions): number => {
+  const normalizedOptions = normalizeOptions(aggregationOptionsFromLiveOptions(0, options));
+  return (
+    (normalizedOptions.windowCount + normalizedOptions.slicesPerWindow - 1) *
+    normalizedOptions.windowStepMs
+  );
+};
+
+const makeMetricsAggregator = (options: MetricsAggregatorLiveOptions = {}) =>
+  Effect.gen(function* () {
+    const samplesRef = yield* Ref.make<ReadonlyArray<RpcMetricSample>>([]);
+    const maxSamples = finitePositiveInteger(options.maxSamples, DEFAULT_MAX_SAMPLES);
+    const pruneIntervalMs = finitePositiveInteger(
+      options.pruneIntervalMs,
+      DEFAULT_PRUNE_INTERVAL_MS,
+    );
+    const retentionMs = retentionMsFor(options);
+
+    const pruneSamples = (nowMs: number) =>
+      Ref.update(samplesRef, (samples) => {
+        const cutoffMs = nowMs - retentionMs;
+        return samples.filter((sample) => sample.timestampMs >= cutoffMs).slice(-maxSamples);
+      });
+
+    const prune: MetricsAggregatorShape["prune"] = (nowMs) =>
+      Effect.gen(function* () {
+        const resolvedNowMs = nowMs ?? (yield* Clock.currentTimeMillis);
+        yield* pruneSamples(resolvedNowMs);
+      });
+
+    const recordRpcSample: MetricsAggregatorShape["recordRpcSample"] = (sample) =>
+      Ref.update(samplesRef, (samples) => [...samples, normalizeSample(sample)].slice(-maxSamples));
+
+    const snapshot: MetricsAggregatorShape["snapshot"] = (nowMs) =>
+      Effect.gen(function* () {
+        const resolvedNowMs = nowMs ?? (yield* Clock.currentTimeMillis);
+        yield* pruneSamples(resolvedNowMs);
+        const samples = yield* Ref.get(samplesRef);
+        return yield* aggregateRpcMetricSamples(
+          samples,
+          aggregationOptionsFromLiveOptions(resolvedNowMs, options),
+        );
+      });
+
+    yield* Effect.forkScoped(
+      prune().pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("metrics.aggregator.prune-failed", { cause }),
+        ),
+        Effect.repeat(Schedule.spaced(Duration.millis(pruneIntervalMs))),
+      ),
+    );
+
+    return {
+      recordRpcSample,
+      snapshot,
+      prune,
+    } satisfies MetricsAggregatorShape;
+  });
+
+export const makeMetricsAggregatorLive = (options?: MetricsAggregatorLiveOptions) =>
+  Layer.effect(MetricsAggregator, makeMetricsAggregator(options));
+
+export const MetricsAggregatorLive = makeMetricsAggregatorLive();

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -88,6 +88,7 @@ import {
   BrowserTraceCollector,
   type BrowserTraceCollectorShape,
 } from "./observability/Services/BrowserTraceCollector.ts";
+import { MetricsAggregatorLive } from "./observability/Services/MetricsAggregator.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
 import {
   ProjectSetupScriptRunner,
@@ -693,6 +694,7 @@ const buildAppUnderTest = (options?: {
           ...options?.layers?.browserTraceCollector,
         }),
       ),
+      Layer.provideMerge(MetricsAggregatorLive),
       Layer.provide(
         Layer.mock(ServerLifecycleEvents)({
           publish: (event) => Effect.succeed({ ...(event as any), sequence: 1 }),
@@ -1064,6 +1066,29 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(response.status, 200);
       assertBrowserApiCorsHeaders(response.headers);
       assert.deepEqual(body, testEnvironmentDescriptor);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("serves authenticated aggregated metrics windows", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const response = yield* HttpClient.get("/metrics/aggregated", {
+        headers: {
+          cookie: yield* getAuthenticatedSessionCookieHeader(),
+        },
+      });
+      const body = (yield* response.json) as ReadonlyArray<{
+        readonly startedAt: string;
+        readonly endedAt: string;
+        readonly sampleCount: number;
+      }>;
+
+      assert.equal(response.status, 200);
+      assert.equal(body.length, 60);
+      assert.equal(typeof body[0]?.startedAt, "string");
+      assert.equal(typeof body[0]?.endedAt, "string");
+      assert.equal(typeof body[0]?.sampleCount, "number");
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -4,6 +4,7 @@ import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 
 import { ServerConfig } from "./config.ts";
 import {
+  aggregatedMetricsRouteLayer,
   attachmentsRouteLayer,
   otlpTracesProxyRouteLayer,
   projectFaviconRouteLayer,
@@ -304,6 +305,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   authPairingCredentialRouteLayer,
   authSessionRouteLayer,
   authWebSocketTokenRouteLayer,
+  aggregatedMetricsRouteLayer,
   attachmentsRouteLayer,
   orchestrationDispatchRouteLayer,
   orchestrationSnapshotRouteLayer,


### PR DESCRIPTION
﻿## Summary
- adds a MetricsAggregator service backed by Effect.Ref and Effect.Schedule
- aggregates RPC metrics into the last 60 time windows using Effect.Stream.sliding
- tracks per-method p50/p95/p99 latency, error percentage, throughput, and request counts
- records unary and stream RPC outcomes into the aggregator
- exposes authenticated JSON windows at GET /metrics/aggregated

## Tests
- vitest run apps/server/src/observability/MetricsAggregator.test.ts apps/server/src/observability/RpcInstrumentation.test.ts
- vitest run apps/server/src/server.test.ts -t "serves authenticated aggregated metrics windows"
- tsc --noEmit -p apps/server/tsconfig.json --pretty false
- oxlint targeted changed files
- oxfmt --check targeted changed files

Fixes #856
