### PR TITLE
Hermes AI [ Crypto ] Fix MultiSigWallet confirmation race condition during execution callback

### DIFF
--- a/solidity/contracts/MultiSigWallet.sol
+++ b/solidity/contracts/MultiSigWallet.sol
@@ -6,6 +6,11 @@ contract MultiSigWallet {
     uint256 public required;
     uint256 public transactionCount;
 
+    struct Confirmation {
+        bool confirmed;
+        uint256 confirmedAtBlock;
+    }
+
     struct Transaction {
         address to;
         uint256 value;
@@ -14,8 +19,12 @@ contract MultiSigWallet {
     }
 
     mapping(uint256 => Transaction) public transactions;
-    mapping(uint256 => mapping(address => bool)) public confirmations;
+    mapping(uint256 => mapping(address => Confirmation)) public confirmations;
     mapping(address => bool) public isOwner;
+    mapping(uint256 => uint256) public confirmedAtBlock;
+
+    uint256 private _executingTxId;
+    bool private _executing;
 
     event Submitted(uint256 indexed txId);
     event Confirmed(uint256 indexed txId, address indexed owner);
@@ -25,6 +34,13 @@ contract MultiSigWallet {
     modifier onlyOwner() {
         require(isOwner[msg.sender], "Not owner");
         _;
+    }
+
+    modifier nonReentrant() {
+        require(!_executing, "Reentrant call");
+        _executing = true;
+        _;
+        _executing = false;
     }
 
     constructor(address[] memory _owners, uint256 _required) {
@@ -37,52 +53,59 @@ contract MultiSigWallet {
         required = _required;
     }
 
-    // BUG: No zero-address validation on `to`
     function submitTransaction(address to, uint256 value, bytes calldata data) external onlyOwner returns (uint256) {
+        require(to != address(0), "Invalid to address");
         uint256 txId = transactionCount++;
-        transactions[txId] = Transaction({
-            to: to,
-            value: value,
-            data: data,
-            executed: false
-        });
+        transactions[txId] = Transaction({to: to, value: value, data: data, executed: false});
         emit Submitted(txId);
         return txId;
     }
 
     function confirmTransaction(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(!confirmations[txId][msg.sender], "Already confirmed");
-        confirmations[txId][msg.sender] = true;
+        require(!confirmations[txId][msg.sender].confirmed, "Already confirmed");
+        require(!_executing || txId != _executingTxId, "Cannot modify during execution");
+        confirmations[txId][msg.sender] = Confirmation({confirmed: true, confirmedAtBlock: block.number});
         emit Confirmed(txId, msg.sender);
     }
 
     function revokeConfirmation(uint256 txId) external onlyOwner {
         require(!transactions[txId].executed, "Already executed");
-        require(confirmations[txId][msg.sender], "Not confirmed");
-        confirmations[txId][msg.sender] = false;
+        require(confirmations[txId][msg.sender].confirmed, "Not confirmed");
+        require(!_executing || txId != _executingTxId, "Cannot modify during execution");
+        confirmations[txId][msg.sender] = Confirmation({confirmed: false, confirmedAtBlock: 0});
         emit Revoked(txId, msg.sender);
     }
 
     function getConfirmationCount(uint256 txId) public view returns (uint256 count) {
         for (uint256 i = 0; i < owners.length; i++) {
-            if (confirmations[txId][owners[i]]) count++;
+            if (confirmations[txId][owners[i]].confirmed) count++;
         }
     }
 
-    // BUG: No reentrancy protection — confirmation can be revoked during callback
-    // BUG: No block-level confirmation snapshot
-    function executeTransaction(uint256 txId) external onlyOwner {
-        require(!transactions[txId].executed, "Already executed");
-        require(getConfirmationCount(txId) >= required, "Not enough confirmations");
+    function getConfirmationCountAtBlock(uint256 txId, uint256 blockNumber) public view returns (uint256 count) {
+        for (uint256 i = 0; i < owners.length; i++) {
+            Confirmation storage c = confirmations[txId][owners[i]];
+            if (c.confirmed && c.confirmedAtBlock <= blockNumber) count++;
+        }
+    }
 
+    function executeTransaction(uint256 txId) external onlyOwner nonReentrant {
+        require(!transactions[txId].executed, "Already executed");
+        uint256 snapshotBlock = block.number;
+        confirmedAtBlock[txId] = snapshotBlock;
+        require(getConfirmationCountAtBlock(txId, snapshotBlock) >= required, "Not enough confirmations");
+        _executingTxId = txId;
         Transaction storage txn = transactions[txId];
         txn.executed = true;
-
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
         require(success, "Execution failed");
-
+        _executingTxId = 0;
         emit Executed(txId);
+    }
+
+    function isConfirmedAtBlock(uint256 txId, uint256 blockNumber) public view returns (bool) {
+        return getConfirmationCountAtBlock(txId, blockNumber) >= required;
     }
 
     receive() external payable {}

--- a/solidity/contracts/_provenance.json
+++ b/solidity/contracts/_provenance.json
@@ -1,0 +1,5 @@
+{
+    "tool_name": "Hermes Agent with DeepSeek v4 Pro",
+    "boot_context": "Hermes Agent by Nous Research. Running on DeepSeek v4 Pro. Windows 10 desktop with full terminal, web, code execution, and Vertex AI Gemini 2.5 Pro access. AI agent autonomously solving bounties on UnsafeLabs/Bounty-Hunters.",
+    "timestamp": "2026-08-09T12:10:00+01:00"
+}


### PR DESCRIPTION
/claim #916

Fixes #916 — MultiSigWallet confirmation race condition.

## Changes
1. Added nonReentrant modifier to executeTransaction
2. Confirmation struct now includes confirmedAtBlock for front-running protection
3. Added isConfirmedAtBlock() for block-level snapshot verification
4. Added zero-address validation in submitTransaction
5. Prevent confirmation changes during active execution
6. Added _provenance.json for audit trail