### PR TITLE
cornerblue [ Crypto ] Fix TokenVesting overflow and revoke accounting (#917)

### DIFF
--- a/solidity/.generation_meta.json
+++ b/solidity/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent":"cornerblue","initial_directives":"BH #917 $350 TokenVesting overflow-safe vestedAmount + correct revoke unvested=total-vested. PR cornerblue [ Crypto ].","date":"2026-07-20T12:12:00Z"}

--- a/solidity/contracts/TokenVesting.sol
+++ b/solidity/contracts/TokenVesting.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+/// @notice Vesting with overflow-safe vestedAmount + correct revoke (#917).
 contract TokenVesting {
     IERC20 public token;
     address public beneficiary;
@@ -26,6 +27,7 @@ contract TokenVesting {
         uint256 _cliffDuration,
         uint256 _vestingDuration
     ) {
+        require(_vestingDuration > 0, "duration");
         token = IERC20(_token);
         beneficiary = _beneficiary;
         owner = msg.sender;
@@ -35,18 +37,21 @@ contract TokenVesting {
         duration = _vestingDuration;
     }
 
-    // BUG: Overflow risk for large allocations — totalAllocation * elapsed can exceed uint256
+    /// @dev Overflow-safe: (alloc / duration) * elapsed + remainder term.
     function vestedAmount() public view returns (uint256) {
         if (block.timestamp < cliff) return 0;
         if (block.timestamp >= start + duration) return totalAllocation;
 
         uint256 elapsed = block.timestamp - start;
-        // This multiplication can overflow for large totalAllocation values
-        return totalAllocation * elapsed / duration;
+        // avoid totalAllocation * elapsed overflow
+        return (totalAllocation / duration) * elapsed
+            + (totalAllocation % duration) * elapsed / duration;
     }
 
     function claimable() public view returns (uint256) {
-        return vestedAmount() - claimed;
+        uint256 vested = vestedAmount();
+        if (vested <= claimed) return 0;
+        return vested - claimed;
     }
 
     function claim() external {
@@ -54,25 +59,27 @@ contract TokenVesting {
         uint256 amount = claimable();
         require(amount > 0, "Nothing to claim");
         claimed += amount;
-        token.transfer(beneficiary, amount);
+        require(token.transfer(beneficiary, amount), "transfer");
         emit TokensClaimed(beneficiary, amount);
     }
 
-    // BUG: Incorrect unvested calculation during cliff period
     function revoke() external {
         require(msg.sender == owner, "Not owner");
         require(!revoked, "Already revoked");
         revoked = true;
 
         uint256 vested = vestedAmount();
-        // BUG: Should be totalAllocation - claimed, not totalAllocation - vested
-        // during cliff, vested is 0 but user may have claimed nothing
+        // Unvested returns to owner; beneficiary gets any unclaimed vested
         uint256 unvested = totalAllocation - vested;
 
         if (vested > claimed) {
-            token.transfer(beneficiary, vested - claimed);
+            uint256 pay = vested - claimed;
+            claimed = vested;
+            require(token.transfer(beneficiary, pay), "benef");
         }
-        token.transfer(owner, unvested);
+        if (unvested > 0) {
+            require(token.transfer(owner, unvested), "owner");
+        }
         emit VestingRevoked(beneficiary, unvested);
     }
 }


### PR DESCRIPTION
Closes #917. Overflow-safe vestedAmount; revoke pays unclaimed vested to beneficiary and unvested to owner. /bounty $350