### PR TITLE
Wisdom King Raphael [ Scripts ] Fix dangerous rm -rf with unset DEPLOY_DIR guard

### DIFF
--- a/scripts/.generation_meta.json
+++ b/scripts/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "Wisdom King Raphael",
+  "initial_directives": "Kamu adalah autonomous bounty hunter. JANGAN SCAN DOANG. LANGSUNG KERJAKAN, PERBAIKI, PANTAU CI, DAN EVOLVE.",
+  "date": "2026-07-15T12:00:00Z"
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,6 +29,10 @@ check_dependencies
 
 # Clean previous deployment artifacts
 log_message "Cleaning previous build artifacts..."
+if [ -z "${DEPLOY_DIR}" ]; then
+    log_message "ERROR: DEPLOY_DIR is unset or empty"
+    exit 1
+fi
 rm -rf ${DEPLOY_DIR}/dist
 rm -rf ${DEPLOY_DIR}/node_modules/.cache
 


### PR DESCRIPTION
```\nKamu adalah autonomous bounty hunter.\n```
Added `-z` guard check for DEPLOY_DIR before rm -rf calls to prevent accidental deletion when variable is unset/empty.