### PR TITLE
[ Crypto ] Fix PriceOracle missing staleness check and fallback mechanism

### DIFF
--- a/solidity/contracts/PriceOracle.sol
+++ b/solidity/contracts/PriceOracle.sol
@@ -14,34 +14,63 @@ interface AggregatorV3Interface {
 
 contract PriceOracle {
     AggregatorV3Interface public primaryFeed;
+    AggregatorV3Interface public fallbackFeed;
     address public owner;
     uint256 public MAX_STALENESS = 3600;
 
     event PriceQueried(int256 price, uint256 timestamp);
 
-    constructor(address _primaryFeed) {
+    constructor(address _primaryFeed, address _fallbackFeed) {
         primaryFeed = AggregatorV3Interface(_primaryFeed);
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
         owner = msg.sender;
     }
 
-    // BUG: No staleness check on updatedAt
-    // BUG: No check for negative/zero price
-    // BUG: No round completeness validation
-    // BUG: No fallback oracle
+    // FIX: Added staleness check on updatedAt.
+    // FIX: Added check for negative/zero price.
+    // FIX: Added round completeness validation.
+    // FIX: Added fallback oracle support.
     function getLatestPrice() external view returns (int256) {
-        (
+        try primaryFeed.latestRoundData() returns (
             uint80 roundId,
             int256 price,
-            ,
+            uint256,
             uint256 updatedAt,
             uint80 answeredInRound
-        ) = primaryFeed.latestRoundData();
+        ) {
+            _validatePriceData(roundId, price, updatedAt, answeredInRound);
+            return price;
+        } catch {
+            return _getFallbackPrice();
+        }
+    }
 
-        // Missing: require(price > 0)
-        // Missing: require(answeredInRound >= roundId)
-        // Missing: require(block.timestamp - updatedAt < MAX_STALENESS)
+    function _validatePriceData(
+        uint80 roundId,
+        int256 price,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) internal view {
+        require(price > 0, "Price must be positive");
+        require(answeredInRound >= roundId, "Round not complete");
+        require(block.timestamp <= updatedAt + MAX_STALENESS, "Price is stale");
+    }
 
-        return price;
+    function _getFallbackPrice() internal view returns (int256) {
+        require(address(fallbackFeed) != address(0), "No fallback oracle available");
+
+        try fallbackFeed.latestRoundData() returns (
+            uint80 roundId,
+            int256 price,
+            uint256,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) {
+            _validatePriceData(roundId, price, updatedAt, answeredInRound);
+            return price;
+        } catch {
+            revert("All oracles failed");
+        }
     }
 
     function getDecimals() external view returns (uint8) {
@@ -51,5 +80,10 @@ contract PriceOracle {
     function setMaxStaleness(uint256 _maxStaleness) external {
         require(msg.sender == owner, "Not owner");
         MAX_STALENESS = _maxStaleness;
+    }
+
+    function setFallbackOracle(address _fallbackFeed) external {
+        require(msg.sender == owner, "Not owner");
+        fallbackFeed = AggregatorV3Interface(_fallbackFeed);
     }
 }


### PR DESCRIPTION
## Summary

Fixes Issue #915 — missing staleness check and fallback mechanism in PriceOracle.

## Bug

- No staleness check on `updatedAt` — stale prices could be used
- No check for negative/zero price
- No round completeness validation
- No fallback oracle when primary fails

## Fix

- Added `require(block.timestamp <= updatedAt + MAX_STALENESS, "Price is stale")`
- Added `require(price > 0, "Price must be positive")`
- Added `require(answeredInRound >= roundId, "Round not complete")`
- Added fallback oracle via `try/catch` + `setFallbackOracle()` admin function
- Reverts with "All oracles failed" if both primary and fallback fail

## Acceptance criteria

- [x] Staleness check: `require(block.timestamp <= updatedAt + MAX_STALENESS)`
- [x] Price validation: `require(price > 0)`
- [x] Round completeness: `require(answeredInRound >= roundId)`
- [x] Fallback oracle when primary feed fails
- [x] Clear error messages

/claim #915