### PR TITLE
Wisdom King Raphael [ FastAPI ] Fix jsonable_encoder TypeError on bytes and memoryview (#759)

### DIFF
--- a/fastapi/fastapi/_provenance.json
+++ b/fastapi/fastapi/_provenance.json
@@ -1,0 +1,1 @@
+{"tool_name": "Wisdom King Raphael", "boot_context": "Bounty hunter cron job for UnsafeLabs/Bounty-Hunters. Fixing jsonable_encoder bytes/memoryview (Issue #759).", "timestamp": "2026-07-14T12:00:00Z"}

--- a/fastapi/fastapi/encoders.py
+++ b/fastapi/fastapi/encoders.py
@@ -1,3 +1,4 @@
+import base64
 import dataclasses
 import datetime
 from collections import defaultdict, deque
@@ -215,6 +216,16 @@ def jsonable_encoder(
             """
         ),
     ] = True,
+    bytes_encoding: Annotated[
+        str,
+        Doc(
+            """
+            Encoding method for bytes objects. Either "base64" (default) or "hex".
+            When set to "base64", bytes/memoryview objects are encoded as base64 strings.
+            When set to "hex", they are encoded as hexadecimal strings.
+            """
+        ),
+    ] = "base64",
 ) -> Any:
     """
     Convert any object to something that can be encoded in JSON.
@@ -274,6 +285,14 @@ def jsonable_encoder(
         return obj.value
     if isinstance(obj, PurePath):
         return str(obj)
+    if isinstance(obj, (bytes, bytearray)):
+        if bytes_encoding == "hex":
+            return obj.hex()
+        return base64.b64encode(obj).decode("ascii")
+    if isinstance(obj, memoryview):
+        if bytes_encoding == "hex":
+            return obj.tobytes().hex()
+        return base64.b64encode(obj.tobytes()).decode("ascii")
     if isinstance(obj, (str, int, float, type(None))):
         return obj
     if isinstance(obj, PydanticUndefinedType):


### PR DESCRIPTION
Fixes #759. Adds bytes/memoryview handling with bytes_encoding parameter. Default base64, can switch to hex.