### PR TITLE
Wisdom King Raphael [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken delegation

### DIFF
--- a/solidity/contracts/.attribution.json
+++ b/solidity/contracts/.attribution.json
@@ -1,0 +1,1 @@
+{"tool": "Wisdom King Raphael", "platform_config": "Wisdom King Raphael — Lord of Wisdom. Autonomous bounty hunter for UnsafeLabs/Bounty-Hunters. Fixes Solidity vulnerabilities with precision.", "date": "2026-07-14T00:00:00Z"}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract GovernanceToken is ERC20 {
+contract GovernanceToken is ERC20, Ownable {
     mapping(address => address) public delegates;
     mapping(address => uint256) public delegatedPower;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
@@ -17,7 +18,6 @@ contract GovernanceToken is ERC20 {
     }
 
     Proposal[] public proposals;
-    address public admin;
 
     event DelegateChanged(address indexed delegator, address indexed toDelegate);
     event ProposalCreated(uint256 indexed proposalId, string description);
@@ -25,33 +25,30 @@ contract GovernanceToken is ERC20 {
 
     constructor(uint256 initialSupply) ERC20("Governance", "GOV") {
         _mint(msg.sender, initialSupply);
-        admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Zero address");
+        require(to != msg.sender, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        require(msg.sender != address(0), "Zero address");
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
-    function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+    function snapshot() external onlyOwner {
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
Fixes #912

**Changes:**
- Replace all `tx.origin` with `msg.sender` in `delegateVote` and `revokeDelegate`
- Add explicit `require(msg.sender != address(0))` guards
- Replace manual admin check with OpenZeppelin `Ownable` `onlyOwner` modifier
- Remove redundant `admin` address variable

**Acceptance Criteria:**
- No `tx.origin` usage remains in the contract ✓
- All authorization uses `msg.sender` ✓
- `onlyOwner` protects admin functions ✓
- Delegated voting still works through legitimate contract interactions ✓