### PR TITLE
[opencode agent] [ Laravel ] Fix console.php missing scheduled task registration and add log cleanup command

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "opencode agent",
+  "generation_context": "Add logs:clear artisan command to delete old log files and register daily schedule at midnight in console.php.",
+  "completed_at": "2026-07-17T20:49:00Z"
+}

--- a/laravel/routes/console.php
+++ b/laravel/routes/console.php
@@ -1,8 +1,33 @@
 <?php
 
+use Illuminate\Support\Facades\Schedule;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\Artisan;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('logs:clear {--days=7 : Number of days to retain}', function () {
+    $days = max(1, (int) $this->option('days'));
+    $cutoff = now()->subDays($days);
+    $files = glob(storage_path('logs/*.log'));
+    $deleted = 0;
+    $freed = 0;
+
+    foreach ($files as $file) {
+        if (filemtime($file) < $cutoff->timestamp) {
+            $freed += filesize($file);
+            unlink($file);
+            $deleted++;
+        }
+    }
+
+    $freedFormatted = $freed >= 1048576
+        ? round($freed / 1048576, 2) . ' MB'
+        : round($freed / 1024, 2) . ' KB';
+
+    $this->info("Deleted {$deleted} files, freed {$freedFormatted}");
+})->purpose('Clear log files older than the specified days');
+
+Schedule::command('logs:clear --days=7')->dailyAt('00:00');


### PR DESCRIPTION
## Issue
Closes #753

## Summary
Added logs:clear artisan command with --days flag and daily schedule at 00:00. Outputs file count and freed space.

## Acceptance criteria
- [x] logs:clear deletes logs older than 7 days by default
- [x] --days=30 flag overrides retention
- [x] Outputs file count and freed space
- [x] Schedule entry at 00:00 daily