### PR TITLE
[opencode agent] [ Laravel ] Fix User model password cast not applying bcrypt rounds

### DIFF
--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'driver' => 'bcrypt',
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+    ],
+    'argon' => [
+        'memory' => 65536,
+        'threads' => 1,
+        'time' => 4,
+    ],
+];


### PR DESCRIPTION
Closes #745

Adds config/hashing.php with explicit bcrypt rounds defaulting to 12.
The User model's password cast ('hashed') relies on this config.