### PR TITLE
Wisdom King Raphael [ Crypto ] Fix first-depositor price manipulation with MINIMUM_LIQUIDITY lock and internal reserves

### DIFF
--- a/contributor_meta.json
+++ b/contributor_meta.json
@@ -1,0 +1,1 @@
+{"agent": "Wisdom King Raphael", "issue": 918, "category": "Crypto", "contract": "LiquidityPool.sol", "timestamp": "2026-07-14T11:39:08Z"}

--- a/solidity/_generation.json
+++ b/solidity/_generation.json
@@ -1,0 +1,1 @@
+{"agent": "Wisdom King Raphael", "pre_task_context": "Kamu adalah autonomous bounty hunter. JANGAN SCAN DOANG. LANGSUNG KERJAKAN, PERBAIKI, PANTAU CI, DAN EVOLVE.", "timestamp": "2026-07-14T11:39:08Z"}

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -7,15 +7,13 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract LiquidityPool is ERC20 {
     IERC20 public tokenA;
     IERC20 public tokenB;
-
     uint256 public reserveA;
     uint256 public reserveB;
-
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -25,58 +23,47 @@ contract LiquidityPool is ERC20 {
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
         tokenA.transferFrom(msg.sender, address(this), amountA);
         tokenB.transferFrom(msg.sender, address(this), amountB);
-
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
+            require(lpTokens > 0, "First deposit too small");
+            _mint(address(0), MINIMUM_LIQUIDITY);
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
             lpTokens = lpFromA < lpFromB ? lpFromA : lpFromB;
         }
-
         require(lpTokens > 0, "Insufficient liquidity");
         _mint(msg.sender, lpTokens);
-
         reserveA += amountA;
         reserveB += amountB;
-
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
-
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
-
+        uint256 totalSupplyValue = totalSupply();
+        amountA = lpTokens * reserveA / totalSupplyValue;
+        amountB = lpTokens * reserveB / totalSupplyValue;
+        require(amountA > 0 && amountB > 0, "Insufficient liquidity");
         _burn(msg.sender, lpTokens);
-
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
-
         reserveA -= amountA;
         reserveB -= amountB;
-
+        tokenA.transfer(msg.sender, amountA);
+        tokenB.transfer(msg.sender, amountB);
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
     }
 
+    function sync() external {
+        uint256 balA = tokenA.balanceOf(address(this));
+        uint256 balB = tokenB.balanceOf(address(this));
+        reserveA = balA;
+        reserveB = balB;
+        emit Sync(reserveA, reserveB);
+    }
+
     function sqrt(uint256 y) internal pure returns (uint256 z) {
-        if (y > 3) {
-            z = y;
-            uint256 x = y / 2 + 1;
-            while (x < z) {
-                z = x;
-                x = (y / x + x) / 2;
-            }
-        } else if (y != 0) {
-            z = 1;
-        }
+        if (y > 3) { z = y; uint256 x = y / 2 + 1; while (x < z) { z = x; x = (y / x + x) / 2; } }
+        else if (y != 0) { z = 1; }
     }
 }


### PR DESCRIPTION
Fixes #918

### Changes
- **MINIMUM_LIQUIDITY lock**: First deposit locks 1000 LP tokens at `address(0)` following Uniswap V2 pattern to prevent first-depositor price manipulation
- **Internal reserves used in removeLiquidity**: Uses `reserveA`/`reserveB` instead of manipulable `balanceOf(address(this))`
- **sync() function**: Updates internal reserves to match actual balances; emits `Sync` event for recovery from donation attacks
- `_generation.json` and `contributor_meta.json` included