### PR TITLE
cornerblue [ Crypto ] Fix first-depositor manipulation in LiquidityPool (#918)

### DIFF
--- a/solidity/.generation_meta.json
+++ b/solidity/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent":"cornerblue","initial_directives":"BH #918 $600 LiquidityPool min liquidity lock + reserve-based remove. PR cornerblue [ Crypto ].","date":"2026-07-20T12:20:00Z"}

--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+/// @notice LP with MINIMUM_LIQUIDITY burn + reserve-based remove (#918).
 contract LiquidityPool is ERC20 {
     IERC20 public tokenA;
     IERC20 public tokenB;
@@ -11,7 +12,6 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
@@ -23,12 +23,15 @@ contract LiquidityPool is ERC20 {
     }
 
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
-        tokenA.transferFrom(msg.sender, address(this), amountA);
-        tokenB.transferFrom(msg.sender, address(this), amountB);
+        require(tokenA.transferFrom(msg.sender, address(this), amountA), "A");
+        require(tokenB.transferFrom(msg.sender, address(this), amountB), "B");
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
             lpTokens = sqrt(amountA * amountB);
+            require(lpTokens > MINIMUM_LIQUIDITY, "min liquidity");
+            // lock minimum liquidity forever (burn to address(0) via mint then burn)
+            _mint(address(0x000000000000000000000000000000000000dEaD), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,25 +47,21 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // Use internal reserves (not balanceOf) to prevent donation attacks
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 
-        tokenA.transfer(msg.sender, amountA);
-        tokenB.transfer(msg.sender, amountB);
-
         reserveA -= amountA;
         reserveB -= amountB;
+
+        require(tokenA.transfer(msg.sender, amountA), "outA");
+        require(tokenB.transfer(msg.sender, amountB), "outB");
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
     }


### PR DESCRIPTION
Closes #918. Burn MINIMUM_LIQUIDITY to dead address on first mint; removeLiquidity uses reserveA/B. /bounty $600