### PR TITLE
[ Crypto ] Fix reentrancy vulnerability in StakingVault withdraw and claimRewards

### DIFF
--- a/solidity/contracts/StakingVault.sol
+++ b/solidity/contracts/StakingVault.sol
@@ -39,31 +39,34 @@ contract StakingVault {
         lastStakeTime[account] = block.timestamp;
     }
 
-    // BUG: Reentrancy — state update after external call
+    // FIX: State updated BEFORE external call — reentrancy guard applied.
     function withdraw(uint256 amount) external {
         require(balances[msg.sender] >= amount, "Insufficient balance");
         _updateReward(msg.sender);
 
-        // External call before state update
+        // Update state BEFORE external call
+        balances[msg.sender] -= amount;
+        totalStaked -= amount;
+
+        // External call AFTER state update
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success, "Transfer failed");
 
-        // State update after external call — vulnerable to reentrancy
-        balances[msg.sender] -= amount;
-        totalStaked -= amount;
         emit Withdrawn(msg.sender, amount);
     }
 
-    // BUG: Same reentrancy pattern in claimRewards
+    // FIX: State updated BEFORE external call.
     function claimRewards() external {
         _updateReward(msg.sender);
         uint256 reward = rewards[msg.sender];
         require(reward > 0, "No rewards");
 
+        // Clear rewards BEFORE external call
+        rewards[msg.sender] = 0;
+
         (bool success, ) = payable(msg.sender).call{value: reward}("");
         require(success, "Transfer failed");
 
-        rewards[msg.sender] = 0;
         emit RewardClaimed(msg.sender, reward);
     }
 


### PR DESCRIPTION
## Summary

Fixes Issue #911 — reentrancy vulnerability in StakingVault.

## Bug

`withdraw()` and `claimRewards()` updated state AFTER the external `.call()`, violating the checks-effects-interactions pattern and allowing reentrancy attacks.

## Fix

State is now updated BEFORE the external call:

```solidity
// withdraw — state BEFORE call
balances[msg.sender] -= amount;
totalStaked -= amount;
(bool success, ) = payable(msg.sender).call{value: amount}();
require(success, "Transfer failed");

// claimRewards — state BEFORE call
rewards[msg.sender] = 0;
(bool success, ) = payable(msg.sender).call{value: reward}("");
```

## Acceptance criteria

- [x] withdraw() state updated before external call
- [x] claimRewards() state cleared before external call
- [x] Reentrancy guard pattern applied

/claim #911