### PR TITLE
fix: prevent first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,11 +11,11 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
@@ -27,8 +27,9 @@ contract LiquidityPool is ERC20 {
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
-            lpTokens = sqrt(amountA * amountB);
+            // Lock MINIMUM_LIQUIDITY to address(0) to prevent first-depositor price manipulation
+            lpTokens = sqrt(amountA * amountB) - MINIMUM_LIQUIDITY;
+            _mint(address(0), MINIMUM_LIQUIDITY);
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,17 +45,13 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // Use internal reserves instead of manipulable balanceOf
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 
@@ -65,6 +62,14 @@ contract LiquidityPool is ERC20 {
         reserveB -= amountB;
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    /// @notice Updates internal reserves to match actual token balances.
+    /// Useful after direct token transfers ("donations") to the pool.
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/test/LiquidityPool.t.sol
+++ b/solidity/test/LiquidityPool.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/LiquidityPool.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract LiquidityPoolTest is Test {
+    LiquidityPool pool;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
+    address attacker = address(0xbad);
+    address user = address(0x1);
+
+    function setUp() public {
+        tokenA = new MockERC20("Token A", "TKA");
+        tokenB = new MockERC20("Token B", "TKB");
+        pool = new LiquidityPool(address(tokenA), address(tokenB));
+        
+        tokenA.mint(attacker, 1000 ether);
+        tokenB.mint(attacker, 1000 ether);
+        tokenA.mint(user, 100 ether);
+        tokenB.mint(user, 100 ether);
+    }
+
+    function testMinimumLiquidityLock() public {
+        // First depositor with tiny amount
+        vm.startPrank(attacker);
+        tokenA.approve(address(pool), 1);
+        tokenB.approve(address(pool), 1);
+        
+        // sqrt(1 * 1) = 1, minus MINIMUM_LIQUIDITY(1000) < 0
+        vm.expectRevert(); // Should revert due to underflow or "Insufficient liquidity"
+        pool.addLiquidity(1, 1);
+        vm.stopPrank();
+    }
+
+    function testFirstDepositLocksMinLiquidity() public {
+        // First deposit with sufficient amount
+        vm.startPrank(attacker);
+        uint256 amount = 1 ether;
+        tokenA.approve(address(pool), amount);
+        tokenB.approve(address(pool), amount);
+        
+        uint256 lpTokens = pool.addLiquidity(amount, amount);
+        
+        // MINIMUM_LIQUIDITY should be locked to address(0)
+        assertEq(pool.balanceOf(address(0)), pool.MINIMUM_LIQUIDITY());
+        // Attacker gets lpTokens - MINIMUM_LIQUIDITY
+        assertGt(lpTokens, 0);
+        vm.stopPrank();
+    }
+
+    function testRemoveLiquidityUsesInternalReserves() public {
+        // Setup: first deposit
+        vm.startPrank(user);
+        uint256 amount = 10 ether;
+        tokenA.approve(address(pool), amount);
+        tokenB.approve(address(pool), amount);
+        pool.addLiquidity(amount, amount);
+        
+        uint256 lpBalance = pool.balanceOf(user);
+        
+        // Direct donation to manipulate balanceOf
+        tokenA.transfer(address(pool), 50 ether);
+        tokenB.transfer(address(pool), 50 ether);
+        
+        // removeLiquidity should use internal reserves, not inflated balanceOf
+        uint256 reserveA_before = pool.reserveA();
+        uint256 reserveB_before = pool.reserveB();
+        
+        pool.removeLiquidity(lpBalance);
+        
+        // After donation manipulation attempt, reserves should be correct
+        assertLt(pool.reserveA(), reserveA_before + 50 ether);
+        assertLt(pool.reserveB(), reserveB_before + 50 ether);
+        vm.stopPrank();
+    }
+
+    function testSyncUpdatesReserves() public {
+        // Setup
+        vm.startPrank(user);
+        uint256 amount = 10 ether;
+        tokenA.approve(address(pool), amount);
+        tokenB.approve(address(pool), amount);
+        pool.addLiquidity(amount, amount);
+        
+        // Direct donation
+        tokenA.transfer(address(pool), 5 ether);
+        
+        uint256 reserveA_before = pool.reserveA();
+        
+        // Sync should update reserves to actual balances
+        pool.sync();
+        
+        assertEq(pool.reserveA(), reserveA_before + 5 ether);
+        vm.stopPrank();
+    }
+
+    function testNormalLiquidityFlow() public {
+        // First deposit
+        vm.startPrank(user);
+        uint256 amount = 10 ether;
+        tokenA.approve(address(pool), amount);
+        tokenB.approve(address(pool), amount);
+        uint256 lp = pool.addLiquidity(amount, amount);
+        assertGt(lp, 0);
+        
+        // Remove liquidity
+        uint256 lpBalance = pool.balanceOf(user);
+        (uint256 outA, uint256 outB) = pool.removeLiquidity(lpBalance);
+        assertGt(outA, 0);
+        assertGt(outB, 0);
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
## Fix: First-Depositor Price Manipulation in LiquidityPool

Closes #918

### Vulnerability
The liquidity pool was susceptible to the classic first-depositor price manipulation attack:
1. No MINIMUM_LIQUIDITY lock — attacker deposits 1 wei, gets 1 LP token, donates large amount → LP price is now manipulated
2. `removeLiquidity` used `balanceOf(address(this))` which is manipulable via direct token transfers

### Changes
1. **MINIMUM_LIQUIDITY lock**: On first deposit, `MINIMUM_LIQUIDITY` (1000) LP tokens are permanently locked to `address(0)`, following the Uniswap V2 pattern
2. **Internal reserves**: `removeLiquidity` now uses `reserveA`/`reserveB` instead of manipulable `balanceOf(address(this))`
3. **sync() function**: Added public `sync()` to reconcile internal reserves with actual token balances after direct transfers

### Tests
- `testMinimumLiquidityLock`: Verifies tiny first deposit reverts
- `testFirstDepositLocksMinLiquidity`: Verifies MINIMUM_LIQUIDITY sent to address(0)
- `testRemoveLiquidityUsesInternalReserves`: Verifies `removeLiquidity` ignores `balanceOf` manipulation
- `testSyncUpdatesReserves`: Verifies `sync()` correctly updates reserves
- `testNormalLiquidityFlow`: End-to-end add+remove test
