### PR TITLE
Wisdom King Raphael [ Crypto ] Fix YieldVault phantom reward accrual and precision loss

### DIFF
--- a/solidity/contracts/YieldVault.sol
+++ b/solidity/contracts/YieldVault.sol
@@ -29,11 +29,12 @@ contract YieldVault {
         rewardDistributor = msg.sender;
     }
 
-    // BUG: Does not cap at periodFinish — accrues phantom rewards after period ends
+    // Caps at periodFinish to prevent phantom rewards after period ends
     function rewardPerToken() public view returns (uint256) {
         if (totalSupply == 0) return rewardPerTokenStored;
+        uint256 applicableTime = lastTimeRewardApplicable();
         return rewardPerTokenStored + (
-            (block.timestamp - lastUpdateTime) * rewardRate * 1e18 / totalSupply
+            (applicableTime - lastUpdateTime) * rewardRate * 1e18 / totalSupply
         );
     }
 
@@ -77,11 +78,10 @@ contract YieldVault {
         }
     }
 
-    // BUG: No access control — anyone can call
-    // BUG: Precision loss in rewardRate calculation
-    function notifyRewardAmount(uint256 reward, uint256 duration) external updateReward(address(0)) {
-        rewardRate = reward / duration;
+    function notifyRewardAmount(uint256 reward, uint256 _duration) external onlyRewardDistributor updateReward(address(0)) {
+        // Use 1e18 precision multiplier to avoid truncation
+        rewardRate = reward * 1e18 / _duration;
         lastUpdateTime = block.timestamp;
-        periodFinish = block.timestamp + duration;
+        periodFinish = block.timestamp + _duration;
     }
 }

--- a/solidity/contracts/_contributor.json
+++ b/solidity/contracts/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "Wisdom King Raphael",
+  "config_snapshot": "Hermes Agent by Nous Research. Model: CMC. Fix YieldVault phantom reward accrual after period expiry + rewardRate precision loss.",
+  "created": "2026-07-15T23:14:43Z"
+}


### PR DESCRIPTION
Fixes #914

## Changes
- `rewardPerToken()`: caps at `lastTimeRewardApplicable()` instead of `block.timestamp` — stops phantom reward accrual after period expiry
- `notifyRewardAmount()`: adds `onlyRewardDistributor` access control and 1e18 precision multiplier to avoid truncation
- `earned()`: cascading fix from corrected rewardPerToken

## Root cause
`rewardPerToken()` used `block.timestamp` instead of capped time, letting rewards accrue indefinitely after period finished. `rewardRate = reward / duration` truncated for small reward amounts.