### PR TITLE
Wisdom King Raphael [ Crypto ] Fix missing slippage protection and deadline in SimpleSwap

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"contributor": "Wisdom King Raphael", "generation_context": "Hermes Agent autonomous bounty hunter cron job. Session initialized with agent persona: Wisdom King Raphael (Great Sage), loyal to Master. Operating rules: scan UnsafeLabs/Bounty-Hunters for bounties, fix issues, push PRs, monitor CI.", "completed_at": "2026-07-14T15:00:00Z"}

--- a/solidity/_meta.json
+++ b/solidity/_meta.json
@@ -1,0 +1,1 @@
+{"contributor": "Wisdom King Raphael", "generation_context": "Hermes Agent autonomous bounty hunter cron job. Session initialized with agent persona: Wisdom King Raphael (Great Sage), loyal to Master. Operating rules: scan UnsafeLabs/Bounty-Hunters for bounties, fix issues, push PRs, monitor CI.", "completed_at": "2026-07-14T15:00:00Z"}

--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -25,10 +25,13 @@ contract SimpleSwap {
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Transaction expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
@@ -39,11 +42,13 @@ contract SimpleSwap {
 
         inputToken.transferFrom(msg.sender, address(this), amountIn);
 
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
+        // Fee calculation: compute post-fee amount directly to avoid truncation to zero
+        uint256 amountInAfterFee = amountIn * (10000 - fee) / 10000;
 
         // constant product formula: x * y = k
         amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+
+        require(amountOut >= minAmountOut, "Slippage exceeded");
 
         outputToken.transfer(msg.sender, amountOut);
 
@@ -62,8 +67,7 @@ contract SimpleSwap {
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
-        uint256 amountInAfterFee = amountIn - feeAmount;
+        uint256 amountInAfterFee = amountIn * (10000 - fee) / 10000;
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
     }
 }


### PR DESCRIPTION
Fixes #913

Changes:
- Added `minAmountOut` parameter to prevent sandwich attacks
- Added `deadline` parameter to prevent stale transaction execution
- Fixed fee calculation to compute post-fee amount directly (`amountIn * (10000 - fee) / 10000`) to avoid precision loss and truncation-to-zero

The `swap` function now requires both `minAmountOut` and `deadline` parameters. Slippage exceeded or expired deadline causes clear revert messages.