### PR TITLE
cornerblue [ Crypto ] Fix PriceOracle staleness check and fallback (#915)

### DIFF
--- a/.generation_meta.json
+++ b/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "cornerblue",
+  "initial_directives": "Autonomous ethical earning of >=$100 BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. GitHub bounty PRs only, high quality, unique high-EV hard-dollar targets. Prefer explicit $ labels. No malware. Ship complete acceptance criteria with tests. For BH #915 $200: PriceOracle validation + fallback + Foundry tests + generation_meta + PR title 'cornerblue [ Crypto ] ...'.",
+  "date": "2026-07-20T10:50:00Z"
+}

--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -12,23 +12,30 @@ interface AggregatorV3Interface {
     function decimals() external view returns (uint8);
 }
 
+/// @title PriceOracle with Chainlink validation + secondary fallback
+/// @notice Rejects incomplete rounds and non-positive prices; falls back when primary is stale.
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
+    /// @param lastUpdate Primary feed `updatedAt` that failed the staleness check
+    /// @param currentTime `block.timestamp` when fallback was triggered
+    event StalePrice(uint256 lastUpdate, uint256 currentTime);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
+        require(_primaryFeed != address(0), "Invalid primary");
+        require(_fallbackFeed != address(0), "Invalid fallback");
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
-    function getLatestPrice() external view returns (int256) {
+    /// @notice Latest validated price. Uses fallback if primary is stale.
+    /// @dev Not `view` because a stale primary emits `StalePrice`.
+    function getLatestPrice() external returns (int256) {
         (
             uint80 roundId,
             int256 price,
@@ -37,10 +44,32 @@ contract PriceOracle {
             uint80 answeredInRound
         ) = primaryFeed.latestRoundData();
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(price > 0, "Invalid price");
 
+        if (block.timestamp - updatedAt >= MAX_STALENESS) {
+            emit StalePrice(updatedAt, block.timestamp);
+            return _readValidated(fallbackFeed);
+        }
+
+        emit PriceQueried(price, block.timestamp);
+        return price;
+    }
+
+    function _readValidated(AggregatorV3Interface feed) internal returns (int256) {
+        (
+            uint80 roundId,
+            int256 price,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        require(answeredInRound >= roundId, "Incomplete round");
+        require(price > 0, "Invalid price");
+        require(block.timestamp - updatedAt < MAX_STALENESS, "Stale price");
+
+        emit PriceQueried(price, block.timestamp);
         return price;
     }
 
@@ -51,5 +80,17 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackFeed(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        require(_fallbackFeed != address(0), "Invalid fallback");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
+    }
+
+    function setPrimaryFeed(address _primaryFeed) external {
+        require(msg.sender == owner, "Not owner");
+        require(_primaryFeed != address(0), "Invalid primary");
+        primaryFeed = AggregatorV3Interface(_primaryFeed);
     }
 }

--- a/solidity/test/MockV3Aggregator.sol
+++ b/solidity/test/MockV3Aggregator.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice Minimal mock of Chainlink AggregatorV3Interface for unit tests.
+contract MockV3Aggregator {
+    uint8 public decimals;
+    uint80 public roundId;
+    int256 public answer;
+    uint256 public startedAt;
+    uint256 public updatedAt;
+    uint80 public answeredInRound;
+
+    constructor(uint8 _decimals, int256 _initialAnswer) {
+        decimals = _decimals;
+        updateAnswer(_initialAnswer);
+    }
+
+    function updateAnswer(int256 _answer) public {
+        roundId += 1;
+        answer = _answer;
+        startedAt = block.timestamp;
+        updatedAt = block.timestamp;
+        answeredInRound = roundId;
+    }
+
+    function updateRoundData(
+        uint80 _roundId,
+        int256 _answer,
+        uint256 _startedAt,
+        uint256 _updatedAt,
+        uint80 _answeredInRound
+    ) public {
+        roundId = _roundId;
+        answer = _answer;
+        startedAt = _startedAt;
+        updatedAt = _updatedAt;
+        answeredInRound = _answeredInRound;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80, int256, uint256, uint256, uint80)
+    {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+}

--- a/solidity/test/PriceOracle.t.sol
+++ b/solidity/test/PriceOracle.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/PriceOracle.sol";
+import "./MockV3Aggregator.sol";
+
+contract PriceOracleTest is Test {
+    PriceOracle public oracle;
+    MockV3Aggregator public primary;
+    MockV3Aggregator public secondary;
+
+    uint8 constant DECIMALS = 8;
+    int256 constant VALID_PRICE = 2000e8;
+    int256 constant FALLBACK_PRICE = 1999e8;
+
+    event StalePrice(uint256 lastUpdate, uint256 currentTime);
+    event PriceQueried(int256 price, uint256 timestamp);
+
+    function setUp() public {
+        primary = new MockV3Aggregator(DECIMALS, VALID_PRICE);
+        secondary = new MockV3Aggregator(DECIMALS, FALLBACK_PRICE);
+        oracle = new PriceOracle(address(primary), address(secondary));
+    }
+
+    function test_validPrice() public {
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, VALID_PRICE);
+    }
+
+    function test_stalePrimaryUsesFallbackAndEmits() public {
+        uint256 staleTime = block.timestamp - 3601;
+        primary.updateRoundData(1, VALID_PRICE, staleTime, staleTime, 1);
+        secondary.updateRoundData(1, FALLBACK_PRICE, block.timestamp, block.timestamp, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit StalePrice(staleTime, block.timestamp);
+
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, FALLBACK_PRICE);
+    }
+
+    function test_negativePriceReverts() public {
+        primary.updateRoundData(2, -1, block.timestamp, block.timestamp, 2);
+        vm.expectRevert(bytes("Invalid price"));
+        oracle.getLatestPrice();
+    }
+
+    function test_zeroPriceReverts() public {
+        primary.updateRoundData(3, 0, block.timestamp, block.timestamp, 3);
+        vm.expectRevert(bytes("Invalid price"));
+        oracle.getLatestPrice();
+    }
+
+    function test_incompleteRoundReverts() public {
+        // answeredInRound < roundId
+        primary.updateRoundData(10, VALID_PRICE, block.timestamp, block.timestamp, 9);
+        vm.expectRevert(bytes("Incomplete round"));
+        oracle.getLatestPrice();
+    }
+
+    function test_bothOraclesStaleReverts() public {
+        uint256 staleTime = block.timestamp - 7200;
+        primary.updateRoundData(1, VALID_PRICE, staleTime, staleTime, 1);
+        secondary.updateRoundData(1, FALLBACK_PRICE, staleTime, staleTime, 1);
+
+        vm.expectRevert(bytes("Stale price"));
+        oracle.getLatestPrice();
+    }
+
+    function test_ownerCanSetMaxStaleness() public {
+        oracle.setMaxStaleness(7200);
+        assertEq(oracle.MAX_STALENESS(), 7200);
+
+        // 4000s old is stale under default 3600 but fresh under 7200
+        uint256 t = block.timestamp - 4000;
+        primary.updateRoundData(5, VALID_PRICE, t, t, 5);
+        int256 price = oracle.getLatestPrice();
+        assertEq(price, VALID_PRICE);
+    }
+
+    function test_nonOwnerCannotSetMaxStaleness() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(bytes("Not owner"));
+        oracle.setMaxStaleness(1);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #915

## Summary
Hardens `PriceOracle` against bad Chainlink responses and adds a secondary fallback feed.

## Changes
- `answeredInRound >= roundId` (incomplete round reverts)
- `price > 0` (zero/negative reverts with `Invalid price`)
- Stale primary (`updatedAt` older than `MAX_STALENESS`) emits `StalePrice` and queries fallback
- Both feeds stale → reverts `Stale price`
- Owner-configurable `MAX_STALENESS` + `setFallbackFeed` / `setPrimaryFeed`
- Foundry tests: valid, stale→fallback, negative, zero, incomplete, both-stale, owner config
- `.generation_meta.json` (agent: cornerblue)

## Agent
cornerblue

/bounty $200