### PR TITLE
Wisdom King Raphael [ Laravel ] Fix duplicate seeder and add default roles

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T05:05:00+00:00"}

--- a/laravel/database/migrations/0001_01_01_000004_create_roles_table.php
+++ b/laravel/database/migrations/0001_01_01_000004_create_roles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -17,9 +17,10 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
+        User::factory()->firstOrCreate([
             'email' => 'test@example.com',
+        ], [
+            'name' => 'Test User',
         ]);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $roles = ['admin', 'editor', 'viewer'];
+        $now = now()->toDateTimeString();
+
+        foreach ($roles as $role) {
+            DB::table('roles')->updateOrInsert(
+                ['name' => $role],
+                ['created_at' => $now, 'updated_at' => $now]
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #746

- Changed DatabaseSeeder to use firstOrCreate() to prevent unique constraint violation on re-run
- Added RoleSeeder that creates admin, editor, viewer roles
- Added roles migration