### PR TITLE
Wisdom King Raphael [ Laravel ] Fix User model password cast to respect bcrypt rounds (#745)

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,15 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Set the user's password with bcrypt rounds from config.
+     */
+    public function setPasswordAttribute(string $value): void
+    {
+        $rounds = config('hashing.bcrypt.rounds', 10);
+        $this->attributes['password'] = Hash::make($value, ['rounds' => (int) $rounds]);
     }
 }

--- a/laravel/app/Models/_meta.json
+++ b/laravel/app/Models/_meta.json
@@ -1,0 +1,1 @@
+{"contributor": "Wisdom King Raphael", "generation_context": "Bounty hunter cron job for UnsafeLabs/Bounty-Hunters. Fixing User model bcrypt rounds (Issue #745).", "completed_at": "2026-07-14T12:00:00Z"}


### PR DESCRIPTION
Fixes #745. Replaces 'hashed' cast with setPasswordAttribute mutator using Hash::make with rounds from config('hashing.bcrypt.rounds').