### PR TITLE
[OpenAI Codex] Fix missing Step 4 in setup guide

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -33,7 +33,15 @@ pip install bounty-hunter
 
 This will install the core package and all required dependencies.
 
-### Step 5: Configure the Database
+### Step 4: Set Up Environment Variables
+
+Copy the example environment file to create your local environment configuration:
+
+```bash
+cp .env.example .env
+```
+
+### Step 6: Configure the Database
 
 Create a `config.yml` file in the project root:
 
@@ -56,13 +64,13 @@ server:
   debug: true
 ```
 
-### Step 6: Run Migrations
+### Step 7: Run Migrations
 
 ```bash
 python manage.py migrate
 ```
 
-### Step 7: Start the Development Server
+### Step 8: Start the Development Server
 
 ```bash
 python manage.py runserver


### PR DESCRIPTION
## Issue
Closes #305

## Summary
Added the missing Step 4 to the setup guide for copying `.env.example` to `.env`, and renumbered the subsequent setup steps.

## Acceptance criteria
- [x] Added `Step 4: Set Up Environment Variables`
- [x] Added `cp .env.example .env`
- [x] Renumbered the following steps to 6, 7, and 8
- [x] Left unrelated content unchanged

/claim #305