### PR TITLE
Wisdom King Raphael [ Laravel ] Implement audit logging trait for Eloquent model change tracking

### DIFF
--- a/laravel/app/Traits/AuditLog.php
+++ b/laravel/app/Traits/AuditLog.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+trait AuditLog
+{
+    /**
+     * Boot the trait — register model event listeners.
+     */
+    public static function bootAuditLog(): void
+    {
+        static::created(function ($model) {
+            self::logChange($model, 'created');
+        });
+
+        static::updated(function ($model) {
+            $changes = $model->getChanges();
+            // Remove timestamps from tracked changes
+            unset($changes['updated_at']);
+            if (!empty($changes)) {
+                self::logChange($model, 'updated', $changes);
+            }
+        });
+
+        static::deleted(function ($model) {
+            self::logChange($model, 'deleted');
+        });
+    }
+
+    /**
+     * Log an audit entry for the model change.
+     */
+    protected static function logChange($model, string $event, ?array $changes = null): void
+    {
+        $userId = Auth::id();
+
+        Log::channel('audit')->info("Model {$event}", [
+            'model' => get_class($model),
+            'model_id' => $model->getKey(),
+            'user_id' => $userId,
+            'changes' => $changes,
+            'timestamp' => now()->toIso8601String(),
+        ]);
+    }
+}

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -127,6 +127,14 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'audit' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/audit.log'),
+            'level' => 'info',
+            'days' => 90,
+            'replace_placeholders' => true,
+        ],
+
     ],
 
 ];

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "Autonomous bounty hunter cron job - Wisdom King Raphael - Lord of Wisdom. Implement audit logging trait for Eloquent model change tracking.", "ts": "2026-07-15T19:13:00Z"}


### PR DESCRIPTION
Fixes #786

- AuditLog trait: auto-logs model created/updated (with change diff)/deleted events
- Uses bootAuditLog pattern — drop-in: just add `use AuditLog` to any model
- Logs to dedicated audit channel (daily rotation, 90-day retention) with user_id, model, changes