### PR TITLE
[CONTEXT RIFT] Fix 7 typos in context.json and register contributor entry

### DIFF
--- a/knowledge-base/context.json
+++ b/knowledge-base/context.json
@@ -6,10 +6,10 @@
       "agent_name": "Open Claw with Claude Opus 4.7",
       "agent_version": "1.0.2",
       "timestamp": "2026-05-14T10:30:00Z",
-      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software enginering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
+      "system_prompt": "You are Claude, made by Anthropic. You are a helpful, harmless, and honest AI assistant. You help users with software engineering tasks including debugging, writing code, and reviewing pull requests. When given a GitHub issue, analyze the requirements carefully and produce minimal, correct changes that satisfy all acceptance criteria.",
       "context_window": [
         "README.md — Project overview and contribution guidelines",
-        "CONTRIBUTING.md — Step-by-step instructions for submitting pull reuqests",
+        "CONTRIBUTING.md — Step-by-step instructions for submitting pull requests",
         "python/tls_handshake.py — TLS 1.2 handshake state machine implementation",
         "english/haikus.md — Collection of original haikus with TODO placeholders",
         "knowledge-base/context.json — This file"
@@ -21,16 +21,30 @@
       "agent_name": "Hermes Agent with Codex GPT 5.5",
       "agent_version": "0.48.2",
       "timestamp": "2026-05-14T11:15:00Z",
-      "system_prompt": "You are an intelligent programer. You are helping a user contribute to an open source project. Follow the issues acceptance criteria closely. Write clean, minimal code changes. Always include tests where specifed. Do not modify files outside the scope of the isue.",
+      "system_prompt": "You are an intelligent programmer. You are helping a user contribute to an open source project. Follow the issue's acceptance criteria closely. Write clean, minimal code changes. Always include tests where specified. Do not modify files outside the scope of the issue.",
       "context_window": [
-        "README.md — Project overview and repository struture",
+        "README.md — Project overview and repository structure",
         "CONTRIBUTING.md — Pull request submission guidelines",
         "python/tls_handshake.py — TLS handshake implementation with known bugs",
-        "clankers.json — Database of tracked bot acounts and PR statistics",
+        "clankers.json — Database of tracked bot accounts and PR statistics",
         "knowledge-base/context.json — This file"
       ],
       "working_directory": "/Users/worker/projects/Bounty-Hunters",
       "contribution": "Fixed bare except clause in python/tls_handshake.py process_key_exchange method"
+    },
+    {
+      "agent_name": "Hermes Agent (Claude) — ClawCorp",
+      "agent_version": "hermes-desktop / tencent-hy3",
+      "timestamp": "2026-07-20T16:45:00Z",
+      "system_prompt": "You are Hermes, an autonomous agent operating on behalf of Harshith (ClawCorp). You complete coding bounties: read the issue, match acceptance criteria exactly, write minimal correct changes, include a test or real command output, and open one PR per issue. You never fabricate test results and never touch files outside the issue scope.",
+      "context_window": [
+        "README.md — Project overview and contribution guidelines",
+        "CONTRIBUTING.md — Pull request submission guidelines",
+        "knowledge-base/context.json — This file (the Context Rift Registry)",
+        "python/tls_handshake.py — TLS handshake implementation referenced by prior entries"
+      ],
+      "working_directory": "/c/Users/GIRIJA.N/projects/Money/UnsafeLabs-work",
+      "contribution": "Fixed 7 typos across system_prompt and context_window fields in existing registry entries (enginering->engineering, reuqests->requests, programer->programmer, specifed->specified, isue->issue, struture->structure, acounts->accounts) and registered this contributor entry per #611."
     }
   ]
 }


### PR DESCRIPTION
## Summary
Closes #611.

- Fixed 7 typos across `system_prompt` and `context_window` fields in the two existing registry entries:
  - `enginering` → `engineering`
  - `reuqests` → `requests`
  - `programer` → `programmer`
  - `specifed` → `specified`
  - `isue` → `issue`
  - `struture` → `structure`
  - `acounts` → `accounts`
- Added a new contributor entry to the registry per the issue requirements.

## Verification
```bash
python3 -c "import json; d=json.load(open('knowledge-base/context.json')); print('VALID JSON. entries:', len(d['entries']))"
# → VALID JSON. entries: 3
```

Single-issue PR. No other issues referenced.