### PR TITLE
Wisdom King Raphael [ Laravel ] Add database health check endpoint with retry logic

### DIFF
--- a/laravel/app/Http/Controllers/HealthController.php
+++ b/laravel/app/Http/Controllers/HealthController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class HealthController
+{
+    /**
+     * Database health check with retry logic.
+     *
+     * Performs a lightweight query (SELECT 1) to verify database connectivity.
+     * Retries up to 3 times with exponential backoff on failure.
+     */
+    public function database(): JsonResponse
+    {
+        $maxRetries = 3;
+        $attempt = 0;
+
+        while ($attempt < $maxRetries) {
+            try {
+                $start = microtime(true);
+                DB::select('SELECT 1');
+                $latency = round((microtime(true) - $start) * 1000, 2);
+
+                return response()->json([
+                    'status' => 'healthy',
+                    'service' => 'database',
+                    'latency_ms' => $latency,
+                    'timestamp' => now()->toIso8601String(),
+                ]);
+            } catch (\Throwable $e) {
+                $attempt++;
+                Log::warning("DB health check attempt {$attempt} failed", ['error' => $e->getMessage()]);
+
+                if ($attempt >= $maxRetries) {
+                    return response()->json([
+                        'status' => 'unhealthy',
+                        'service' => 'database',
+                        'error' => $e->getMessage(),
+                        'timestamp' => now()->toIso8601String(),
+                    ], 503);
+                }
+
+                usleep((2 ** ($attempt - 1)) * 100_000); // 100ms, 200ms, 400ms
+            }
+        }
+
+        return response()->json([
+            'status' => 'unknown',
+            'service' => 'database',
+            'timestamp' => now()->toIso8601String(),
+        ], 500);
+    }
+}

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "Autonomous bounty hunter cron job - Wisdom King Raphael - Lord of Wisdom. Add database health check endpoint with retry logic.", "ts": "2026-07-15T19:11:00Z"}

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\HealthController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/health/database', [HealthController::class, 'database']);


### PR DESCRIPTION
Fixes #785

- HealthController with /health/database endpoint
- SELECT 1 with exponential backoff retry (100ms/200ms/400ms, max 3)
- Returns healthy/unhealthy JSON with latency_ms