### PR TITLE
Wisdom King Raphael [ Crypto ] Fix MultiSigWallet confirmation race condition during execution callback

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T01:57:40+00:00"}

--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-contract MultiSigWallet {
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+contract MultiSigWallet is ReentrancyGuard {
     address[] public owners;
     uint256 public required;
     uint256 public transactionCount;
@@ -11,6 +13,7 @@ contract MultiSigWallet {
         uint256 value;
         bytes data;
         bool executed;
+        uint256 confirmedCount;
     }
 
     mapping(uint256 => Transaction) public transactions;
@@ -37,52 +40,52 @@ contract MultiSigWallet {
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid recipient");
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
             value: value,
             data: data,
-            executed: false
+            executed: false,
+            confirmedCount: 0
         });
         emit Submitted(txId);
         return txId;
     }
 
     function confirmTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
+        Transaction storage txn = transactions[txId];
+        require(!txn.executed, "Already executed");
         require(!confirmations[txId][msg.sender], "Already confirmed");
         confirmations[txId][msg.sender] = true;
+        txn.confirmedCount++;
         emit Confirmed(txId, msg.sender);
     }
 
     function revokeConfirmation(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
+        Transaction storage txn = transactions[txId];
+        require(!txn.executed, "Already executed");
         require(confirmations[txId][msg.sender], "Not confirmed");
         confirmations[txId][msg.sender] = false;
+        txn.confirmedCount--;
         emit Revoked(txId, msg.sender);
     }
 
-    function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
-        for (uint256 i = 0; i < owners.length; i++) {
-            if (confirmations[txId][owners[i]]) count++;
-        }
+    function getConfirmationCount(uint256 txId) public view returns (uint256) {
+        return transactions[txId].confirmedCount;
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
-
+    function executeTransaction(uint256 txId) external onlyOwner nonReentrant {
         Transaction storage txn = transactions[txId];
+        require(!txn.executed, "Already executed");
+        require(txn.confirmedCount >= required, "Not enough confirmations");
+
         txn.executed = true;
+        emit Executed(txId);
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
         require(success, "Execution failed");
-
-        emit Executed(txId);
     }
 
     receive() external payable {}


### PR DESCRIPTION
## Fix for Issue #916

### Changes
- **ReentrancyGuard**: `executeTransaction` protected with `nonReentrant` modifier
- **Atomic confirmedCount**: Added `confirmedCount` field to Transaction struct, updated atomically on confirm/revoke
- **O(1) confirmation check**: `getConfirmationCount` now reads `confirmedCount` directly instead of loop
- **Zero-address check**: `submitTransaction` validates `to != address(0)`
- **CEI pattern**: `executed = true` + emit before external call, preventing re-entry state corruption

### Why
The original code recalculated confirmation count via a loop over owners during `executeTransaction`. During the external call, a malicious contract could revoke confirmations and re-enter, causing the count to fall below `required` after execution was marked. The atomic counter and nonReentrant guard block this.

Closes #916