### PR TITLE
Wisdom King Raphael [ Crypto ] Fix cross-chain replay attack in CrossChainBridge signature verification

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T01:57:40+00:00"}

--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -9,6 +9,15 @@ contract CrossChainBridge {
     uint256 public nonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public senderNonce;
+
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256(
+        "Transfer(address recipient,uint256 amount,uint256 nonce)"
+    );
+    bytes32 public immutable DOMAIN_SEPARATOR;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -16,6 +25,13 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid,
+            address(this)
+        ));
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
@@ -24,34 +40,33 @@ contract CrossChainBridge {
         emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
+        require(transferNonce == senderNonce[recipient], "Invalid nonce");
+
+        bytes32 structHash = keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
             recipient,
             amount,
             transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
         ));
 
-        require(!processedTransfers[transferHash], "Already processed");
-        require(verifySignature(transferHash, signature), "Invalid signature");
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
+        require(!processedTransfers[digest], "Already processed");
+        require(verifySignature(digest, signature), "Invalid signature");
 
-        processedTransfers[transferHash] = true;
+        processedTransfers[digest] = true;
+        senderNonce[recipient]++;
         bridgeToken.transfer(recipient, amount);
 
-        emit TransferProcessed(transferHash, recipient, amount);
+        emit TransferProcessed(digest, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
-    function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
+    function verifySignature(bytes32 digest, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
         bytes32 r;
@@ -66,12 +81,8 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
-
-        // BUG: Missing require(recovered != address(0))
+        address recovered = ecrecover(digest, v, r, s);
+        require(recovered != address(0), "Invalid signature: zero address");
         return recovered == validator;
     }
 


### PR DESCRIPTION
## Fix for Issue #920

### Changes
- **EIP-712 typed data signing**: Domain separator includes name, version, chainId, and verifyingContract to prevent cross-chain and post-upgrade replay
- **Per-sender nonces** (`senderNonce` mapping) increments on each transfer to prevent same-chain replay
- **ecrecover zero-address check**: Rejects invalid signatures that recover to address(0)
- **Structured digest**: Uses EIP-712 `\x19\x01` prefix with DOMAIN_SEPARATOR + typed struct hash

### Acceptance Criteria
- ✅ Signed messages include chain ID, nonce, and contract address
- ✅ Same message cannot be replayed on a different chain (chainId in domain separator)
- ✅ Same message cannot be replayed on the same chain (per-sender nonce)
- ✅ Contract upgrade does not allow old message replay (contract address in domain separator)
- ✅ ecrecover zero-address result is rejected
- ✅ EIP-712 domain separator correctly constructed
- ✅ Nonce is queryable per sender via `senderNonce[address]`
- ✅ Contributor metadata included

Closes #920