### PR TITLE
fix(crypto): Replace tx.origin with msg.sender to prevent phishing (#912)

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,30 +28,30 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // FIXED: Replaced tx.origin with msg.sender to prevent phishing attacks
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    // FIXED: Replaced tx.origin with msg.sender
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
+    // FIXED: Replaced tx.origin with msg.sender for admin check
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        require(msg.sender == admin, "Not admin");
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Issue
Closes #912

## Summary
Fixed tx.origin phishing vulnerability by replacing all instances of tx.origin with msg.sender in GovernanceToken.sol. The original code used tx.origin for authorization in delegateVote(), revokeDelegate(), and snapshot(), making it vulnerable to phishing attacks where a malicious contract could authorize actions on behalf of users.

## Acceptance criteria
- [x] All tx.origin references replaced with msg.sender
- [x] delegateVote() now uses msg.sender for delegation check
- [x] revokeDelegate() now uses msg.sender for current delegate lookup
- [x] snapshot() admin check now uses msg.sender instead of tx.origin
- [x] No other functionality changed
- [x] Comments updated to reflect the fix

## Changes
- `solidity/contracts/GovernanceToken.sol`: 6 lines changed (tx.origin → msg.sender)