### PR TITLE
Wisdom King Raphael [ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/.generation_meta.json
+++ b/solidity/contracts/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent": "Wisdom King Raphael", "initial_directives": "Autonomous bounty hunter. Filter by '💎 Bounty'. Skip T3 Code. Read issue body for correct provenance filename. Complete #611 and #270 for merge priority.", "date": "2026-07-15T12:35:00Z"}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,42 +14,55 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    event FallbackUsed(address indexed feed, uint256 timestamp);
 
-    constructor(address _primaryFeed) {
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    constructor(address _primaryFeed, address _fallbackFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
-        (
-            uint80 roundId,
-            int256 price,
-            ,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+    function getLatestPrice() public view returns (int256) {
+        // Try primary feed with full validation
+        (uint80 roundId, int256 price, , uint256 updatedAt, uint80 answeredInRound) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        if (price > 0 && answeredInRound >= roundId && block.timestamp - updatedAt < MAX_STALENESS) {
+            return price;
+        }
 
-        return price;
+        // Fallback to secondary feed
+        if (address(fallbackFeed) != address(0)) {
+            (uint80 fallbackRoundId, int256 fallbackPrice, , uint256 fallbackUpdatedAt, uint80 fallbackAnsweredInRound) = fallbackFeed.latestRoundData();
+
+            require(fallbackPrice > 0, "Fallback price is zero or negative");
+            require(fallbackAnsweredInRound >= fallbackRoundId, "Fallback round not complete");
+            require(block.timestamp - fallbackUpdatedAt < MAX_STALENESS, "Fallback price is stale");
+
+            return fallbackPrice;
+        }
+
+        revert("Oracle: no valid price available");
     }
 
     function getDecimals() external view returns (uint8) {
         return primaryFeed.decimals();
     }
 
-    function setMaxStaleness(uint256 _maxStaleness) external {
-        require(msg.sender == owner, "Not owner");
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external onlyOwner {
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
     }
 }


### PR DESCRIPTION
Fixes #915

## Changes
- **Staleness check**: require(block.timestamp - updatedAt < MAX_STALENESS)
- **Round completeness**: require(answeredInRound >= roundId)
- **Positive price**: require(price > 0)
- **Fallback oracle**: secondary feed with full validation chain
- **onlyOwner**: access control on setMaxStaleness and setFallbackFeed

## Acceptance
- Stale prices rejected
- Incomplete rounds rejected
- Zero/negative prices rejected
- Falls back to secondary oracle on primary failure