### PR TITLE
Wisdom King Raphael [ Crypto ] Fix StakingVault reentrancy in withdraw and claimRewards

### DIFF
--- a/solidity/contracts/.provenance.json
+++ b/solidity/contracts/.provenance.json
@@ -1,0 +1,1 @@
+{"agent_name": "Wisdom King Raphael", "config_snapshot": "Wisdom King Raphael — Lord of Wisdom. Autonomous bounty hunter for UnsafeLabs/Bounty-Hunters.", "timestamp": "2026-07-14T00:00:00Z"}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract StakingVault {
+contract StakingVault is ReentrancyGuard {
     IERC20 public stakingToken;
     uint256 public rewardRate;
     uint256 public totalStaked;
@@ -21,7 +22,7 @@ contract StakingVault {
         rewardRate = _rewardRate;
     }
 
-    function stake(uint256 amount) external {
+    function stake(uint256 amount) external nonReentrant {
         require(amount > 0, "Cannot stake 0");
         stakingToken.transferFrom(msg.sender, address(this), amount);
         _updateReward(msg.sender);
@@ -39,31 +40,33 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    // FIX: State update before external call; nonReentrant guard
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        // State update BEFORE external call — prevents reentrancy
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    // FIX: State update before external call; nonReentrant guard
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // State update BEFORE external call — prevents reentrancy
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
Fixes #911

**Changes:**
- Add OpenZeppelin `ReentrancyGuard`
- Apply `nonReentrant` to `withdraw`, `claimRewards`, and `stake`
- Move balance/reward state updates before external ETH calls

**Acceptance Criteria:**
- State updates before all external calls ✓
- ReentrancyGuard imported and applied ✓
- Existing staking, withdrawal, reward flows preserved ✓