### PR TITLE
Hermes Agent [Crypto] Fix cross-chain replay attack in CrossChainBridge signature verification

### DIFF
--- a/solidity/contracts/CrossChainBridge.sol
+++ b/solidity/contracts/CrossChainBridge.sol
@@ -6,9 +6,15 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract CrossChainBridge {
     IERC20 public bridgeToken;
     address public validator;
-    uint256 public nonce;
+    uint256 public globalNonce;
 
     mapping(bytes32 => bool) public processedTransfers;
+    mapping(address => uint256) public senderNonces;
+
+    // EIP-712 domain separator
+    bytes32 public constant EIP712_DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 public constant TRANSFER_TYPEHASH = keccak256("Transfer(address recipient,uint256 amount,uint256 nonce)");
+    bytes32 public DOMAIN_SEPARATOR;
 
     event TransferInitiated(address indexed sender, uint256 amount, uint256 targetChain, uint256 nonce);
     event TransferProcessed(bytes32 indexed transferHash, address indexed recipient, uint256 amount);
@@ -16,41 +22,68 @@ contract CrossChainBridge {
     constructor(address _bridgeToken, address _validator) {
         bridgeToken = IERC20(_bridgeToken);
         validator = _validator;
+        DOMAIN_SEPARATOR = _buildDomainSeparator();
+    }
+
+    function _buildDomainSeparator() internal view returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256("CrossChainBridge"),
+            keccak256("1"),
+            block.chainid,
+            address(this)
+        ));
     }
 
     function initiateTransfer(uint256 amount, uint256 targetChain) external {
         require(amount > 0, "Amount must be > 0");
         bridgeToken.transferFrom(msg.sender, address(this), amount);
-        emit TransferInitiated(msg.sender, amount, targetChain, nonce++);
+        emit TransferInitiated(msg.sender, amount, targetChain, globalNonce++);
     }
 
-    // BUG: No chain ID in hash — cross-chain replay possible
-    // BUG: No nonce per sender — same-chain replay possible
-    // BUG: No contract address in hash — replay after upgrade possible
     function processTransfer(
         address recipient,
         uint256 amount,
         uint256 transferNonce,
         bytes calldata signature
     ) external {
-        bytes32 transferHash = keccak256(abi.encodePacked(
-            recipient,
-            amount,
-            transferNonce
-            // Missing: block.chainid
-            // Missing: address(this)
-        ));
+        bytes32 transferHash = _hashTransfer(recipient, amount, transferNonce);
+        bytes32 digest = _hashTypedData(transferHash);
 
-        require(!processedTransfers[transferHash], "Already processed");
-        require(verifySignature(transferHash, signature), "Invalid signature");
+        require(!processedTransfers[digest], "Already processed");
+        require(verifySignature(digest, signature), "Invalid signature");
 
-        processedTransfers[transferHash] = true;
+        processedTransfers[digest] = true;
         bridgeToken.transfer(recipient, amount);
 
-        emit TransferProcessed(transferHash, recipient, amount);
+        emit TransferProcessed(digest, recipient, amount);
     }
 
-    // BUG: Does not check for zero-address return from ecrecover
+    function _hashTransfer(address recipient, uint256 amount, uint256 nonce) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            TRANSFER_TYPEHASH,
+            recipient,
+            amount,
+            nonce
+        ));
+    }
+
+    function _hashTypedData(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked(
+            "\x19\x01",
+            DOMAIN_SEPARATOR,
+            structHash
+        ));
+    }
+
+    function refreshDomainSeparator() external {
+        DOMAIN_SEPARATOR = _buildDomainSeparator();
+    }
+
+    function getDomainSeparator() external view returns (bytes32) {
+        return DOMAIN_SEPARATOR;
+    }
+
     function verifySignature(bytes32 hash, bytes calldata signature) public view returns (bool) {
         require(signature.length == 65, "Invalid signature length");
 
@@ -66,12 +99,10 @@ contract CrossChainBridge {
 
         if (v < 27) v += 27;
 
-        address recovered = ecrecover(
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
-            v, r, s
-        );
+        address recovered = ecrecover(hash, v, r, s);
 
-        // BUG: Missing require(recovered != address(0))
+        require(recovered != address(0), "Invalid signature: zero-address");
+
         return recovered == validator;
     }
 


### PR DESCRIPTION
This PR fixes the cross-chain replay attack vulnerability in CrossChainBridge.sol:

- Implements EIP-712 typed data signing with domain separator binding chain ID, contract name, version, and verifying contract
- Chain ID prevents cross-chain replay
- Contract address prevents replay after proxy upgrades
- Nonce in struct prevents same-chain replay
- Zero-address check in ecrecover rejects invalid signatures
- refreshDomainSeparator() for safe proxy upgrade support

Closes #920

/claim #920