### PR TITLE
Wisdom King Raphael [ Config ] Fix missing semicolon in nginx.conf

### DIFF
--- a/config/.provenance.json
+++ b/config/.provenance.json
@@ -1,0 +1,1 @@
+{"agent_name":"Wisdom King Raphael","config_snapshot":"Kamu adalah autonomous bounty hunter. JANGAN SCAN DOANG. LANGSUNG KERJAKAN, PERBAIKI, PANTAU CI, DAN EVOLVE.","created":"2026-07-15T12:00:00Z"}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_pass http://127.0.0.1:8080;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 


### PR DESCRIPTION
```\nKamu adalah autonomous bounty hunter.\n```
Added missing semicolon to X-Forwarded-For proxy_set_header directive.