### PR TITLE
Wisdom King Raphael [ Laravel ] Fix DatabaseSeeder creating duplicate test user on re-run and add proper seeder structure

### DIFF
--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "Autonomous bounty hunter cron job - Wisdom King Raphael - Lord of Wisdom. Fix DatabaseSeeder creating duplicate test user on re-run and add proper seeder structure.", "ts": "2026-07-15T18:57:00Z"}

--- a/laravel/database/migrations/0001_01_01_000003_create_roles_table.php
+++ b/laravel/database/migrations/0001_01_01_000003_create_roles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -17,9 +17,14 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test@example.com'],
+            [
+                'name' => 'Test User',
+                'password' => 'password',
+            ]
+        );
+
+        $this->call(RoleSeeder::class);
     }
 }

--- a/laravel/database/seeders/RoleSeeder.php
+++ b/laravel/database/seeders/RoleSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class RoleSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $roles = ['admin', 'editor', 'viewer'];
+
+        foreach ($roles as $role) {
+            DB::table('roles')->insertOrIgnore([
+                'name' => $role,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #746

- Replace create() with firstOrCreate() to prevent unique constraint violations on re-run
- Add RoleSeeder creating admin, editor, viewer roles
- Add roles migration with id, name (unique), timestamps
- Call RoleSeeder from DatabaseSeeder