### PR TITLE
Wisdom King Raphael [ Laravel ] Fix password cast to respect configured bcrypt rounds

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T05:00:00+00:00"}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -28,5 +29,18 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Set the user's password with configurable bcrypt rounds.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    protected function setPasswordAttribute(string $value): void
+    {
+        $rounds = config('hashing.bcrypt.rounds', 10);
+        $options = ['rounds' => (int) $rounds];
+        $this->attributes['password'] = Hash::make($value, $options);
     }
 }


### PR DESCRIPTION
Fixes #745

- Added custom setPasswordAttribute mutator to User model
- Reads bcrypt rounds from config('hashing.bcrypt.rounds') with fallback to 10
- Passes options array to Hash::make() instead of relying on default cast behavior