### PR TITLE
Wisdom King Raphael [ Laravel ] Add failed job monitoring listener and summary command

### DIFF
--- a/laravel/app/Console/Commands/FailedJobSummary.php
+++ b/laravel/app/Console/Commands/FailedJobSummary.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class FailedJobSummary extends Command
+{
+    protected $signature = 'queue:failed-summary {--hours=24 : Hours to look back}';
+    protected $description = 'Show a summary of recently failed jobs with counts';
+
+    public function handle(): int
+    {
+        $hours = (int) $this->option('hours');
+        $since = now()->subHours($hours);
+
+        $failed = DB::table('failed_jobs')
+            ->where('failed_at', '>=', $since)
+            ->get();
+
+        if ($failed->isEmpty()) {
+            $this->info("No failed jobs in the last {$hours} hours.");
+            return self::SUCCESS;
+        }
+
+        $byType = $failed->groupBy(function ($job) {
+            $payload = json_decode($job->payload, true);
+            return $payload['displayName'] ?? 'unknown';
+        });
+
+        $this->table(
+            ['Job Type', 'Count', 'First Failed', 'Last Failed'],
+            $byType->map(function ($jobs, $type) {
+                return [
+                    $type,
+                    $jobs->count(),
+                    $jobs->min('failed_at'),
+                    $jobs->max('failed_at'),
+                ];
+            })->toArray()
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/laravel/app/Listeners/FailedJobListener.php
+++ b/laravel/app/Listeners/FailedJobListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Log;
+
+class FailedJobListener
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(JobFailed $event): void
+    {
+        Log::channel('failed_jobs')->warning('Job failed', [
+            'connection' => $event->connectionName,
+            'job' => $event->job->resolveName(),
+            'payload' => $event->job->payload(),
+            'exception' => $event->exception->getMessage(),
+            'trace' => $event->exception->getTraceAsString(),
+            'timestamp' => now()->toIso8601String(),
+        ]);
+    }
+}

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -3,6 +3,9 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Queue\Events\JobFailed;
+use App\Listeners\FailedJobListener;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Event::listen(JobFailed::class, FailedJobListener::class);
     }
 }

--- a/laravel/config/logging.php
+++ b/laravel/config/logging.php
@@ -127,6 +127,14 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        'failed_jobs' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/failed_jobs.log'),
+            'level' => 'warning',
+            'days' => 30,
+            'replace_placeholders' => true,
+        ],
+
     ],
 
 ];

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "Autonomous bounty hunter cron job - Wisdom King Raphael - Lord of Wisdom. Add failed job monitoring listener and summary command.", "ts": "2026-07-15T19:17:00Z"}


### PR DESCRIPTION
Fixes #789

- FailedJobListener: logs failed jobs to dedicated channel with full context
- queue:failed-summary command: aggregated view by job type, count, time range
- failed_jobs log channel: daily rotation, 30-day retention
- Registered in AppServiceProvider via Event::listen