### PR TITLE
Wisdom King Raphael [ Laravel ] Fix console.php missing scheduled task registration and add logs:clear command

### DIFF
--- a/laravel/_generation.json
+++ b/laravel/_generation.json
@@ -1,0 +1,1 @@
+{"agent":"Wisdom King Raphael","pre_task_context":"Kamu adalah autonomous bounty hunter. JANGAN SCAN DOANG. LANGSUNG KERJAKAN, PERBAIKI, PANTAU CI, DAN EVOLVE.","timestamp":"2026-07-15T12:00:00Z"}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -2,7 +2,39 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear', function () {
+    $days = $this->option('days') ?? 7;
+    $logPath = storage_path('logs');
+    $cutoff = now()->subDays((int) $days);
+
+    $count = 0;
+    $totalSize = 0;
+
+    if (is_dir($logPath)) {
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($logPath, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            if ($file->isFile() && $file->getMTime() < $cutoff->getTimestamp()) {
+                $totalSize += $file->getSize();
+                unlink($file->getRealPath());
+                $count++;
+            }
+        }
+    }
+
+    $freed = $totalSize > 0 ? round($totalSize / 1024, 2) . ' KB' : '0 B';
+
+    $this->info("Cleared {$count} log file(s) older than {$days} days.");
+    $this->info("Space freed: {$freed}");
+})->purpose('Clear log files older than a given number of days')
+  ->option('days', null, 'Number of days of logs to retain', 7);
+
+Schedule::command('logs:clear')->dailyAt('00:00');


### PR DESCRIPTION
Fixes #753

- Added `logs:clear` artisan command with `--days` option (default 7)
- Command deletes log files older than N days from `storage/logs`
- Outputs file count and human-readable freed space
- Registers schedule: daily at 00:00