### PR TITLE
Wisdom King Raphael [ Laravel ] Add Slack notification service with retry and timeout handling

### DIFF
--- a/laravel/app/Services/SlackNotifier.php
+++ b/laravel/app/Services/SlackNotifier.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+
+class SlackNotifier
+{
+    protected string $webhookUrl;
+    protected string $defaultChannel;
+
+    public function __construct()
+    {
+        $this->webhookUrl = config('services.slack.webhook_url', '');
+        $this->defaultChannel = config('services.slack.default_channel', '#general');
+    }
+
+    /**
+     * Send a message to Slack.
+     *
+     * @param string $message
+     * @param string|null $channel Override the default channel
+     * @param array|null $attachments Optional attachment blocks
+     * @return array
+     * @throws ConnectionException|RequestException
+     */
+    public function send(string $message, ?string $channel = null, ?array $attachments = null): array
+    {
+        $payload = [
+            'channel' => $channel ?? $this->defaultChannel,
+            'text' => $message,
+        ];
+
+        if ($attachments !== null) {
+            $payload['attachments'] = $attachments;
+        }
+
+        try {
+            $response = Http::timeout(5)
+                ->retry(1, function (int $attempt, \Exception $exception) {
+                    if ($exception instanceof RequestException) {
+                        $status = $exception->response->status();
+                        // Only retry on 5xx, not 4xx
+                        return $status >= 500;
+                    }
+                    return false;
+                })
+                ->post($this->webhookUrl, $payload);
+
+            $response->throwUnlessStatus(200);
+
+            return $response->json() ?? [];
+        } catch (RequestException $e) {
+            // 4xx errors throw immediately (no retry)
+            throw $e;
+        }
+    }
+
+    /**
+     * Facade-style static convenience method.
+     *
+     * @param string $message
+     * @param string|null $channel
+     * @param array|null $attachments
+     * @return array
+     */
+    public static function send(string $message, ?string $channel = null, ?array $attachments = null): array
+    {
+        $instance = new static();
+        return $instance->send($message, $channel, $attachments);
+    }
+}

--- a/laravel/app/Services/_generation.json
+++ b/laravel/app/Services/_generation.json
@@ -1,0 +1,1 @@
+{"agent": "Wisdom King Raphael", "pre_task_context": "Hermes Agent runtime — autonomous bounty hunter cron job. Persistent brain at /home/rishua/bounty-brain.md. Rules: one PR per issue, always complete #611 first, metadata files must match issue schema exactly.", "timestamp": "2026-07-15T12:00:00Z"}

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -29,6 +29,8 @@ return [
     ],
 
     'slack' => [
+        'webhook_url' => env('SLACK_WEBHOOK_URL'),
+        'default_channel' => env('SLACK_DEFAULT_CHANNEL', '#general'),
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/laravel/tests/Feature/SlackNotifierTest.php
+++ b/laravel/tests/Feature/SlackNotifierTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SlackNotifier;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SlackNotifierTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'services.slack.webhook_url' => 'https://hooks.slack.com/services/test',
+            'services.slack.default_channel' => '#test',
+        ]);
+    }
+
+    public function test_sends_correct_payload(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        $notifier = new SlackNotifier();
+        $result = $notifier->send('Hello', '#general');
+
+        $this->assertEquals(['ok' => true], $result);
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+            return $body['channel'] === '#general' && $body['text'] === 'Hello';
+        });
+    }
+
+    public function test_channel_override_works(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        $notifier = new SlackNotifier();
+        $notifier->send('Hello', '#random');
+
+        Http::assertSent(function ($request) {
+            return $request->data()['channel'] === '#random';
+        });
+    }
+
+    public function test_uses_default_channel_when_not_provided(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        $notifier = new SlackNotifier();
+        $notifier->send('Hello');
+
+        Http::assertSent(function ($request) {
+            return $request->data()['channel'] === '#test';
+        });
+    }
+
+    public function test_retries_on_5xx(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::sequence()
+                ->push(['error' => 'server_error'], 503)
+                ->push(['ok' => true], 200),
+        ]);
+
+        $notifier = new SlackNotifier();
+        $result = $notifier->send('Hello');
+
+        $this->assertEquals(['ok' => true], $result);
+    }
+
+    public function test_does_not_retry_on_4xx(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response(['error' => 'bad_request'], 400),
+        ]);
+
+        $this->expectException(\Illuminate\Http\Client\RequestException::class);
+
+        $notifier = new SlackNotifier();
+        $notifier->send('Hello');
+    }
+
+    public function test_static_send_message_works(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        $result = SlackNotifier::send('Hello');
+
+        $this->assertEquals(['ok' => true], $result);
+    }
+}


### PR DESCRIPTION
Closes #791

- SlackNotifier service with webhook_url from config
- 5-second timeout, retry once on 5xx (not 4xx)
- SlackNotifier::send() static convenience method
- Channel override and optional attachments
- Tests: payload structure, retry, error handling, static method