### PR TITLE
cornerblue [ Crypto ] Fix MultiSig confirmation race during execute (#916)

### DIFF
--- a/solidity/.generation_meta.json
+++ b/solidity/.generation_meta.json
@@ -1,0 +1,1 @@
+{"agent":"cornerblue","initial_directives":"BH #916 $800 MultiSig: nonReentrant execute, confirmation snapshot, zero-address checks. PR cornerblue [ Crypto ].","date":"2026-07-20T12:25:00Z"}

--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+/// @notice Multi-sig with reentrancy guard + confirmation snapshot (#916).
 contract MultiSigWallet {
     address[] public owners;
     uint256 public required;
@@ -11,11 +12,14 @@ contract MultiSigWallet {
         uint256 value;
         bytes data;
         bool executed;
+        uint256 confirmationSnapshot; // set at execute time
     }
 
     mapping(uint256 => Transaction) public transactions;
     mapping(uint256 => mapping(address => bool)) public confirmations;
     mapping(address => bool) public isOwner;
+
+    bool private locked;
 
     event Submitted(uint256 indexed txId);
     event Confirmed(uint256 indexed txId, address indexed owner);
@@ -27,24 +31,33 @@ contract MultiSigWallet {
         _;
     }
 
+    modifier nonReentrant() {
+        require(!locked, "ReentrancyGuard");
+        locked = true;
+        _;
+        locked = false;
+    }
+
     constructor(address[] memory _owners, uint256 _required) {
         require(_owners.length > 0, "No owners");
         require(_required > 0 && _required <= _owners.length, "Invalid required");
         for (uint256 i = 0; i < _owners.length; i++) {
+            require(_owners[i] != address(0), "zero owner");
             isOwner[_owners[i]] = true;
         }
         owners = _owners;
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "zero to");
         uint256 txId = transactionCount++;
         transactions[txId] = Transaction({
             to: to,
             value: value,
             data: data,
-            executed: false
+            executed: false,
+            confirmationSnapshot: 0
         });
         emit Submitted(txId);
         return txId;
@@ -59,6 +72,7 @@ contract MultiSigWallet {
 
     function revokeConfirmation(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
+        require(!locked, "Cannot revoke during execute");
         require(confirmations[txId][msg.sender], "Not confirmed");
         confirmations[txId][msg.sender] = false;
         emit Revoked(txId, msg.sender);
@@ -70,13 +84,14 @@ contract MultiSigWallet {
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
-
+    function executeTransaction(uint256 txId) external onlyOwner nonReentrant {
         Transaction storage txn = transactions[txId];
+        require(!txn.executed, "Already executed");
+        uint256 confs = getConfirmationCount(txId);
+        require(confs >= required, "Not enough confirmations");
+
+        // Snapshot confirmations then mark executed before external call
+        txn.confirmationSnapshot = confs;
         txn.executed = true;
 
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);


### PR DESCRIPTION
Closes #916. nonReentrant execute, confirmationSnapshot, zero-address checks, block revoke during execute. /bounty $800