### PR TITLE
cornerblue [ Crypto ] Fix StakingVault reentrancy in withdraw/claimRewards (#911)

### DIFF
--- a/solidity/.generation_meta.json
+++ b/solidity/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "cornerblue",
+  "initial_directives": "Autonomous ethical earning >=$100 BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar BH crypto bounties. #911 $450: fix reentrancy in StakingVault withdraw/claimRewards with CEI + nonReentrant; use ERC20 transfer for stake withdraw; tests; generation_meta; PR title cornerblue [ Crypto ].",
+  "date": "2026-07-20T12:00:00Z"
+}

--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+/// @notice Staking vault with CEI-ordered withdraw/claim (fixes reentrancy #911).
 contract StakingVault {
     IERC20 public stakingToken;
     uint256 public rewardRate;
@@ -12,22 +13,32 @@ contract StakingVault {
     mapping(address => uint256) public rewards;
     mapping(address => uint256) public lastStakeTime;
 
+    bool private locked;
+
     event Staked(address indexed user, uint256 amount);
     event Withdrawn(address indexed user, uint256 amount);
     event RewardClaimed(address indexed user, uint256 amount);
+
+    modifier nonReentrant() {
+        require(!locked, "ReentrancyGuard");
+        locked = true;
+        _;
+        locked = false;
+    }
 
     constructor(address _stakingToken, uint256 _rewardRate) {
         stakingToken = IERC20(_stakingToken);
         rewardRate = _rewardRate;
     }
 
-    function stake(uint256 amount) external {
+    function stake(uint256 amount) external nonReentrant {
         require(amount > 0, "Cannot stake 0");
-        stakingToken.transferFrom(msg.sender, address(this), amount);
         _updateReward(msg.sender);
         balances[msg.sender] += amount;
         totalStaked += amount;
         lastStakeTime[msg.sender] = block.timestamp;
+        // external call last
+        require(stakingToken.transferFrom(msg.sender, address(this), amount), "transferFrom failed");
         emit Staked(msg.sender, amount);
     }
 
@@ -39,31 +50,30 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
-    function withdraw(uint256 amount) external {
+    /// @notice Withdraw staked tokens (ERC20). CEI + nonReentrant.
+    function withdraw(uint256 amount) external nonReentrant {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
-        require(success, "Transfer failed");
-
-        // State update after external call — vulnerable to reentrancy
+        // Effects before interactions
         balances[msg.sender] -= amount;
         totalStaked -= amount;
+
+        require(stakingToken.transfer(msg.sender, amount), "transfer failed");
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
-    function claimRewards() external {
+    function claimRewards() external nonReentrant {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // Effects before interactions
+        rewards[msg.sender] = 0;
+
+        // Rewards paid in ETH via receive() funding; if insufficient, transfer reverts
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
-
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 
@@ -72,6 +82,7 @@ contract StakingVault {
     }
 
     function getPendingRewards(address account) external view returns (uint256) {
+        if (balances[account] == 0) return rewards[account];
         uint256 timeStaked = block.timestamp - lastStakeTime[account];
         return rewards[account] + balances[account] * timeStaked * rewardRate / 1e18;
     }

--- a/solidity/test/StakingVault.t.sol
+++ b/solidity/test/StakingVault.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/StakingVault.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock", "MCK") {}
+    function mint(address to, uint256 amt) external { _mint(to, amt); }
+}
+
+contract StakingVaultTest is Test {
+    StakingVault vault;
+    MockERC20 token;
+
+    function setUp() public {
+        token = new MockERC20();
+        vault = new StakingVault(address(token), 1e18);
+        token.mint(address(this), 1000 ether);
+        token.approve(address(vault), type(uint256).max);
+        (bool ok,) = address(vault).call{value: 10 ether}("");
+        require(ok);
+    }
+
+    receive() external payable {}
+
+    function test_stakeAndWithdraw() public {
+        vault.stake(100 ether);
+        assertEq(vault.balances(address(this)), 100 ether);
+        vault.withdraw(40 ether);
+        assertEq(vault.balances(address(this)), 60 ether);
+        assertEq(token.balanceOf(address(this)), 940 ether);
+    }
+
+    function test_claimRewardsAfterTime() public {
+        vault.stake(50 ether);
+        vm.warp(block.timestamp + 10);
+        vault.claimRewards();
+        assertEq(vault.rewards(address(this)), 0);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #911

## Summary
Fixes reentrancy in StakingVault (**\$450**).

## Changes
- Checks-Effects-Interactions on withdraw / claimRewards
- nonReentrant guard on stake/withdraw/claim
- withdraw uses ERC20 stakingToken.transfer (matches stake)
- Foundry tests + generation_meta

/bounty \$450