### PR TITLE
cornerblue [ FastAPI ] Add run_concurrently with semaphore and timeout (#803)

### DIFF
--- a/fastapi/_contributor.json
+++ b/fastapi/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "cornerblue",
+  "runtime_instructions": "Autonomous ethical earning of >=$100 confirmed BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. Prefer zero installs, no malware. Ship high quality. Issue #803 $50: run_concurrently with semaphore, order preservation, ConcurrencyError, timeout, tests, _contributor.json, PR title cornerblue [ FastAPI ].",
+  "timestamp": "2026-07-20T11:15:00Z"
+}

--- a/fastapi/fastapi/concurrency.py
+++ b/fastapi/fastapi/concurrency.py
@@ -1,7 +1,8 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable, Coroutine, Sequence
 from contextlib import AbstractContextManager
 from contextlib import asynccontextmanager as asynccontextmanager
-from typing import TypeVar
+from typing import Any, List, Optional, TypeVar, Union
 
 import anyio.to_thread
 from anyio import CapacityLimiter
@@ -12,6 +13,109 @@ from starlette.concurrency import (  # noqa
 )
 
 _T = TypeVar("_T")
+
+
+class ConcurrencyError(Exception):
+    """Raised when one or more concurrent tasks fail.
+
+    `exceptions` is a list aligned with the input tasks: `None` for successes,
+    or the exception instance for failures.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        exceptions: List[Optional[BaseException]],
+        results: Optional[List[Any]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.exceptions = exceptions
+        self.results = results
+
+    @property
+    def failures(self) -> List[BaseException]:
+        return [e for e in self.exceptions if e is not None]
+
+
+async def run_concurrently(
+    coroutines: Sequence[Union[Coroutine[Any, Any, _T], Awaitable[_T]]],
+    max_concurrency: int = 10,
+    timeout: Optional[float] = None,
+) -> List[_T]:
+    """
+    Run awaitables concurrently with a semaphore limit.
+
+    - Results are returned in the same order as `coroutines`.
+    - If any task fails, a `ConcurrencyError` is raised after all tasks finish
+      (or are cancelled on timeout), carrying every failure.
+    - If `timeout` is exceeded, remaining tasks are cancelled and a
+      `ConcurrencyError` is raised with partial `results` (successes filled,
+      failures/timeouts as exceptions).
+    """
+    if max_concurrency < 1:
+        raise ValueError("max_concurrency must be >= 1")
+
+    n = len(coroutines)
+    if n == 0:
+        return []
+
+    sem = asyncio.Semaphore(max_concurrency)
+    results: List[Any] = [None] * n
+    errors: List[Optional[BaseException]] = [None] * n
+
+    async def _run(index: int, coro: Union[Coroutine[Any, Any, _T], Awaitable[_T]]) -> None:
+        async with sem:
+            try:
+                results[index] = await coro
+            except asyncio.CancelledError:
+                # Treat cancel as timeout/cancellation error for that slot
+                errors[index] = asyncio.TimeoutError("task cancelled due to timeout")
+                raise
+            except BaseException as exc:  # noqa: BLE001 — collect all failures
+                errors[index] = exc
+
+    tasks = [
+        asyncio.create_task(_run(i, c), name=f"run_concurrently[{i}]")
+        for i, c in enumerate(coroutines)
+    ]
+
+    try:
+        if timeout is None:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        else:
+            done, pending = await asyncio.wait(
+                tasks, timeout=timeout, return_when=asyncio.ALL_COMPLETED
+            )
+            if pending:
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                # Mark slots still empty without error as timeout
+                for i in range(n):
+                    if errors[i] is None and results[i] is None and not tasks[i].done():
+                        errors[i] = asyncio.TimeoutError("timeout")
+                    elif errors[i] is None and results[i] is None:
+                        # cancelled path may have set TimeoutError already
+                        if tasks[i].cancelled() and errors[i] is None:
+                            errors[i] = asyncio.TimeoutError("timeout")
+                # Fill any cancelled tasks that raised CancelledError into errors
+                for i, t in enumerate(tasks):
+                    if errors[i] is None and results[i] is None:
+                        errors[i] = asyncio.TimeoutError("timeout")
+    finally:
+        # Ensure no dangling tasks
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+
+    if any(e is not None for e in errors):
+        raise ConcurrencyError(
+            "One or more concurrent tasks failed",
+            exceptions=errors,
+            results=list(results),
+        )
+
+    return list(results)  # type: ignore[return-value]
 
 
 @asynccontextmanager

--- a/fastapi/tests/test_run_concurrently.py
+++ b/fastapi/tests/test_run_concurrently.py
@@ -1,0 +1,142 @@
+"""Tests for run_concurrently (issue #803)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PATH = _ROOT / "fastapi" / "concurrency.py"
+
+
+def _load():
+    name = "fastapi_concurrency_local"
+    if name in sys.modules:
+        del sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_order_preserved_despite_completion_order():
+    mod = _load()
+
+    async def main():
+        async def slow():
+            await asyncio.sleep(0.05)
+            return "slow"
+
+        async def fast():
+            await asyncio.sleep(0.001)
+            return "fast"
+
+        return await mod.run_concurrently([slow(), fast()], max_concurrency=2)
+
+    assert asyncio.run(main()) == ["slow", "fast"]
+
+
+def test_max_concurrency_limits_parallelism():
+    mod = _load()
+
+    async def main():
+        current = 0
+        peak = 0
+        lock = asyncio.Lock()
+
+        async def worker():
+            nonlocal current, peak
+            async with lock:
+                current += 1
+                peak = max(peak, current)
+            await asyncio.sleep(0.03)
+            async with lock:
+                current -= 1
+            return 1
+
+        await mod.run_concurrently([worker() for _ in range(6)], max_concurrency=2)
+        return peak
+
+    assert asyncio.run(main()) <= 2
+
+
+def test_max_concurrency_one_is_sequential():
+    mod = _load()
+
+    async def main():
+        log = []
+
+        async def w(i):
+            log.append(("start", i))
+            await asyncio.sleep(0.01)
+            log.append(("end", i))
+            return i
+
+        out = await mod.run_concurrently([w(0), w(1), w(2)], max_concurrency=1)
+        return out, log
+
+    out, log = asyncio.run(main())
+    assert out == [0, 1, 2]
+    assert log == [
+        ("start", 0),
+        ("end", 0),
+        ("start", 1),
+        ("end", 1),
+        ("start", 2),
+        ("end", 2),
+    ]
+
+
+def test_error_collection():
+    mod = _load()
+
+    async def main():
+        async def ok():
+            return 1
+
+        async def bad():
+            raise ValueError("boom")
+
+        try:
+            await mod.run_concurrently([ok(), bad(), ok()], max_concurrency=3)
+            return None
+        except mod.ConcurrencyError as err:
+            return err
+
+    err = asyncio.run(main())
+    assert err is not None
+    assert err.exceptions[0] is None
+    assert isinstance(err.exceptions[1], ValueError)
+    assert err.exceptions[2] is None
+    assert len(err.failures) == 1
+
+
+def test_timeout_cancels_and_reports():
+    mod = _load()
+
+    async def main():
+        async def quick():
+            await asyncio.sleep(0.01)
+            return "q"
+
+        async def slow():
+            await asyncio.sleep(2.0)
+            return "s"
+
+        t0 = time.monotonic()
+        try:
+            await mod.run_concurrently([quick(), slow()], max_concurrency=2, timeout=0.1)
+            return None, None, 0.0
+        except mod.ConcurrencyError as err:
+            return err, time.monotonic() - t0
+
+    err, elapsed = asyncio.run(main())
+    assert err is not None
+    assert elapsed < 1.0
+    assert err.results[0] == "q"
+    assert err.exceptions[1] is not None


### PR DESCRIPTION
## Issue
Closes #803

## Summary
Adds `run_concurrently` to `fastapi/concurrency.py` for the **\$50** bounty.

## Behavior
- `max_concurrency` via `asyncio.Semaphore`
- Results in input order
- Failures collected into `ConcurrencyError.exceptions` (aligned list)
- `timeout` cancels remaining tasks and reports partial results + errors
- `max_concurrency=1` is sequential

## Tests
`tests/test_run_concurrently.py` — **5 passed**

## Contributor
`fastapi/_contributor.json` (identity: cornerblue)

/bounty \$50