### PR TITLE
[opencode agent] [ Crypto ] Fix zero-fee flash loans and add pool drainage protection

### DIFF
--- a/solidity/contracts/FlashLoan.sol
+++ b/solidity/contracts/FlashLoan.sol
@@ -9,12 +9,14 @@ interface IFlashLoanReceiver {
 
 contract FlashLoan {
     IERC20 public loanToken;
-    uint256 public feeBPS; // fee in basis points
+    uint256 public feeBPS;
     uint256 public totalFees;
+    uint256 public poolBalance;
     address public owner;
     bool public paused;
 
     event FlashLoanExecuted(address indexed borrower, uint256 amount, uint256 fee);
+    event PausedToggled(bool paused);
 
     constructor(address _loanToken, uint256 _feeBPS) {
         loanToken = IERC20(_loanToken);
@@ -22,26 +24,18 @@ contract FlashLoan {
         owner = msg.sender;
     }
 
-    // BUG: Fee truncates to zero for small loan amounts
-    // BUG: No max loan amount — can drain entire pool
-    // BUG: Uses balanceOf for validation — rebasing tokens can manipulate
     function flashLoan(uint256 amount, bytes calldata data) external {
         require(!paused, "Paused");
         require(amount > 0, "Amount must be > 0");
+        require(amount <= poolBalance / 2, "Exceeds max loan");
 
-        uint256 balanceBefore = loanToken.balanceOf(address(this));
-        require(balanceBefore >= amount, "Insufficient pool balance");
-
-        // BUG: Truncates to 0 when amount < 10000/feeBPS
         uint256 fee = amount * feeBPS / 10000;
+        if (fee == 0) fee = 1;
+        require(poolBalance >= amount + totalFees, "Insufficient pool");
 
         loanToken.transfer(msg.sender, amount);
-
         IFlashLoanReceiver(msg.sender).onFlashLoan(address(loanToken), amount, fee, data);
-
-        // BUG: balanceOf can be manipulated by rebasing tokens
-        uint256 balanceAfter = loanToken.balanceOf(address(this));
-        require(balanceAfter >= balanceBefore + fee, "Loan not repaid");
+        loanToken.transferFrom(msg.sender, address(this), amount + fee);
 
         totalFees += fee;
         emit FlashLoanExecuted(msg.sender, amount, fee);
@@ -49,17 +43,28 @@ contract FlashLoan {
 
     function depositToPool(uint256 amount) external {
         loanToken.transferFrom(msg.sender, address(this), amount);
+        poolBalance += amount;
     }
 
     function withdrawFees() external {
         require(msg.sender == owner, "Not owner");
         uint256 fees = totalFees;
         totalFees = 0;
+        poolBalance -= fees;
         loanToken.transfer(owner, fees);
     }
 
-    // BUG: No emergency pause function
+    function togglePause() external {
+        require(msg.sender == owner, "Not owner");
+        paused = !paused;
+        emit PausedToggled(paused);
+    }
+
+    function syncBalance() external {
+        poolBalance = loanToken.balanceOf(address(this)) - totalFees;
+    }
+
     function getPoolBalance() external view returns (uint256) {
-        return loanToken.balanceOf(address(this));
+        return poolBalance;
     }
 }

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "opencode agent",
+  "generation_context": "Fix FlashLoan zero-fee vulnerability, pool drainage, and rebasing token manipulation. Added minimum 1-unit fee, max loan cap at 50% of pool, internal poolBalance accounting, and owner togglePause.",
+  "completed_at": "2026-07-17T20:46:00Z"
+}


### PR DESCRIPTION
## Issue
Closes #919

## Summary
Added minimum 1-unit fee, 50% pool cap, internal poolBalance accounting, and emergency togglePause.

## Acceptance criteria
- [x] Minimum fee of 1 token prevents free flash loans
- [x] Loans exceeding 50% of pool balance are rejected
- [x] Internal accounting prevents rebasing token exploits
- [x] Emergency pause disables flash loans
- [x] syncBalance to reconcile direct transfers