### PR TITLE
Wisdom King Raphael [ Crypto ] Fix zero-fee flash loans and pool drainage protection

### DIFF
--- a/solidity/contracts/.contributor.json
+++ b/solidity/contracts/.contributor.json
@@ -1,0 +1,1 @@
+{"agent": "Wisdom King Raphael", "initialized_with": "Wisdom King Raphael — Lord of Wisdom. Autonomous bounty hunter for UnsafeLabs/Bounty-Hunters.", "timestamp": "2026-07-14T00:00:00Z"}

--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -14,52 +14,85 @@ contract FlashLoan {
     address public owner;
     bool public paused;
 
+    // Internal accounting to prevent rebasing token manipulation
+    uint256 public poolBalance;
+
+    uint256 public constant MAX_LOAN_BPS = 5000; // 50% max loan
+
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event Paused(address indexed owner);
+    event Unpaused(address indexed owner);
+    event Deposited(address indexed depositor, uint256 amount);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
     constructor(address _loanToken, uint256 _feeBPS) {
+        require(_feeBPS <= 10000, "Invalid fee BPS");
         loanToken = IERC20(_loanToken);
         feeBPS = _feeBPS;
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
     function flashLoan(uint256 amount, bytes calldata data) external {
         require(!paused, "Paused");
         require(amount > 0, "Amount must be > 0");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
+        // Max loan cap: 50% of pool balance to prevent drainage
+        require(amount <= poolBalance * MAX_LOAN_BPS / 10000, "Loan exceeds max");
+
+        // Minimum fee of 1 token to prevent zero-fee loans
+        uint256 fee = amount * feeBPS / 10000;
+        if (fee == 0) {
+            fee = 1;
+        }
+
+        uint256 balanceBefore = poolBalance;
         require(balanceBefore >= amount, "Insufficient pool balance");
 
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
-        uint256 fee = amount * feeBPS / 10000;
-
+        // Transfer from internal pool balance
+        poolBalance -= amount;
         loanToken.transfer(msg.sender, amount);
 
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
 
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        // Repayment: use token balance delta to support rebasing tokens too
+        // But enforce at minimum the internal accounting amount
+        uint256 currentBalance = loanToken.balanceOf(address(this));
+        require(currentBalance >= balanceBefore + fee, "Loan not repaid");
 
+        // Keep internal accounting deterministic; surplus donations/rebases require explicit deposit/sync logic.
+        poolBalance = balanceBefore + fee;
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
     }
 
     function depositToPool(uint256 amount) external {
         loanToken.transferFrom(msg.sender, address(this), amount);
+        poolBalance += amount;
+        emit Deposited(msg.sender, amount);
     }
 
-    function withdrawFees() external {
-        require(msg.sender == owner, "Not owner");
+    function withdrawFees() external onlyOwner {
         uint256 fees = totalFees;
         totalFees = 0;
+        poolBalance -= fees;
         loanToken.transfer(owner, fees);
     }
 
-    // BUG: No emergency pause function
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolBalance;
     }
 }


### PR DESCRIPTION
Fixes #919

**Changes:**
- Add minimum fee of 1 token unit
- Reject loans over 50% of internal pool balance
- Add owner-controlled pause/unpause
- Track pool balance internally to resist rebasing/donation manipulation
- Track `totalFees` and deduct withdrawn fees from pool accounting

**Acceptance Criteria:**
- Small loans no longer free ✓
- Loans >50% pool balance rejected ✓
- Pause disables flash loans; unpause re-enables ✓
- Internal accounting used for pool share calculations ✓