### PR TITLE
cornerblue [ FastAPI ] Add FastAPITestClient auth and WebSocket helpers (#804)

### DIFF
--- a/fastapi/.audit.json
+++ b/fastapi/.audit.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "cornerblue",
+  "environment_config": "Autonomous ethical earning of >=$100 confirmed BTC to wallet bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. GitHub bounty PRs only with hard-dollar labels. No malware, prefer zero installs. Quality ship. Session goal: UnsafeLabs/Bounty-Hunters issue #804 $200 FastAPITestClient with authenticate, authenticate_basic, ws_connect, assert_status, reset_auth; keep TestClient re-export; tests; .audit.json; PR title cornerblue [ FastAPI ].",
+  "completed_at": "2026-07-20T11:05:00Z"
+}

--- a/fastapi/fastapi/testclient.py
+++ b/fastapi/fastapi/testclient.py
@@ -1,1 +1,84 @@
-from starlette.testclient import TestClient as TestClient  # noqa
+import base64
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+from starlette.testclient import TestClient as TestClient  # noqa: F401
+
+# Re-export base TestClient for backward compatibility (do not change import path).
+__all__ = ["TestClient", "FastAPITestClient"]
+
+
+class FastAPITestClient(TestClient):
+    """
+    Starlette/FastAPI TestClient with auth + WebSocket helpers (bounty #804).
+
+    Extends TestClient without changing the existing `TestClient` re-export.
+    """
+
+    def __init__(self, app: Any, *args: Any, **kwargs: Any) -> None:
+        super().__init__(app, *args, **kwargs)
+        self._auth_headers: Dict[str, str] = {}
+
+    def _merge_headers(
+        self, headers: Optional[Union[Mapping[str, str], Dict[str, str]]]
+    ) -> Dict[str, str]:
+        merged: Dict[str, str] = dict(self._auth_headers)
+        if headers:
+            merged.update(dict(headers))
+        return merged
+
+    def authenticate(self, token: str) -> None:
+        """Attach `Authorization: Bearer <token>` to all subsequent requests."""
+        self._auth_headers["Authorization"] = f"Bearer {token}"
+
+    def authenticate_basic(self, username: str, password: str) -> None:
+        """Attach HTTP Basic Authorization (base64 username:password)."""
+        raw = f"{username}:{password}".encode("utf-8")
+        encoded = base64.b64encode(raw).decode("ascii")
+        self._auth_headers["Authorization"] = f"Basic {encoded}"
+
+    def reset_auth(self) -> None:
+        """Clear authentication headers set via authenticate / authenticate_basic."""
+        self._auth_headers.clear()
+
+    def request(self, method: str, url: str, **kwargs: Any):  # type: ignore[override]
+        headers = self._merge_headers(kwargs.pop("headers", None))
+        return super().request(method, url, headers=headers, **kwargs)
+
+    def assert_status(
+        self,
+        method: str,
+        url: str,
+        expected_status: int,
+        **kwargs: Any,
+    ):
+        """
+        Perform a request and assert the response status code.
+        Raises AssertionError with expected vs actual on mismatch.
+        """
+        response = self.request(method, url, **kwargs)
+        if response.status_code != expected_status:
+            body = getattr(response, "text", "")[:500]
+            raise AssertionError(
+                f"Expected status {expected_status}, got {response.status_code} "
+                f"for {method.upper()} {url}. Body: {body!r}"
+            )
+        return response
+
+    def ws_connect(
+        self,
+        url: str,
+        headers: Optional[Mapping[str, str]] = None,
+        subprotocols: Optional[List[str]] = None,
+        **kwargs: Any,
+    ):
+        """
+        Open a WebSocket with optional custom headers and subprotocols.
+        Returns the same context manager as TestClient.websocket_connect.
+        """
+        merged = self._merge_headers(headers)
+        return self.websocket_connect(
+            url,
+            headers=merged,
+            subprotocols=subprotocols,
+            **kwargs,
+        )

--- a/fastapi/tests/test_fastapi_testclient_helpers.py
+++ b/fastapi/tests/test_fastapi_testclient_helpers.py
@@ -1,0 +1,135 @@
+"""Tests for FastAPITestClient auth and WebSocket helpers (issue #804).
+
+Uses Starlette ASGI apps so tests run without requiring the full local
+FastAPI package tree (which may need Python 3.10+).
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import sys
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route, WebSocketRoute
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocket, WebSocketDisconnect
+
+# Load FastAPITestClient from local package path without importing fastapi/__init__.py
+_ROOT = Path(__file__).resolve().parents[1]
+_TC_PATH = _ROOT / "fastapi" / "testclient.py"
+_spec = importlib.util.spec_from_file_location("fastapi_testclient_local", _TC_PATH)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["fastapi_testclient_local"] = _mod
+_spec.loader.exec_module(_mod)
+FastAPITestClient = _mod.FastAPITestClient
+
+
+async def public(request: Request):
+    return JSONResponse({"ok": True})
+
+
+async def secure(request: Request):
+    auth = request.headers.get("authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        return JSONResponse({"detail": "missing bearer"}, status_code=401)
+    token = auth.split(" ", 1)[1]
+    return JSONResponse({"token": token})
+
+
+async def basic(request: Request):
+    return JSONResponse({"authorization": request.headers.get("authorization")})
+
+
+async def ws_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        data = await websocket.receive_text()
+        auth = websocket.headers.get("authorization", "")
+        await websocket.send_text(f"{auth}|{data}")
+    except WebSocketDisconnect:
+        pass
+
+
+def create_app() -> Starlette:
+    return Starlette(
+        routes=[
+            Route("/public", public),
+            Route("/secure", secure),
+            Route("/basic", basic),
+            WebSocketRoute("/ws", ws_endpoint),
+        ]
+    )
+
+
+def test_existing_testclient_still_usable():
+    app = create_app()
+    client = TestClient(app)
+    assert client.get("/public").status_code == 200
+
+
+def test_authenticate_sets_bearer_for_following_requests():
+    app = create_app()
+    client = FastAPITestClient(app)
+    assert client.get("/secure").status_code == 401
+    client.authenticate("secret-token")
+    r = client.get("/secure")
+    assert r.status_code == 200
+    assert r.json()["token"] == "secret-token"
+    assert client.get("/secure").json()["token"] == "secret-token"
+
+
+def test_authenticate_replaces_previous_token():
+    app = create_app()
+    client = FastAPITestClient(app)
+    client.authenticate("first")
+    client.authenticate("second")
+    assert client.get("/secure").json()["token"] == "second"
+
+
+def test_reset_auth_clears_token():
+    app = create_app()
+    client = FastAPITestClient(app)
+    client.authenticate("tok")
+    client.reset_auth()
+    assert client.get("/secure").status_code == 401
+
+
+def test_authenticate_basic_encodes_header():
+    app = create_app()
+    client = FastAPITestClient(app)
+    client.authenticate_basic("alice", "wonderland")
+    expected = "Basic " + base64.b64encode(b"alice:wonderland").decode("ascii")
+    assert client._auth_headers["Authorization"] == expected
+    r = client.get("/basic")
+    assert r.json()["authorization"] == expected
+
+
+def test_assert_status_ok_and_fail():
+    app = create_app()
+    client = FastAPITestClient(app)
+    r = client.assert_status("GET", "/public", 200)
+    assert r.json()["ok"] is True
+    raised = False
+    try:
+        client.assert_status("GET", "/public", 500)
+    except AssertionError as e:
+        raised = True
+        assert "Expected status 500" in str(e)
+        assert "got 200" in str(e)
+    assert raised
+
+
+def test_ws_connect_with_headers():
+    app = create_app()
+    client = FastAPITestClient(app)
+    client.authenticate("ws-token")
+    with client.ws_connect("/ws") as ws:
+        ws.send_text("hello")
+        msg = ws.receive_text()
+    assert "Bearer ws-token" in msg
+    assert "hello" in msg


### PR DESCRIPTION
## Issue
Closes #804

## Summary
Adds `FastAPITestClient` with auth and WebSocket helpers for the **\$200** FastAPI bounty.

## API
- `authenticate(token)` — Bearer for all subsequent requests
- `authenticate_basic(user, pass)` — HTTP Basic
- `reset_auth()` — clear auth state
- `assert_status(method, url, expected)` — request + status assert
- `ws_connect(url, headers=..., subprotocols=...)` — WebSocket with headers
- Existing `from fastapi.testclient import TestClient` unchanged

## Tests
`tests/test_fastapi_testclient_helpers.py` — **7 passed**

## Audit
`fastapi/.audit.json` (contributor: cornerblue)

/bounty \$200