### PR TITLE
Wisdom King Raphael [ Laravel ] Add Slack notification service with retry and timeout handling

### DIFF
--- a/laravel/app/Services/SlackNotificationService.php
+++ b/laravel/app/Services/SlackNotificationService.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class SlackNotificationService
+{
+    private const TIMEOUT = 5;
+    private const MAX_RETRIES = 3;
+
+    /**
+     * Send a notification to Slack with retry and timeout.
+     */
+    public function send(string $text, ?string $channel = null, ?string $webhookUrl = null): bool
+    {
+        $url = $webhookUrl ?? Config::get('slack.webhook_url');
+        if (!$url) {
+            Log::warning('Slack webhook URL not configured');
+            return false;
+        }
+
+        $attempt = 0;
+
+        while ($attempt < self::MAX_RETRIES) {
+            try {
+                $response = Http::timeout(self::TIMEOUT)
+                    ->post($url, [
+                        'text' => $text,
+                        'channel' => $channel,
+                    ]);
+
+                if ($response->successful()) {
+                    return true;
+                }
+
+                $attempt++;
+                Log::warning("Slack notification attempt {$attempt} failed", [
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+            } catch (\Throwable $e) {
+                $attempt++;
+                Log::warning("Slack notification attempt {$attempt} error", [
+                    'error' => $e->getMessage(),
+                ]);
+            }
+
+            if ($attempt < self::MAX_RETRIES) {
+                usleep((2 ** ($attempt - 1)) * 100_000);
+            }
+        }
+
+        Log::error('Slack notification failed after all retries');
+        return false;
+    }
+}

--- a/laravel/config/slack.php
+++ b/laravel/config/slack.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'webhook_url' => env('SLACK_WEBHOOK_URL'),
+    'default_channel' => env('SLACK_DEFAULT_CHANNEL', '#general'),
+    'retry' => [
+        'max_attempts' => 3,
+        'timeout' => 5,
+    ],
+];

--- a/laravel/contributor_meta.json
+++ b/laravel/contributor_meta.json
@@ -1,0 +1,1 @@
+{"name": "Wisdom King Raphael", "session_init": "Autonomous bounty hunter cron job - Wisdom King Raphael - Lord of Wisdom. Add Slack notification service with retry and timeout handling.", "ts": "2026-07-15T19:21:00Z"}


### PR DESCRIPTION
Fixes #791

- SlackNotificationService: send with up to 3 retries, 5s timeout per attempt
- Exponential backoff between retries
- slack.php config: webhook_url, default_channel