### PR TITLE
cornerblue [ FastAPI ] SSE disconnect, filter, replay, broadcast (#798)

### DIFF
--- a/fastapi/fastapi/.contributor.json
+++ b/fastapi/fastapi/.contributor.json
@@ -1,0 +1,5 @@
+{
+  "agent": "cornerblue",
+  "initialized_with": "Autonomous ethical earning of >=$100 confirmed BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. Prefer zero installs, no malware. Ship high quality. Unique high-EV filter. Issue #798 $400: SSEManager disconnect detection, event_type filter, last_event_id replay, retry field, broadcast, tests, .contributor.json, PR title cornerblue [ FastAPI ].",
+  "timestamp": "2026-07-20T12:05:00Z"
+}

--- a/fastapi/fastapi/sse_manager.py
+++ b/fastapi/fastapi/sse_manager.py
@@ -1,0 +1,199 @@
+"""SSE disconnect detection, filtering, replay, and broadcast manager (issue #798)."""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Callable, Deque, Dict, Iterable, List, Optional, Set
+
+
+@dataclass
+class SSEEvent:
+    id: str
+    event: str
+    data: Any
+    retry: Optional[int] = None
+    ts: float = field(default_factory=time.time)
+
+    def encode(self) -> str:
+        lines: List[str] = []
+        if self.id is not None:
+            lines.append(f"id: {self.id}")
+        if self.event:
+            lines.append(f"event: {self.event}")
+        if self.retry is not None:
+            lines.append(f"retry: {int(self.retry)}")
+        payload = self.data if isinstance(self.data, str) else str(self.data)
+        for part in payload.splitlines() or [""]:
+            lines.append(f"data: {part}")
+        return "\n".join(lines) + "\n\n"
+
+
+class SSEConnection:
+    def __init__(
+        self,
+        conn_id: str,
+        *,
+        event_types: Optional[Set[str]] = None,
+        last_event_id: Optional[str] = None,
+        retry_ms: int = 3000,
+    ) -> None:
+        self.conn_id = conn_id
+        self.event_types = event_types  # None = all
+        self.last_event_id = last_event_id
+        self.retry_ms = retry_ms
+        self.queue: asyncio.Queue[Optional[SSEEvent]] = asyncio.Queue()
+        self.closed = False
+
+    def accepts(self, event: SSEEvent) -> bool:
+        if self.event_types is None:
+            return True
+        return event.event in self.event_types
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        await self.queue.put(None)  # sentinel
+
+
+class SSEManager:
+    """
+    Manage multiple SSE connections with broadcast, filtering, and replay.
+    """
+
+    def __init__(self, *, history_size: int = 256, default_retry_ms: int = 3000) -> None:
+        self._id_counter = itertools.count(1)
+        self._conn_counter = itertools.count(1)
+        self.connections: Dict[str, SSEConnection] = {}
+        self.history: Deque[SSEEvent] = deque(maxlen=history_size)
+        self.default_retry_ms = default_retry_ms
+        self._lock = asyncio.Lock()
+
+    def next_event_id(self) -> str:
+        return str(next(self._id_counter))
+
+    def _events_after(self, last_event_id: Optional[str]) -> List[SSEEvent]:
+        if not last_event_id:
+            return []
+        out: List[SSEEvent] = []
+        seen = False
+        for ev in self.history:
+            if seen:
+                out.append(ev)
+            elif ev.id == last_event_id:
+                seen = True
+        # If id not found, replay nothing (or full history — prefer nothing for safety)
+        return out
+
+    async def connect(
+        self,
+        *,
+        event_type: Optional[str] = None,
+        event_types: Optional[Iterable[str]] = None,
+        last_event_id: Optional[str] = None,
+        retry_ms: Optional[int] = None,
+    ) -> SSEConnection:
+        types: Optional[Set[str]] = None
+        if event_type:
+            types = {event_type}
+        if event_types:
+            types = set(event_types) if types is None else types | set(event_types)
+
+        conn = SSEConnection(
+            conn_id=f"c{next(self._conn_counter)}",
+            event_types=types,
+            last_event_id=last_event_id,
+            retry_ms=retry_ms if retry_ms is not None else self.default_retry_ms,
+        )
+        async with self._lock:
+            self.connections[conn.conn_id] = conn
+        return conn
+
+    async def disconnect(self, conn_id: str) -> None:
+        async with self._lock:
+            conn = self.connections.pop(conn_id, None)
+        if conn:
+            await conn.close()
+
+    async def publish(
+        self,
+        data: Any,
+        *,
+        event: str = "message",
+        event_id: Optional[str] = None,
+        retry: Optional[int] = None,
+    ) -> SSEEvent:
+        ev = SSEEvent(
+            id=event_id or self.next_event_id(),
+            event=event,
+            data=data,
+            retry=retry if retry is not None else self.default_retry_ms,
+        )
+        async with self._lock:
+            self.history.append(ev)
+            targets = list(self.connections.values())
+        for conn in targets:
+            if conn.closed or not conn.accepts(ev):
+                continue
+            await conn.queue.put(ev)
+        return ev
+
+    async def broadcast(self, data: Any, *, event: str = "message") -> SSEEvent:
+        return await self.publish(data, event=event)
+
+    async def broadcast_filtered(
+        self, data: Any, *, event: str, event_types: Optional[Set[str]] = None
+    ) -> SSEEvent:
+        """Publish an event that only matching connections receive (via event name)."""
+        return await self.publish(data, event=event)
+
+    async def stream(self, conn: SSEConnection) -> AsyncIterator[str]:
+        """
+        Yield encoded SSE frames until client disconnect (conn.closed / sentinel).
+        Replays history after last_event_id first, then live queue.
+        """
+        # Initial retry hint
+        yield f"retry: {conn.retry_ms}\n\n"
+
+        for ev in self._events_after(conn.last_event_id):
+            if conn.accepts(ev):
+                yield ev.encode()
+
+        try:
+            while not conn.closed:
+                item = await conn.queue.get()
+                if item is None:
+                    break
+                yield item.encode()
+        except asyncio.CancelledError:
+            # Client disconnect / task cancel — clean exit, no raise to caller path
+            return
+        finally:
+            await self.disconnect(conn.conn_id)
+
+
+async def sse_event_generator(
+    manager: SSEManager,
+    *,
+    event_type: Optional[str] = None,
+    last_event_id: Optional[str] = None,
+    retry_ms: int = 3000,
+    is_disconnected: Optional[Callable[[], bool]] = None,
+) -> AsyncIterator[str]:
+    """
+    High-level generator: stops cleanly when `is_disconnected()` becomes True.
+    """
+    conn = await manager.connect(
+        event_type=event_type, last_event_id=last_event_id, retry_ms=retry_ms
+    )
+    try:
+        async for chunk in manager.stream(conn):
+            if is_disconnected is not None and is_disconnected():
+                break
+            yield chunk
+    finally:
+        await manager.disconnect(conn.conn_id)

--- a/fastapi/tests/test_sse_manager.py
+++ b/fastapi/tests/test_sse_manager.py
@@ -1,0 +1,126 @@
+"""Tests for SSEManager (issue #798)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[1] / "fastapi" / "sse_manager.py"
+
+
+def _load():
+    name = "sse_manager_local"
+    if name in sys.modules:
+        del sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_filter_and_broadcast():
+    mod = _load()
+
+    async def main():
+        mgr = mod.SSEManager(default_retry_ms=1500)
+        c_all = await mgr.connect()
+        c_chat = await mgr.connect(event_type="chat")
+        await mgr.publish("hello", event="chat")
+        await mgr.publish("sys", event="system")
+        # all gets both; chat only chat
+        e1 = await asyncio.wait_for(c_all.queue.get(), timeout=1)
+        e2 = await asyncio.wait_for(c_all.queue.get(), timeout=1)
+        assert {e1.event, e2.event} == {"chat", "system"}
+        e3 = await asyncio.wait_for(c_chat.queue.get(), timeout=1)
+        assert e3.event == "chat" and e3.data == "hello"
+        assert c_chat.queue.empty()
+        await mgr.disconnect(c_all.conn_id)
+        await mgr.disconnect(c_chat.conn_id)
+
+    asyncio.run(main())
+
+
+def test_replay_last_event_id():
+    mod = _load()
+
+    async def main():
+        mgr = mod.SSEManager()
+        e1 = await mgr.publish("a", event="m")
+        e2 = await mgr.publish("b", event="m")
+        e3 = await mgr.publish("c", event="m")
+        conn = await mgr.connect(last_event_id=e1.id)
+        chunks = []
+        # only take replay portion via private helper
+        replay = mgr._events_after(e1.id)
+        assert [x.data for x in replay] == ["b", "c"]
+        assert e2.id and e3.id
+        await mgr.disconnect(conn.conn_id)
+
+    asyncio.run(main())
+
+
+def test_retry_field_in_stream():
+    mod = _load()
+
+    async def main():
+        mgr = mod.SSEManager(default_retry_ms=2500)
+        conn = await mgr.connect(retry_ms=2500)
+        await mgr.publish("x", event="m", retry=2500)
+        gen = mgr.stream(conn)
+        first = await gen.__anext__()
+        assert first.startswith("retry: 2500")
+        second = await gen.__anext__()
+        assert "retry: 2500" in second
+        assert "data: x" in second
+        await mgr.disconnect(conn.conn_id)
+
+    asyncio.run(main())
+
+
+def test_disconnect_stops_cleanly():
+    mod = _load()
+
+    async def main():
+        mgr = mod.SSEManager()
+        disconnected = {"v": False}
+
+        async def produce():
+            for i in range(5):
+                await mgr.publish(f"n{i}", event="tick")
+                await asyncio.sleep(0.01)
+
+        prod = asyncio.create_task(produce())
+        chunks = []
+        async for ch in mod.sse_event_generator(
+            mgr, is_disconnected=lambda: disconnected["v"]
+        ):
+            chunks.append(ch)
+            if len(chunks) >= 3:
+                disconnected["v"] = True
+        await prod
+        assert len(chunks) >= 1
+        # no exception raised
+
+    asyncio.run(main())
+
+
+def test_encode_format():
+    mod = _load()
+    ev = mod.SSEEvent(id="9", event="chat", data="hi", retry=1000)
+    wire = ev.encode()
+    assert "id: 9" in wire
+    assert "event: chat" in wire
+    assert "retry: 1000" in wire
+    assert "data: hi" in wire
+    assert wire.endswith("\n\n")
+
+
+if __name__ == "__main__":
+    for n, f in list(globals().items()):
+        if n.startswith("test_") and callable(f):
+            f()
+            print("ok", n)
+    print("ALL PASSED")


### PR DESCRIPTION
## Issue
Closes #798

## Summary
SSE connection manager (**\$400**).

## Features
- \`SSEManager\` multi-connection broadcast
- \`event_type\` filter per connection
- \`last_event_id\` history replay
- \`retry:\` field (configurable ms)
- Clean disconnect (no exception noise)
- 5 unit tests

/bounty \$400