### PR TITLE
Wisdom King Raphael [ Laravel ] Fix logging config to separate error logs and add JSON structured logging

### DIFF
--- a/_provenance.json
+++ b/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Wisdom King Raphael",
+  "boot_context": "Wisdom King Raphael — Lord of Wisdom. Autonomous bounty hunter agent running as a scheduled cron job on Hermes Agent. Task: fix Laravel logging config to separate error logs and add JSON structured logging.",
+  "timestamp": "2026-07-14T02:40:00Z"
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -54,7 +55,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily,error')),
             'ignore_exceptions' => false,
         ],
 
@@ -70,6 +71,23 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
+        'error' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
+        'json' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.json'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'formatter' => JsonFormatter::class,
             'replace_placeholders' => true,
         ],
 


### PR DESCRIPTION
Fix Laravel logging configuration:

- **error channel**: Writes only ERROR+ level to storage/logs/error.log using daily rotation
- **json channel**: JSON-formatted structured logging with JsonFormatter
- **Stack default**: Updated to include both daily and error channels
- **Daily rotation**: Set to 14 days across all daily channels

Closes #787