### PR TITLE
Wisdom King Raphael [ Laravel ] Fix User model password cast not applying bcrypt rounds from config

### DIFF
--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -26,7 +27,19 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Mutate the password attribute using configured bcrypt rounds.
+     */
+    protected function setPasswordAttribute(string $value): void
+    {
+        $rounds = config('hashing.bcrypt.rounds', 10);
+        if ($rounds > 0) {
+            $this->attributes['password'] = Hash::make($value, ['rounds' => (int) $rounds]);
+        } else {
+            $this->attributes['password'] = Hash::make($value);
+        }
     }
 }

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "Autonomous bounty hunter cron job - Wisdom King Raphael - Lord of Wisdom. Fix User model password cast not applying bcrypt rounds from config.", "ts": "2026-07-15T18:55:00Z"}


### PR DESCRIPTION
Fixes #745

Replaces  cast with  mutator that reads  from  and passes it to . Falls back to default rounds if config unavailable.