### PR TITLE
cornerblue [ T3 Code ] IPC message queuing for backend disconnect (#826)

### DIFF
--- a/t3code/apps/desktop/src/ipc/IpcMessageQueue.test.ts
+++ b/t3code/apps/desktop/src/ipc/IpcMessageQueue.test.ts
@@ -1,0 +1,77 @@
+import {
+  IpcMessageQueue,
+  TimeoutError,
+  DEFAULT_MAX_QUEUE,
+} from "./IpcMessageQueue.ts";
+
+function assert(c: unknown, m: string): asserts c {
+  if (!c) throw new Error(m);
+}
+
+let t = 1_000_000;
+const now = () => t;
+const sent: string[] = [];
+
+const q = new IpcMessageQueue<string, string>({
+  send: async (p) => {
+    sent.push(p);
+    return `ok:${p}`;
+  },
+  maxSize: 3,
+  ttlMs: 30_000,
+  now,
+  initialState: "disconnected",
+});
+
+// connectionState subscription
+const states: string[] = [];
+const unsub = q.subscribe((s) => states.push(s));
+assert(states[0] === "disconnected", "initial emit");
+
+// Queue during downtime
+const p1 = q.call("a");
+const p2 = q.call("b");
+assert(q.size === 2, "queued 2");
+assert(sent.length === 0, "not sent yet");
+
+// Reconnect flushes FIFO
+q.setConnectionState("reconnecting");
+q.setConnectionState("connected");
+const r1 = await p1;
+const r2 = await p2;
+assert(r1 === "ok:a" && r2 === "ok:b", "fifo results");
+assert(sent.join(",") === "a,b", "fifo order");
+assert(states.includes("connected") && states.includes("reconnecting"), "states");
+
+// Healthy bypass
+sent.length = 0;
+const direct = await q.call("c");
+assert(direct === "ok:c" && sent.join(",") === "c", "bypass");
+assert(q.size === 0, "empty queue");
+
+// Max size drops oldest
+q.setConnectionState("disconnected");
+const d1 = q.call("old1").then(
+  () => "resolved",
+  (e) => (e instanceof TimeoutError ? "timeout" : "err"),
+);
+q.call("old2");
+q.call("old3");
+q.call("new4"); // should drop old1
+assert(q.size === 3, "max 3");
+const d1r = await d1;
+assert(d1r === "timeout", "oldest dropped");
+
+// Expiry
+t += 31_000;
+const exp = q.call("x").then(
+  () => "ok",
+  (e) => (e instanceof TimeoutError ? "timeout" : "err"),
+);
+// expireOld on next call
+q.call("y");
+// the expired ones in queue get rejected on expireOld
+assert(DEFAULT_MAX_QUEUE === 100, "default max");
+
+unsub();
+console.log("IpcMessageQueue tests: all passed");

--- a/t3code/apps/desktop/src/ipc/IpcMessageQueue.test.ts
+++ b/t3code/apps/desktop/src/ipc/IpcMessageQueue.test.ts
@@ -23,55 +23,61 @@ const q = new IpcMessageQueue<string, string>({
   initialState: "disconnected",
 });
 
-// connectionState subscription
 const states: string[] = [];
 const unsub = q.subscribe((s) => states.push(s));
 assert(states[0] === "disconnected", "initial emit");
 
-// Queue during downtime
 const p1 = q.call("a");
 const p2 = q.call("b");
 assert(q.size === 2, "queued 2");
 assert(sent.length === 0, "not sent yet");
 
-// Reconnect flushes FIFO
 q.setConnectionState("reconnecting");
 q.setConnectionState("connected");
-const r1 = await p1;
-const r2 = await p2;
-assert(r1 === "ok:a" && r2 === "ok:b", "fifo results");
+assert((await p1) === "ok:a" && (await p2) === "ok:b", "fifo results");
 assert(sent.join(",") === "a,b", "fifo order");
-assert(states.includes("connected") && states.includes("reconnecting"), "states");
 
-// Healthy bypass
 sent.length = 0;
-const direct = await q.call("c");
-assert(direct === "ok:c" && sent.join(",") === "c", "bypass");
-assert(q.size === 0, "empty queue");
+assert((await q.call("c")) === "ok:c", "bypass");
+assert(q.size === 0, "empty");
 
-// Max size drops oldest
 q.setConnectionState("disconnected");
 const d1 = q.call("old1").then(
   () => "resolved",
   (e) => (e instanceof TimeoutError ? "timeout" : "err"),
 );
-q.call("old2");
-q.call("old3");
-q.call("new4"); // should drop old1
+void q.call("old2").catch(() => {});
+void q.call("old3").catch(() => {});
+void q.call("new4").catch(() => {}); // drops old1
 assert(q.size === 3, "max 3");
-const d1r = await d1;
-assert(d1r === "timeout", "oldest dropped");
+assert((await d1) === "timeout", "oldest dropped");
 
-// Expiry
+// Expiry: advance clock, next call expires prior entries
+const pending = [
+  q.call("will-expire-1").then(() => "ok", (e) => (e instanceof TimeoutError ? "timeout" : "err")),
+  q.call("will-expire-2").then(() => "ok", (e) => (e instanceof TimeoutError ? "timeout" : "err")),
+];
+// queue has 3 from before + maybe more — set disconnected clean queue by new instance
+const q2 = new IpcMessageQueue<string, string>({
+  send: async (p) => `ok:${p}`,
+  maxSize: 10,
+  ttlMs: 30_000,
+  now,
+  initialState: "disconnected",
+});
+const e1 = q2.call("x").then(() => "ok", (e) => (e instanceof TimeoutError ? "timeout" : "err"));
+const e2 = q2.call("y").then(() => "ok", (e) => (e instanceof TimeoutError ? "timeout" : "err"));
 t += 31_000;
-const exp = q.call("x").then(
-  () => "ok",
-  (e) => (e instanceof TimeoutError ? "timeout" : "err"),
-);
-// expireOld on next call
-q.call("y");
-// the expired ones in queue get rejected on expireOld
+// trigger expire via call while still disconnected
+const e3 = q2.call("z").then(() => "ok", (e) => (e instanceof TimeoutError ? "timeout" : "err"));
+assert((await e1) === "timeout", "e1 expired");
+assert((await e2) === "timeout", "e2 expired");
+// z still in queue (fresh)
+assert(q2.size >= 1, "z queued");
 assert(DEFAULT_MAX_QUEUE === 100, "default max");
+// prevent unhandled from first pending array
+await Promise.all(pending).catch(() => {});
+await e3.catch(() => {});
 
 unsub();
 console.log("IpcMessageQueue tests: all passed");

--- a/t3code/apps/desktop/src/ipc/IpcMessageQueue.ts
+++ b/t3code/apps/desktop/src/ipc/IpcMessageQueue.ts
@@ -1,0 +1,141 @@
+/**
+ * IPC message queue for backend disconnect resilience (issue #826).
+ */
+
+export const DEFAULT_MAX_QUEUE = 100;
+export const DEFAULT_TTL_MS = 30_000;
+
+export type ConnectionState = "connected" | "disconnected" | "reconnecting";
+
+export class TimeoutError extends Error {
+  readonly _tag = "TimeoutError" as const;
+  constructor(message = "IPC message expired in queue") {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+export interface QueuedMessage<T = unknown> {
+  id: string;
+  payload: T;
+  enqueuedAt: number;
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+}
+
+export type StateListener = (state: ConnectionState) => void;
+
+export class IpcMessageQueue<TPayload = unknown, TResult = unknown> {
+  private queue: QueuedMessage<TPayload>[] = [];
+  private state: ConnectionState = "disconnected";
+  private listeners = new Set<StateListener>();
+  private readonly maxSize: number;
+  private readonly ttlMs: number;
+  private now: () => number;
+  private sendFn: (payload: TPayload) => Promise<TResult>;
+  private flushing = false;
+
+  constructor(options: {
+    send: (payload: TPayload) => Promise<TResult>;
+    maxSize?: number;
+    ttlMs?: number;
+    now?: () => number;
+    initialState?: ConnectionState;
+  }) {
+    this.sendFn = options.send;
+    this.maxSize = options.maxSize ?? DEFAULT_MAX_QUEUE;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? Date.now;
+    this.state = options.initialState ?? "disconnected";
+  }
+
+  get connectionState(): ConnectionState {
+    return this.state;
+  }
+
+  get size(): number {
+    return this.queue.length;
+  }
+
+  /** Observable-style subscription for UI connection status. */
+  subscribe(listener: StateListener): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => this.listeners.delete(listener);
+  }
+
+  setConnectionState(next: ConnectionState): void {
+    if (this.state === next) return;
+    this.state = next;
+    for (const l of this.listeners) l(next);
+    if (next === "connected") {
+      void this.flush();
+    }
+  }
+
+  /**
+   * RPC call: bypass queue when healthy; otherwise enqueue.
+   */
+  async call(payload: TPayload): Promise<TResult> {
+    this.expireOld();
+    if (this.state === "connected" && !this.flushing && this.queue.length === 0) {
+      return this.sendFn(payload);
+    }
+    return this.enqueue(payload);
+  }
+
+  private enqueue(payload: TPayload): Promise<TResult> {
+    return new Promise<TResult>((resolve, reject) => {
+      // Drop oldest when full
+      while (this.queue.length >= this.maxSize) {
+        const old = this.queue.shift();
+        if (old) old.reject(new TimeoutError("IPC queue overflow: dropped oldest message"));
+      }
+      const msg: QueuedMessage<TPayload> = {
+        id: `m_${this.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        payload,
+        enqueuedAt: this.now(),
+        resolve: resolve as (v: unknown) => void,
+        reject,
+      };
+      this.queue.push(msg);
+    });
+  }
+
+  private expireOld(): void {
+    const now = this.now();
+    const keep: QueuedMessage<TPayload>[] = [];
+    for (const m of this.queue) {
+      if (now - m.enqueuedAt > this.ttlMs) {
+        m.reject(new TimeoutError());
+      } else {
+        keep.push(m);
+      }
+    }
+    this.queue = keep;
+  }
+
+  /** Flush queue FIFO on reconnect; drain completely before direct sends. */
+  async flush(): Promise<void> {
+    if (this.flushing) return;
+    this.flushing = true;
+    try {
+      this.expireOld();
+      while (this.queue.length > 0 && this.state === "connected") {
+        const m = this.queue.shift()!;
+        if (this.now() - m.enqueuedAt > this.ttlMs) {
+          m.reject(new TimeoutError());
+          continue;
+        }
+        try {
+          const result = await this.sendFn(m.payload);
+          m.resolve(result);
+        } catch (err) {
+          m.reject(err);
+        }
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+}

--- a/t3code/apps/desktop/src/ipc/_contributor.json
+++ b/t3code/apps/desktop/src/ipc/_contributor.json
@@ -1,0 +1,5 @@
+{
+  "identity": "cornerblue",
+  "runtime_instructions": "Autonomous ethical earning of >=$100 confirmed BTC to bc1qjtevjy8gldfhkra6n5g4yclpr5uafyd7k0j2ls. Hard-dollar GitHub bounties only. Prefer zero installs, no malware. Ship high quality. Unique high-EV filter. Issue #826 $300: IpcMessageQueue max 100 FIFO, 30s TTL TimeoutError, connectionState connected/disconnected/reconnecting, flush on reconnect, bypass when healthy, tests, _contributor.json, PR title cornerblue [ T3 Code ].",
+  "timestamp": "2026-07-20T13:00:00Z"
+}


### PR DESCRIPTION
## Issue
Closes #826

## Summary
IPC message queue (**$300**).

## Features
- Queue max 100 FIFO; drop oldest when full
- 30s TTL → TimeoutError
- connectionState: connected / disconnected / reconnecting
- Flush in order on reconnect
- Bypass queue when healthy

/bounty $300