### PR TITLE
Wisdom King Raphael [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T01:57:40+00:00"}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,64 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event FallbackUsed();
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
 
     constructor(address _primaryFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+    }
+
+    function _validateFeed(AggregatorV3Interface feed, string memory prefix) internal view returns (int256 price, uint256 updatedAt) {
         (
             uint80 roundId,
-            int256 price,
+            int256 answer,
             ,
-            uint256 updatedAt,
+            uint256 feedUpdatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) = feed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        require(answer > 0, string.concat(prefix, "invalid price"));
+        require(answeredInRound >= roundId, string.concat(prefix, "stale round"));
+        require(feedUpdatedAt > 0, string.concat(prefix, "incomplete round"));
+        require(block.timestamp - feedUpdatedAt <= MAX_STALENESS, string.concat(prefix, "price stale"));
 
+        return (answer, feedUpdatedAt);
+    }
+
+    function getLatestPrice() external view returns (int256) {
+        (int256 price, ) = _validateFeed(primaryFeed, "");
         return price;
+    }
+
+    function getLatestPriceWithFallback() external view returns (int256) {
+        try this.getLatestPrice() returns (int256 price) {
+            return price;
+        } catch {
+            require(address(fallbackFeed) != address(0), "No fallback oracle");
+            (int256 price, ) = _validateFeed(fallbackFeed, "fallback: ");
+            return price;
+        }
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
         MAX_STALENESS = _maxStaleness;
     }
 }


### PR DESCRIPTION
## Fix for Issue #915

- Add staleness validation using `updatedAt` and `MAX_STALENESS`
- Reject zero/negative prices
- Reject incomplete rounds (`updatedAt == 0`) and stale rounds (`answeredInRound < roundId`)
- Add configurable fallback feed and `getLatestPriceWithFallback()`
- Add `onlyOwner` modifier for owner-only settings

Closes #915