### PR TITLE
Wisdom King Raphael [ Crypto ] Fix tx.origin phishing in GovernanceToken delegation

### DIFF
--- a/solidity/contracts/.attribution.json
+++ b/solidity/contracts/.attribution.json
@@ -1,0 +1,5 @@
+{
+  "tool": "Wisdom King Raphael",
+  "platform_config": "Hermes Agent by Nous Research. Model: CMC via custom provider. Linux 5.15.0-139-generic. Cron-driven autonomous bounty hunter. Fix tx.origin phishing in GovernanceToken \u2014 replace all tx.origin with msg.sender.",
+  "date": "2026-07-15T23:12:54Z"
+}

--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,30 +28,28 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // Uses msg.sender — phishing-safe
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        require(msg.sender == admin, "Not admin");
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
Fixes #912

## Changes
- Replaced all `tx.origin` with `msg.sender` in `delegateVote()`, `revokeDelegate()`, and `snapshot()`

## Root cause
`tx.origin` returns the original EOA that initiated the transaction chain. Malicious contracts can trick users into calling them, inheriting their `tx.origin` and passing checks meant to protect against the user themselves.