### PR TITLE
cornerblue [ T3 Code ] Add gzip and brotli response compression helpers (#863)

### DIFF
--- a/t3code/apps/server/src/_provenance.json
+++ b/t3code/apps/server/src/_provenance.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "cornerblue",
+  "boot_context": "Autonomous ethical earning of >=$100 confirmed BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. Prefer zero installs, no malware. BH #863 $260: gzip+brotli compression helpers for HTTP layer, min 1KB, prefer br, skip images/archives, env compression level, request decompress, tests, provenance. PR title cornerblue [ T3 Code ].",
+  "timestamp": "2026-07-20T12:40:00Z"
+}

--- a/t3code/apps/server/src/http.ts
+++ b/t3code/apps/server/src/http.ts
@@ -1,3 +1,4 @@
+export * from "./httpCompression.ts";
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
 import * as Data from "effect/Data";

--- a/t3code/apps/server/src/httpCompression.test.ts
+++ b/t3code/apps/server/src/httpCompression.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPRESSION_MIN_BYTES,
+  compressBody,
+  decompressBody,
+  negotiateEncoding,
+  shouldCompressBody,
+  shouldSkipContentType,
+} from "./httpCompression.ts";
+
+describe("httpCompression (#863)", () => {
+  it("prefers brotli over gzip", () => {
+    expect(negotiateEncoding("gzip, deflate, br")).toBe("br");
+    expect(negotiateEncoding("gzip")).toBe("gzip");
+    expect(negotiateEncoding(null)).toBeNull();
+  });
+
+  it("skips images and archives", () => {
+    expect(shouldSkipContentType("image/png")).toBe(true);
+    expect(shouldSkipContentType("application/zip")).toBe(true);
+    expect(shouldSkipContentType("application/json")).toBe(false);
+  });
+
+  it("skips bodies under 1KB", () => {
+    expect(shouldCompressBody(100, "application/json", "br")).toBeNull();
+    expect(shouldCompressBody(COMPRESSION_MIN_BYTES, "application/json", "br")).toBe(
+      "br",
+    );
+  });
+
+  it("round-trips gzip", async () => {
+    const raw = new TextEncoder().encode("x".repeat(2000));
+    const gz = await compressBody(raw, "gzip", 4);
+    expect(gz.byteLength).toBeLessThan(raw.byteLength);
+    const back = await decompressBody(gz, "gzip");
+    expect(new TextDecoder().decode(back)).toBe("x".repeat(2000));
+  });
+
+  it("round-trips brotli", async () => {
+    const raw = new TextEncoder().encode(JSON.stringify({ a: "y".repeat(1500) }));
+    const br = await compressBody(raw, "br", 4);
+    expect(br.byteLength).toBeLessThan(raw.byteLength);
+    const back = await decompressBody(br, "br");
+    expect(JSON.parse(new TextDecoder().decode(back)).a.length).toBe(1500);
+  });
+});

--- a/t3code/apps/server/src/httpCompression.ts
+++ b/t3code/apps/server/src/httpCompression.ts
@@ -1,0 +1,133 @@
+/**
+ * Response compression helpers for the HTTP layer (issue #863).
+ *
+ * Pure negotiation + content-type skip rules so handlers can compress
+ * payloads >1KB when clients advertise gzip/br. Prefer brotli over gzip.
+ */
+
+export type CompressionEncoding = "br" | "gzip";
+
+const SKIP_TYPES = [
+  "image/",
+  "audio/",
+  "video/",
+  "application/zip",
+  "application/gzip",
+  "application/x-gzip",
+  "application/x-brotli",
+  "application/octet-stream",
+  "application/pdf",
+  "application/x-tar",
+  "application/x-7z-compressed",
+  "application/x-rar-compressed",
+];
+
+/** Minimum body size (bytes) before compression is considered. */
+export const COMPRESSION_MIN_BYTES = 1024;
+
+/**
+ * Read compression level from env (1–11 for brotli-ish scale, mapped for gzip 1–9).
+ * Default 4 for speed (<5ms target on typical JSON).
+ */
+export function compressionLevelFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.T3_HTTP_COMPRESSION_LEVEL ?? env.HTTP_COMPRESSION_LEVEL;
+  if (!raw) return 4;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return 4;
+  return Math.min(11, Math.floor(n));
+}
+
+/**
+ * Prefer brotli over gzip when both appear in Accept-Encoding.
+ */
+export function negotiateEncoding(
+  acceptEncoding: string | null | undefined,
+): CompressionEncoding | null {
+  if (!acceptEncoding) return null;
+  const parts = acceptEncoding
+    .toLowerCase()
+    .split(",")
+    .map((p) => p.trim().split(";")[0]?.trim())
+    .filter(Boolean) as string[];
+  if (parts.includes("br") || parts.some((p) => p === "br")) return "br";
+  // also accept "br;q=1.0" already stripped
+  if (parts.includes("*") && !parts.includes("identity")) {
+    // wildcard: prefer br
+    return "br";
+  }
+  if (parts.includes("gzip") || parts.includes("x-gzip")) return "gzip";
+  // ordered scan for q-values omitted for simplicity: first match of br then gzip
+  for (const p of parts) {
+    if (p === "br") return "br";
+  }
+  for (const p of parts) {
+    if (p === "gzip" || p === "x-gzip") return "gzip";
+  }
+  return null;
+}
+
+export function shouldSkipContentType(contentType: string | null | undefined): boolean {
+  if (!contentType) return false;
+  const ct = contentType.toLowerCase().split(";")[0]?.trim() ?? "";
+  return SKIP_TYPES.some((prefix) =>
+    prefix.endsWith("/") ? ct.startsWith(prefix) : ct === prefix,
+  );
+}
+
+export function shouldCompressBody(
+  byteLength: number,
+  contentType: string | null | undefined,
+  acceptEncoding: string | null | undefined,
+): CompressionEncoding | null {
+  if (byteLength < COMPRESSION_MIN_BYTES) return null;
+  if (shouldSkipContentType(contentType)) return null;
+  return negotiateEncoding(acceptEncoding);
+}
+
+/**
+ * Compress a Uint8Array with the chosen encoding using Node zlib.
+ */
+export async function compressBody(
+  body: Uint8Array,
+  encoding: CompressionEncoding,
+  level: number = compressionLevelFromEnv(),
+): Promise<Uint8Array> {
+  const zlib = await import("node:zlib");
+  const { promisify } = await import("node:util");
+  if (encoding === "br") {
+    const brotli = promisify(zlib.brotliCompress);
+    return new Uint8Array(
+      await brotli(body, {
+        params: {
+          [zlib.constants.BROTLI_PARAM_QUALITY]: Math.min(11, Math.max(0, level)),
+        },
+      }),
+    );
+  }
+  const gzip = promisify(zlib.gzip);
+  return new Uint8Array(await gzip(body, { level: Math.min(9, Math.max(1, level)) }));
+}
+
+/**
+ * Decompress request bodies when Content-Encoding is gzip/br.
+ */
+export async function decompressBody(
+  body: Uint8Array,
+  contentEncoding: string | null | undefined,
+): Promise<Uint8Array> {
+  if (!contentEncoding) return body;
+  const enc = contentEncoding.toLowerCase().trim();
+  const zlib = await import("node:zlib");
+  const { promisify } = await import("node:util");
+  if (enc === "br") {
+    const brotli = promisify(zlib.brotliDecompress);
+    return new Uint8Array(await brotli(body));
+  }
+  if (enc === "gzip" || enc === "x-gzip") {
+    const gunzip = promisify(zlib.gunzip);
+    return new Uint8Array(await gunzip(body));
+  }
+  return body;
+}


### PR DESCRIPTION
## Issue
Closes #863

## Summary
HTTP compression helpers for the server (**\$260**).

## Deliverables
- \`httpCompression.ts\`: negotiate encoding (prefer brotli), min 1KB, skip images/archives, compress/decompress via zlib, \`T3_HTTP_COMPRESSION_LEVEL\` env
- Re-export from \`http.ts\`
- Tests for preference, skip types, size threshold, gzip/brotli round-trip
- \`_provenance.json\`

## Note
Middleware wiring into Effect HttpRouter can use these pure helpers without changing route handlers first.

/bounty \$260