### PR TITLE
feat(t3code): deep linking via t3code:// protocol (#864)

### DIFF
--- a/t3code/apps/desktop/src/deepLink/parseDeepLink.test.ts
+++ b/t3code/apps/desktop/src/deepLink/parseDeepLink.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseDeepLink, sanitizeProjectPath } from "./parseDeepLink.ts";
+
+describe("sanitizeProjectPath", () => {
+  it("accepts absolute posix paths", () => {
+    expect(sanitizeProjectPath("/Users/me/repo")).toBe("/Users/me/repo");
+  });
+  it("accepts windows paths", () => {
+    expect(sanitizeProjectPath("C:\\Users\\me\\repo")).toBe("C:\\Users\\me\\repo");
+  });
+  it("rejects traversal", () => {
+    expect(sanitizeProjectPath("/tmp/../etc/passwd")).toBeNull();
+    expect(sanitizeProjectPath("%2e%2e/secret")).toBeNull();
+  });
+  it("rejects relative paths", () => {
+    expect(sanitizeProjectPath("relative/path")).toBeNull();
+  });
+});
+
+describe("parseDeepLink", () => {
+  it("parses open project", () => {
+    const r = parseDeepLink("t3code://open/project?path=%2Ftmp%2Fdemo");
+    expect(r).toEqual({ ok: true, action: { kind: "open_project", path: "/tmp/demo" } });
+  });
+  it("parses chat thread", () => {
+    const r = parseDeepLink("t3code://chat/thread?id=abc-123");
+    expect(r).toEqual({ ok: true, action: { kind: "chat_thread", id: "abc-123" } });
+  });
+  it("parses settings", () => {
+    expect(parseDeepLink("t3code://settings").ok).toBe(true);
+    if (parseDeepLink("t3code://settings").ok) {
+      expect(parseDeepLink("t3code://settings").action).toEqual({ kind: "settings" });
+    }
+  });
+  it("accepts t3 scheme alias", () => {
+    const r = parseDeepLink("t3://open/project?path=/home/a/b");
+    expect(r.ok).toBe(true);
+  });
+  it("rejects path traversal in project path", () => {
+    const r = parseDeepLink("t3code://open/project?path=/tmp/../etc");
+    expect(r).toEqual({ ok: false, error: "invalid_project_path" });
+  });
+  it("rejects bad thread id", () => {
+    const r = parseDeepLink("t3code://chat/thread?id=../../x");
+    expect(r.ok).toBe(false);
+  });
+});

--- a/t3code/apps/desktop/src/deepLink/parseDeepLink.ts
+++ b/t3code/apps/desktop/src/deepLink/parseDeepLink.ts
@@ -1,0 +1,83 @@
+/**
+ * Parse t3code:// deep links for desktop navigation.
+ * Supported:
+ *   t3code://open/project?path=/abs/path
+ *   t3code://chat/thread?id=abc123
+ *   t3code://settings
+ * Also accepts t3:// as an alias for the existing desktop scheme.
+ */
+
+export type DeepLinkAction =
+  | { readonly kind: "open_project"; readonly path: string }
+  | { readonly kind: "chat_thread"; readonly id: string }
+  | { readonly kind: "settings" };
+
+export type DeepLinkParseResult =
+  | { readonly ok: true; readonly action: DeepLinkAction }
+  | { readonly ok: false; readonly error: string };
+
+const SCHEMES = new Set(["t3code:", "t3:"]);
+
+/** Reject path traversal and empty project paths. */
+export function sanitizeProjectPath(raw: string): string | null {
+  if (!raw || typeof raw !== "string") return null;
+  let path = raw.trim();
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    return null;
+  }
+  if (path.length === 0 || path.length > 4096) return null;
+  // Disallow null bytes and obvious traversal
+  if (path.includes("\0") || path.includes("..")) return null;
+  // Windows drive or absolute posix
+  const isWinAbs = /^[a-zA-Z]:[\\/]/.test(path);
+  const isPosixAbs = path.startsWith("/");
+  if (!isWinAbs && !isPosixAbs) return null;
+  return path;
+}
+
+export function parseDeepLink(urlString: string): DeepLinkParseResult {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return { ok: false, error: "invalid_url" };
+  }
+
+  if (!SCHEMES.has(url.protocol)) {
+    return { ok: false, error: "unsupported_scheme" };
+  }
+
+  // hostname is first segment for non-standard schemes: t3code://open/project
+  const host = url.hostname.toLowerCase();
+  const pathParts = url.pathname.split("/").filter(Boolean);
+  const segments = [host, ...pathParts].filter(Boolean);
+
+  if (segments[0] === "settings" || (segments[0] === "open" && segments[1] === "settings")) {
+    return { ok: true, action: { kind: "settings" } };
+  }
+
+  if (segments[0] === "open" && segments[1] === "project") {
+    const projectPath = sanitizeProjectPath(url.searchParams.get("path") ?? "");
+    if (!projectPath) {
+      return { ok: false, error: "invalid_project_path" };
+    }
+    return { ok: true, action: { kind: "open_project", path: projectPath } };
+  }
+
+  if (segments[0] === "chat" && segments[1] === "thread") {
+    const id = (url.searchParams.get("id") ?? "").trim();
+    if (!id || id.length > 256 || !/^[a-zA-Z0-9._-]+$/.test(id)) {
+      return { ok: false, error: "invalid_thread_id" };
+    }
+    return { ok: true, action: { kind: "chat_thread", id } };
+  }
+
+  // t3code://settings (empty host, path /settings)
+  if (url.pathname === "/settings" || url.pathname === "settings") {
+    return { ok: true, action: { kind: "settings" } };
+  }
+
+  return { ok: false, error: "unknown_route" };
+}

--- a/t3code/apps/desktop/src/deepLink/registerDeepLinkProtocol.ts
+++ b/t3code/apps/desktop/src/deepLink/registerDeepLinkProtocol.ts
@@ -1,0 +1,61 @@
+import type * as Electron from "electron";
+import { parseDeepLink, type DeepLinkAction } from "./parseDeepLink.ts";
+
+const PROTOCOL = "t3code";
+
+export function registerAsDefaultProtocolClient(app: Electron.App): boolean {
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      return app.setAsDefaultProtocolClient(PROTOCOL, process.execPath, [
+        process.argv[1]!,
+      ]);
+    }
+  }
+  return app.setAsDefaultProtocolClient(PROTOCOL);
+}
+
+export function extractDeepLinkFromArgv(argv: readonly string[]): string | null {
+  return argv.find((a) => a.startsWith("t3code://") || a.startsWith("t3://")) ?? null;
+}
+
+export type DeepLinkHandler = (action: DeepLinkAction) => void;
+
+/**
+ * Wire open-url (macOS) + second-instance (Windows/Linux) + cold-start argv.
+ * Returns dispose function.
+ */
+export function attachDeepLinkListeners(
+  app: Electron.App,
+  onAction: DeepLinkHandler,
+): () => void {
+  const handleRaw = (url: string) => {
+    const parsed = parseDeepLink(url);
+    if (parsed.ok) onAction(parsed.action);
+  };
+
+  const onOpenUrl = (event: Electron.Event, url: string) => {
+    event.preventDefault();
+    handleRaw(url);
+  };
+
+  const onSecondInstance = (_event: Electron.Event, argv: string[]) => {
+    const url = extractDeepLinkFromArgv(argv);
+    if (url) handleRaw(url);
+  };
+
+  app.on("open-url", onOpenUrl);
+  app.on("second-instance", onSecondInstance);
+
+  // Cold start: process argv may contain the deep link
+  const cold = extractDeepLinkFromArgv(process.argv);
+  if (cold) {
+    // Defer until app ready typically handled by caller; fire now if already ready
+    if (app.isReady()) handleRaw(cold);
+    else app.whenReady().then(() => handleRaw(cold));
+  }
+
+  return () => {
+    app.off("open-url", onOpenUrl);
+    app.off("second-instance", onSecondInstance);
+  };
+}


### PR DESCRIPTION
## Summary
Implements **#864** deep-link foundation for the Electron desktop app.

### Routes
| URL | Action |
|-----|--------|
| `t3code://open/project?path=/abs/path` | open project (absolute path only) |
| `t3code://chat/thread?id=…` | open chat thread |
| `t3code://settings` | open settings |

### Security
- Project paths: absolute only; rejects `..` / traversal / relative paths
- Thread IDs: constrained charset + length
- `t3://` accepted as alias for existing desktop scheme family

### Files
- `t3code/apps/desktop/src/deepLink/parseDeepLink.ts` (+ tests)
- `t3code/apps/desktop/src/deepLink/registerDeepLinkProtocol.ts` (register default client + open-url / second-instance)

### Test plan
- [x] Unit tests for parse/sanitize (path traversal, happy paths)
- [ ] Manual: register protocol, click `t3code://settings` from browser

Closes #864