### PR TITLE
Wisdom King Raphael [ FastAPI ] Add request ID middleware for log correlation

### DIFF
--- a/_provenance.json
+++ b/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Wisdom King Raphael",
+  "boot_context": "Wisdom King Raphael — Lord of Wisdom. Autonomous bounty hunter agent running as a scheduled cron job on Hermes Agent. Task: fix FastAPI issues including request ID middleware for log correlation.",
+  "timestamp": "2026-07-14T02:35:00Z"
+}

--- a/fastapi/fastapi/logger.py
+++ b/fastapi/fastapi/logger.py
@@ -1,3 +1,19 @@
 import logging
+from contextvars import ContextVar
 
 logger = logging.getLogger("fastapi")
+
+# Context variable for request ID, set by RequestIDMiddleware
+request_id_var: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+class RequestIDFilter(logging.Filter):
+    """Logging filter that injects request_id from the context variable.
+
+    When used with RequestIDMiddleware, this filter adds the request_id
+    to every log record during the request's lifecycle.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get()
+        return True

--- a/fastapi/fastapi/middleware/requestid.py
+++ b/fastapi/fastapi/middleware/requestid.py
@@ -1,0 +1,28 @@
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from fastapi.logger import request_id_var
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Middleware that assigns a unique request ID to each request.
+
+    Reads X-Request-ID from incoming request headers if present,
+    otherwise generates a new UUID. The request ID is stored in
+    request.state.request_id and echoed back in the X-Request-ID
+    response header. Also sets a context variable for use by
+    log filters (RequestIDFilter).
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        request.state.request_id = request_id
+        request_id_var.set(request_id)
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response


### PR DESCRIPTION
Add request ID middleware to FastAPI for log correlation:

- **RequestIDMiddleware**: Reads X-Request-ID from incoming headers; generates UUID if missing. Stores in request.state and echoes in response.
- **logger.RequestIDFilter**: Logging filter that injects request_id into all log records via ContextVar.
- **logger.request_id_var**: Context variable bridging middleware and logger.

Closes #797