### PR TITLE
[Crypto] Fix first-depositor price manipulation in LiquidityPool

### DIFF
--- a/solidity/contracts/LiquidityPool.sol
+++ b/solidity/contracts/LiquidityPool.sol
@@ -11,24 +11,27 @@ contract LiquidityPool is ERC20 {
     uint256 public reserveA;
     uint256 public reserveB;
 
-    // BUG: No MINIMUM_LIQUIDITY lock — first depositor can manipulate LP price
     uint256 public constant MINIMUM_LIQUIDITY = 1000;
 
     event LiquidityAdded(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
     event LiquidityRemoved(address indexed provider, uint256 amountA, uint256 amountB, uint256 lpTokens);
+    event Sync(uint256 reserveA, uint256 reserveB);
 
     constructor(address _tokenA, address _tokenB) ERC20("LP Token", "LP") {
         tokenA = IERC20(_tokenA);
         tokenB = IERC20(_tokenB);
     }
 
+    // FIX: Lock MINIMUM_LIQUIDITY on first deposit to prevent price manipulation
     function addLiquidity(uint256 amountA, uint256 amountB) external returns (uint256 lpTokens) {
         tokenA.transferFrom(msg.sender, address(this), amountA);
         tokenB.transferFrom(msg.sender, address(this), amountB);
 
         if (totalSupply() == 0) {
-            // BUG: No minimum liquidity lock to address(0)
+            // FIX: Calculate LP tokens and lock MINIMUM_LIQUIDITY at address(0)
             lpTokens = sqrt(amountA * amountB);
+            _mint(address(0), MINIMUM_LIQUIDITY);
+            lpTokens -= MINIMUM_LIQUIDITY;
         } else {
             uint256 lpFromA = amountA * totalSupply() / reserveA;
             uint256 lpFromB = amountB * totalSupply() / reserveB;
@@ -44,17 +47,14 @@ contract LiquidityPool is ERC20 {
         emit LiquidityAdded(msg.sender, amountA, amountB, lpTokens);
     }
 
-    // BUG: Uses balanceOf instead of internal reserves — manipulable via direct transfer
+    // FIX: Use internal reserves instead of balanceOf — prevents manipulation via direct transfer
     function removeLiquidity(uint256 lpTokens) external returns (uint256 amountA, uint256 amountB) {
         require(lpTokens > 0, "Must burn > 0");
         require(balanceOf(msg.sender) >= lpTokens, "Insufficient LP tokens");
 
-        // BUG: Should use reserveA/reserveB, not balanceOf
-        uint256 balA = tokenA.balanceOf(address(this));
-        uint256 balB = tokenB.balanceOf(address(this));
-
-        amountA = lpTokens * balA / totalSupply();
-        amountB = lpTokens * balB / totalSupply();
+        // FIX: Use internal reserves (reserveA/reserveB) instead of balanceOf
+        amountA = lpTokens * reserveA / totalSupply();
+        amountB = lpTokens * reserveB / totalSupply();
 
         _burn(msg.sender, lpTokens);
 
@@ -65,6 +65,13 @@ contract LiquidityPool is ERC20 {
         reserveB -= amountB;
 
         emit LiquidityRemoved(msg.sender, amountA, amountB, lpTokens);
+    }
+
+    // FIX: Sync function to update reserves from actual balances (recovery from donation attacks)
+    function sync() external {
+        reserveA = tokenA.balanceOf(address(this));
+        reserveB = tokenB.balanceOf(address(this));
+        emit Sync(reserveA, reserveB);
     }
 
     function sqrt(uint256 y) internal pure returns (uint256 z) {

--- a/solidity/test/LiquidityPool.test.sol
+++ b/solidity/test/LiquidityPool.test.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/LiquidityPool.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+// Mock ERC20 Token
+contract MockToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract LiquidityPoolTest is Test {
+    LiquidityPool public pool;
+    MockToken public tokenA;
+    MockToken public tokenB;
+    address public user1 = address(0x1);
+    address public user2 = address(0x2);
+    address public attacker = address(0x3);
+
+    function setUp() public {
+        tokenA = new MockToken("Token A", "TKA");
+        tokenB = new MockToken("Token B", "TKB");
+        pool = new LiquidityPool(address(tokenA), address(tokenB));
+
+        // Mint tokens to users
+        tokenA.mint(user1, 1000000e18);
+        tokenB.mint(user1, 1000000e18);
+        tokenA.mint(user2, 1000000e18);
+        tokenB.mint(user2, 1000000e18);
+        tokenA.mint(attacker, 1000000e18);
+        tokenB.mint(attacker, 1000000e18);
+
+        // Approvals
+        vm.prank(user1);
+        tokenA.approve(address(pool), type(uint256).max);
+        vm.prank(user1);
+        tokenB.approve(address(pool), type(uint256).max);
+        vm.prank(user2);
+        tokenA.approve(address(pool), type(uint256).max);
+        vm.prank(user2);
+        tokenB.approve(address(pool), type(uint256).max);
+        vm.prank(attacker);
+        tokenA.approve(address(pool), type(uint256).max);
+        vm.prank(attacker);
+        tokenB.approve(address(pool), type(uint256).max);
+    }
+
+    function testFirstDepositLocksMinimumLiquidity() public {
+        // First deposit
+        vm.prank(user1);
+        pool.addLiquidity(10000e18, 10000e18);
+
+        // Check that MINIMUM_LIQUIDITY is locked at address(0)
+        uint256 lockedBalance = pool.balanceOf(address(0));
+        assertEq(lockedBalance, 1000);
+
+        // User1 should have less than sqrt(10000 * 10000)
+        uint256 user1Balance = pool.balanceOf(user1);
+        assertLt(user1Balance, 10000e18);
+        assertEq(user1Balance, 10000e18 - 1000);
+    }
+
+    function testPriceManipulationPrevented() public {
+        // Attacker tries to manipulate by being first depositor with tiny amount
+        vm.prank(attacker);
+        pool.addLiquidity(1e18, 1e18);
+
+        // Attacker gets LP tokens minus MINIMUM_LIQUIDITY
+        uint256 attackerLP = pool.balanceOf(attacker);
+        assertEq(attackerLP, 1e18 - 1000);
+
+        // Attacker donates large amount directly to pool
+        vm.prank(attacker);
+        tokenA.transfer(address(pool), 100000e18);
+
+        // Second user deposits
+        vm.prank(user1);
+        pool.addLiquidity(10000e18, 10000e18);
+
+        // User1 should get fair LP tokens based on reserves
+        uint256 user1LP = pool.balanceOf(user1);
+        assertGt(user1LP, attackerLP);
+
+        // Remove liquidity should use internal reserves, not manipulated balance
+        vm.prank(user1);
+        (uint256 amountA, uint256 amountB) = pool.removeLiquidity(user1LP);
+
+        // Should get proportional share based on reserves, not manipulated balance
+        assertGt(amountA, 0);
+        assertGt(amountB, 0);
+    }
+
+    function testDonationAttackPrevented() public {
+        // Setup: user1 adds liquidity
+        vm.prank(user1);
+        pool.addLiquidity(10000e18, 10000e18);
+
+        uint256 user1LP = pool.balanceOf(user1);
+
+        // Attacker donates tokens directly (donation attack)
+        vm.prank(attacker);
+        tokenA.transfer(address(pool), 50000e18);
+
+        // User1 removes liquidity - should get fair share based on reserves
+        vm.prank(user1);
+        (uint256 amountA, uint256 amountB) = pool.removeLiquidity(user1LP);
+
+        // Should get 50% of reserves, not affected by donation
+        assertApproxEqAbs(amountA, 5000e18, 1e18);
+        assertApproxEqAbs(amountB, 10000e18, 1e18);
+    }
+
+    function testSyncRecovery() public {
+        // Setup: user1 adds liquidity
+        vm.prank(user1);
+        pool.addLiquidity(10000e18, 10000e18);
+
+        // Attacker donates tokens
+        vm.prank(attacker);
+        tokenA.transfer(address(pool), 50000e18);
+
+        // Sync updates reserves to match actual balances
+        pool.sync();
+
+        // Now reserves match actual balances
+        assertEq(pool.reserveA(), 60000e18);
+        assertEq(pool.reserveB(), 10000e18);
+    }
+
+    function testNormalAddRemoveLiquidity() public {
+        // Add liquidity
+        vm.prank(user1);
+        pool.addLiquidity(10000e18, 10000e18);
+
+        uint256 lpTokens = pool.balanceOf(user1);
+        assertGt(lpTokens, 0);
+
+        // Remove liquidity
+        vm.prank(user1);
+        (uint256 amountA, uint256 amountB) = pool.removeLiquidity(lpTokens);
+
+        assertGt(amountA, 0);
+        assertGt(amountB, 0);
+    }
+}


### PR DESCRIPTION
Summary
Added MINIMUM_LIQUIDITY lock on first deposit and switched to internal reserves to prevent price manipulation attacks.

Changes Made
- Added MINIMUM_LIQUIDITY lock at address(0) on first deposit (Uniswap V2 pattern)
- Changed removeLiquidity to use internal reserves (reserveA/reserveB) instead of balanceOf
- Added sync() function for recovery from donation attacks
- Added Sync event

Why This Fixes The Vulnerability
- First depositor can no longer manipulate LP token price
- Direct token transfers to pool don't affect LP token pricing
- Internal accounting prevents balance manipulation attacks

/claim #918