### PR TITLE
[ Crypto ] Fix tx.origin phishing vulnerability in GovernanceToken delegation

### DIFF
--- a/solidity/contracts/GovernanceToken.sol
+++ b/solidity/contracts/GovernanceToken.sol
@@ -28,30 +28,30 @@ contract GovernanceToken is ERC20 {
         admin = msg.sender;
     }
 
-    // BUG: Uses tx.origin instead of msg.sender — phishing vulnerability
+    // FIX: Replaced tx.origin with msg.sender to prevent phishing attacks.
     function delegateVote(address to) external {
-        require(tx.origin != to, "Cannot delegate to self");
-        address previousDelegate = delegates[tx.origin];
+        require(msg.sender != to, "Cannot delegate to self");
+        address previousDelegate = delegates[msg.sender];
         if (previousDelegate != address(0)) {
-            delegatedPower[previousDelegate] -= balanceOf(tx.origin);
+            delegatedPower[previousDelegate] -= balanceOf(msg.sender);
         }
-        delegates[tx.origin] = to;
-        delegatedPower[to] += balanceOf(tx.origin);
-        emit DelegateChanged(tx.origin, to);
+        delegates[msg.sender] = to;
+        delegatedPower[to] += balanceOf(msg.sender);
+        emit DelegateChanged(msg.sender, to);
     }
 
-    // BUG: Same tx.origin issue
+    // FIX: Replaced tx.origin with msg.sender.
     function revokeDelegate() external {
-        address currentDelegate = delegates[tx.origin];
+        address currentDelegate = delegates[msg.sender];
         require(currentDelegate != address(0), "No delegate");
-        delegatedPower[currentDelegate] -= balanceOf(tx.origin);
-        delegates[tx.origin] = address(0);
-        emit DelegateChanged(tx.origin, address(0));
+        delegatedPower[currentDelegate] -= balanceOf(msg.sender);
+        delegates[msg.sender] = address(0);
+        emit DelegateChanged(msg.sender, address(0));
     }
 
-    // BUG: tx.origin for admin check
+    // FIX: Replaced tx.origin with msg.sender for admin check.
     function snapshot() external {
-        require(tx.origin == admin, "Not admin");
+        require(msg.sender == admin, "Not admin");
         // snapshot logic placeholder
     }
 


### PR DESCRIPTION
## Summary

Fixes Issue #912 — tx.origin phishing vulnerability in GovernanceToken.

## Bug

`tx.origin` used instead of `msg.sender` in `delegateVote()`, `revokeDelegate()`, and `snapshot()`. This allows phishing attacks where a malicious contract interposes between the user and the governance contract.

## Fix

Replaced all `tx.origin` references with `msg.sender`:

```solidity
// Before (vulnerable)
require(tx.origin != to, "Cannot delegate to self");

// After (secure)
require(msg.sender != to, "Cannot delegate to self");
```

## Acceptance criteria

- [x] delegateVote uses msg.sender
- [x] revokeDelegate uses msg.sender
- [x] snapshot uses msg.sender for admin check
- [x] No tx.origin references remain

/claim #912