### PR TITLE
cornerblue [ Laravel ] API AuthController with Sanctum tokens (#752)

### DIFF
--- a/laravel/.generation_meta.json
+++ b/laravel/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "cornerblue",
+  "initial_directives": "Autonomous ethical earning of >=$100 confirmed BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. Prefer zero installs, no malware. High quality. BH #752 $200: AuthController register/login/logout with Laravel Sanctum, routes/api.php, validation, JSON status codes, generation_meta.json, PR title cornerblue [ Laravel ].",
+  "date": "2026-07-20T11:40:00Z"
+}

--- a/laravel/app/Http/Controllers/AuthController.php
+++ b/laravel/app/Http/Controllers/AuthController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    /**
+     * Register a new user and return a Sanctum API token.
+     */
+    public function register(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => $validated['password'],
+        ]);
+
+        $token = $user->createToken('api')->plainTextToken;
+
+        return response()->json([
+            'user' => $user,
+            'token' => $token,
+            'message' => 'Registration successful',
+        ], 201);
+    }
+
+    /**
+     * Authenticate with email/password and return a Sanctum API token.
+     */
+    public function login(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::where('email', $validated['email'])->first();
+
+        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+            return response()->json([
+                'message' => 'Invalid credentials',
+            ], 401);
+        }
+
+        $token = $user->createToken('api')->plainTextToken;
+
+        return response()->json([
+            'user' => $user,
+            'token' => $token,
+            'message' => 'Login successful',
+        ], 200);
+    }
+
+    /**
+     * Revoke the current access token (requires auth:sanctum).
+     */
+    public function logout(Request $request): JsonResponse
+    {
+        $token = $request->user()?->currentAccessToken();
+        if ($token) {
+            $token->delete();
+        }
+
+        return response()->json([
+            'message' => 'Logged out',
+        ], 200);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -2,20 +2,20 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * Get the attributes that should be cast.

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -3,12 +3,16 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
-    "keywords": ["laravel", "framework"],
+    "keywords": [
+        "laravel",
+        "framework"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.3",
         "laravel/framework": "^13.8",
-        "laravel/tinker": "^3.0"
+        "laravel/tinker": "^3.0",
+        "laravel/sanctum": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);

--- a/laravel/tests/Unit/AuthControllerStructureTest.php
+++ b/laravel/tests/Unit/AuthControllerStructureTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\AuthController;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Structural tests for AuthController (issue #752).
+ * Full HTTP/Sanctum integration requires a booted Laravel app + DB.
+ */
+class AuthControllerStructureTest extends TestCase
+{
+    public function test_auth_controller_has_register_login_logout(): void
+    {
+        $class = new ReflectionClass(AuthController::class);
+        foreach (['register', 'login', 'logout'] as $method) {
+            $this->assertTrue($class->hasMethod($method), "missing method $method");
+            $m = $class->getMethod($method);
+            $this->assertTrue($m->isPublic());
+        }
+    }
+
+    public function test_api_routes_file_registers_auth_endpoints(): void
+    {
+        $path = dirname(__DIR__, 2).'/routes/api.php';
+        $this->assertFileExists($path);
+        $src = file_get_contents($path);
+        $this->assertStringContainsString("/register", $src);
+        $this->assertStringContainsString("/login", $src);
+        $this->assertStringContainsString("/logout", $src);
+        $this->assertStringContainsString('AuthController', $src);
+        $this->assertStringContainsString('auth:sanctum', $src);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #752

## Summary
Implements API authentication for the **\$200** Laravel bounty.

## Endpoints
- \`POST /api/register\` — name, email, password, password_confirmation → **201** + token
- \`POST /api/login\` — email, password → **200** + token, or **401** invalid credentials
- \`POST /api/logout\` — \`auth:sanctum\` → revokes current token **200**

## Changes
- \`AuthController\` register / login / logout
- \`routes/api.php\` + bootstrap \`api\` routing
- \`User\` uses \`HasApiTokens\`
- \`laravel/sanctum\` in composer.json
- \`.generation_meta.json\` (agent: cornerblue)
- Structural unit tests for controller methods + routes

/bounty \$200