### PR TITLE
cornerblue [ T3 Code ] Checkpoint snapshot pruning with retention (#838)

### DIFF
--- a/t3code/apps/server/src/checkpointing/CheckpointPruner.test.ts
+++ b/t3code/apps/server/src/checkpointing/CheckpointPruner.test.ts
@@ -1,0 +1,73 @@
+import {
+  CheckpointPruner,
+  parsePruneDays,
+  selectSnapshotsToPrune,
+  formatPruneReport,
+  DEFAULT_KEEP_PER_SESSION,
+} from "./CheckpointPruner.ts";
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg);
+}
+
+const day = 24 * 60 * 60 * 1000;
+const now = 1_700_000_000_000;
+
+const snaps = [
+  { id: "a1", sessionId: "s1", createdAt: now - 10 * day, sizeBytes: 100 },
+  { id: "a2", sessionId: "s1", createdAt: now - 9 * day, sizeBytes: 100 },
+  { id: "a3", sessionId: "s1", createdAt: now - 8 * day, sizeBytes: 100 },
+  { id: "a4", sessionId: "s1", createdAt: now - 1 * day, sizeBytes: 50 }, // recent
+  { id: "b1", sessionId: "s2", createdAt: now - 30 * day, sizeBytes: 200 },
+  { id: "b2", sessionId: "s2", createdAt: now - 20 * day, sizeBytes: 200 },
+  { id: "b3", sessionId: "s2", createdAt: now - 15 * day, sizeBytes: 200 },
+  { id: "b4", sessionId: "s2", createdAt: now - 14 * day, sizeBytes: 200 },
+];
+
+// keep 3 newest per session even if old
+const { deleteIds, keepIds } = selectSnapshotsToPrune(snaps, {
+  retentionDays: 7,
+  keepPerSession: 3,
+  now,
+});
+// s1 newest 3: a4,a3,a2 protected; a1 old unprotected => delete
+assert(keepIds.has("a4") && keepIds.has("a3") && keepIds.has("a2"), "s1 keep 3");
+assert(deleteIds.has("a1"), "s1 oldest deleted");
+// s2 all older than 7d but keep 3 newest b4,b3,b2; delete b1
+assert(keepIds.has("b4") && keepIds.has("b3") && keepIds.has("b2"), "s2 keep 3");
+assert(deleteIds.has("b1"), "s2 oldest deleted");
+assert(DEFAULT_KEEP_PER_SESSION === 3, "default keep 3");
+
+// In-memory store prune
+const store = {
+  data: snaps.slice(),
+  list() {
+    return this.data;
+  },
+  deleteMany(ids: string[]) {
+    const set = new Set(ids);
+    const before = this.data.length;
+    this.data = this.data.filter((s) => !set.has(s.id));
+    return before - this.data.length;
+  },
+};
+const pruner = new CheckpointPruner(store);
+const result = await pruner.prune({ retentionDays: 7, now });
+assert(result.snapshots_deleted === 2, `deleted 2 got ${result.snapshots_deleted}`);
+assert(result.bytes_freed === 300, `bytes ${result.bytes_freed}`);
+assert(result.duration_ms >= 0, "duration");
+assert(store.data.length === 6, "remaining");
+
+// CLI --days
+assert(parsePruneDays(["checkpoint:prune", "--days", "14"]) === 14, "days 14");
+assert(parsePruneDays(["checkpoint:prune"]) === 7, "default days");
+const report = formatPruneReport(result);
+assert(report.includes("snapshots_deleted=2"), "report");
+
+// Concurrent: two prunes do not throw
+await Promise.all([
+  pruner.prune({ retentionDays: 7, now }),
+  pruner.prune({ retentionDays: 7, now }),
+]);
+
+console.log("CheckpointPruner tests: passed");

--- a/t3code/apps/server/src/checkpointing/CheckpointPruner.ts
+++ b/t3code/apps/server/src/checkpointing/CheckpointPruner.ts
@@ -1,0 +1,126 @@
+/**
+ * Snapshot pruning with retention window and per-session keep-N (issue #838).
+ */
+
+export const DEFAULT_RETENTION_DAYS = 7;
+export const DEFAULT_KEEP_PER_SESSION = 3;
+export const DEFAULT_SCHEDULE_MS = 60 * 60 * 1000; // 1 hour
+
+export interface SnapshotMeta {
+  id: string;
+  sessionId: string;
+  createdAt: number; // epoch ms
+  sizeBytes: number;
+}
+
+export interface PruneOptions {
+  retentionDays?: number;
+  keepPerSession?: number;
+  now?: number;
+}
+
+export interface PruneResult {
+  snapshots_deleted: number;
+  bytes_freed: number;
+  duration_ms: number;
+  deletedIds: string[];
+  keptIds: string[];
+}
+
+/**
+ * Decide which snapshots to delete.
+ * - Always keep the newest `keepPerSession` per sessionId.
+ * - Among the rest, delete those older than retentionDays.
+ */
+export function selectSnapshotsToPrune(
+  snapshots: readonly SnapshotMeta[],
+  options: PruneOptions = {},
+): { deleteIds: Set<string>; keepIds: Set<string> } {
+  const retentionDays = options.retentionDays ?? DEFAULT_RETENTION_DAYS;
+  const keepPerSession = options.keepPerSession ?? DEFAULT_KEEP_PER_SESSION;
+  const now = options.now ?? Date.now();
+  const cutoff = now - retentionDays * 24 * 60 * 60 * 1000;
+
+  const bySession = new Map<string, SnapshotMeta[]>();
+  for (const s of snapshots) {
+    const list = bySession.get(s.sessionId) ?? [];
+    list.push(s);
+    bySession.set(s.sessionId, list);
+  }
+
+  const protectedIds = new Set<string>();
+  for (const list of bySession.values()) {
+    list
+      .slice()
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, keepPerSession)
+      .forEach((s) => protectedIds.add(s.id));
+  }
+
+  const deleteIds = new Set<string>();
+  const keepIds = new Set<string>();
+  for (const s of snapshots) {
+    if (protectedIds.has(s.id)) {
+      keepIds.add(s.id);
+      continue;
+    }
+    if (s.createdAt < cutoff) {
+      deleteIds.add(s.id);
+    } else {
+      keepIds.add(s.id);
+    }
+  }
+  return { deleteIds, keepIds };
+}
+
+export class CheckpointPruner {
+  constructor(
+    private readonly store: {
+      list(): SnapshotMeta[] | Promise<SnapshotMeta[]>;
+      deleteMany(ids: string[]): number | Promise<number>;
+      sizeOf?(id: string): number;
+    },
+  ) {}
+
+  async prune(options: PruneOptions = {}): Promise<PruneResult> {
+    const started = Date.now();
+    const snapshots = await this.store.list();
+    const { deleteIds, keepIds } = selectSnapshotsToPrune(snapshots, options);
+    const sizeMap = new Map(snapshots.map((s) => [s.id, s.sizeBytes]));
+    let bytes = 0;
+    for (const id of deleteIds) {
+      bytes += sizeMap.get(id) ?? this.store.sizeOf?.(id) ?? 0;
+    }
+    const deleted = deleteIds.size
+      ? await this.store.deleteMany([...deleteIds])
+      : 0;
+    return {
+      snapshots_deleted: typeof deleted === "number" ? deleted : deleteIds.size,
+      bytes_freed: bytes,
+      duration_ms: Date.now() - started,
+      deletedIds: [...deleteIds],
+      keptIds: [...keepIds],
+    };
+  }
+}
+
+/** CLI-shaped helper: parse --days and run prune. */
+export function parsePruneDays(argv: string[], fallback = DEFAULT_RETENTION_DAYS): number {
+  const idx = argv.findIndex((a) => a === "--days" || a === "-d");
+  if (idx >= 0 && argv[idx + 1]) {
+    const n = Number(argv[idx + 1]);
+    if (!Number.isFinite(n) || n < 0) {
+      throw new Error("--days must be a non-negative number");
+    }
+    return n;
+  }
+  return fallback;
+}
+
+export function formatPruneReport(result: PruneResult): string {
+  return [
+    `snapshots_deleted=${result.snapshots_deleted}`,
+    `bytes_freed=${result.bytes_freed}`,
+    `duration_ms=${result.duration_ms}`,
+  ].join(" ");
+}

--- a/t3code/apps/server/src/checkpointing/CheckpointPruner.ts
+++ b/t3code/apps/server/src/checkpointing/CheckpointPruner.ts
@@ -74,13 +74,19 @@ export function selectSnapshotsToPrune(
 }
 
 export class CheckpointPruner {
-  constructor(
-    private readonly store: {
-      list(): SnapshotMeta[] | Promise<SnapshotMeta[]>;
-      deleteMany(ids: string[]): number | Promise<number>;
-      sizeOf?(id: string): number;
-    },
-  ) {}
+  private readonly store: {
+    list(): SnapshotMeta[] | Promise<SnapshotMeta[]>;
+    deleteMany(ids: string[]): number | Promise<number>;
+    sizeOf?(id: string): number;
+  };
+
+  constructor(store: {
+    list(): SnapshotMeta[] | Promise<SnapshotMeta[]>;
+    deleteMany(ids: string[]): number | Promise<number>;
+    sizeOf?(id: string): number;
+  }) {
+    this.store = store;
+  }
 
   async prune(options: PruneOptions = {}): Promise<PruneResult> {
     const started = Date.now();

--- a/t3code/apps/server/src/checkpointing/_meta.json
+++ b/t3code/apps/server/src/checkpointing/_meta.json
@@ -1,0 +1,5 @@
+{
+  "contributor": "cornerblue",
+  "generation_context": "Autonomous ethical earning of >=$100 confirmed BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. Prefer zero installs, no malware. Ship high quality. Unique high-EV filter. Issue #838 $350: CheckpointPruner retention 7d, keep 3 per session, metrics, --days CLI helper, tests concurrent, _meta.json, PR title cornerblue [ T3 Code ].",
+  "completed_at": "2026-07-20T12:40:00Z"
+}


### PR DESCRIPTION
## Issue
Closes #838

## Summary
Checkpoint snapshot pruning (**\$350**).

## Features
- \`selectSnapshotsToPrune\`: retention days + keep 3 newest / session
- \`CheckpointPruner.prune\` metrics: snapshots_deleted, bytes_freed, duration_ms
- \`parsePruneDays(--days)\` for CLI
- Concurrent prune safe (no throw)
- Unit tests

/bounty \$350