### PR TITLE
cornerblue [ Laravel ] Fix User model password cast bcrypt rounds (#745)

### DIFF
--- a/laravel/_meta.json
+++ b/laravel/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "cornerblue",
+  "generation_context": "Autonomous ethical earning of >=$100 BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. BH #745 $50: User password cast respect bcrypt rounds from config/hashing.php; mutator + factory + unit tests + _meta.json; PR title cornerblue [ Laravel ].",
+  "completed_at": "2026-07-20T11:25:00Z"
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,13 +2,13 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -16,6 +16,23 @@ class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    /**
+     * Hash password using configured bcrypt rounds from config/hashing.php.
+     */
+    public function setPasswordAttribute(string $value): void
+    {
+        // Already-hashed bcrypt strings start with $2y$ / $2a$ / $2b$
+        if (preg_match('/^\$2[ayb]\$/', $value) === 1) {
+            $this->attributes['password'] = $value;
+            return;
+        }
+
+        $rounds = (int) config('hashing.bcrypt.rounds', 12);
+        $this->attributes['password'] = Hash::make($value, [
+            'rounds' => $rounds,
+        ]);
+    }
 
     /**
      * Get the attributes that should be cast.
@@ -26,7 +43,7 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
+            // password uses setPasswordAttribute mutator (configured rounds)
         ];
     }
 }

--- a/laravel/config/hashing.php
+++ b/laravel/config/hashing.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'driver' => 'bcrypt',
+    'bcrypt' => [
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+    ],
+    'argon' => [
+        'memory' => 65536,
+        'threads' => 1,
+        'time' => 4,
+    ],
+];

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -24,11 +24,15 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $rounds = (int) config('hashing.bcrypt.rounds', 12);
+
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$password ??= Hash::make('password', [
+                'rounds' => $rounds,
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/laravel/tests/Unit/UserPasswordRoundsTest.php
+++ b/laravel/tests/Unit/UserPasswordRoundsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserPasswordRoundsTest extends TestCase
+{
+    public function test_password_uses_configured_bcrypt_rounds(): void
+    {
+        config(['hashing.bcrypt.rounds' => 12]);
+
+        $user = new User();
+        $user->password = 'secret-password';
+
+        $hash = $user->password;
+        $this->assertTrue(Hash::check('secret-password', $hash));
+
+        // bcrypt cost is encoded as $2y$12$...
+        $this->assertMatchesRegularExpression('/^\$2[ayb]\$12\$/', $hash);
+    }
+
+    public function test_password_uses_custom_rounds_from_config(): void
+    {
+        config(['hashing.bcrypt.rounds' => 8]);
+
+        $user = new User();
+        $user->password = 'another-secret';
+
+        $hash = $user->password;
+        $this->assertTrue(Hash::check('another-secret', $hash));
+        $this->assertMatchesRegularExpression('/^\$2[ayb]\$08\$/', $hash);
+    }
+
+    public function test_hash_check_still_works_for_default_rounds_hashes(): void
+    {
+        // Simulate legacy hash created with default cost 10
+        $legacy = password_hash('legacy-pass', PASSWORD_BCRYPT, ['cost' => 10]);
+        $this->assertTrue(Hash::check('legacy-pass', $legacy));
+    }
+}


### PR DESCRIPTION
## Issue
Closes #745

## Summary
User password hashing now uses \`config('hashing.bcrypt.rounds')\` (\$50 bounty).

## Changes
- \`setPasswordAttribute\` mutator with explicit rounds
- \`config/hashing.php\` with \`BCRYPT_ROUNDS\` default 12
- \`UserFactory\` hashes with configured rounds
- Unit tests for cost encoding + Hash::check on legacy cost-10 hashes
- \`laravel/_meta.json\`

/bounty \$50