### PR TITLE
cornerblue [ Crypto ] Fix SimpleSwap slippage protection and deadline (#913)

### DIFF
--- a/solidity/.generation_meta.json
+++ b/solidity/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "cornerblue",
+  "initial_directives": "Earn >=$100 BTC hard-dollar bounties. BH #913 $300 SimpleSwap: minAmountOut, deadline, non-zero fee for small amounts. generation_meta. PR title cornerblue [ Crypto ].",
+  "date": "2026-07-20T12:05:00Z"
+}

--- a/solidity/contracts/SimpleSwap.sol
+++ b/solidity/contracts/SimpleSwap.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+/// @notice AMM swap with minAmountOut + deadline (fixes #913 sandwich/stale-tx).
 contract SimpleSwap {
     IERC20 public tokenA;
     IERC20 public tokenB;
     uint256 public reserveA;
     uint256 public reserveB;
-    uint256 public fee; // basis points, e.g. 30 = 0.3%
+    uint256 public fee; // basis points
 
     event Swap(address indexed user, address tokenIn, uint256 amountIn, uint256 amountOut);
 
@@ -19,16 +20,19 @@ contract SimpleSwap {
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(tokenA.transferFrom(msg.sender, address(this), amountA), "A");
+        require(tokenB.transferFrom(msg.sender, address(this), amountB), "B");
         reserveA += amountA;
         reserveB += amountB;
     }
 
-    // BUG: No minAmountOut parameter — vulnerable to sandwich attacks
-    // BUG: No deadline parameter — stale transactions can be executed
-    // BUG: Fee calculation truncates to zero for small amounts
-    function swap(address tokenIn, uint256 amountIn) external returns (uint256 amountOut) {
+    function swap(
+        address tokenIn,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256 amountOut) {
+        require(block.timestamp <= deadline, "Expired");
         require(tokenIn == address(tokenA) || tokenIn == address(tokenB), "Invalid token");
         require(amountIn > 0, "Amount must be > 0");
 
@@ -37,15 +41,22 @@ contract SimpleSwap {
             ? (tokenA, tokenB, reserveA, reserveB)
             : (tokenB, tokenA, reserveB, reserveA);
 
-        inputToken.transferFrom(msg.sender, address(this), amountIn);
+        require(inputToken.transferFrom(msg.sender, address(this), amountIn), "in");
 
-        uint256 feeAmount = amountIn * fee / 10000;
+        // Fee with ceil to avoid zero-fee tiny swaps when feeBPS > 0
+        uint256 feeAmount = 0;
+        if (fee > 0) {
+            feeAmount = (amountIn * fee + 9999) / 10000;
+            if (feeAmount == 0) feeAmount = 1;
+            if (feeAmount > amountIn) feeAmount = amountIn;
+        }
         uint256 amountInAfterFee = amountIn - feeAmount;
+        require(amountInAfterFee > 0, "Fee consumes input");
 
-        // constant product formula: x * y = k
         amountOut = (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
+        require(amountOut >= minAmountOut, "Slippage");
 
-        outputToken.transfer(msg.sender, amountOut);
+        require(outputToken.transfer(msg.sender, amountOut), "out");
 
         if (isTokenA) {
             reserveA += amountIn;
@@ -62,8 +73,14 @@ contract SimpleSwap {
         bool isTokenA = tokenIn == address(tokenA);
         uint256 reserveIn = isTokenA ? reserveA : reserveB;
         uint256 reserveOut = isTokenA ? reserveB : reserveA;
-        uint256 feeAmount = amountIn * fee / 10000;
+        uint256 feeAmount = 0;
+        if (fee > 0) {
+            feeAmount = (amountIn * fee + 9999) / 10000;
+            if (feeAmount == 0) feeAmount = 1;
+            if (feeAmount > amountIn) feeAmount = amountIn;
+        }
         uint256 amountInAfterFee = amountIn - feeAmount;
+        if (amountInAfterFee == 0) return 0;
         return (reserveOut * amountInAfterFee) / (reserveIn + amountInAfterFee);
     }
 }


### PR DESCRIPTION
Closes #913. Adds minAmountOut + deadline; fee ceil so tiny swaps cannot skip fees. /bounty $300