### PR TITLE
Wisdom King Raphael [ Laravel ] Add database health check endpoint with retry logic

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T05:15:00+00:00"}

--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class HealthController extends Controller
+{
+    /**
+     * Check database connectivity and return health status.
+     */
+    public function database(Request $request): JsonResponse
+    {
+        $maxRetries = (int) ($request->query('retries', 3));
+        $retryDelay = (int) ($request->query('retry_delay', 100));
+
+        for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
+            try {
+                $start = microtime(true);
+                DB::connection()->getPdo();
+                $latency = round((microtime(true) - $start) * 1000, 2);
+
+                return response()->json([
+                    'status' => 'healthy',
+                    'driver' => DB::connection()->getDriverName(),
+                    'latency_ms' => $latency,
+                    'connection_name' => DB::connection()->getName(),
+                ]);
+            } catch (\Exception $e) {
+                if ($attempt === $maxRetries) {
+                    return response()->json([
+                        'status' => 'unhealthy',
+                        'error' => $e->getMessage(),
+                        'attempts' => $attempt,
+                    ], 503);
+                }
+                usleep($retryDelay * 1000);
+            }
+        }
+    }
+}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\HealthController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);


### PR DESCRIPTION
Fixes #785

- Created HealthController with database() method
- Tests active DB connection, returns status, driver, latency_ms, connection_name
- Configurable retries and delay via query params (retries, retry_delay)
- Returns 503 with error message on prolonged failure
- Added GET /health/database route