### PR TITLE
Codex GPT-5 [ T3 Code ] Add gzip and brotli HTTP compression

### DIFF
--- a/t3code/_provenance.json
+++ b/t3code/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Codex GPT-5",
+  "boot_context": "Public-safe submission metadata only. Private system, developer, runtime, user, credential, and workspace instructions are intentionally not included.",
+  "timestamp": "2026-07-12T23:18:30.6466523+00:00"
+}

--- a/t3code/apps/server/src/bin.test.ts
+++ b/t3code/apps/server/src/bin.test.ts
@@ -17,7 +17,12 @@ import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
 import { cli } from "./bin.ts";
-import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "./config.ts";
+import {
+  DEFAULT_HTTP_COMPRESSION_LEVEL,
+  deriveServerPaths,
+  ServerConfig,
+  type ServerConfigShape,
+} from "./config.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import {
@@ -78,6 +83,7 @@ const makeCliTestServerConfig = (baseDir: string) =>
       logWebSocketEvents: false,
       tailscaleServeEnabled: false,
       tailscaleServePort: 443,
+      httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
     } satisfies ServerConfigShape;
   });
 

--- a/t3code/apps/server/src/cli/config.test.ts
+++ b/t3code/apps/server/src/cli/config.test.ts
@@ -15,7 +15,7 @@ import {
 } from "@t3tools/contracts";
 import * as NetService from "@t3tools/shared/Net";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { deriveServerPaths } from "../config.ts";
+import { DEFAULT_HTTP_COMPRESSION_LEVEL, deriveServerPaths } from "../config.ts";
 import { resolveServerConfig } from "./config.ts";
 
 const encodeDesktopBootstrap = Schema.encodeEffect(Schema.fromJsonString(DesktopBackendBootstrap));
@@ -92,6 +92,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
                   T3CODE_NO_BROWSER: "true",
                   T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "false",
                   T3CODE_LOG_WS_EVENTS: "true",
+                  T3CODE_COMPRESSION_LEVEL: "8",
                 },
               }),
             ),
@@ -118,6 +119,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: true,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        httpCompressionLevel: 8,
       });
     }),
   );
@@ -184,6 +186,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: true,
         tailscaleServeEnabled: true,
         tailscaleServePort: 8443,
+        httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
       });
     }),
   );
@@ -253,6 +256,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
       });
     }),
   );
@@ -327,6 +331,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
       });
       assert.equal(join(baseDir, "userdata"), resolved.stateDir);
     }),
@@ -452,6 +457,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: true,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
       });
     }),
   );
@@ -521,6 +527,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
       });
     }),
   );
@@ -584,6 +591,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
       });
     }),
   );

--- a/t3code/apps/server/src/cli/config.ts
+++ b/t3code/apps/server/src/cli/config.ts
@@ -16,6 +16,7 @@ import { Argument, Flag } from "effect/unstable/cli";
 import { readBootstrapEnvelope } from "../bootstrap.ts";
 import {
   DEFAULT_PORT,
+  DEFAULT_HTTP_COMPRESSION_LEVEL,
   deriveServerPaths,
   ensureServerDirectories,
   resolveStaticDir,
@@ -135,6 +136,9 @@ const EnvServerConfig = Config.all({
   tailscaleServePort: Config.port("T3CODE_TAILSCALE_SERVE_PORT").pipe(
     Config.option,
     Config.map(Option.getOrUndefined),
+  ),
+  httpCompressionLevel: Config.int("T3CODE_COMPRESSION_LEVEL").pipe(
+    Config.withDefault(DEFAULT_HTTP_COMPRESSION_LEVEL),
   ),
 });
 
@@ -374,6 +378,7 @@ export const resolveServerConfig = (
       logWebSocketEvents,
       tailscaleServeEnabled,
       tailscaleServePort,
+      httpCompressionLevel: env.httpCompressionLevel,
     };
 
     return config;

--- a/t3code/apps/server/src/config.ts
+++ b/t3code/apps/server/src/config.ts
@@ -15,6 +15,7 @@ import * as Schema from "effect/Schema";
 import * as Context from "effect/Context";
 
 export const DEFAULT_PORT = 3773;
+export const DEFAULT_HTTP_COMPRESSION_LEVEL = 6;
 
 export const RuntimeMode = Schema.Literals(["web", "desktop"]);
 export type RuntimeMode = typeof RuntimeMode.Type;
@@ -73,6 +74,7 @@ export interface ServerConfigShape extends ServerDerivedPaths {
   readonly logWebSocketEvents: boolean;
   readonly tailscaleServeEnabled: boolean;
   readonly tailscaleServePort: number;
+  readonly httpCompressionLevel: number;
 }
 
 export const deriveServerPaths = Effect.fn(function* (
@@ -168,6 +170,7 @@ export class ServerConfig extends Context.Service<ServerConfig, ServerConfigShap
           logWebSocketEvents: false,
           tailscaleServeEnabled: false,
           tailscaleServePort: 443,
+          httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
           port: 0,
           host: undefined,
           desktopBootstrapToken: undefined,

--- a/t3code/apps/server/src/environment/Layers/ServerEnvironment.test.ts
+++ b/t3code/apps/server/src/environment/Layers/ServerEnvironment.test.ts
@@ -8,7 +8,12 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
 
-import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "../../config.ts";
+import {
+  DEFAULT_HTTP_COMPRESSION_LEVEL,
+  deriveServerPaths,
+  ServerConfig,
+  type ServerConfigShape,
+} from "../../config.ts";
 import { ServerEnvironment } from "../Services/ServerEnvironment.ts";
 import { ServerEnvironmentLive } from "./ServerEnvironment.ts";
 
@@ -37,6 +42,7 @@ const makeServerConfig = Effect.fn(function* (baseDir: string) {
     logWebSocketEvents: false,
     tailscaleServeEnabled: false,
     tailscaleServePort: 443,
+    httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
     port: 0,
     host: undefined,
     desktopBootstrapToken: undefined,

--- a/t3code/apps/server/src/http.test.ts
+++ b/t3code/apps/server/src/http.test.ts
@@ -1,6 +1,23 @@
+import { promisify } from "node:util";
+import { brotliDecompress, gzip, gunzip } from "node:zlib";
+
+import * as Effect from "effect/Effect";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { describe, expect, it } from "vitest";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import {
+  chooseResponseCompressionEncoding,
+  compressHttpResponseForRequest,
+  decompressHttpRequest,
+  isLoopbackHostname,
+  normalizeHttpCompressionLevel,
+  resolveDevRedirectUrl,
+  shouldSkipCompressionContentType,
+} from "./http.ts";
+
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+const brotliDecompressAsync = promisify(brotliDecompress);
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +40,118 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("http compression", () => {
+  it("prefers brotli over gzip when both encodings are accepted", () => {
+    expect(chooseResponseCompressionEncoding("gzip, br")).toBe("br");
+    expect(chooseResponseCompressionEncoding("gzip;q=1, br;q=0.4")).toBe("br");
+    expect(chooseResponseCompressionEncoding("br;q=0, gzip")).toBe("gzip");
+    expect(chooseResponseCompressionEncoding("identity")).toBeUndefined();
+  });
+
+  it("clamps compression levels to zlib's supported brotli range", () => {
+    expect(normalizeHttpCompressionLevel(-2)).toBe(0);
+    expect(normalizeHttpCompressionLevel(4.4)).toBe(4);
+    expect(normalizeHttpCompressionLevel(99)).toBe(11);
+    expect(normalizeHttpCompressionLevel(Number.NaN)).toBe(6);
+  });
+
+  it("skips already-compressed content types", () => {
+    expect(shouldSkipCompressionContentType("image/png")).toBe(true);
+    expect(shouldSkipCompressionContentType("application/zip")).toBe(true);
+    expect(shouldSkipCompressionContentType("application/json")).toBe(false);
+  });
+
+  it("brotli-compresses eligible responses and sets response headers", async () => {
+    const request = HttpServerRequest.fromWeb(
+      new Request("http://localhost/api/data", {
+        headers: { "Accept-Encoding": "gzip, br" },
+      }),
+    );
+    const payload = { value: "x".repeat(2_000) };
+    const response = HttpServerResponse.jsonUnsafe(payload);
+
+    const compressed = await Effect.runPromise(
+      compressHttpResponseForRequest(request, response, 5),
+    );
+
+    expect(compressed.headers["content-encoding"]).toBe("br");
+    expect(compressed.headers.vary).toBe("Accept-Encoding");
+    expect(compressed.body._tag).toBe("Uint8Array");
+    if (compressed.body._tag !== "Uint8Array") return;
+
+    expect(compressed.body.contentLength).toBeLessThan(JSON.stringify(payload).length);
+    const decompressed = await brotliDecompressAsync(Buffer.from(compressed.body.body));
+    expect(JSON.parse(decompressed.toString("utf8"))).toEqual(payload);
+  });
+
+  it("gzip-compresses eligible responses when brotli is not accepted", async () => {
+    const request = HttpServerRequest.fromWeb(
+      new Request("http://localhost/api/data", {
+        headers: { "Accept-Encoding": "gzip" },
+      }),
+    );
+    const payload = "hello ".repeat(300);
+    const response = HttpServerResponse.text(payload, {
+      contentType: "text/plain; charset=utf-8",
+    });
+
+    const compressed = await Effect.runPromise(
+      compressHttpResponseForRequest(request, response, 5),
+    );
+
+    expect(compressed.headers["content-encoding"]).toBe("gzip");
+    expect(compressed.body._tag).toBe("Uint8Array");
+    if (compressed.body._tag !== "Uint8Array") return;
+
+    const decompressed = await gunzipAsync(Buffer.from(compressed.body.body));
+    expect(decompressed.toString("utf8")).toBe(payload);
+  });
+
+  it("does not compress small responses or image responses", async () => {
+    const request = HttpServerRequest.fromWeb(
+      new Request("http://localhost/api/data", {
+        headers: { "Accept-Encoding": "br, gzip" },
+      }),
+    );
+    const smallResponse = HttpServerResponse.text("small");
+    const imageResponse = HttpServerResponse.uint8Array(new Uint8Array(2_048), {
+      contentType: "image/png",
+    });
+
+    const smallResult = await Effect.runPromise(
+      compressHttpResponseForRequest(request, smallResponse, 5),
+    );
+    const imageResult = await Effect.runPromise(
+      compressHttpResponseForRequest(request, imageResponse, 5),
+    );
+
+    expect(smallResult.headers["content-encoding"]).toBeUndefined();
+    expect(imageResult.headers["content-encoding"]).toBeUndefined();
+  });
+
+  it("decompresses gzip request bodies before handlers parse JSON", async () => {
+    const payload = { traces: [{ id: "trace-1" }] };
+    const compressed = await gzipAsync(Buffer.from(JSON.stringify(payload)));
+    const request = HttpServerRequest.fromWeb(
+      new Request("http://localhost/api/observability/v1/traces", {
+        method: "POST",
+        headers: {
+          "Content-Encoding": "gzip",
+          "Content-Type": "application/json",
+        },
+        body: compressed,
+      }),
+    );
+
+    const decompressed = await Effect.runPromise(decompressHttpRequest(request));
+
+    expect(decompressed.headers["content-encoding"]).toBeUndefined();
+    expect(decompressed.headers["content-length"]).toBe(
+      Buffer.byteLength(JSON.stringify(payload)).toString(),
+    );
+    await expect(Effect.runPromise(decompressed.json)).resolves.toEqual(payload);
   });
 });

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,3 +1,6 @@
+import { promisify } from "node:util";
+import { brotliCompress, brotliDecompress, constants, gzip, gunzip } from "node:zlib";
+
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
 import * as Data from "effect/Data";
@@ -5,6 +8,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import type * as Types from "effect/Types";
 import { cast } from "effect/Function";
 import {
   HttpBody,
@@ -22,7 +26,7 @@ import {
   resolveAttachmentRelativePath,
 } from "./attachmentPaths.ts";
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
-import { resolveStaticDir, ServerConfig } from "./config.ts";
+import { DEFAULT_HTTP_COMPRESSION_LEVEL, resolveStaticDir, ServerConfig } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
@@ -38,11 +42,243 @@ const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
+const RESPONSE_COMPRESSION_MIN_BYTES = 1024;
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
+const brotliCompressAsync = promisify(brotliCompress);
+const brotliDecompressAsync = promisify(brotliDecompress);
+
+export type HttpCompressionEncoding = "br" | "gzip";
+
+class HttpCompressionError extends Data.TaggedError("HttpCompressionError")<{
+  readonly cause: unknown;
+  readonly operation: "compress" | "decompress";
+}> {}
+
+const compressedContentTypes = new Set([
+  "application/gzip",
+  "application/java-archive",
+  "application/octet-stream",
+  "application/pdf",
+  "application/vnd.rar",
+  "application/x-7z-compressed",
+  "application/x-bzip",
+  "application/x-bzip2",
+  "application/x-gzip",
+  "application/x-rar-compressed",
+  "application/x-tar",
+  "application/zip",
+  "application/zstd",
+]);
+
+function parseAcceptedEncodings(acceptEncoding: string | undefined): Set<string> {
+  const accepted = new Set<string>();
+  for (const rawPart of acceptEncoding?.split(",") ?? []) {
+    const [encodingPart, ...parameters] = rawPart.trim().split(";");
+    const encoding = encodingPart?.trim().toLowerCase();
+    if (!encoding) continue;
+
+    const qParameter = parameters.find((parameter) => parameter.trim().startsWith("q="));
+    const qValue = qParameter ? Number.parseFloat(qParameter.trim().slice(2)) : 1;
+    if (!Number.isFinite(qValue) || qValue <= 0) continue;
+    accepted.add(encoding);
+  }
+  return accepted;
+}
+
+export function chooseResponseCompressionEncoding(
+  acceptEncoding: string | undefined,
+): HttpCompressionEncoding | undefined {
+  const accepted = parseAcceptedEncodings(acceptEncoding);
+  if (accepted.has("br") || accepted.has("*")) return "br";
+  if (accepted.has("gzip")) return "gzip";
+  return undefined;
+}
+
+export function normalizeHttpCompressionLevel(level: number): number {
+  if (!Number.isFinite(level)) return DEFAULT_HTTP_COMPRESSION_LEVEL;
+  return Math.min(11, Math.max(0, Math.round(level)));
+}
+
+export function shouldSkipCompressionContentType(contentType: string | undefined): boolean {
+  if (!contentType) return false;
+
+  const normalized = contentType.split(";")[0]?.trim().toLowerCase();
+  if (!normalized) return false;
+
+  return (
+    normalized.startsWith("audio/") ||
+    normalized.startsWith("font/") ||
+    normalized.startsWith("image/") ||
+    normalized.startsWith("video/") ||
+    compressedContentTypes.has(normalized)
+  );
+}
+
+function mergeVaryHeader(current: string | undefined, nextValue: string): string {
+  const values =
+    current
+      ?.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean) ?? [];
+  if (values.some((value) => value.toLowerCase() === nextValue.toLowerCase())) {
+    return values.join(", ");
+  }
+  return [...values, nextValue].join(", ");
+}
+
+function isCompressibleResponse(response: HttpServerResponse.HttpServerResponse): boolean {
+  if (response.status === 204 || response.status === 304) return false;
+  if (response.headers["content-encoding"]) return false;
+  if (response.body._tag !== "Uint8Array") return false;
+  if (response.body.contentLength < RESPONSE_COMPRESSION_MIN_BYTES) return false;
+  return !shouldSkipCompressionContentType(response.body.contentType);
+}
+
+function compressBytes(
+  bytes: Uint8Array,
+  encoding: HttpCompressionEncoding,
+  level: number,
+): Effect.Effect<Uint8Array, HttpCompressionError> {
+  const normalizedLevel = normalizeHttpCompressionLevel(level);
+  return Effect.tryPromise({
+    try: async () => {
+      if (encoding === "br") {
+        return await brotliCompressAsync(Buffer.from(bytes), {
+          params: {
+            [constants.BROTLI_PARAM_QUALITY]: normalizedLevel,
+          },
+        });
+      }
+
+      return await gzipAsync(Buffer.from(bytes), {
+        level: Math.min(9, normalizedLevel),
+      });
+    },
+    catch: (cause) => new HttpCompressionError({ cause, operation: "compress" }),
+  }).pipe(Effect.map((buffer) => new Uint8Array(buffer)));
+}
+
+export function compressHttpResponseForRequest(
+  request: HttpServerRequest.HttpServerRequest,
+  response: HttpServerResponse.HttpServerResponse,
+  compressionLevel: number,
+): Effect.Effect<HttpServerResponse.HttpServerResponse, HttpCompressionError> {
+  const encoding = chooseResponseCompressionEncoding(request.headers["accept-encoding"]);
+  if (!encoding || !isCompressibleResponse(response)) {
+    return Effect.succeed(response);
+  }
+
+  const body = response.body;
+  if (body._tag !== "Uint8Array") {
+    return Effect.succeed(response);
+  }
+
+  return Effect.map(compressBytes(body.body, encoding, compressionLevel), (compressedBody) =>
+    HttpServerResponse.setHeaders(
+      HttpServerResponse.setBody(response, HttpBody.uint8Array(compressedBody, body.contentType)),
+      {
+        "Content-Encoding": encoding,
+        Vary: mergeVaryHeader(response.headers.vary, "Accept-Encoding"),
+      },
+    ),
+  );
+}
+
+function decodeRequestBody(
+  bytes: Uint8Array,
+  encoding: string,
+): Effect.Effect<Uint8Array, HttpCompressionError> {
+  return Effect.tryPromise({
+    try: async () => {
+      if (encoding === "br") {
+        return await brotliDecompressAsync(Buffer.from(bytes));
+      }
+      return await gunzipAsync(Buffer.from(bytes));
+    },
+    catch: (cause) => new HttpCompressionError({ cause, operation: "decompress" }),
+  }).pipe(Effect.map((buffer) => new Uint8Array(buffer)));
+}
+
+export function decompressHttpRequest(
+  request: HttpServerRequest.HttpServerRequest,
+): Effect.Effect<HttpServerRequest.HttpServerRequest, HttpCompressionError> {
+  const contentEncoding = request.headers["content-encoding"]?.trim().toLowerCase();
+  if (contentEncoding !== "gzip" && contentEncoding !== "br") {
+    return Effect.succeed(request);
+  }
+
+  return Effect.gen(function* () {
+    const compressedBytes = new Uint8Array(
+      yield* request.arrayBuffer.pipe(
+        Effect.mapError((cause) => new HttpCompressionError({ cause, operation: "decompress" })),
+      ),
+    );
+    const decompressedBytes = yield* decodeRequestBody(compressedBytes, contentEncoding);
+    const headers = new Headers({ ...request.headers });
+    headers.delete("content-encoding");
+    headers.set("content-length", decompressedBytes.byteLength.toString());
+
+    const sourceUrl = request.source instanceof Request ? request.source.url : request.originalUrl;
+    const url = sourceUrl.startsWith("/") ? `http://localhost${sourceUrl}` : sourceUrl;
+    const webRequest = new Request(url, {
+      method: request.method,
+      headers,
+      body: request.method === "GET" || request.method === "HEAD" ? undefined : decompressedBytes,
+    });
+
+    return HttpServerRequest.fromWeb(webRequest).modify({
+      url: request.url,
+      remoteAddress: request.remoteAddress,
+    });
+  });
+}
+
+const httpCompressionMiddleware = (
+  handler: Effect.Effect<HttpServerResponse.HttpServerResponse, Types.unhandled>,
+) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const config = yield* ServerConfig;
+    const decompressedRequest = yield* decompressHttpRequest(request).pipe(
+      Effect.match({
+        onFailure: () => undefined,
+        onSuccess: (request) => request,
+      }),
+    );
+
+    if (!decompressedRequest) {
+      return HttpServerResponse.jsonUnsafe(
+        {
+          error: "Invalid compressed request body",
+        },
+        { status: 400 },
+      );
+    }
+
+    const response = yield* handler.pipe(
+      Effect.provideService(HttpServerRequest.HttpServerRequest, decompressedRequest),
+    );
+
+    return yield* compressHttpResponseForRequest(
+      decompressedRequest,
+      response,
+      config.httpCompressionLevel,
+    ).pipe(
+      Effect.catch((cause) =>
+        Effect.logWarning("Failed to compress HTTP response", { cause }).pipe(Effect.as(response)),
+      ),
+    );
+  });
 
 export const browserApiCorsLayer = HttpRouter.cors({
   allowedMethods: [...browserApiCorsAllowedMethods],
   allowedHeaders: [...browserApiCorsAllowedHeaders],
   maxAge: 600,
+});
+
+export const httpCompressionRouteLayer = HttpRouter.middleware(httpCompressionMiddleware, {
+  global: true,
 });
 
 export function isLoopbackHostname(hostname: string): boolean {

--- a/t3code/apps/server/src/server.test.ts
+++ b/t3code/apps/server/src/server.test.ts
@@ -54,7 +54,7 @@ import { vi } from "vitest";
 const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
 
 import type { ServerConfigShape } from "./config.ts";
-import { deriveServerPaths, ServerConfig } from "./config.ts";
+import { DEFAULT_HTTP_COMPRESSION_LEVEL, deriveServerPaths, ServerConfig } from "./config.ts";
 import { makeRoutesLayer } from "./server.ts";
 import { resolveAttachmentRelativePath } from "./attachmentPaths.ts";
 import {
@@ -371,6 +371,7 @@ const buildAppUnderTest = (options?: {
       logWebSocketEvents: false,
       tailscaleServeEnabled: false,
       tailscaleServePort: 443,
+      httpCompressionLevel: DEFAULT_HTTP_COMPRESSION_LEVEL,
       ...options?.config,
     };
     const layerConfig = Layer.succeed(ServerConfig, config);

--- a/t3code/apps/server/src/server.ts
+++ b/t3code/apps/server/src/server.ts
@@ -10,6 +10,7 @@ import {
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   browserApiCorsLayer,
+  httpCompressionRouteLayer,
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
@@ -312,7 +313,7 @@ export const makeRoutesLayer = Layer.mergeAll(
   serverEnvironmentRouteLayer,
   staticAndDevRouteLayer,
   websocketRpcRouteLayer,
-).pipe(Layer.provide(browserApiCorsLayer));
+).pipe(Layer.provide(Layer.mergeAll(browserApiCorsLayer, httpCompressionRouteLayer)));
 
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {


### PR DESCRIPTION
﻿/claim #863

## Summary
- Add global HTTP compression middleware for eligible responses larger than 1KB.
- Prefer brotli over gzip when the client accepts both, and set Content-Encoding plus Vary: Accept-Encoding.
- Skip already-compressed media/archive content types and decompress incoming gzip/brotli request bodies before handler parsing.
- Add T3CODE_COMPRESSION_LEVEL with a default compression level and test coverage for response compression, request decompression, and config resolution.

## Provenance
- _provenance.json includes public-safe submission metadata only.
- Private system, developer, runtime, user, credential, and workspace instructions are intentionally not included.

## Validation
- vitest run apps/server/src/http.test.ts
- vitest run apps/server/src/cli/config.test.ts -t "falls back to effect/config values"
- oxfmt --check on touched files
- oxlint on touched files
- git diff --check
- Full server typecheck was attempted; this checkout still reports unrelated existing Effect diagnostic/dependency noise outside the touched files, and a filtered pass showed no diagnostics for the modified server files.
