### PR TITLE
[Wisdom King Raphael] [ FastAPI ] Fix validation error handler missing request context and add body redaction

### DIFF
--- a/fastapi/fastapi/_meta.json
+++ b/fastapi/fastapi/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Wisdom King Raphael",
+  "generation_context": "Host: Linux (5.15.0-139-generic)\nUser home directory: /home/rishua\nCurrent working directory: /home/rishua\n\nActive Hermes profile: default...\nYou are running as a scheduled cron job. There is no user present — you cannot ask questions, request clarification, or wait for follow-up. Execute the task fully and autonomously...\n\nRespond ultra-terse. Maximum compression. Telegraphic. Strip conjunctions. One word when one word enough...\nYou are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written...",
+  "completed_at": "2026-07-15T02:45:00Z"
+}

--- a/fastapi/fastapi/exception_handlers.py
+++ b/fastapi/fastapi/exception_handlers.py
@@ -1,3 +1,6 @@
+import re
+from typing import Any
+
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, WebSocketRequestValidationError
 from fastapi.utils import is_body_allowed_for_status_code
@@ -6,6 +9,21 @@ from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import WS_1008_POLICY_VIOLATION
+
+SENSITIVE_FIELD_PATTERN = re.compile(r"(?i)password|secret|token|api_key", re.IGNORECASE)
+
+def _redact_sensitive(data: dict | list | Any, depth: int = 0) -> dict | list | Any:
+    """Recursively redact sensitive fields. Max depth 10."""
+    if depth > 10:
+        return data
+    if isinstance(data, dict):
+        return {
+            k: "***REDACTED***" if isinstance(k, str) and SENSITIVE_FIELD_PATTERN.search(k) else _redact_sensitive(v, depth + 1)
+            for k, v in data.items()
+        }
+    if isinstance(data, list):
+        return [_redact_sensitive(item, depth + 1) for item in data]
+    return data
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
@@ -20,10 +38,25 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> Respon
 async def request_validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    return JSONResponse(
-        status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
-    )
+    error_response: dict[str, Any] = {
+        "detail": jsonable_encoder(exc.errors()),
+        "path": request.url.path,
+        "method": request.method,
+    }
+    # Include body in debug mode with redaction
+    app = getattr(request.app, "debug", False)
+    if app:
+        try:
+            body = await request.json()
+            error_response["body"] = _redact_sensitive(body)
+        except Exception:
+            try:
+                body_bytes = await request.body()
+                if body_bytes:
+                    error_response["body"] = "[non-JSON body omitted]"
+            except Exception:
+                pass
+    return JSONResponse(status_code=422, content=error_response)
 
 
 async def websocket_request_validation_exception_handler(


### PR DESCRIPTION
## Fixes #757

### Changes
- Added `path` and `method` fields to validation error responses
- In debug mode: echoes received `body` in error response
- Sensitive fields (password, secret, token, api_key) redacted as ***REDACTED***
- Recursive redaction — works on nested objects and arrays
- Non-debug mode: no body included (unchanged behavior)
- Non-JSON bodies: safe fallback with omission notice
- Max depth 10 to prevent infinite recursion

### Files changed
- `fastapi/fastapi/exception_handlers.py`: handler update + redaction helper
- `fastapi/fastapi/_meta.json`: provenance