### PR TITLE
Wisdom King Raphael [ Laravel ] Implement API authentication controller with token-based login and registration

### DIFF
--- a/laravel/app/Http/Controllers/.generation_meta.json
+++ b/laravel/app/Http/Controllers/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent": "Wisdom King Raphael", "initial_directives": "Hermes Agent runtime — autonomous bounty hunter cron job. Persistent brain at /home/rishua/bounty-brain.md. Rules: one PR per issue, always complete #611 first, metadata files must match issue schema exactly.", "date": "2026-07-15T12:00:00Z"}

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+
+class AuthController extends Controller
+{
+    public function register(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        $tokenObj = $user->createToken('api-token');
+
+        return response()->json([
+            'message' => 'User registered successfully',
+            'user' => $user,
+            'token' => $tokenObj->plainTextToken,
+        ], 201);
+    }
+
+    public function login(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user = User::where('email', $request->email)->first();
+
+        if (! $user || ! Hash::check($request->password, $user->password)) {
+            return response()->json([
+                'message' => 'Invalid credentials',
+            ], 401);
+        }
+
+        $tokenObj = $user->createToken('api-token');
+
+        return response()->json([
+            'message' => 'Login successful',
+            'user' => $user,
+            'token' => $tokenObj->plainTextToken,
+        ], 200);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $user = AuthController::resolveUserFromToken($request);
+
+        if ($user) {
+            $user->forceFill(['remember_token' => null])->save();
+        }
+
+        return response()->json([
+            'message' => 'Logged out successfully',
+        ], 200);
+    }
+
+    private static function resolveUserFromToken(Request $request): ?User
+    {
+        $header = $request->header('Authorization', '');
+        if (! str_starts_with($header, 'Bearer ')) {
+            return null;
+        }
+
+        $token = substr($header, 7);
+        $hashedToken = hash('sha256', $token);
+
+        return User::where('remember_token', $hashedToken)->first();
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,13 +2,13 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -17,16 +17,33 @@ class User extends Authenticatable
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
 
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
     protected function casts(): array
     {
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function createToken(string $name): object
+    {
+        $tokenString = Str::random(64);
+        $this->forceFill([
+            'remember_token' => hash('sha256', $tokenString),
+        ])->save();
+
+        return new class($tokenString)
+        {
+            public string $plainTextToken;
+            public function __construct(string $token)
+            {
+                $this->plainTextToken = $token;
+            }
+        };
+    }
+
+    public function currentAccessToken(): ?object
+    {
+        return null;
     }
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+Route::post('/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
Closes #752

- AuthController with register, login, logout methods
- Token-based auth with SHA-256 hashed tokens
- POST /api/register with validation (unique email, min 8 char password)
- POST /api/login returns 401 on invalid credentials
- POST /api/logout clears current token
- API routes registered in bootstrap/app.php