### PR TITLE
Wisdom King Raphael [ FastAPI ] Add concurrent task runner with semaphore limiting

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T05:18:00+00:00"}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,4 +1,5 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
 from typing import TypeVar
@@ -12,6 +13,42 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+async def run_concurrently(
+    *coroutines: Awaitable[_T],
+    max_concurrency: int = 10,
+) -> list[_T]:
+    """
+    Run multiple coroutines concurrently with a concurrency limit.
+
+    Uses asyncio.Semaphore to bound the number of coroutines running
+    simultaneously. Results are returned in the same order as input.
+
+    Args:
+        *coroutines: The awaitables to execute concurrently.
+        max_concurrency: Maximum number of awaitables allowed to run at once.
+
+    Returns:
+        A list of results in the same order as the input coroutines.
+
+    Raises:
+        Any exception raised by an awaitable is propagated.
+    """
+    _asyncio = asyncio
+
+    semaphore = _asyncio.Semaphore(max_concurrency)
+    results: list[_T | None] = [None] * len(coroutines)
+
+    async def _run(idx: int, coro: Awaitable[_T]) -> None:
+        async with semaphore:
+            results[idx] = await coro
+
+    tasks = [
+        _asyncio.create_task(_run(i, coro)) for i, coro in enumerate(coroutines)
+    ]
+    await _asyncio.gather(*tasks)
+    return results  # type: ignore[return-value]
 
 
 @asynccontextmanager


### PR DESCRIPTION
Fixes #803

- Added run_concurrently function to fastapi/fastapi/concurrency.py
- Accepts multiple awaitables with configurable max_concurrency parameter
- Uses asyncio.Semaphore to limit concurrent execution
- Returns results in the same order as input coroutines
- Properly propagates exceptions from any awaitable