### PR TITLE
Wisdom King Raphael [ Laravel ] Add failed job monitoring and summary command

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "You are Wisdom King Raphael, autonomous bounty hunter.", "ts": "2026-07-14T05:45:00+00:00"}

--- a/laravel/app/Listeners/LogFailedJob.php
+++ b/laravel/app/Listeners/LogFailedJob.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+
+class LogFailedJob
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(JobFailed $event): void
+    {
+        $exception = $event->exception;
+        $job = $event->job;
+
+        $logData = [
+            'job_id' => $job->getJobId() ?? 'unknown',
+            'queue' => $job->getQueue(),
+            'name' => $job->payload()['displayName'] ?? 'unknown',
+            'attempts' => $job->attempts(),
+            'exception' => get_class($exception),
+            'message' => $exception->getMessage(),
+            'failed_at' => now()->toDateTimeString(),
+        ];
+
+        Log::channel('failed_jobs')->error('Job failed', $logData);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogFailedJob;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, LogFailedJob::class);
     }
 }

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -127,6 +127,14 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'failed_jobs' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/failed_jobs.log'),
+            'level' => 'error',
+            'days' => 30,
+            'replace_placeholders' => true,
+        ],
+
     ],
 
 ];

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,27 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('queue:failed-summary', function () {
+    $failures = DB::table('failed_jobs')
+        ->selectRaw("json_unquote(json_extract(payload, '$.displayName')) as job_name, count(*) as count")
+        ->groupBy('job_name')
+        ->orderByDesc('count')
+        ->get();
+
+    if ($failures->isEmpty()) {
+        $this->info('No failed jobs.');
+        return;
+    }
+
+    $this->table(
+        ['Job', 'Count'],
+        $failures->map(fn ($f) => [$f->job_name ?? 'unknown', $f->count])->toArray()
+    );
+})->purpose('Show summary of failed jobs grouped by type');


### PR DESCRIPTION
Fixes #789

- Created LogFailedJob listener logging job_id, queue, name, exception on failure
- Registered JobFailed event listener in AppServiceProvider
- Added failed_jobs log channel with daily rotation
- Added queue:failed-summary artisan command grouped by job type