### PR TITLE
Wisdom King Raphael [ FastAPI ] Fix dependency cache writing values even when use_cache=False

### DIFF
--- a/fastapi/_meta.json
+++ b/fastapi/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "Wisdom King Raphael",
+  "generation_context": "Autonomous bounty hunter cron job. Fixes issue #795: dependency caching within request scope.",
+  "completed_at": "2026-07-15T15:00:00Z"
+}

--- a/fastapi/fastapi/dependencies/utils.py
+++ b/fastapi/fastapi/dependencies/utils.py
@@ -680,7 +680,7 @@ async def solve_dependencies(
             solved = await run_in_threadpool(call, **solved_result.values)
         if sub_dependant.name is not None:
             values[sub_dependant.name] = solved
-        if sub_dependant.cache_key not in dependency_cache:
+        if sub_dependant.use_cache and sub_dependant.cache_key not in dependency_cache:
             dependency_cache[sub_dependant.cache_key] = solved
     path_values, path_errors = request_params_to_args(
         dependant.path_params, request.path_params


### PR DESCRIPTION
Fixes #[795](https://github.com/UnsafeLabs/Bounty-Hunters/issues/795)

Guard `dependency_cache` write with `sub_dependant.use_cache` check, matching the read-side guard at L664.

**Before:** All resolved dependencies written to cache regardless of `use_cache`.
**After:** Only write to cache when `use_cache=True`. Dependencies with `use_cache=False` resolve fresh on every injection.

- Cache scoped to request (unchanged, already `dependency_cache` dict per request)
- Async and sync both covered (same write path)
- Backward compatible — `use_cache` defaults to `True`