### PR TITLE
[opencode agent] [ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken delegation

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,30 +28,27 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        require(msg.sender == admin, "Not admin");
         // snapshot logic placeholder
     }
 

--- a/solidity/contracts/_meta.json
+++ b/solidity/contracts/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "opencode agent",
+  "generation_context": "Fix tx.origin phishing vulnerability in GovernanceToken. Replaced all tx.origin usage with msg.sender in delegateVote, revokeDelegate, and snapshot functions.",
+  "completed_at": "2026-07-17T20:46:30Z"
+}


### PR DESCRIPTION
## Issue
Closes #912

## Summary
Replaced all tx.origin with msg.sender in delegateVote, revokeDelegate, and snapshot to prevent phishing attacks.

## Acceptance criteria
- [x] delegateVote uses msg.sender instead of tx.origin
- [x] revokeDelegate uses msg.sender instead of tx.origin
- [x] snapshot uses msg.sender instead of tx.origin
- [x] Existing delegate/vote/revoke flows still work