### PR TITLE
[ Crypto ] Fix missing slippage protection and deadline in SimpleSwap

### DIFF
--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -11,6 +11,7 @@ contract SimpleSwap {
     uint256 public fee; // basis points, e.g. 30 = 0.3%
 
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
+    event SwapFailed(address indexed user, uint256 minAmountOut, uint256 actualOutput);
 
     constructor(address _tokenA, address _tokenB, uint256 _fee) {
         tokenA = IERC20(_tokenA);
@@ -25,10 +26,8 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(address tokenIn, uint256 amountIn, uint256 minAmountOut, uint256 deadline) external returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Transaction expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
@@ -39,11 +38,17 @@ contract SimpleSwap {
 
         inputToken.transferFrom(msg.sender, address(this), amountIn);
 
+        // Fee with explicit floor guard — if fee would round to zero, enforce minimum 1 wei fee
         uint256 feeAmount = amountIn * fee / 10000;
+        if (fee > 0 && feeAmount == 0) {
+            feeAmount = 1;
+        }
         uint256 amountInAfterFee = amountIn - feeAmount;
 
         // constant product formula: x * y = k
         amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+
+        require(amountOut >= minAmountOut, "Slippage exceeded");
 
         outputToken.transfer(msg.sender, amountOut);
 
@@ -63,6 +68,9 @@ contract SimpleSwap {
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
         uint256 feeAmount = amountIn * fee / 10000;
+        if (fee > 0 && feeAmount == 0) {
+            feeAmount = 1;
+        }
         uint256 amountInAfterFee = amountIn - feeAmount;
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
     }


### PR DESCRIPTION
## Changes

- Added `minAmountOut` parameter to prevent sandwich attacks
- Added `deadline` parameter to expire stale transactions
- Added zero-fee rounding guard: when fee > 0 but feeAmount rounds to 0, enforce minimum 1 wei fee

## Verification
All three bugs noted in #913 are resolved.

Closes #913