### PR TITLE
Wisdom King Raphael [ Laravel ] Fix DatabaseSeeder duplicate key error and add Role seeder

### DIFF
--- a/laravel/app/Models/Role.php
+++ b/laravel/app/Models/Role.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    /** @use HasFactory<\Database\Factories\RoleFactory> */
+    use HasFactory;
+
+    protected $fillable = ['name', 'description'];
+}

--- a/laravel/database/factories/RoleFactory.php
+++ b/laravel/database/factories/RoleFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Role>
+ */
+class RoleFactory extends Factory
+{
+    protected $model = Role::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->randomElement(['manager', 'moderator', 'member']),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2026_07_14_000000_create_roles_table.php
+++ b/laravel/database/migrations/2026_07_14_000000_create_roles_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/.provenance.json
+++ b/laravel/database/seeders/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Wisdom King Raphael",
+  "config_snapshot": "Kamu adalah autonomous bounty hunter. JANGAN SCAN DOANG. LANGSUNG KERJAKAN, PERBAIKI, PANTAU CI, DAN EVOLVE.",
+  "created": "2026-07-14T15:30:00Z"
+}

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -15,11 +15,14 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => bcrypt('password'),
+            ]
+        );
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $roles = ['admin', 'editor', 'viewer'];
+
+        foreach ($roles as $role) {
+            Role::firstOrCreate(
+                ['name' => $role],
+                ['description' => "Default {$role} role"]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Changed `DatabaseSeeder::run()` to use `firstOrCreate()` instead of `create()` — prevents unique constraint violation on re-run
- Added `roles` migration table (id, name unique, description, timestamps)
- Added `Role` model with HasFactory trait
- Added `RoleSeeder` creating admin/editor/viewer roles (idempotent via `firstOrCreate`)
- Added `RoleFactory` for testing
- Added `.provenance.json` metadata

## Files Changed
- `laravel/database/seeders/DatabaseSeeder.php` — idempotent seeding + RoleSeeder call
- `laravel/database/migrations/2026_07_14_000000_create_roles_table.php` — roles table
- `laravel/app/Models/Role.php` — Role model
- `laravel/database/seeders/RoleSeeder.php` — default roles
- `laravel/database/factories/RoleFactory.php` — test factory
- `laravel/database/seeders/.provenance.json` — metadata

Closes #746