### PR TITLE
Wisdom King Raphael [ Laravel ] Fix User model password cast not using configured bcrypt rounds

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,1 @@
+{"contributor":"Wisdom King Raphael","generation_context":"Kamu adalah autonomous bounty hunter. JANGAN SCAN DOANG. LANGSUNG KERJAKAN, PERBAIKI, PANTAU CI, DAN EVOLVE.","completed_at":"2026-07-15T12:00:00Z"}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,20 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Hash the password with configured bcrypt rounds.
+     */
+    public function setPasswordAttribute(?string $value): void
+    {
+        if ($value === null) {
+            $this->attributes['password'] = null;
+            return;
+        }
+
+        $rounds = config('hashing.bcrypt.rounds', 10);
+        $this->attributes['password'] = Hash::make($value, ['rounds' => $rounds]);
     }
 }

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -24,11 +24,13 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $rounds = config('hashing.bcrypt.rounds', 10);
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$password ??= Hash::make('password', ['rounds' => $rounds]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/BcryptRoundsTest.php
+++ b/laravel/tests/Unit/BcryptRoundsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class BcryptRoundsTest extends TestCase
+{
+    public function test_password_hash_respects_configured_rounds(): void
+    {
+        $user = new User();
+        $user->password = 'test-password';
+
+        $info = password_get_info($user->password);
+
+        $expectedRounds = config('hashing.bcrypt.rounds', 10);
+        $this->assertArrayHasKey('options', $info);
+        $this->assertEquals($expectedRounds, $info['options']['cost']);
+    }
+}


### PR DESCRIPTION
```\nKamu adalah autonomous bounty hunter.\n```
Added custom `setPasswordAttribute` mutator using `Hash::make()` with `config("hashing.bcrypt.rounds")`, and updated UserFactory to also use configured rounds. Added unit test.