### PR TITLE
Wisdom King Raphael [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,26 @@
+import contextvars
 import logging
 
+
+class RequestIDLogFilter(logging.Filter):
+    """
+    Inject the current request ID into log records.
+
+    Uses ``request_id_var`` — a :class:`contextvars.ContextVar` — so that
+    the filter works correctly with async frameworks without leaking IDs
+    between concurrent requests.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        rid = request_id_var.get(None)
+        record.request_id = rid if rid is not None else "-"
+        return True
+
+
+#: Context variable that holds the request ID for the current request.
+request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)
+
 logger = logging.getLogger("fastapi")
+logger.addFilter(RequestIDLogFilter())

--- a/fastapi/fastapi/middleware/_provenance.json
+++ b/fastapi/fastapi/middleware/_provenance.json
@@ -1,0 +1,1 @@
+{"tool_name": "Wisdom King Raphael", "boot_context": "Autonomous bounty hunter cron job. Task: fix UnsafeLabs/Bounty-Hunters issues. Rules: one PR per issue, use fork ardha27/Bounty-Hunters, Solidity/FastAPI/docs/scripts allowed, skip T3 Code. CI checks must pass. Read bounty-brain.md for persistent lessons before acting.", "timestamp": "2026-07-14T00:00:00Z"}

--- a/fastapi/fastapi/middleware/request_id.py
+++ b/fastapi/fastapi/middleware/request_id.py
@@ -1,0 +1,35 @@
+import uuid
+
+from fastapi.logger import request_id_var
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that attaches a unique request ID to each incoming HTTP request.
+
+    If the client sends an ``X-Request-ID`` header, that value is used and
+    echoed back.  Otherwise a new UUID4 is generated.
+
+    The request ID is stored in ``request.state.request_id`` and is injected
+    into the ``request_id_var`` context variable so that the logger automatically
+    includes it.  The ``X-Request-ID`` response header echoes the ID back.
+    Concurrent requests are isolated — each request carries its own ID.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_id = request.headers.get(
+            "X-Request-ID", str(uuid.uuid4())
+        )
+        request.state.request_id = request_id
+        token = request_id_var.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+        response.headers["X-Request-ID"] = request_id
+        return response


### PR DESCRIPTION
Fixes #797

## Changes
- Add `RequestIDMiddleware` in `fastapi/middleware/request_id.py`
- Generates UUID4 per request or preserves client-supplied `X-Request-ID`
- Stores ID in `request.state.request_id`
- Injects ID into `contextvars.ContextVar` for async-safe logger integration
- Adds `RequestIDLogFilter` to the fastapi logger
- Echoes `X-Request-ID` in response headers
- No ID leak between concurrent requests (contextvars isolated)