### PR TITLE
cornerblue [ T3 Code ] Sliding window metrics aggregation (#856)

### DIFF
--- a/t3code/apps/server/src/observability/.generation_meta.json
+++ b/t3code/apps/server/src/observability/.generation_meta.json
@@ -1,0 +1,5 @@
+{
+  "agent": "cornerblue",
+  "initial_directives": "Autonomous ethical earning of >=$100 BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar bounties. BH #856 $380 MetricsAggregator 1-minute windows, p50/p95/p99, error rate, throughput, 60-window ring, tests, generation_meta. PR title cornerblue [ T3 Code ].",
+  "date": "2026-07-20T12:55:00Z"
+}

--- a/t3code/apps/server/src/observability/MetricsAggregator.test.ts
+++ b/t3code/apps/server/src/observability/MetricsAggregator.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  MetricsAggregator,
+  aggregateSamples,
+  percentile,
+} from "./MetricsAggregator.ts";
+
+describe("MetricsAggregator (#856)", () => {
+  it("computes percentiles on sorted arrays", () => {
+    const s = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(s, 50)).toBe(5.5);
+    expect(percentile(s, 90)).toBeCloseTo(9.1, 5);
+    expect(percentile([7], 99)).toBe(7);
+  });
+
+  it("aggregates error rate and throughput", () => {
+    const start = 1_000_000;
+    const samples = [
+      { method: "rpc.a", latencyMs: 10, ok: true, at: start + 100 },
+      { method: "rpc.a", latencyMs: 30, ok: false, at: start + 200 },
+      { method: "rpc.a", latencyMs: 20, ok: true, at: start + 300 },
+    ];
+    const win = aggregateSamples(samples, start, start + 60_000);
+    const m = win.methods.find((x) => x.method === "rpc.a")!;
+    expect(m.count).toBe(3);
+    expect(m.errorCount).toBe(1);
+    expect(m.errorRatePct).toBeCloseTo(33.333, 2);
+    expect(m.p50Ms).toBe(20);
+  });
+
+  it("retains at most 60 windows", () => {
+    const now = 1_000_000;
+    const agg = new MetricsAggregator({ windowMs: 1000, maxWindows: 60, now });
+    for (let i = 0; i < 80; i++) {
+      agg.record({
+        method: "x",
+        latencyMs: i,
+        ok: true,
+        at: now + i * 1000 + 10,
+      });
+      agg.rotate(now + (i + 1) * 1000);
+    }
+    expect(agg.getWindows().length).toBeLessThanOrEqual(60);
+  });
+
+  it("exports JSON shape for /metrics/aggregated", () => {
+    const agg = new MetricsAggregator({ windowMs: 1000, maxWindows: 5, now: 0 });
+    agg.record({ method: "ping", latencyMs: 5, ok: true, at: 100 });
+    agg.rotate(1000);
+    const json = agg.toJSON();
+    expect(json.windowMs).toBe(1000);
+    expect(json.maxWindows).toBe(5);
+    expect(Array.isArray(json.windows)).toBe(true);
+  });
+});

--- a/t3code/apps/server/src/observability/MetricsAggregator.ts
+++ b/t3code/apps/server/src/observability/MetricsAggregator.ts
@@ -1,0 +1,133 @@
+/**
+ * Sliding-window RPC metrics aggregator (issue #856).
+ *
+ * Collects per-method samples into 1-minute windows with p50/p95/p99,
+ * error rate, and throughput. Circular buffer of last 60 windows (1 hour).
+ */
+
+export type RpcSample = {
+  method: string;
+  latencyMs: number;
+  ok: boolean;
+  at: number; // epoch ms
+};
+
+export type MethodStats = {
+  method: string;
+  count: number;
+  errorCount: number;
+  errorRatePct: number;
+  throughputRps: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+};
+
+export type MetricsWindow = {
+  windowStart: number;
+  windowEnd: number;
+  methods: MethodStats[];
+};
+
+const WINDOW_MS = 60_000;
+const MAX_WINDOWS = 60;
+
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const w = rank - lo;
+  return sorted[lo] * (1 - w) + sorted[hi] * w;
+}
+
+export function aggregateSamples(
+  samples: RpcSample[],
+  windowStart: number,
+  windowEnd: number,
+): MetricsWindow {
+  const byMethod = new Map<string, RpcSample[]>();
+  for (const s of samples) {
+    if (s.at < windowStart || s.at >= windowEnd) continue;
+    const list = byMethod.get(s.method) ?? [];
+    list.push(s);
+    byMethod.set(s.method, list);
+  }
+  const durationSec = Math.max(0.001, (windowEnd - windowStart) / 1000);
+  const methods: MethodStats[] = [];
+  for (const [method, list] of byMethod) {
+    const latencies = list.map((x) => x.latencyMs).sort((a, b) => a - b);
+    const errorCount = list.filter((x) => !x.ok).length;
+    methods.push({
+      method,
+      count: list.length,
+      errorCount,
+      errorRatePct: (errorCount / list.length) * 100,
+      throughputRps: list.length / durationSec,
+      p50Ms: percentile(latencies, 50),
+      p95Ms: percentile(latencies, 95),
+      p99Ms: percentile(latencies, 99),
+    });
+  }
+  methods.sort((a, b) => a.method.localeCompare(b.method));
+  return { windowStart, windowEnd, methods };
+}
+
+export class MetricsAggregator {
+  private readonly samples: RpcSample[] = [];
+  private readonly windows: MetricsWindow[] = [];
+  private currentWindowStart: number;
+  private readonly windowMs: number;
+  private readonly maxWindows: number;
+
+  constructor(opts?: { windowMs?: number; maxWindows?: number; now?: number }) {
+    this.windowMs = opts?.windowMs ?? WINDOW_MS;
+    this.maxWindows = opts?.maxWindows ?? MAX_WINDOWS;
+    const now = opts?.now ?? Date.now();
+    this.currentWindowStart = now - (now % this.windowMs);
+  }
+
+  record(sample: Omit<RpcSample, "at"> & { at?: number }): void {
+    const at = sample.at ?? Date.now();
+    this.samples.push({ ...sample, at });
+    this.rotate(at);
+    // Bound raw samples to last 2 windows of time
+    const cutoff = at - this.windowMs * 2;
+    while (this.samples.length && this.samples[0].at < cutoff) {
+      this.samples.shift();
+    }
+  }
+
+  /** Force window rotation using `now`. */
+  rotate(now: number = Date.now()): void {
+    while (now >= this.currentWindowStart + this.windowMs) {
+      const start = this.currentWindowStart;
+      const end = start + this.windowMs;
+      const win = aggregateSamples(this.samples, start, end);
+      this.windows.push(win);
+      while (this.windows.length > this.maxWindows) {
+        this.windows.shift();
+      }
+      this.currentWindowStart = end;
+    }
+  }
+
+  /** Last 60 completed windows (oldest first). */
+  getWindows(): MetricsWindow[] {
+    this.rotate();
+    return [...this.windows];
+  }
+
+  /** JSON payload for GET /metrics/aggregated */
+  toJSON(): { windows: MetricsWindow[]; windowMs: number; maxWindows: number } {
+    return {
+      windows: this.getWindows(),
+      windowMs: this.windowMs,
+      maxWindows: this.maxWindows,
+    };
+  }
+}
+
+export const metricsAggregator = new MetricsAggregator();


### PR DESCRIPTION
## Issue
Closes #856

## Summary
RPC metrics aggregator (**$380**).

## Features
- 1-minute windows, last 60 retained
- per-method p50/p95/p99, error rate %, throughput rps
- `toJSON()` for `/metrics/aggregated`
- tests for percentiles, aggregation, buffer bounds

/bounty $380