### PR TITLE
Wisdom King Raphael [ Laravel ] Implement webhook system with HMAC signature and retry queue

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T05:28:00+00:00"}

--- a/laravel/app/Http/Controllers/WebhookController.php
+++ b/laravel/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Webhook;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WebhookController extends Controller
+{
+    /**
+     * List all webhooks.
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json(Webhook::all());
+    }
+
+    /**
+     * Create a new webhook.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'url' => 'required|url',
+            'secret' => 'required|string|min:16',
+            'events' => 'required|array',
+            'events.*' => 'string',
+        ]);
+
+        $webhook = Webhook::create($validated);
+
+        return response()->json($webhook, 201);
+    }
+
+    /**
+     * Show a webhook with recent deliveries.
+     */
+    public function show(Webhook $webhook): JsonResponse
+    {
+        return response()->json(
+            $webhook->load(['deliveries' => fn ($q) => $q->latest()->limit(20)])
+        );
+    }
+
+    /**
+     * Update a webhook.
+     */
+    public function update(Request $request, Webhook $webhook): JsonResponse
+    {
+        $validated = $request->validate([
+            'url' => 'sometimes|url',
+            'secret' => 'sometimes|string|min:16',
+            'events' => 'sometimes|array',
+            'events.*' => 'string',
+            'active' => 'sometimes|boolean',
+        ]);
+
+        $webhook->update($validated);
+
+        return response()->json($webhook);
+    }
+
+    /**
+     * Delete a webhook.
+     */
+    public function destroy(Webhook $webhook): JsonResponse
+    {
+        $webhook->delete();
+
+        return response()->json(['message' => 'Webhook deleted']);
+    }
+}

--- a/laravel/app/Models/Webhook.php
+++ b/laravel/app/Models/Webhook.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Webhook extends Model
+{
+    protected $fillable = [
+        'url',
+        'secret',
+        'events',
+        'active',
+    ];
+
+    protected $casts = [
+        'events' => 'array',
+        'active' => 'boolean',
+    ];
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+}

--- a/laravel/app/Models/WebhookDelivery.php
+++ b/laravel/app/Models/WebhookDelivery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebhookDelivery extends Model
+{
+    protected $fillable = [
+        'webhook_id',
+        'event',
+        'payload',
+        'response_code',
+        'attempts',
+        'next_retry_at',
+        'delivered_at',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'next_retry_at' => 'datetime',
+        'delivered_at' => 'datetime',
+    ];
+
+    public function webhook(): BelongsTo
+    {
+        return $this->belongsTo(Webhook::class);
+    }
+}

--- a/laravel/app/Services/WebhookDispatcher.php
+++ b/laravel/app/Services/WebhookDispatcher.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Webhook;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Facades\Http;
+
+class WebhookDispatcher
+{
+    const MAX_RETRIES = 5;
+    const RETRY_BACKOFF = [5, 15, 60, 300, 900]; // seconds
+
+    /**
+     * Dispatch a webhook event to all matching webhooks.
+     */
+    public function dispatch(string $event, array $payload): void
+    {
+        $webhooks = Webhook::where('active', true)
+            ->whereJsonContains('events', $event)
+            ->get();
+
+        foreach ($webhooks as $webhook) {
+            $this->sendWebhook($webhook, $event, $payload);
+        }
+    }
+
+    /**
+     * Send to a single webhook with signature and retry.
+     */
+    private function sendWebhook(Webhook $webhook, string $event, array $payload): void
+    {
+        $body = json_encode($payload);
+        $signature = hash_hmac('sha256', $body, $webhook->secret);
+
+        $delivery = WebhookDelivery::create([
+            'webhook_id' => $webhook->id,
+            'event' => $event,
+            'payload' => $payload,
+            'attempts' => 0,
+            'next_retry_at' => now()->addSeconds(self::RETRY_BACKOFF[0] ?? 60),
+        ]);
+
+        $this->attempt($webhook, $delivery, $body, $signature, 1);
+    }
+
+    /**
+     * Attempt delivery with retry/backoff.
+     */
+    private function attempt(Webhook $webhook, WebhookDelivery $delivery, string $body, string $signature, int $attempt): void
+    {
+        try {
+            $response = Http::timeout(10)
+                ->withHeaders([
+                    'Content-Type' => 'application/json',
+                    'X-Webhook-Signature' => 'sha256=' . $signature,
+                    'X-Webhook-Event' => $delivery->event,
+                    'X-Webhook-Delivery-ID' => (string) $delivery->id,
+                ])
+                ->send('POST', $webhook->url, ['body' => $body]);
+
+            $delivery->response_code = $response->status();
+            $delivery->attempts = $attempt;
+
+            if ($response->successful()) {
+                $delivery->delivered_at = now();
+                $delivery->next_retry_at = null;
+                $delivery->save();
+                return;
+            }
+
+            if ($response->serverError() || $response->status() === 429) {
+                $this->scheduleRetry($delivery, $attempt);
+            } else {
+                $delivery->next_retry_at = null;
+                $delivery->save();
+            }
+        } catch (\Exception $e) {
+            $delivery->attempts = $attempt;
+            $this->scheduleRetry($delivery, $attempt);
+        }
+    }
+
+    /**
+     * Schedule a retry with exponential backoff.
+     */
+    private function scheduleRetry(WebhookDelivery $delivery, int $attempt): void
+    {
+        if ($attempt >= self::MAX_RETRIES) {
+            $delivery->next_retry_at = null;
+        } else {
+            $delay = self::RETRY_BACKOFF[$attempt - 1] ?? 900;
+            $delivery->next_retry_at = now()->addSeconds($delay);
+        }
+        $delivery->save();
+    }
+
+    /**
+     * Process pending retries (intended for scheduled task).
+     */
+    public function processRetries(): int
+    {
+        $pending = WebhookDelivery::whereNull('delivered_at')
+            ->where('next_retry_at', '<=', now())
+            ->where('attempts', '<', self::MAX_RETRIES)
+            ->get();
+
+        $processed = 0;
+        foreach ($pending as $delivery) {
+            $webhook = $delivery->webhook;
+            $body = json_encode($delivery->payload);
+            $signature = hash_hmac('sha256', $body, $webhook->secret);
+            $this->attempt($webhook, $delivery, $body, $signature, $delivery->attempts + 1);
+            $processed++;
+        }
+
+        return $processed;
+    }
+}

--- a/laravel/database/migrations/0001_01_01_000005_create_webhooks_table.php
+++ b/laravel/database/migrations/0001_01_01_000005_create_webhooks_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhooks', function (Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->string('secret');
+            $table->json('events');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('webhook_id')->constrained()->cascadeOnDelete();
+            $table->string('event');
+            $table->json('payload');
+            $table->integer('response_code')->nullable();
+            $table->integer('attempts')->default(0);
+            $table->timestamp('next_retry_at')->nullable();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+        Schema::dropIfExists('webhooks');
+    }
+};

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,16 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('webhooks:process-retries', function () {
+    $dispatcher = new \App\Services\WebhookDispatcher();
+    $count = $dispatcher->processRetries();
+    $this->info("Processed {$count} webhook retries.");
+})->purpose('Process pending webhook retries');
+
+Schedule::command('webhooks:process-retries')->everyMinute();

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,16 @@
 <?php
 
+use App\Http\Controllers\WebhookController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::prefix('api/webhooks')->group(function () {
+    Route::get('/', [WebhookController::class, 'index']);
+    Route::post('/', [WebhookController::class, 'store']);
+    Route::get('/{webhook}', [WebhookController::class, 'show']);
+    Route::put('/{webhook}', [WebhookController::class, 'update']);
+    Route::delete('/{webhook}', [WebhookController::class, 'destroy']);
 });


### PR DESCRIPTION
Fixes #754

- Webhook & WebhookDelivery models with full migration
- WebhookDispatcher with HMAC-SHA256 signature verification via X-Webhook-Signature header
- Exponential backoff retry (5s, 15s, 60s, 5m, 15m) up to 5 attempts
- WebhookController CRUD API: index, store, show, update, destroy
- webhooks:process-retries artisan command with every-minute schedule
- Event-based routing: webhooks dispatch only to matching event subs