### PR TITLE
cornerblue [ T3 Code ] ChatView ARIA and keyboard navigation (#852)

### DIFF
--- a/t3code/apps/web/src/components/.provenance.json
+++ b/t3code/apps/web/src/components/.provenance.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "cornerblue",
+  "config_snapshot": "Autonomous ethical earning of >=$100 confirmed BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. Prefer zero installs, no malware. BH #852 $50: ChatView ARIA role=log aria-live, listitem messages, skip links, keyboard ArrowUp/Down Escape to composer, provenance.json, PR title cornerblue [ T3 Code ].",
+  "created": "2026-07-20T11:30:00Z"
+}

--- a/t3code/apps/web/src/components/ChatView.tsx
+++ b/t3code/apps/web/src/components/ChatView.tsx
@@ -3551,7 +3551,28 @@ export default function ChatView(props: ChatViewProps) {
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
+          <div className="relative flex min-h-0 flex-1 flex-col" id="chat-messages-region">
+            {/* Accessibility skip links (visually hidden until focused) */}
+            <nav aria-label="Chat regions" className="sr-only focus-within:not-sr-only">
+              <a
+                href="#chat-messages-region"
+                className="absolute left-2 top-2 z-50 rounded bg-background px-3 py-1.5 text-sm shadow focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                Skip to messages
+              </a>
+              <a
+                href="#chat-composer-region"
+                className="absolute left-2 top-10 z-50 rounded bg-background px-3 py-1.5 text-sm shadow focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                Skip to composer
+              </a>
+              <a
+                href="#app-sidebar"
+                className="absolute left-2 top-[4.5rem] z-50 rounded bg-background px-3 py-1.5 text-sm shadow focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                Skip to sidebar
+              </a>
+            </nav>
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}
@@ -3596,6 +3617,7 @@ export default function ChatView(props: ChatViewProps) {
 
           {/* Input bar */}
           <div
+            id="chat-composer-region"
             className={cn(
               "pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] pt-1.5 sm:pl-[calc(env(safe-area-inset-left)+1.25rem)] sm:pr-[calc(env(safe-area-inset-right)+1.25rem)] sm:pt-2",
               isGitRepo

--- a/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/t3code/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -190,6 +190,50 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     }
   }, [listRef, onIsAtEndChange]);
 
+  // Keyboard navigation between message listitems (ArrowUp/Down, Escape to composer)
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      const inComposer = Boolean(target.closest("#chat-composer-region"));
+      const items = Array.from(
+        document.querySelectorAll<HTMLElement>('[role="listitem"][data-message-id]'),
+      );
+      if (items.length === 0) return;
+
+      if (event.key === "Escape") {
+        const composer = document.querySelector<HTMLElement>(
+          "#chat-composer-region textarea, #chat-composer-region [contenteditable='true'], #chat-composer-region button",
+        );
+        composer?.focus();
+        return;
+      }
+
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      // Allow arrow keys in text fields for caret movement
+      if (
+        inComposer &&
+        (target.tagName === "TEXTAREA" ||
+          target.tagName === "INPUT" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      const active = document.activeElement as HTMLElement | null;
+      const idx = active ? items.indexOf(active) : -1;
+      let next = idx;
+      if (event.key === "ArrowDown") next = Math.min(items.length - 1, Math.max(0, idx) + 1);
+      if (event.key === "ArrowUp") next = Math.max(0, (idx < 0 ? items.length : idx) - 1);
+      if (next !== idx && items[next]) {
+        event.preventDefault();
+        items[next].focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   const previousRowCountRef = useRef(rows.length);
   useEffect(() => {
     const previousRowCount = previousRowCountRef.current;
@@ -277,6 +321,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           maintainScrollAtEndThreshold={0.1}
           maintainVisibleContentPosition
           onScroll={handleScroll}
+          role="log"
+          aria-live="polite"
+          aria-label="Chat messages"
           className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
           ListHeaderComponent={TIMELINE_LIST_HEADER}
           ListFooterComponent={TIMELINE_LIST_FOOTER}
@@ -302,9 +349,12 @@ type TimelineRow = MessagesTimelineRow;
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
   return (
     <div
+      role={row.kind === "message" ? "listitem" : undefined}
+      tabIndex={row.kind === "message" ? 0 : undefined}
       className={cn(
         "pb-4",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
+        row.kind === "message" ? "outline-none focus-visible:ring-2 focus-visible:ring-ring/60" : null,
       )}
       data-timeline-row-id={row.id}
       data-timeline-row-kind={row.kind}


### PR DESCRIPTION
## Issue
Closes #852

## Summary
Accessibility pass on ChatView / MessagesTimeline for the **\$50** bounty.

## Changes
- Messages list: \`role="log"\` + \`aria-live="polite"\`
- Message rows: \`role="listitem"\` + focusable for keyboard
- Skip links: messages, composer, sidebar (visually hidden until focused)
- Keyboard: ArrowUp/Down between messages; Escape focuses composer
- Composer region id for skip targets; send already has aria-labels
- \`.provenance.json\` (agent_name: cornerblue)

/bounty \$50