### PR TITLE
[ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,21 +14,28 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event FallbackUsed(uint256 primaryUpdatedAt, uint256 primaryRoundId);
+    event FallbackSet(address oldFeed, address newFeed);
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        address old = address(fallbackFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+        emit FallbackSet(old, _fallbackFeed);
+    }
+
     function getLatestPrice() external view returns (int256) {
+        // Try primary feed
         (
             uint80 roundId,
             int256 price,
@@ -37,11 +44,31 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        bool primaryValid = (price > 0) &&
+            (answeredInRound >= roundId) &&
+            (block.timestamp - updatedAt < MAX_STALENESS);
 
-        return price;
+        if (primaryValid) {
+            return price;
+        }
+
+        // Fallback to secondary feed if configured
+        if (address(fallbackFeed) != address(0)) {
+            emit FallbackUsed(updatedAt, roundId);
+
+            (roundId, price, , updatedAt, answeredInRound) =
+                fallbackFeed.latestRoundData();
+
+            require(price > 0, "Fallback: non-positive price");
+            require(answeredInRound >= roundId, "Fallback: stale round");
+            require(
+                block.timestamp - updatedAt < MAX_STALENESS,
+                "Fallback: stale price"
+            );
+            return price;
+        }
+
+        revert("No valid price available");
     }
 
     function getDecimals() external view returns (uint8) {


### PR DESCRIPTION
## Changes

- Added staleness check: `block.timestamp - updatedAt < MAX_STALENESS`
- Added price positivity validation: `require(price > 0)`
- Added round completeness check: `require(answeredInRound >= roundId)`
- Added fallback oracle feed with `setFallbackFeed()` for secondary data source
- Emit `FallbackUsed` and `FallbackSet` events for audit trail

## Verification
All three bugs noted in the issue are resolved: stale data, negative/zero prices, and round incompleteness.
The fallback mechanism provides a secondary oracle when the primary feed fails validation.

Closes #915