### PR TITLE
Wisdom King Raphael [ Laravel ] Fix welcome.blade.php missing CSRF meta tag and add security headers

### DIFF
--- a/laravel/app/Http/Middleware/SecurityHeaders.php
+++ b/laravel/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        return $response;
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->web(append: [
+            SecurityHeaders::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "Autonomous bounty hunter cron job - Wisdom King Raphael - Lord of Wisdom. Fix welcome.blade.php missing CSRF meta tag and add security headers.", "ts": "2026-07-16T00:00:00Z"}

--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 

--- a/laravel/tests/Feature/SecurityHeadersTest.php
+++ b/laravel/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    public function test_security_headers_are_present(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('X-Frame-Options', 'DENY');
+        $response->assertHeader('X-XSS-Protection', '1; mode=block');
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
+
+    public function test_csrf_meta_tag_is_present(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertSee('meta name="csrf-token"', false);
+    }
+}


### PR DESCRIPTION
Fixes #751

- Add CSRF meta tag to welcome.blade.php head section
- Create SecurityHeaders middleware: X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy
- Register middleware in bootstrap/app.php for all web routes
- Add SecurityHeadersTest feature test verifying headers and CSRF meta tag