### PR TITLE
Wisdom King Raphael [ Crypto ] Fix StakingVault reentrancy with nonReentrant modifier and CEI pattern

### DIFF
--- a/solidity/contracts/.provenance.json
+++ b/solidity/contracts/.provenance.json
@@ -1,0 +1,8 @@
+{
+  "agent_name": "Wisdom King Raphael",
+  "config_snapshot": "You are running as a scheduled cron job. There is no user present. Execute the task fully and autonomously. You are an autonomous bounty hunter for UnsafeLabs/Bounty-Hunters. Scan issues labeled \"\ud83d\udc8e Bounty\", fix vulnerabilities, push PRs, monitor CI, handle reviews, merge when ready. Crypto/Solidity issues: fix reentrancy, tx.origin, overflow, zero-fee, missing validation, slippage, race conditions, price manipulation. Use CEI pattern, nonReentrant modifier, zero-address checks, .call{value} over .transfer. Create provenance JSON files as specified in each issue body. Brainfuck: bracket-balanced, verify with checker. FastAPI: encoders, utils, logger, OpenAPI. Laravel: rate limiting, caching, auth, validation. Skip T3 Code without bun. Do not work on issues with existing PRs. Always check PR list first. Use fork ardha27/Bounty-Hunters for pushes.",
+  "created": "2026-07-15T23:12:17Z",
+  "platform_config": "Hermes Agent by Nous Research. Model: CMC via custom provider. Linux 5.15.0-139-generic. Profile: default. Cron-driven autonomous execution.",
+  "boot_context": "Autonomous bounty hunter cron job. Complete instructions: scan open bounty issues, fix vulnerabilities (reentrancy/CEI/tx.origin/overflow/slippage/price manipulation), create PRs, monitor CI, handle reviews, update bounty-brain.md with lessons learned. Crypto contracts need reentrancy guards with locked flag modifier (not OZ import for gas), state updates before external calls, zero-address validation. Brainfuck programs must be bracket-balanced. Provenance filenames vary per issue - always read issue body.",
+  "issue_id": 911
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -12,6 +12,15 @@ contract StakingVault {
     mapping(address => uint256) public rewards;
     mapping(address => uint256) public lastStakeTime;
 
+    bool private _locked;
+
+    modifier nonReentrant() {
+        require(!_locked, "Reentrant call");
+        _locked = true;
+        _;
+        _locked = false;
+    }
+
     event Staked(address indexed user, uint256 amount);
     event Withdrawn(address indexed user, uint256 amount);
     event RewardClaimed(address indexed user, uint256 amount);
@@ -39,32 +48,34 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    // CEI: state update before external call, nonReentrant guard
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
-        require(success, "Transfer failed");
-
-        // State update after external call — vulnerable to reentrancy
+        // State update before external call — CEI pattern
         balances[msg.sender] -= amount;
         totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
+
+        // External call after state update
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Transfer failed");
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    // CEI: state update before external call, nonReentrant guard
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
-        (bool success, ) = payable(msg.sender).call{value: reward}("");
-        require(success, "Transfer failed");
-
+        // State update before external call — CEI pattern
         rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
+
+        // External call after state update
+        (bool success, ) = payable(msg.sender).call{value: reward}("");
+        require(success, "Transfer failed");
     }
 
     function getStakedBalance(address account) external view returns (uint256) {


### PR DESCRIPTION
Fixes #911

## Changes
- Added `nonReentrant` modifier using locked-flag pattern (no OZ import — saves gas)
- Applied CEI (Checks-Effects-Interactions) to `withdraw()`: state update before external call
- Applied CEI to `claimRewards()`: state update before external call

## Root cause
Both functions made external `.call{value}` before updating `balances`/`rewards`, enabling reentrant calls to drain funds repeatedly.