### PR TITLE
opencode [ T3 Code ] Fix ProviderModelPicker persistence across reloads

### DIFF
--- a/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/t3code/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -82,6 +82,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   terminalOpen: boolean;
   onRequestClose?: () => void;
   onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
+  onResetDefault?: () => void;
 }) {
   const {
     keybindings: providedKeybindings,
@@ -641,6 +642,20 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             <ComboboxEmpty className="not-empty:py-6 empty:h-0 text-xs font-normal leading-snug">
               No models found
             </ComboboxEmpty>
+            {props.onResetDefault && (
+              <div className="border-t px-2 py-2">
+                <button
+                  type="button"
+                  className="w-full rounded px-2 py-1.5 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground text-left"
+                  onClick={() => {
+                    props.onResetDefault?.();
+                    props.onRequestClose?.();
+                  }}
+                >
+                  Reset to default
+                </button>
+              </div>
+            )}
           </div>
         </Combobox>
       </div>

--- a/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/t3code/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -3,7 +3,7 @@ import {
   type ProviderDriverKind,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
@@ -19,6 +19,9 @@ import {
 } from "./providerIconUtils";
 import { setModelPickerOpen } from "../../modelPickerOpenState";
 import type { ProviderInstanceEntry } from "../../providerInstances";
+
+const STORAGE_KEY_PROVIDER = "t3tools:selectedProviderId";
+const STORAGE_KEY_MODEL = "t3tools:selectedModel";
 
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   /**
@@ -88,9 +91,53 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
 
   const handleInstanceModelChange = (instanceId: ProviderInstanceId, model: string) => {
     if (props.disabled) return;
+    if (typeof window !== "undefined") {
+      try {
+        localStorage.setItem(STORAGE_KEY_PROVIDER, instanceId);
+        localStorage.setItem(STORAGE_KEY_MODEL, model);
+      } catch {}
+    }
     props.onInstanceModelChange(instanceId, model);
     setIsMenuOpen(false);
   };
+
+  const handleResetDefault = useCallback(() => {
+    if (typeof window !== "undefined") {
+      try {
+        localStorage.removeItem(STORAGE_KEY_PROVIDER);
+        localStorage.removeItem(STORAGE_KEY_MODEL);
+      } catch {}
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const savedProvider = localStorage.getItem(STORAGE_KEY_PROVIDER);
+    const savedModel = localStorage.getItem(STORAGE_KEY_MODEL);
+    if (!savedProvider || !savedModel) return;
+    const instanceExists = props.instanceEntries.some(
+      (entry) => entry.instanceId === savedProvider,
+    );
+    if (!instanceExists) return;
+    props.onInstanceModelChange(savedProvider as ProviderInstanceId, savedModel);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY_PROVIDER && e.newValue) {
+        const instanceExists = props.instanceEntries.some(
+          (entry) => entry.instanceId === e.newValue,
+        );
+        if (instanceExists && props.model) {
+          const savedModel = localStorage.getItem(STORAGE_KEY_MODEL);
+          props.onInstanceModelChange(e.newValue as ProviderInstanceId, savedModel ?? props.model);
+        }
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [props.model]);
 
   return (
     <Popover
@@ -180,6 +227,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           terminalOpen={props.terminalOpen ?? false}
           onRequestClose={() => setIsMenuOpen(false)}
           onInstanceModelChange={handleInstanceModelChange}
+          onResetDefault={handleResetDefault}
         />
       </PopoverPopup>
     </Popover>

--- a/t3code/apps/web/src/components/chat/_generation.json
+++ b/t3code/apps/web/src/components/chat/_generation.json
@@ -1,0 +1,5 @@
+{
+  "agent": "opencode",
+  "pre_task_context": "Fixed ProviderModelPicker not persisting selection across page reloads. Added localStorage persistence with namespaced keys, cross-tab sync via storage event, graceful fallback to first provider if persisted value is invalid, and a Reset to default button in the picker.",
+  "timestamp": "2026-07-17T21:30:00Z"
+}


### PR DESCRIPTION
## Description

Persist selected provider ID and model to localStorage so the selection survives page reloads.

**Changes:**
- Save selection to localStorage (`t3tools:`-namespaced keys) on provider/model change
- Restore persisted selection on mount; fall back to first available provider if saved one is unavailable
- Cross-tab sync via `storage` event
- "Reset to default" button in picker clears localStorage and closes picker
- `_generation.json` included per acceptance criteria

Closes #834