### PR TITLE
opencode [ FastAPI ] Add concurrent task runner with semaphore limiting and timeout

### DIFF
--- a/fastapi/fastapi/_contributor.json
+++ b/fastapi/fastapi/_contributor.json
@@ -1,0 +1,1 @@
+{"identity": "opencode", "runtime_instructions": "Implementing concurrent task runner with semaphore limiting and timeout per issue #803", "timestamp": "2026-07-18T00:00:00Z"}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,8 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Coroutine, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +13,12 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    def __init__(self, exceptions: list[Exception]) -> None:
+        self.exceptions = exceptions
+        super().__init__(f"{len(exceptions)} task(s) failed: {exceptions}")
 
 
 @asynccontextmanager
@@ -39,3 +46,43 @@ async def contextmanager_in_threadpool(
         await anyio.to_thread.run_sync(
             cm.__exit__, None, None, None, limiter=exit_limiter
         )
+
+
+async def run_concurrently(
+    coros: Sequence[Coroutine[Any, Any, _T]],
+    max_concurrency: int = 0,
+    timeout: float | None = None,
+) -> list[_T]:
+    semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency > 0 else None
+    exceptions: list[Exception] = []
+    results: list[_T | None] = [None] * len(coros)
+    completed = [False] * len(coros)
+
+    async def _run(idx: int, coro: Coroutine[Any, Any, _T]) -> None:
+        try:
+            if semaphore:
+                async with semaphore:
+                    results[idx] = await coro
+            else:
+                results[idx] = await coro
+            completed[idx] = True
+        except Exception as e:
+            exceptions.append(e)
+            completed[idx] = True
+
+    tasks = [_run(i, c) for i, c in enumerate(coros)]
+    if timeout is not None:
+        try:
+            await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=timeout)
+        except asyncio.TimeoutError:
+            timeout_error = TimeoutError(f"Task execution timed out after {timeout}s")
+            for i, done in enumerate(completed):
+                if not done:
+                    exceptions.append(timeout_error)
+                    completed[i] = True
+    else:
+        await asyncio.gather(*tasks)
+
+    if exceptions:
+        raise ConcurrencyError(exceptions)
+    return list(results)  # type: ignore[return-value]

--- a/fastapi/tests/test_concurrency.py
+++ b/fastapi/tests/test_concurrency.py
@@ -1,0 +1,69 @@
+import asyncio
+
+import pytest
+from fastapi.concurrency import ConcurrencyError, run_concurrently
+
+
+async def _noop() -> str:
+    return "ok"
+
+
+async def _slow(delay: float, value: str) -> str:
+    await asyncio.sleep(delay)
+    return value
+
+
+async def _fail(msg: str) -> str:
+    raise ValueError(msg)
+
+
+@pytest.mark.anyio
+async def test_basic_execution():
+    results = await run_concurrently([_noop(), _noop()])
+    assert results == ["ok", "ok"]
+
+
+@pytest.mark.anyio
+async def test_maintains_order():
+    coros = [_slow(0.05, "first"), _slow(0.01, "second")]
+    results = await run_concurrently(coros)
+    assert results == ["first", "second"]
+
+
+@pytest.mark.anyio
+async def test_max_concurrency_one():
+    start = asyncio.get_event_loop().time()
+    coros = [_slow(0.1, "a"), _slow(0.1, "b")]
+    await run_concurrently(coros, max_concurrency=1)
+    elapsed = asyncio.get_event_loop().time() - start
+    assert elapsed >= 0.2
+
+
+@pytest.mark.anyio
+async def test_max_concurrency_greater_than_count():
+    coros = [_slow(0.02, "a"), _slow(0.02, "b")]
+    results = await run_concurrently(coros, max_concurrency=10)
+    assert results == ["a", "b"]
+
+
+@pytest.mark.anyio
+async def test_concurrency_error_with_exceptions():
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([_fail("bad"), _noop()])
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], ValueError)
+
+
+@pytest.mark.anyio
+async def test_concurrency_error_all_failures():
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([_fail("e1"), _fail("e2")])
+    assert len(exc_info.value.exceptions) == 2
+
+
+@pytest.mark.anyio
+async def test_timeout_cancels_remaining():
+    with pytest.raises(ConcurrencyError) as exc_info:
+        await run_concurrently([_slow(0.01, "fast"), _slow(10, "slow")], timeout=0.05)
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], TimeoutError)


### PR DESCRIPTION
Closes #803

## Summary
- Added run_concurrently function to fastapi/fastapi/concurrency.py
- Uses asyncio.Semaphore to limit concurrent execution
- Returns results in input order regardless of completion order
- Raises ConcurrencyError with all failed task exceptions
- Supports timeout parameter to cancel remaining tasks
- Added _contributor.json