### PR TITLE
Wisdom King Raphael [ Laravel ] Add Auditable trait for Eloquent model audit logging

### DIFF
--- a/laravel/app/Models/AuditLog.php
+++ b/laravel/app/Models/AuditLog.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class AuditLog extends Model
+{
+    protected $table = 'audit_logs';
+
+    protected $fillable = [
+        'auditable_type',
+        'auditable_id',
+        'event',
+        'old_values',
+        'new_values',
+        'user_id',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected $casts = [
+        'old_values' => 'array',
+        'new_values' => 'array',
+    ];
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\Auditable;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -15,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, Auditable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/app/Traits/.provenance.json
+++ b/laravel/app/Traits/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Wisdom King Raphael",
+  "config_snapshot": "Kamu adalah autonomous bounty hunter. JANGAN SCAN DOANG. LANGSUNG KERJAKAN, PERBAIKI, PANTAU CI, DAN EVOLVE.",
+  "created": "2026-07-14T15:30:00Z"
+}

--- a/laravel/app/Traits/Auditable.php
+++ b/laravel/app/Traits/Auditable.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\AuditLog;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Request;
+
+trait Auditable
+{
+    protected static $sensitiveFields = ['password', 'password_confirmation', 'remember_token', 'api_key', 'token', 'secret'];
+
+    protected static function bootAuditable(): void
+    {
+        static::created(function ($model) {
+            $model->logAudit('created', null, $model->getAuditAttributes());
+        });
+
+        static::updated(function ($model) {
+            $original = collect($model->getOriginal())
+                ->only(array_keys($model->getAuditAttributes()))
+                ->toArray();
+            $model->logAudit('updated', $original, $model->getAuditAttributes());
+        });
+
+        static::deleted(function ($model) {
+            $model->logAudit('deleted', $model->getAuditAttributes(), null);
+        });
+    }
+
+    public function getAuditAttributes(): array
+    {
+        $attributes = $this->getAttributes();
+
+        foreach (static::$sensitiveFields as $field) {
+            if (array_key_exists($field, $attributes)) {
+                $attributes[$field] = '[REDACTED]';
+            }
+        }
+
+        return $attributes;
+    }
+
+    public function logAudit(string $event, ?array $oldValues, ?array $newValues): AuditLog
+    {
+        return AuditLog::create([
+            'auditable_type' => static::class,
+            'auditable_id' => $this->getKey(),
+            'event' => $event,
+            'old_values' => $oldValues,
+            'new_values' => $newValues,
+            'user_id' => Auth::id(),
+            'ip_address' => Request::ip(),
+            'user_agent' => Request::userAgent(),
+        ]);
+    }
+
+    public function getAuditHistory()
+    {
+        return AuditLog::where('auditable_type', static::class)
+            ->where('auditable_id', $this->getKey())
+            ->orderBy('created_at', 'desc')
+            ->get();
+    }
+
+    public function auditLogs()
+    {
+        return $this->morphMany(AuditLog::class, 'auditable');
+    }
+}

--- a/laravel/database/migrations/2026_07_14_000001_create_audit_logs_table.php
+++ b/laravel/database/migrations/2026_07_14_000001_create_audit_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->unsignedBigInteger('auditable_id');
+            $table->string('event');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['auditable_type', 'auditable_id']);
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};


### PR DESCRIPTION
## Summary

- Added `Auditable` trait that listens to created/updated/deleted Eloquent model events
- Added `AuditLog` model with polymorphic `auditable` relationship
- Added `audit_logs` migration with JSON `old_values`/`new_values` fields
- Sensitive fields (password, token, secret, api_key) are redacted in audit data
- Stores `user_id`, `ip_address`, `user_agent` with each log entry
- Added `getAuditHistory()` method returning logs in reverse chronological order
- Applied `Auditable` trait to User model as example

## Files Changed
- `laravel/app/Traits/Auditable.php` — the trait
- `laravel/app/Models/AuditLog.php` — the model
- `laravel/database/migrations/2026_07_14_000001_create_audit_logs_table.php` — migration
- `laravel/app/Models/User.php` — trait applied
- `laravel/app/Traits/.provenance.json` — metadata

Closes #786