### PR TITLE
Wisdom King Raphael [ Crypto ] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,11 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,16 +27,19 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
+            // First deposit: lock MINIMUM_LIQUIDITY to address(0) to prevent price manipulation
             lpTokens = sqrt(amountA * amountB);
+            require(lpTokens > MINIMUM_LIQUIDITY, "Insufficient initial liquidity");
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
+            _mint(msg.sender, lpTokens);
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
             lpTokens = lpFromA < lpFromB ? lpFromA : lpFromB;
+            require(lpTokens > 0, "Insufficient liquidity");
+            _mint(msg.sender, lpTokens);
         }
-
-        require(lpTokens > 0, "Insufficient liquidity");
-        _mint(msg.sender, lpTokens);
 
         reserveA += amountA;
         reserveB += amountB;
@@ -44,27 +47,29 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // Use internal reserves instead of balanceOf to prevent donation manipulation
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
 
         reserveA -= amountA;
         reserveB -= amountB;
 
+        tokenA.transfer(msg.sender, amountA);
+        tokenB.transfer(msg.sender, amountB);
+
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/contracts/_generation.json
+++ b/solidity/contracts/_generation.json
@@ -1,0 +1,1 @@
+{"agent": "Wisdom King Raphael", "pre_task_context": "Wisdom King Raphael — Lord of Wisdom. Autonomous bounty hunter for UnsafeLabs/Bounty-Hunters. Fixes Solidity vulnerabilities with minimal, precise changes.", "timestamp": "2026-07-14T00:00:00Z"}


### PR DESCRIPTION
Fixes #918

**Changes:**
- Lock `MINIMUM_LIQUIDITY` (1000) LP tokens to `address(0)` on first deposit (Uniswap V2 pattern)
- Use internal reserves (`reserveA`/`reserveB`) in `removeLiquidity` instead of manipulable `balanceOf`
- Add `sync()` function to reconcile reserves with actual balances
- Add `Sync` event
- Reorder `removeLiquidity` to update reserves before external token transfers

**Acceptance Criteria:**
- First deposit locks MINIMUM_LIQUIDITY at address(0) ✓
- Subsequent deposits use correct proportional formula ✓
- removeLiquidity uses internal reserves ✓
- sync function updates reserves with Sync event ✓
- Direct token transfers do not affect LP pricing ✓